### PR TITLE
WUL-203 docs: refresh public current-state documentation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -5,6 +5,7 @@ Deve cambiare raramente: qui ci sono i confini, non i dettagli di implementazion
 Per il resto:
 
 - [docs/walkthrough.md](./docs/walkthrough.md) (end-to-end, web + native)
+- [docs/STATE_OF_THE_SYSTEM.md](./docs/STATE_OF_THE_SYSTEM.md) (lettura completa dello stato corrente)
 - [docs/topologia-dati-flussi.md](./docs/topologia-dati-flussi.md) (topologia dati + percorsi digitali end-to-end)
 - [docs/ARCHITETTURA.md](./docs/ARCHITETTURA.md) e [docs/system_architecture.md](./docs/system_architecture.md) (deep dive)
 - [docs/adr/](./docs/adr/README.md) (decisioni architetturali)
@@ -164,8 +165,11 @@ flowchart TB
   - retrocompatibile all'interno della stessa major
 - `local-only` come default e `network-home-base` come opt-in paired/read-only-first.
 - `patients.documentInsights` puo convivere con artifact documentali piu ricchi, ma gli artifact persistiti restano locali e cifrati.
+- `Clinical Workbench / Graphite` resta l'unica shell web ufficiale su `main`;
+  nuove sperimentazioni non diventano selector runtime persistiti senza
+  workstream e decisione espliciti.
 - Principio local-only: nessuna dipendenza cloud di default.
-- Boundary SISS/FSE: oggi orchestrazione locale + percorsi ufficiali; niente claim
+- Boundary SISS/FSE: oggi coordinamento contestuale + percorsi ufficiali; niente claim
   di integrazione regionale nativa certificata fuori dal perimetro documentato.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,15 @@ Questo file raccoglie i cambiamenti rilevanti di MediFlow.
 Il formato è basato su [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 e questo progetto aderisce al [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2026-04-19
+## [Unreleased] - 2026-05-01
 
 ### ✨ Aggiunto
 
 - **Home-base read-only eseguibile**: modalita `network-home-base`, overview Settings, pairing PHI-safe e primo data plane `/api/v1/network/patients*` protetto da `paired client + sessione operatore`.
 - **Document intelligence piu esplicita**: first slice runtime del `document evidence ledger` con artifact `parse/evidence` cifrato sugli allegati e primo consumer artifact-first in `AI Patient Insight`.
 - **Nuova anagrafica document-driven reviewable**: create-flow da documento con review esplicita, riconciliazione locale ICD/AIFA e persistenza prudente delle terapie confermate.
+- **Clinical Workbench unico su `main`**: preview profiles runtime ritirati; AI, Smart Import e contesto paziente SISS/FSE vivono nella shell ufficiale.
+- **Corpus SISS/FSE locale**: manifest sorgenti, sync incrementale e report di freschezza preparano le integrazioni regionali future senza entrare nel runtime clinico.
 - **Lane AI opt-in e shadow-only piu disciplinate**: comparator cloud `gpt-5.4` per engineering interno e adapter OpenMed `redaction.v1` separato dal runtime clinico.
 
 ### 🧪 Migliorato
@@ -26,9 +28,11 @@ e questo progetto aderisce al [Semantic Versioning](https://semver.org/spec/v2.0
 
 ### 📚 Documentazione
 
+- **Lettura completa dello stato sistema**: aggiunto `docs/STATE_OF_THE_SYSTEM.md` come punto canonico unico per prodotto, runtime, dati, sicurezza, AI/document intelligence, home-base, SISS/FSE, Apple clients e split private/OSS.
 - **Repo/GitHub riallineati al runtime reale**: README, piani, walkthrough, topologia dati, roadmap e sintesi architetturale descrivono ora `home-base` read-only, artifact `parse/evidence`, comparator/shadow lane e guard di revisione della shell locale.
-- **Narrativa `v0.5` riallineata tra private e OSS**: README, FAQ, roadmap, architettura e mappe documentali chiariscono che il salto pubblico rilevante e `v0.3 -> v0.5`, esplicitano preview profiles locali, boundary SISS attuale e direzione `macOS + iPadOS/iPhone` tramite `home-base`.
-- **Export OSS piu netto**: la preparazione della repo pubblica omette anche il piano operativo di breve e ripulisce i riferimenti ai documenti interni di orchestrazione/attribution, lasciando in pubblico solo materiale di prodotto, architettura e uso reale.
+- **Narrativa `v0.5` piu chiara**: README, FAQ, roadmap, architettura e mappe documentali raccontano lo stato corrente senza confronti interni, con Clinical Workbench unico, boundary SISS attuale e direzione `macOS + iPadOS/iPhone` tramite `home-base`.
+- **Sweep WUL-203**: riferimento, supporto e overview docs riallineati allo stato corrente di `main`, con rimozione dei residui che presentavano i preview profiles come runtime disponibile.
+- **Copy pubblico piu armonico**: le superfici GitHub privilegiano prodotto, architettura e uso reale, senza rimandi a processi interni o screenshot non piu rappresentativi.
 
 ## [0.5.0] - 2026-03-29
 
@@ -76,7 +80,7 @@ e questo progetto aderisce al [Semantic Versioning](https://semver.org/spec/v2.0
 - **Patient PDF report**: report esteso con sezioni cliniche più complete e copertura automatica sulle sezioni generate.
 - **Clinical facts benchmark**: introdotto il corpus sintetico per osservazioni `LOINC/UCUM`, con decisione `hybrid` di default e fallback `rules` tracciato.
 - **Stabilizzazione web/core pre-version-bump**: normalizzazione condivisa dei payload paziente, parsing condiviso dei campi strutturati, gate `typecheck` stabile e scomposizione incrementale dei file più densi (`SecurityProvider`, `SettingsPage`).
-- **Tooling di progetto**: playbook operativo interno, import backlog automatizzato e controllo piu esplicito del flusso OSS/private.
+- **Tooling di progetto**: strumenti di manutenzione piu ordinati, import backlog automatizzato e controllo piu esplicito della pubblicazione.
 
 ### 🐛 Risolto
 
@@ -99,7 +103,7 @@ e questo progetto aderisce al [Semantic Versioning](https://semver.org/spec/v2.0
 - **Walkthrough e mappe canoniche aggiornate** per flusso OCR-first, smart import reviewable, backup scheduler/retention, parity sweep e governance OpenAPI.
 - **Baseline e matrici canoniche** aggiunte per GTW/FSE, SISS certificato, benchmark clinical facts e stabilizzazione web/core pre-release.
 - **Freeze esplicito del filone macOS**: patch notes, roadmap e guide native chiariscono che la parity macOS entra in rebuild controllato dopo `v0.4.0`, senza bloccare l'evoluzione web/core.
-- **Indice markdown e playbook operativi** estesi per rendere ricostruibile il lavoro tra Git, Linear, docs e repo OSS.
+- **Indice markdown e playbook operativi** estesi per rendere ricostruibile il lavoro tra repository, documentazione e verifiche.
 
 ## [0.3.1] - 2026-02-18
 
@@ -126,12 +130,12 @@ e questo progetto aderisce al [Semantic Versioning](https://semver.org/spec/v2.0
 
 - **Mappa canonica documentazione** (`docs/README.md`) con ordine fonti e responsabilità per tema.
 - **Classificazione documenti** con stato `CANONICAL`, `SECONDARY`, `LEGACY`.
-- **Allineamento release docs**: intestazioni versione, roadmap e metadati `PLANS`.
+- **Allineamento release docs**: intestazioni versione, roadmap e metadati documentali.
 
 ### 🙏 Tributo OpenHospital
 
 - Questo rilascio è anche un tributo a OpenHospital: non una copia 1:1, ma un percorso di apprendimento e adattamento di pratiche mature (guardrail, integrità dati, contratti API espliciti, auditabilità) al modello local-first/zero-knowledge di MediFlow.
-- La traiettoria di allineamento resta esplicita e incrementale, con evidenza operativa mantenuta nel workspace privato di lavoro.
+- La traiettoria di allineamento resta esplicita e incrementale, con evidenza operativa mantenuta separata dal racconto di prodotto.
 
 ### 🗓 Timeline (ieri e oggi)
 
@@ -165,5 +169,5 @@ e questo progetto aderisce al [Semantic Versioning](https://semver.org/spec/v2.0
 
 ### 📦 Infrastruttura
 
-- **Docker All-in-One**: Nuovo `docker-compose.yml` che orchestra App (Next.js), ICD-API e Ollama.
+- **Docker All-in-One**: Nuovo `docker-compose.yml` che avvia App (Next.js), ICD-API e Ollama.
 - **Script di Avvio**: `Start_MediFlow.command` semplificato per macOS ("Click & Run").

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,22 +17,6 @@ Se vuoi cambiare confini di sicurezza, scrivi prima un ADR (vedi sotto).
 
 ---
 
-## Igiene workflow e tracciabilita
-
-Per i lavori non banali, il default operativo e questo:
-
-- una issue Linear per ogni unita di delivery
-- un branch dedicato per ogni issue attiva
-- commit piccoli, leggibili e con issue ID
-- push su checkpoint stabili, non solo a fine lavoro
-- PR `Draft` appena il workstream supera una singola sessione o un solo commit utile
-- verifica esplicita di cosa e stato testato e cosa no
-
-Se durante il lavoro lo scope cambia davvero, non allargare il branch in modo
-silenzioso: apri un nuovo capitolo con nuova issue / nuovo branch / nuova PR.
-
----
-
 ## Prerequisiti
 
 - Node.js **v20+** consigliato
@@ -50,13 +34,15 @@ cd mediflow
 npm install
 ```
 
-### Avvio (stack locale completo consigliato)
+### Avvio (stack web locale consigliato)
 
 ```bash
 ./Start_MediFlow.command
 ```
 
 Poi apri: `http://localhost:3000`
+
+`Start_MediFlow.command` avvia la web app e i servizi locali opzionali; il client macOS resta su launcher separato (`./scripts/Launch_MediFlowMac.command`).
 
 ### Avvio (solo web)
 
@@ -162,6 +148,7 @@ Usalo quando tocchi:
 - Guard revisione shell locale: `lib/app-revision.ts`, `app/api/system/revision/route.ts`, `components/app-revision-guard.tsx`, `Start_MediFlow.command`
 
 Documentazione tecnica:
+- [docs/STATE_OF_THE_SYSTEM.md](./docs/STATE_OF_THE_SYSTEM.md) (lettura completa dello stato corrente)
 - [docs/README.md](./docs/README.md) (mappa canonica documentazione)
 - [docs/markdown-index.md](./docs/markdown-index.md) (inventario completo markdown)
 - [docs/walkthrough.md](./docs/walkthrough.md)

--- a/README.md
+++ b/README.md
@@ -1,33 +1,31 @@
 # MediFlow v0.5.0
 
-> Cartella clinica territoriale local-first.  
-> Privata per impostazione, veloce nell’uso, concreta nel metodo.
-
-![MediFlow Screenshot](screenshot.png)
+> Cartella clinica territoriale local-first.
+> Dati vicini al medico, flusso rapido, privacy come impostazione di base.
 
 ## Perché MediFlow
 
 MediFlow nasce dal lavoro reale con i pazienti, non da un esercizio teorico.
 
-L’idea è semplice: una cartella clinica deve aiutare chi cura a ritrovare informazioni, seguire terapie, annotare decisioni, conservare documenti e mantenere continuità, senza trasformare ogni gesto in burocrazia digitale.
+Una cartella clinica deve aiutare chi cura a ritrovare informazioni, seguire terapie, annotare decisioni, conservare documenti e mantenere continuità, senza trasformare ogni gesto in burocrazia digitale.
 
 Nel contesto territoriale italiano questo bisogno è ancora più evidente: il tempo è poco, i dati sono sensibili, i percorsi sono spesso frammentati e gli strumenti disponibili non sempre rispettano il modo in cui il lavoro clinico viene davvero svolto.
 
 MediFlow prova a rispondere a questo spazio: una base locale, leggibile, prudente e modulare per la gestione quotidiana dei pazienti.
 
-Non nasce per sostituire i canali istituzionali, né per fingere integrazioni che non esistono. Nasce per dare ordine, continuità e controllo al lavoro clinico di tutti i giorni.
+Non nasce per sostituire i canali istituzionali, né per promettere integrazioni che non sono ancora dimostrate. Nasce per dare ordine, continuità e controllo al lavoro clinico di tutti i giorni.
 
-## L’idea
+## L'idea
 
-MediFlow è una web app locale per la gestione di dati clinici, terapie, note e documenti.
+MediFlow è una web app locale per gestire dati clinici, terapie, note e documenti.
 
-Il principio guida è **local-first**: il dato resta vicino a chi lo produce e lo usa. Il cloud non è un requisito per lavorare, e l’architettura è pensata per ridurre al minimo la dipendenza da servizi esterni.
+Il principio guida è **local-first**: il dato resta vicino a chi lo produce e lo usa. Il cloud non è un requisito per lavorare, e l'architettura è pensata per ridurre al minimo la dipendenza da servizi esterni.
 
 La direzione è quella di uno strumento:
 
-- sobrio nell’interfaccia;
+- sobrio nell'interfaccia;
 - esplicito nei confini;
-- prudente nell’uso dell’AI;
+- prudente nell'uso dell'AI;
 - rispettoso della privacy;
 - adatto a crescere senza diventare opaco.
 
@@ -41,53 +39,30 @@ In questa versione MediFlow include:
 - **AI locale** per insight e OCR, senza egress di default;
 - **import documentale reviewable**, con smart import prudente;
 - **modalità `home-base` read-only** per client Apple paired;
-- **boundary SISS/FSE dichiarato in modo realistico**: handoff contestuale e percorso prescrittivo `webapp-assisted`, non integrazione regionale nativa già risolta;
-- **preview profiles locali** per provare parti sperimentali senza sporcare il checkout stabile.
+- **boundary SISS/FSE realistico**: handoff contestuale e percorso prescrittivo `webapp-assisted`, non integrazione regionale nativa già risolta;
+- **Clinical Workbench unico** come superficie stabile su `main`.
 
-## Dal lavoro clinico al codice
+## Direzione attuale
 
-MediFlow è sviluppato a partire da un’esigenza pratica: costruire uno strumento che rispetti il ritmo, le responsabilità e i limiti del lavoro territoriale.
+La traiettoria di MediFlow è semplice da leggere:
 
-La cartella clinica non è solo un archivio. È memoria operativa, supporto decisionale, continuità narrativa e protezione del dato.
+- rendere più solida la gestione locale del dato;
+- mantenere AI e import documentale sempre rivedibili dal medico;
+- far crescere i client Apple attorno al Mac come `home-base`;
+- integrare i percorsi regionali solo dove il boundary è chiaro e verificabile.
 
-Per questo il progetto dà importanza a tre aspetti:
-
-1. **controllo locale del dato**;
-2. **chiarezza dei flussi**;
-3. **prudenza sulle automazioni**.
-
-L’obiettivo non è aggiungere complessità, ma togliere attrito dove possibile.
-
-## Il salto da `v0.3` a `v0.5`
-
-Per chi arriva dalla `v0.3` pubblica, il salto principale non è solo tecnico.
-
-La `v0.5` porta:
-
-- più struttura sul dato;
-- più chiarezza sui boundary;
-- più prudenza nei flussi AI;
-- più direzione sul lavoro multi-device;
-- una distinzione più netta tra ciò che è già operativo e ciò che è ancora in definizione.
-
-MediFlow resta un progetto in evoluzione, ma questa versione prova a rendere più leggibile la sua traiettoria.
-
-## Cosa MediFlow non pretende di essere
+## Confini dichiarati
 
 MediFlow non vuole raccontare più di quanto possa dimostrare.
 
-Per questo è importante chiarire alcuni punti:
-
-- **nessun cloud obbligatorio**: il default resta locale;
-- **nessuna app iPad/iPhone dichiarata come già completa**: la direzione multi-device esiste, ma il perimetro operativo attuale è `home-base + paired client`, con approccio read-only-first;
-- **nessuna integrazione SISS/FSE certificata dichiarata senza prove**: il percorso attuale è contestuale e `webapp-assisted`, usando i canali ufficiali;
-- **nessuna delega cieca all’AI**: l’AI locale può aiutare, ma non sostituisce revisione, giudizio clinico e responsabilità professionale.
+- **Nessun cloud obbligatorio**: il default resta locale.
+- **Nessuna app iPad/iPhone dichiarata come già completa**: la direzione multi-device esiste, ma il perimetro operativo attuale è `home-base + paired client`, con approccio read-only-first.
+- **Nessuna integrazione SISS/FSE certificata dichiarata senza prove**: il percorso attuale è contestuale e `webapp-assisted`, usando i canali ufficiali.
+- **Nessuna delega cieca all'AI**: l'AI locale può aiutare, ma non sostituisce revisione, giudizio clinico e responsabilità professionale.
 
 ## Perché open source
 
 MediFlow nasce come progetto personale, ma ha senso solo se può diventare una base aperta, verificabile e migliorabile.
-
-L’ambizione è costruire un gestionale clinico territoriale essenziale, gratuito, ispezionabile e adattabile: non un prodotto chiuso da subire, ma una base comune da comprendere, discutere e far crescere.
 
 Open source, in questo caso, significa soprattutto:
 
@@ -100,6 +75,7 @@ Open source, in questo caso, significa soprattutto:
 ## Documentazione
 
 - [FAQ](./docs/FAQ.md)
+- [Stato del sistema](./docs/STATE_OF_THE_SYSTEM.md)
 - [Roadmap](./docs/ROADMAP.md)
 - [Compliance](./docs/COMPLIANCE.md)
 - [Document map](./docs/README.md)
@@ -111,3 +87,10 @@ git clone https://github.com/Wulfgardr/mediflow
 cd mediflow
 npm install
 ./Start_MediFlow.command
+```
+
+Apri `http://localhost:3000`.
+
+## Licenza
+
+MIT License.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,6 +9,7 @@ Questo documento definisce confini di sicurezza e aspettative minime per chi con
 ## Riferimenti correlati
 
 - [ARCHITECTURE.md](./ARCHITECTURE.md) (confini architetturali stabili)
+- [docs/STATE_OF_THE_SYSTEM.md](./docs/STATE_OF_THE_SYSTEM.md) (stato corrente completo e boundary operativi)
 - [docs/topologia-dati-flussi.md](./docs/topologia-dati-flussi.md) (percorsi dato e trust boundaries)
 - [docs/walkthrough.md](./docs/walkthrough.md) (flussi operativi end-to-end)
 - [docs/adr/](./docs/adr/README.md) (decisioni con impatto sicurezza)
@@ -133,20 +134,6 @@ devono rispettare queste regole aggiuntive:
 L'autofill automatico resta ammesso solo nei casi gia documentati e prudenti
 (es. codici ICD espliciti in fonte documentale, vedi ADR 0011).
 
-## Comparator cloud opt-in
-
-non cambia il default `local-first`.
-
-Regole minime:
-
-- e ammesso solo come lane interna di engineering, mai come runtime clinico
-- usa solo case pack privati, redatti/minimizzati e fuori Git
-- richiede approvazione umana esplicita prima di qualunque export
-- non puo scrivere dati paziente, generare apply automatici o essere committato
-  nel repository
-
----
-
 ## Logging e redazione
 
 I dati sanitari non devono trapelare dai log.
@@ -169,7 +156,6 @@ La taxonomy audit canonica e definita in [docs/adr/0015-audit-taxonomy-minimum-c
 - `summarySnapshot` o `parseEvidenceArtifactSnapshot` grezzi
 - token, PIN, chiavi o salt
 - prompt AI completi, risposte AI grezze e descrizioni cliniche non redatte
-- case pack privati/comparator cloud o output non minimizzati di shadow eval
 
 ### Puoi loggare (preferibile)
 - conteggi (es. numero record)
@@ -228,8 +214,8 @@ Opzionali (se usati nella toolchain):
 
 Se ritieni di aver trovato una vulnerabilità:
 
-1. Preferisci canale privato (GitHub Security Advisories / Security tab), se disponibile.
-2. Se il canale privato non è disponibile, apri una issue **senza dettagli sensibili**:
+1. Preferisci un canale riservato (GitHub Security Advisories / Security tab), se disponibile.
+2. Se il canale riservato non è disponibile, apri una issue **senza dettagli sensibili**:
    - descrivi impatto e area coinvolta
    - fornisci passi minimi di riproduzione
    - evita dati reali, token o payload decifrati

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -2,6 +2,7 @@
 
 > [!NOTE]
 > **Stato documento: SECONDARY (FAQ pubblica e orientamento rapido).**
+> Per una lettura completa parti da [docs/STATE_OF_THE_SYSTEM.md](./STATE_OF_THE_SYSTEM.md).
 > Per i confini canonici valgono sempre [ARCHITECTURE.md](../ARCHITECTURE.md), [SECURITY.md](../SECURITY.md), [docs/ROADMAP.md](./ROADMAP.md) e [docs/walkthrough.md](./walkthrough.md).
 
 ## MediFlow è cloud?
@@ -10,9 +11,9 @@ No, di default no.
 
 Il progetto nasce `local-first`: database locale, AI locale, servizi locali. Se esistono lane di confronto o shadow evaluation, restano opt-in, separate e non fanno parte del runtime clinico ordinario.
 
-## Qual è il salto tra `v0.3` e `v0.5`?
+## Che cosa è cambiato in `v0.5`?
 
-Il salto è soprattutto di maturità:
+`v0.5` rende MediFlow più maturo e più leggibile:
 
 - storage e sicurezza più solidi;
 - contratto locale `/api/v1` più chiaro;
@@ -21,7 +22,11 @@ Il salto è soprattutto di maturità:
 - direzione multi-device più leggibile;
 - boundary SISS/FSE raccontati senza scorciatoie narrative.
 
-`v0.4` resta una tappa tecnica importante, ma il salto pubblico oggi si legge meglio come `0.3 -> 0.5`.
+`v0.4` resta una tappa tecnica importante; `v0.5` è la baseline più chiara per capire lo stato attuale del progetto.
+
+Per il quadro dettagliato, inclusi runtime reale, home-base, document
+intelligence, AI locale, SISS/FSE, Apple clients e split pubblico/privato, vedi
+[docs/STATE_OF_THE_SYSTEM.md](./STATE_OF_THE_SYSTEM.md).
 
 ## Posso usarlo su Mac, iPad o iPhone?
 
@@ -44,18 +49,18 @@ Oggi questo perimetro è:
 - protetto da credenziale device + sessione operatore;
 - ancora `read-only-first`.
 
-## Cosa sono i Preview Profiles?
+## Ci sono ancora Preview Profiles?
 
-Sono profili locali di preview disponibili in ambiente non-production per provare alcune fette sperimentali senza cambiare branch o checkout.
+No, non su `main`.
 
-Oggi coprono, in modo separato:
+Oggi esiste una sola shell ufficiale, il `Clinical Workbench / Graphite`, e le
+superfici gia mature vivono direttamente li dentro:
 
-- direzione visiva `Liquid`;
-- stack AI;
-- review import;
-- contesto paziente SISS.
+- stack AI locale;
+- Smart Import reviewable;
+- contesto paziente SISS/FSE.
 
-Servono a testare e confrontare. Non sostituiscono il profilo stabile.
+Le sperimentazioni future devono arrivare in modo esplicito e verificabile, non come selector persistiti nelle `Impostazioni`.
 
 ## Cosa vuol dire integrazione SISS in MediFlow, oggi?
 
@@ -78,9 +83,3 @@ Non vuol dire ancora:
 Non nel path di default.
 
 OCR e sintesi usano runtime locali. Se esistono lane separate di benchmark o comparazione, sono esplicitamente distinte dal runtime clinico e non vanno lette come comportamento standard del prodotto.
-
-## Perché nella repo OSS manca qualcosa che esiste nella repo privata?
-
-Per scelta.
-
-La facciata OSS deve esporre il prodotto, l'architettura e i boundary pubblicabili. I materiali interni di orchestrazione, il piano engineering attivo e la documentazione privata restano fuori.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,39 +2,28 @@
 
 Questo file è il punto di ingresso unico: dove leggere, cosa aggiornare e quale documento prevale.
 
-Ultimo aggiornamento: 2026-04-19
+Ultimo aggiornamento: 2026-05-01
 
-> [!NOTE]
-> La repo OSS omette i documenti interni di orchestrazione, attribution, piano operativo a breve e workspace privati. In pubblico devono restare leggibili soprattutto `README`, `docs/FAQ.md`, `docs/ROADMAP.md`, `ARCHITECTURE.md`, `docs/walkthrough.md` e i documenti canonici di prodotto/architettura che descrivono solo cio che e davvero esposto.
+## Percorso di lettura consigliato
 
-## Policy di consultazione (agent)
-
-Documenti da consultare **sempre**:
+Per orientarti rapidamente:
 
 1. [README.md](../README.md)
-3. [docs/README.md](./README.md) (questo file)
-4. [ARCHITECTURE.md](../ARCHITECTURE.md)
-5. [SECURITY.md](../SECURITY.md)
-6. [CONTRIBUTING.md](../CONTRIBUTING.md)
+2. [docs/README.md](./README.md) (questo file)
+3. [ARCHITECTURE.md](../ARCHITECTURE.md)
+4. [SECURITY.md](../SECURITY.md)
+5. [CONTRIBUTING.md](../CONTRIBUTING.md)
+6. [docs/ROADMAP.md](./ROADMAP.md)
+7. [docs/walkthrough.md](./walkthrough.md)
 8. [docs/adr/](./adr/README.md) (partendo dai più recenti)
 
-Documenti da consultare **al bisogno**:
+Approfondimenti utili:
 
 - Mappa completa markdown: [docs/markdown-index.md](./markdown-index.md)
 - FAQ pubbliche e stato sintetico del prodotto: [docs/FAQ.md](./FAQ.md)
 - Walkthrough operativo end-to-end: [docs/walkthrough.md](./walkthrough.md)
 - Parity web/macOS: [docs/parity-matrix.md](./parity-matrix.md)
 - Contratto OpenAPI `/api/v1`: [docs/openapi/mediflow-v1.yaml](./openapi/mediflow-v1.yaml), [docs/openapi/README.md](./openapi/README.md), [docs/adr/0010-openapi-spec-first-for-api-v1.md](./adr/0010-openapi-spec-first-for-api-v1.md)
-
-## Ordine di lettura consigliato
-
-1. [README.md](../README.md)
-3. [ARCHITECTURE.md](../ARCHITECTURE.md)
-4. [SECURITY.md](../SECURITY.md)
-5. [CONTRIBUTING.md](../CONTRIBUTING.md)
-6. [docs/adr/](./adr/README.md) (partendo dai più recenti)
-8. [docs/walkthrough.md](./walkthrough.md)
-9. [docs/markdown-index.md](./markdown-index.md)
 
 ## Convenzione stato documenti
 
@@ -47,6 +36,7 @@ Documenti da consultare **al bisogno**:
 | Tema | File canonico | Stato | Note |
 | --- | --- | --- | --- |
 | Onboarding progetto | [README.md](../README.md) | `CANONICAL` | Punto di ingresso generale. |
+| Stato completo del sistema | [docs/STATE_OF_THE_SYSTEM.md](./STATE_OF_THE_SYSTEM.md) | `CANONICAL` | Lettura unificata corrente: prodotto, runtime, boundary, AI/document intelligence, Apple clients e split private/OSS. |
 | Visione architetturale stabile | [ARCHITECTURE.md](../ARCHITECTURE.md) | `CANONICAL` | Confini e principi che cambiano raramente. |
 | Sicurezza e redazione dati | [SECURITY.md](../SECURITY.md) | `CANONICAL` | Policy di sicurezza, threat model, logging rules. |
 | Workflow di contribuzione | [CONTRIBUTING.md](../CONTRIBUTING.md) | `CANONICAL` | Definition of Done e routine verifica. |
@@ -54,18 +44,20 @@ Documenti da consultare **al bisogno**:
 | Contratto API locale `/api/v1` | [docs/openapi/mediflow-v1.yaml](./openapi/mediflow-v1.yaml) | `CANONICAL` | Spec OpenAPI client-facing; processo/versioning governati da ADR 0010. |
 | Runbook manutenzione OpenAPI | [docs/openapi/README.md](./openapi/README.md) | `SECONDARY` | Workflow operativo per mantenere aggiornata la spec durante lo sviluppo. |
 | Matrice parity web/macOS | [docs/parity-matrix.md](./parity-matrix.md) | `CANONICAL` | Gate capability-by-capability (funzioni/campi/flessibilita/autonomia). |
-| FAQ pubbliche | [docs/FAQ.md](./FAQ.md) | `SECONDARY` | Sintesi rapida per chi deve capire in poche righe cosa fa oggi MediFlow, cosa cambia tra `v0.3` e `v0.5`, quali sono i boundary dichiarati e perche alcune note restano private. |
+| FAQ pubbliche | [docs/FAQ.md](./FAQ.md) | `SECONDARY` | Sintesi rapida per capire cosa fa oggi MediFlow, quali sono i boundary dichiarati e come orientarsi nel progetto. |
 | Roadmap terminologie/FSE | [docs/FSE2-terminology-roadmap.md](./FSE2-terminology-roadmap.md) | `CANONICAL` | Evoluzione codifiche cliniche e compliance documentale (coerente con ADR 0006). |
 | Matrice baseline ufficiale GTW/FSE | [docs/fse-gtw-baseline-alignment.md](./fse-gtw-baseline-alignment.md) | `CANONICAL` | Gap analysis versionata tra artifact ministeriali `it-fse-support` e stato reale MediFlow. |
 | Baseline SISS | [docs/siss-baseline.md](./siss-baseline.md) | `CANONICAL` | Stato attuale, fonti ufficiali, matrice del prototipo contestuale e sequenza `WUL-43` -> `WUL-45` -> `WUL-44` -> `WUL-178` -> `WUL-180` per l'integrazione SISS. |
 | Fattibilita SSI/A2A SISS oltre `portal-handoff` | [docs/siss-ssi-a2a-feasibility.md](./siss-ssi-a2a-feasibility.md) | `CANONICAL` | Boundary ufficiale del filone `WUL-180`: cosa e integrabile davvero con `SSI`, `A2A`, `webapp` e onboarding regionale, e cosa non e ancora dimostrabile con sole fonti pubbliche. |
 | Modulo Prescrittivo Regionale | [docs/siss-modulo-prescrittivo-regionale.md](./siss-modulo-prescrittivo-regionale.md) | `CANONICAL` | Nota scenario-specific `WUL-181`: chiarisce per il prescrittivo il boundary tra handoff, richiamo della webapp ufficiale, uso di WS/API e UI custom non ancora dimostrata. |
+| Corpus documentale SISS/FSE | [docs/siss-fse-docs-corpus.md](./siss-fse-docs-corpus.md) | `CANONICAL` | Governa `WUL-176` e `WUL-179`: catalogo sorgenti, fetch/sync locale fuori Git, placeholder `manual-import` e report di freshness come base documentale delle integrazioni regionali. |
 | Walkthrough end-to-end | [docs/walkthrough.md](./walkthrough.md) | `CANONICAL` | Mappa operativa web + native + servizi locali, inclusi `home-base` read-only, document intelligence artifact-first e guard di revisione shell. |
 | Topologia dati e flussi | [docs/topologia-dati-flussi.md](./topologia-dati-flussi.md) | `CANONICAL` | Percorsi dati digitali end-to-end (cifratura, API, storage, trust boundaries), inclusi artifact documentali cifrati e boundary `network-home-base`. |
 | Indice completo Markdown repo | [docs/markdown-index.md](./markdown-index.md) | `CANONICAL` | Elenco navigabile e descrittivo di tutti i `.md` tracciati nel repository. |
 | Testing app macOS | [docs/native-testing.md](./native-testing.md) | `CANONICAL` | Strategia e workflow ufficiale test native (XCTest/Xcode). |
+| Smoke paired mobile home-base | [docs/mobile-home-base-smoke.md](./mobile-home-base-smoke.md) | `SECONDARY` | Runbook operativo per smoke iPhone/iPad contro `home-base` reale con pairing temporaneo e sessione operatore. |
 | Deep dive tecnico architettura | [docs/ARCHITETTURA.md](./ARCHITETTURA.md) | `SECONDARY` | Approfondimento tecnico esteso. |
-| Sintesi operativa architettura | [docs/system_architecture.md](./system_architecture.md) | `SECONDARY` | Versione compatta/rapida del sistema reale post-`v0.5.0`, con overview su home-base, document intelligence e guardrail locali. |
+| Sintesi operativa architettura | [docs/system_architecture.md](./system_architecture.md) | `SECONDARY` | Versione compatta/rapida del sistema reale su `main`, con overview su Clinical Workbench, home-base, document intelligence, SISS/FSE e guardrail locali. |
 | Setup client macOS e TLS locale | [docs/NATIVE.md](./NATIVE.md), [docs/native-testing.md](./native-testing.md), [docs/native-setup.md](./native-setup.md), [docs/native-launch.md](./native-launch.md), [docs/local-api-tls.md](./local-api-tls.md) | `CANONICAL` | Materiale operativo nativo. Dopo `v0.5.0` descrive lo snapshot corrente e i vincoli da preservare durante il rebuild controllato della shell macOS. |
 | Compliance/GDPR/FHIR | [docs/COMPLIANCE.md](./COMPLIANCE.md) | `CANONICAL` | Quadro compliance e interoperabilità. |
 | Manuale utente medico | [docs/MANUALE.md](./MANUALE.md) | `CANONICAL` | Uso prodotto lato clinico. |
@@ -83,6 +75,10 @@ Documenti da consultare **al bisogno**:
 | ADR SISS local adapter contract and error taxonomy | [docs/adr/0025-siss-local-adapter-contract-and-error-taxonomy.md](./adr/0025-siss-local-adapter-contract-and-error-taxonomy.md) | `CANONICAL` | Foundation locale del filone SISS: azioni tipizzate, error taxonomy stabile, retry transiente e metadata audit redatti prima dell'integrazione UI. |
 | ADR boundary integrazione nativa SISS oltre `portal-handoff` | [docs/adr/0045-siss-native-integration-boundary-requires-qualified-ssi.md](./adr/0045-siss-native-integration-boundary-requires-qualified-ssi.md) | `CANONICAL` | Fissa il boundary `WUL-180`: la vera integrazione nativa SISS/FSE richiede scenari approvati, qualifica/provisioning coerenti col contesto `SSI`, e non puo essere trattata come semplice consumo libero del backend regionale. |
 | ADR first slice prescrittivo regionale `webapp-assisted` | [docs/adr/0046-modulo-prescrittivo-regionale-first-slice-webapp-assisted.md](./adr/0046-modulo-prescrittivo-regionale-first-slice-webapp-assisted.md) | `CANONICAL` | Fissa la decisione `WUL-181`: il primo step oltre l'handoff per il prescrittivo usa il percorso ufficiale della webapp regionale e non una UI custom MediFlow. |
+| ADR Graphite workbench come unica shell web ufficiale | [docs/adr/0047-graphite-workbench-single-official-web-shell.md](./adr/0047-graphite-workbench-single-official-web-shell.md) | `CANONICAL` | Fissa `WUL-196`: la shell Graphite/Clinical Workbench diventa il solo runtime UI supportato su `main`, senza chooser visuale persistito o shell concorrenti. |
+| ADR ritiro preview profiles funzionali su `main` | [docs/adr/0050-functional-preview-profiles-retired-on-mainline.md](./adr/0050-functional-preview-profiles-retired-on-mainline.md) | `CANONICAL` | Fissa `WUL-199`: il workbench ufficiale non espone piu preview profiles runtime; AI e Smart Import restano live e il contesto paziente SISS diventa stabile nella scheda paziente. |
+| ADR architettura shared Apple client e runtime `home-base` packaged | [docs/adr/0048-apple-shared-client-architecture-and-home-base-runtime.md](./adr/0048-apple-shared-client-architecture-and-home-base-runtime.md) | `CANONICAL` | Governa `WUL-188`: core Apple condiviso, shell distinte per macOS/iPhone/iPad, Mac packaged come nodo `home-base` autorevole, client mobili paired senza accesso diretto a SQLite e parity non-AI estesa via `/api/v1/network/*`. |
+| ADR corpus documentale SISS/FSE locale | [docs/adr/0049-siss-fse-document-corpus-and-local-mcp-layer.md](./adr/0049-siss-fse-document-corpus-and-local-mcp-layer.md) | `CANONICAL` | Fissa `WUL-176`: prima corpus locale/versionato e fetch/sync controllato, poi eventuale MCP solo sopra un corpus approvato, non scraping live come sorgente primaria. |
 | ADR PIN rotation via client-side rewrap | [docs/adr/0026-pin-rotation-via-client-side-rewrap.md](./adr/0026-pin-rotation-via-client-side-rewrap.md) | `CANONICAL` | Cambio PIN zero-knowledge: il client riavvolge la stessa master key con un nuovo KEK derivato dal nuovo PIN, senza ricifrare i dati clinici. |
 | ADR local-only default e network home-base opt-in | [docs/adr/0034-local-only-default-and-network-home-base-opt-in.md](./adr/0034-local-only-default-and-network-home-base-opt-in.md) | `CANONICAL` | Governa `WUL-117`: `local-only` resta il default, `network home-base` diventa una modalita esplicita su LAN fidata, il nodo paired e autorevole solo in modalita network e la first thin slice resta read-only prima di replica/sync. |
 | ADR thin slice replica network home-base come snapshot mirror | [docs/adr/0035-network-replica-thin-slice-snapshot-mirror.md](./adr/0035-network-replica-thin-slice-snapshot-mirror.md) | `CANONICAL` | Governa `WUL-120`: la first thin slice di replica resta uno snapshot mirror governato con fallback locale esplicito e manual review, senza introdurre ancora sync record-level o multi-master. |
@@ -94,7 +90,6 @@ Documenti da consultare **al bisogno**:
 
 - [docs/product_roadmap.md](./product_roadmap.md): alias storico della roadmap prodotto, da considerare **deprecato**. La fonte attiva è [docs/ROADMAP.md](./ROADMAP.md).
 - `docs/index.html`: pagina visuale legacy utile per consultazione rapida, ma non fonte di verità per decisioni architetturali.
-- Alcuni documenti interni restano volutamente fuori dall'export OSS: playbook di orchestrazione, attribution agent, piano operativo di breve e workspace privati locali.
 
 ## Regole rapide di mantenimento
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,13 +2,7 @@
 
 > **Dove siamo e dove vogliamo andare.**
 > v0.5.0 (release corrente) — Marzo 2026
-> Fonte roadmap prodotto canonica (vedi anche [docs/README.md](./README.md) per mappa completa documenti).
-
-> [!NOTE]
-> Per chi arriva dalla `v0.3` pubblica, il salto da leggere oggi è `0.3 -> 0.5`.
-> `v0.4.0` resta una tappa tecnica decisiva, ma non è più la cornice narrativa giusta per il frontespizio del progetto.
-
----
+> Fonte roadmap prodotto canonica (vedi anche [docs/STATE_OF_THE_SYSTEM.md](./STATE_OF_THE_SYSTEM.md) per la lettura completa corrente e [docs/README.md](./README.md) per mappa completa documenti).
 
 ## Fatto (v0.3.0)
 
@@ -54,6 +48,11 @@ Base tecnica più solida, con flussi documentali e contratti locali molto più e
 
 ## In corso (post-v0.5)
 
+La lettura operativa piu completa del ciclo post-v0.5 e ora
+[docs/STATE_OF_THE_SYSTEM.md](./STATE_OF_THE_SYSTEM.md): questo file resta la
+roadmap prodotto, mentre lo stato del sistema tiene insieme runtime effettivo,
+boundary, document intelligence, home-base, Apple clients e split private/OSS.
+
 ### Modalita network home-base
 
 * **Nodo centrale locale**: pairing esplicito, capability discovery e primo data plane read-only sono gia entrati su `main`; restano da estendere UX, replica e write boundary.
@@ -67,15 +66,22 @@ Base tecnica più solida, con flussi documentali e contratti locali molto più e
 
 ### Esperienza nativa
 
-* **Nuova shell macOS**: rebuild controllato dell'app nativa, preservando `/api/v1`, TLS locale e semantica security/sessione.
-* **Parita futura per sweep**: riaprire il filone parity solo dopo il nuovo shell, non sul client storico.
-* **App iPadOS/iOS**: consultazione rapida in mobilita coerente con il modello `home-base`, paired e read-only-first.
+* **Nuova shell macOS `home-base`**: rebuild controllato dell'app nativa, packaged e capace di gestire il runtime locale senza dipendere dal terminale, preservando `/api/v1`, TLS locale e semantica security/sessione.
+* **Family Apple condivisa per contratto**: convergenza tramite core Swift condiviso e API versionate, con shell distinte per macOS, iPhone e iPad ma stesso comportamento clinico sui moduli condivisi.
+* **App iPadOS/iOS paired**: consultazione e workflow non-AI coerenti con il modello `home-base`, paired e read-only-first oggi, con cache locale cifrata e nessun accesso diretto al file SQLite del Mac.
 
-### Profili locali di preview
+### Shell ufficiale e sperimentazioni controllate
 
-* **Preview profilo interfaccia**: confronto tra baseline clinica e direzione `Liquid`.
-* **Preview stack AI**: verifica locale di fette AI senza promuoverle in automatico nel runtime.
-* **Preview smart import e SISS context**: sperimentazione controllata su percorsi review-first e pannello contestuale, senza cambiare il profilo stabile del checkout.
+* **Shell web ufficiale**: `Clinical Workbench / Graphite` e la grammatica unica supportata su `main`.
+* **Niente preview profiles su `main`**: AI, Smart Import e contesto paziente SISS/FSE vivono direttamente nella shell ufficiale quando sono maturi.
+* **Sperimentazioni esplicite**: nuove fette AI, import o SISS entrano solo dopo verifica dedicata, non come selector runtime persistito.
+* **Guardrail locali**: revision fingerprint, `/api/system/revision` e reset `.next` source-aware riducono il rischio di testare una shell stale.
+
+### SISS/FSE e base documentale regionale
+
+* **Boundary attuale**: MediFlow prepara il contesto e richiama percorsi ufficiali; il prescrittivo resta `webapp-assisted` e non una UI regionale custom dentro MediFlow.
+* **Corpus locale SISS/FSE**: manifest sorgenti, fetch/sync incrementale e report di freschezza sono gia su `main` come base di lavoro documentale, fuori dal runtime clinico.
+* **Integrazione piu profonda**: prima di codice runtime servono scenari approvati, qualifica/provisioning coerenti con `SSI/A2A` e documentazione scenario-specific verificabile.
 
 ### Interazione vocale
 

--- a/docs/STATE_OF_THE_SYSTEM.md
+++ b/docs/STATE_OF_THE_SYSTEM.md
@@ -1,0 +1,499 @@
+# Stato del Sistema MediFlow
+
+> [!IMPORTANT]
+> **Stato documento: CANONICAL (lettura completa dello stato corrente).**
+> Questo documento e il punto di lettura piu ampio per capire cosa esiste oggi,
+> cosa e solo direzione dichiarata e quali boundary non vanno superati.
+>
+> Per i principi stabili prevalgono sempre [ARCHITECTURE.md](../ARCHITECTURE.md)
+> e [SECURITY.md](../SECURITY.md). Per il flusso operativo end-to-end prevale
+> [docs/walkthrough.md](./walkthrough.md). Le priorita operative a breve restano
+> nel piano engineering del workspace sorgente.
+
+Ultimo aggiornamento: 2026-05-01
+
+---
+
+## 1. Lettura rapida
+
+MediFlow e una cartella clinica local-first per il lavoro territoriale quotidiano.
+Lo stato corrente non va letto come una semplice web app con AI aggiunta: e un
+sistema locale ibrido in cui il Mac resta il nodo autorevole, il database e
+SQLite cifrato, la web app e la superficie primaria, i client Apple futuri si
+appoggiano a contratti locali versionati e ogni integrazione esterna resta
+dentro boundary documentati.
+
+La fotografia corrente e questa:
+
+- **Superficie primaria**: web app Next.js locale, avviata sul Mac.
+- **Shell ufficiale**: `Clinical Workbench / Graphite`, unica shell supportata
+  su `main`.
+- **Storage autorevole**: un solo file SQLite locale (`medical.db`), con accesso
+  server via Drizzle e cifratura client-side dei campi clinici.
+- **Sicurezza di default**: local-only, zero-knowledge a riposo, nessun cloud o
+  telemetry default-on.
+- **Contratto condiviso**: `/api/v1/*` per client native/locali; OpenAPI come
+  riferimento anti-drift per la parte stabile.
+- **Home-base**: modalita opt-in in cui il Mac espone una first slice
+  `/api/v1/network/*` read-only verso client paired su rete fidata.
+- **Document intelligence**: Smart Import, nuova anagrafica da documento e
+  `AI Patient Insight` restano reviewable; gli allegati possono persistere
+  artifact cifrati `parse/evidence`.
+- **AI**: runtime locale per default, benchmark e shadow lane separati dal
+  prodotto clinico.
+- **SISS/FSE**: handoff contestuale e flussi `webapp-assisted`; nessuna
+  integrazione regionale nativa certificata dichiarata senza `SSI/A2A` e scenari
+  approvati.
+- **OSS**: la repo pubblica deve restare prodotto-centrica, senza materiale
+  interno di coordinamento, attribuzione agentica, piani privati o runtime data.
+
+---
+
+## 2. Cosa e gia deciso
+
+### 2.1 Local-first non e un dettaglio
+
+Il default architetturale e locale:
+
+- il dato nasce nel browser/client locale;
+- i campi clinici sensibili vengono cifrati prima della persistenza;
+- lo storage autorevole vive su disco locale;
+- i servizi AI/OCR e terminologici sono locali quando presenti;
+- l'eventuale rete locale e opt-in e bounded.
+
+Questo significa che non sono ammessi, senza ADR e documentazione esplicita:
+
+- sync cloud implicita;
+- telemetry o analytics in background;
+- runtime AI remoto come default;
+- upload automatico di documenti clinici;
+- database remoto multi-tenant;
+- bypass del nodo Mac `home-base` per i client mobili.
+
+### 2.2 La shell web ufficiale e una sola
+
+`Clinical Workbench / Graphite` e la shell web ufficiale. I vecchi confronti di
+stile e i `Preview Profiles` funzionali sono ritirati da `main`.
+
+Conseguenze pratiche:
+
+- non si aggiungono nuovi chooser permanenti per shell alternative;
+- AI, Smart Import e contesto paziente SISS sono parte del workbench quando
+  maturi;
+- nuove sperimentazioni devono vivere come workstream espliciti, non come
+  selector nascosti nelle impostazioni;
+- la documentazione pubblica deve parlare di una sola esperienza supportata.
+
+Documenti/ADR principali:
+
+- [ADR 0047](./adr/0047-graphite-workbench-single-official-web-shell.md)
+- [ADR 0050](./adr/0050-functional-preview-profiles-retired-on-mainline.md)
+- [docs/walkthrough.md](./walkthrough.md)
+
+### 2.3 Il Mac resta il nodo autorevole
+
+Il disegno Apple non e "tre app con tre store dati". E una family architecture:
+
+- Mac come `home-base`;
+- SQLite autorevole solo sul Mac;
+- API versionate e boundary di rete espliciti;
+- core Swift condiviso in prospettiva;
+- shell distinte per macOS, iPhone e iPad;
+- client mobili paired, con cache derivata e riconciliazione esplicita quando
+  quella parte verra implementata.
+
+Oggi la first slice disponibile e read-only. Write remoti, sync record-level,
+replica automatica e multi-master sono fuori scope corrente.
+
+Documenti/ADR principali:
+
+- [ADR 0034](./adr/0034-local-only-default-and-network-home-base-opt-in.md)
+- [ADR 0038](./adr/0038-network-readonly-data-plane-auth-boundary.md)
+- [ADR 0048](./adr/0048-apple-shared-client-architecture-and-home-base-runtime.md)
+- [docs/mobile-home-base-smoke.md](./mobile-home-base-smoke.md)
+
+### 2.4 Il documento e evidenza, non testo da ingoiare
+
+La direzione document intelligence e `artifact-first`:
+
+- il documento viene normalizzato;
+- OCR/estrazione restano locali;
+- il risultato va trattato come evidenza reviewable;
+- `summarySnapshot` e `parseEvidenceArtifactSnapshot` sono dati clinici e
+  persistono cifrati;
+- `patients.documentInsights` resta una projection compatibile, non il modello
+  finale ideale.
+
+Il sistema non deve promuovere automaticamente diagnosi o terapie solo perche
+compaiono in testo libero. La scrittura strutturata richiede review e soglie di
+certezza documentate.
+
+Documenti/ADR principali:
+
+- ADR 0040 (private)
+- [ADR 0042](./adr/0042-document-driven-new-patient-review-and-prudent-therapy-persistence.md)
+
+### 2.5 Le integrazioni regionali restano dentro canali ufficiali
+
+MediFlow puo aiutare l'operatore a preparare il contesto e aprire il percorso
+corretto, ma non deve raccontare una integrazione SISS/FSE nativa quando manca
+qualifica, provisioning o scenario approvato.
+
+Stato attuale:
+
+- `portal-handoff` e `webapp-assisted` sono ammessi e documentati;
+- il prescrittivo regionale usa il percorso ufficiale;
+- il corpus SISS/FSE locale serve a governare decisioni future;
+- SGDT/FSE/prescrittivo nativo richiedono analisi scenario-specific;
+- documenti autenticati o non redistribuibili restano fuori Git.
+
+Documenti/ADR principali:
+
+- [docs/siss-baseline.md](./siss-baseline.md)
+- [docs/siss-ssi-a2a-feasibility.md](./siss-ssi-a2a-feasibility.md)
+- [docs/siss-modulo-prescrittivo-regionale.md](./siss-modulo-prescrittivo-regionale.md)
+- [docs/siss-fse-docs-corpus.md](./siss-fse-docs-corpus.md)
+- [ADR 0045](./adr/0045-siss-native-integration-boundary-requires-qualified-ssi.md)
+- [ADR 0046](./adr/0046-modulo-prescrittivo-regionale-first-slice-webapp-assisted.md)
+- [ADR 0049](./adr/0049-siss-fse-document-corpus-and-local-mcp-layer.md)
+
+---
+
+## 3. Superfici runtime
+
+| Superficie | Stato | Uso reale | Boundary |
+| --- | --- | --- | --- |
+| Web app locale | Primaria | Lavoro clinico quotidiano sul Mac | HTTP localhost, sessione web |
+| `/api/*` | Runtime web | CRUD, auth, proxy locali, sistema | Session cookie |
+| `/api/v1/*` | Contratto locale/shared | Client native e superfici stabili | Bearer token locale, TLS proxy |
+| `/api/v1/network/*` | First slice home-base | Lista/dettaglio pazienti read-only da device paired | Credenziale device + sessione operatore |
+| macOS storico | Snapshot congelato | Riferimento di parity e compat, non base del prossimo sviluppo | Rebuild controllato |
+| iPhone/iPad | Direzione post-v0.5 | Client paired non-AI, cache derivata futura | No SQLite diretto |
+| Ollama | Opzionale locale | AI/OCR/sintesi dove disponibile | Solo localhost |
+| ICD-11 Docker | Opzionale locale | Diagnosi/coding | Solo localhost |
+| OpenMed | Shadow/benchmark | Redaction lane locale non client-facing | Non runtime clinico |
+
+---
+
+## 4. Percorso dati clinici
+
+### 4.1 Scrittura web ordinaria
+
+1. Il medico opera nella web app.
+2. Il client possiede la master key solo in RAM dopo unlock.
+3. I campi sensibili vengono cifrati lato client.
+4. Il payload cifrato arriva alle route `/api/*`.
+5. Il server persiste su SQLite.
+6. Audit/log restano PHI-safe e non sostituiscono il dato clinico.
+
+### 4.2 Lettura e rendering
+
+1. Il server legge record cifrati.
+2. Il client riceve dati nel formato previsto.
+3. La decifratura avviene nel browser/client con master key in memoria.
+4. UI e componenti clinici mostrano solo il necessario per il workflow corrente.
+
+### 4.3 Allegati e artifact documentali
+
+1. Upload documento.
+2. Normalizzazione input e OCR locale.
+3. Sintesi/estrazione locale.
+4. Persistenza cifrata di:
+   - allegato;
+   - `summarySnapshot`;
+   - `parseEvidenceArtifactSnapshot`;
+   - projection `documentInsights` quando serve compatibilita.
+5. Consumer reviewable:
+   - `AI Patient Insight`;
+   - Smart Import;
+   - nuova anagrafica da documento;
+   - troubleshooting documentale.
+
+### 4.4 Home-base read-only
+
+1. Operatore abilita `network-home-base`.
+2. Device remoto apre un pairing intent PHI-safe.
+3. Nodo Mac conferma esplicitamente il device.
+4. Il device riceve una credenziale dedicata.
+5. Le route `/api/v1/network/patients*` rispondono solo se:
+   - device paired valido;
+   - sessione operatore valida sul nodo;
+   - scope clinico risolto dal nodo.
+6. Il data plane resta read-only.
+
+---
+
+## 5. AI stack e regole di promozione
+
+### 5.1 Runtime operativo
+
+Il runtime AI operativo resta locale. Il default generativo protetto e trattato
+come baseline finche benchmark e governance non giustificano un cambio.
+
+Le superfici operative includono:
+
+- `AI Patient Insight`;
+- Smart Import reviewable;
+- sintesi documentale;
+- eventuali helper locali di normalizzazione/estrazione.
+
+### 5.2 Lane benchmark-only
+
+Le lane seguenti non vanno lette come runtime clinico disponibile solo perche
+sono documentate o benchmarkate:
+
+- OpenMed redaction;
+- HUMADEX / OpenMed NER;
+- challenger generativi non promossi;
+- TurboQuant / MLX runtime experiments;
+- comparator cloud opt-in.
+
+Per promuovere una lane servono:
+
+- corpus sintetico o case pack governato;
+- benchmark ripetibile;
+- stop-rules;
+- shadow mode quando applicabile;
+- rollback/fallback chiari;
+- aggiornamento docs/ADR se cambia un boundary.
+
+### 5.3 Comparator cloud
+
+Il comparator cloud e ammesso solo come strumento interno opt-in di engineering,
+su case pack privati redatti/minimizzati e fuori Git. Non e un canale runtime,
+non scrive dati paziente e non cambia il default local-first.
+
+---
+
+## 6. Documentazione: come leggere il repository
+
+### 6.1 Percorso consigliato per capire tutto
+
+1. [README.md](../README.md): ingresso prodotto.
+2. [docs/STATE_OF_THE_SYSTEM.md](./STATE_OF_THE_SYSTEM.md): lettura completa
+   dello stato corrente.
+3. [ARCHITECTURE.md](../ARCHITECTURE.md): principi stabili.
+4. [SECURITY.md](../SECURITY.md): threat model, privacy, logging e redazione.
+5. [docs/walkthrough.md](./walkthrough.md): flusso end-to-end.
+6. [docs/topologia-dati-flussi.md](./topologia-dati-flussi.md): percorsi dati
+   e trust boundaries.
+7. [docs/README.md](./README.md): mappa canonica e fonti autorevoli per tema.
+8. [docs/markdown-index.md](./markdown-index.md): inventario completo.
+9. [docs/adr/README.md](./adr/README.md): decisioni architetturali.
+10. Piano engineering privato: priorita operative a breve, disponibile solo nel
+    workspace sorgente quando presente.
+
+### 6.2 Documenti pubblici vs documenti privati
+
+Il workspace sorgente puo contenere:
+
+- piani operativi a breve;
+- attribution agentica;
+- playbook interni di delivery e tracciabilita;
+- runbook interni di benchmark e shadow evaluation;
+- riferimenti a vault o workspace locali privati, sempre senza PHI in Git.
+
+La repo OSS deve contenere:
+
+- prodotto e installazione;
+- architettura e sicurezza;
+- roadmap pubblica;
+- FAQ;
+- walkthrough e documenti canonici non interni;
+- ADR pubblicabili;
+- script runtime necessari alla app nuda.
+
+La repo OSS non deve contenere:
+
+- database reali o runtime artifacts;
+- `medical.db`, `.sqlite`, `.sqlite3`, `.next`, `tmp-*`;
+- piani interni e attribution agentica;
+- riferimenti a tracker interni, branch interni, coordinamento agentico o materiali non
+  esportabili;
+- documenti riservati o fonti autenticate del corpus SISS/FSE.
+
+---
+
+## 7. Stato per area funzionale
+
+### 7.1 Pazienti e cartella clinica
+
+Disponibile:
+
+- anagrafica paziente;
+- diario clinico;
+- terapie;
+- osservazioni;
+- appuntamenti/checkup;
+- allegati;
+- archiviazione paziente;
+- campi strutturati e projection documentale;
+- versioning/compare-on-write sui percorsi rilevanti.
+
+Da preservare:
+
+- cifratura client-side;
+- conflitti espliciti;
+- audit PHI-safe;
+- niente scritture remote non governate.
+
+### 7.2 Backup, restore e continuita
+
+Disponibile:
+
+- artifact backup v1;
+- preflight restore;
+- scheduler notturno via macOS `launchd`;
+- retention `keep-last-N`;
+- guardrail anti-regressione.
+
+Da preservare:
+
+- nessun backup con PHI in repo;
+- restore distruttivo solo dopo preflight;
+- documentazione aggiornata quando cambiano manifest o schema.
+
+### 7.3 Smart Import e nuova anagrafica da documento
+
+Disponibile:
+
+- OCR/local parsing;
+- review di suggerimenti;
+- soppressione rumore quando una fonte non introduce novita clinica;
+- create-flow document-driven con persistenza prudente delle terapie.
+
+Fuori scope:
+
+- auto-promozione di diagnosi/terapie da testo libero ambiguo;
+- import silenzioso di documenti reali senza review;
+- uso di documenti reali come fixture Git.
+
+### 7.4 SISS, FSE e Protesica
+
+Disponibile:
+
+- pannello contestuale paziente SISS;
+- launcher/handoff verso percorsi ufficiali;
+- prescrittivo `webapp-assisted`;
+- corpus locale SISS/FSE con sync/freshness;
+- diario locale protesico document-backed e handoff `Protesica-RL`.
+
+Fuori scope:
+
+- canale SISS nativo certificato non dimostrato;
+- UI prescrittiva custom sostitutiva del modulo regionale;
+- scraping aggressivo;
+- bypass di autenticazioni o vincoli regionali.
+
+### 7.5 Apple/native
+
+Disponibile:
+
+- shell macOS storica come snapshot;
+- contratto `/api/v1`;
+- TLS proxy locale;
+- runbook native/testing/parity;
+- direzione ADR per rebuild family Apple.
+
+Direzione:
+
+- macOS packaged `home-base`;
+- shared core Swift;
+- iPhone/iPad paired;
+- parity non-AI tramite API;
+- cache locale cifrata derivata e riconciliazione esplicita.
+
+Fuori scope corrente:
+
+- accesso diretto a SQLite da mobile;
+- sync cloud;
+- write remote generici;
+- AI plane remoto dentro il data plane clinico.
+
+---
+
+## 8. Regole di manutenzione
+
+Quando cambia una feature runtime:
+
+- aggiorna il documento canonico dell'area;
+- aggiorna [docs/walkthrough.md](./walkthrough.md) se cambia il flusso reale;
+- aggiorna [docs/topologia-dati-flussi.md](./topologia-dati-flussi.md) se
+  cambiano trust boundary, API o percorsi dati;
+- aggiorna [docs/README.md](./README.md) se cambia la fonte autorevole;
+- aggiorna [docs/markdown-index.md](./markdown-index.md) se aggiungi, rimuovi o
+  rinomini Markdown;
+- aggiorna il piano engineering privato se cambia priorita operativa.
+
+Quando cambia un boundary:
+
+- scrivi o aggiorna ADR prima del codice;
+- verifica [SECURITY.md](../SECURITY.md);
+- verifica impatto OpenAPI se riguarda `/api/v1`;
+- dichiara esplicitamente cosa resta fuori scope.
+
+Quando esporti OSS:
+
+- esegui `MEDIFLOW_OSS_TARGET_DIR=<target> npm run prepare:oss` su una
+  destinazione di prova;
+- verifica che non compaiano DB, runtime artifacts o documenti interni;
+- cerca termini interni e riferimenti privati;
+
+---
+
+## 9. Check rapidi
+
+### 9.1 Verifica docs-only
+
+Per una modifica solo documentale:
+
+```bash
+git diff --check
+rg --files -g '*.md' | sort
+MEDIFLOW_OSS_TARGET_DIR=/tmp/mediflow-oss-docs-check npm run prepare:oss
+```
+
+Se i documenti toccano esempi di comandi, contratti o script, esegui anche il
+comando citato o dichiara perche non e stato eseguito.
+
+### 9.2 Verifica runtime generale
+
+Per modifiche applicative non banali:
+
+```bash
+npm run lint
+npm run typecheck
+npm run build
+npm run check:never-regress
+```
+
+In piu:
+
+- `/api/v1`: `npm run check:openapi:drift`
+- pazienti/versioning: `npm run test:concurrency:patients`
+- home-base network: `npm run test:network:home-base-readonly`
+- document intelligence: `npm run test:document-synthesis`, `npm run
+  test:ai-context`, `npm run test:pdf-service`
+- nuova anagrafica da documento: `npm run test:patient-document-import`
+
+---
+
+## 10. Stop rules
+
+Fermati e scrivi prima un ADR o una nota ADR-style se il lavoro propone:
+
+- nuovo canale cloud;
+- nuova superficie remota di scrittura;
+- cambio del modello di cifratura/PIN/master key;
+- promozione di una lane AI benchmark-only nel runtime clinico;
+- integrazione SISS/FSE oltre `webapp-assisted`;
+- accesso diretto a SQLite da client mobile;
+- schema persistente nuovo per document intelligence;
+- rimozione di guardrail zero-knowledge, audit o no-egress.
+
+Fermati e apri/spezza workstream se:
+
+- il diff supera un singolo tema;
+- una doc pubblica richiede materiale privato per restare comprensibile;
+- una modifica OSS trascina riferimenti interni;
+- il worktree contiene cambi non correlati.

--- a/docs/adr/0024-web-core-stabilization-before-next-version-bump.md
+++ b/docs/adr/0024-web-core-stabilization-before-next-version-bump.md
@@ -94,7 +94,7 @@ riusabile e verificabile.
 Questa ADR non include:
 
 - rebuild o parity del client macOS
-- merge automatico della review queue Linear gia aperta
+- merge automatico di code di review esterne gia aperte
 - UI refresh ampio, redesign accessibilita o theme work
 - nuove dipendenze JS/TS
 - unificazione delle semantics `GET` web vs `/api/v1` sui pazienti

--- a/docs/adr/0046-modulo-prescrittivo-regionale-first-slice-webapp-assisted.md
+++ b/docs/adr/0046-modulo-prescrittivo-regionale-first-slice-webapp-assisted.md
@@ -73,7 +73,7 @@ prescrittivo regionale e:
 
 Questo significa:
 
-- MediFlow puo preparare il contesto paziente e l'orchestrazione locale
+- MediFlow puo preparare il contesto paziente e il coordinamento locale
 - l'atto prescrittivo vero resta nel `Modulo Prescrittivo Regionale`
   ufficiale
 - non trattiamo questa slice come `prescrittivo nativo MediFlow`

--- a/docs/markdown-index.md
+++ b/docs/markdown-index.md
@@ -4,21 +4,21 @@
 > GitHub mostra in alto solo alcuni file speciali (`README`, `CONTRIBUTING`, `SECURITY`, ecc.).
 > Questo file elenca invece **tutti** i `.md` tracciati nella repository con una sintesi rapida d'uso.
 
-Ultimo aggiornamento: 2026-04-19
+Ultimo aggiornamento: 2026-05-01
 
 ## Come usare questo indice
 
 - Se devi capire **quali file sono canonici**, parti da [docs/README.md](./README.md).
 - Se devi trovare **dove sta un tema specifico**, usa le tabelle qui sotto.
 - Se aggiungi/rimuovi/rinomini un `.md`, aggiorna subito questo file e [docs/README.md](./README.md).
-- Nella repo OSS alcuni file interni non sono presenti: orchestrazione agent, attribution, piano operativo a breve e workspace privati restano nel workspace privato.
 
-## Orchestrazione e governance (consultazione sempre)
+## Orientamento e governance
 
 | File | Scopo | Quando consultarlo |
 | --- | --- | --- |
 | [README.md](../README.md) | Onboarding generale progetto e punti di accesso documentazione. | Sempre, in fase di avvio. |
 | [docs/README.md](./README.md) | Mappa canonica della documentazione (fonte autorevole per tema). | Sempre, per decidere precedenze. |
+| [docs/STATE_OF_THE_SYSTEM.md](./STATE_OF_THE_SYSTEM.md) | Lettura completa dello stato corrente: prodotto, runtime, dati, AI/document intelligence, home-base, SISS/FSE, Apple clients e split private/OSS. | Sempre, quando serve una vista unica e aggiornata senza ricostruire il quadro da piu documenti. |
 | [ARCHITECTURE.md](../ARCHITECTURE.md) | Visione architetturale stabile, confini e non-obiettivi. | Sempre, per cambi tecnici non banali. |
 | [SECURITY.md](../SECURITY.md) | Policy sicurezza, threat model e regole redazione/logging. | Sempre, per qualunque cambio dati/API. |
 | [CONTRIBUTING.md](../CONTRIBUTING.md) | Workflow contributivo e Definition of Done. | Sempre, prima di chiudere un task. |
@@ -29,10 +29,11 @@ Ultimo aggiornamento: 2026-04-19
 | File | Scopo | Quando consultarlo |
 | --- | --- | --- |
 | [docs/walkthrough.md](./walkthrough.md) | Walkthrough canonico end-to-end (web + native + servizi locali), con stato reale di `home-base`, document intelligence e shell locale. | Per capire flussi completi e integrazione moduli. |
+| [docs/STATE_OF_THE_SYSTEM.md](./STATE_OF_THE_SYSTEM.md) | Stato canonico complessivo del sistema, pensato come lettura unica per onboarding profondo e review trasversale. | Quando devi capire cosa esiste davvero oggi, cosa e direzione e quali confini non vanno superati. |
 | [docs/topologia-dati-flussi.md](./topologia-dati-flussi.md) | Topologia dati, trust boundaries, cifratura e percorsi digitali, inclusi artifact documentali cifrati e boundary `network-home-base`. | Per analisi data flow e impatti sicurezza. |
 | [docs/parity-matrix.md](./parity-matrix.md) | Stato parity web/macOS su moduli core e gap operativi. | Per steering parity e release readiness. |
 | [docs/ARCHITETTURA.md](./ARCHITETTURA.md) | Deep dive tecnico esteso dell'architettura MediFlow. | Per approfondimenti implementativi. |
-| [docs/system_architecture.md](./system_architecture.md) | Sintesi rapida dell'architettura operativa aggiornata al main post-`v0.5.0`. | Per overview veloce in onboarding/review. |
+| [docs/system_architecture.md](./system_architecture.md) | Sintesi rapida dell'architettura operativa aggiornata al `main` corrente: Clinical Workbench unico, home-base, document intelligence, SISS/FSE e guardrail locali. | Per overview veloce in onboarding/review. |
 
 ## Native, setup e testing
 
@@ -43,6 +44,7 @@ Ultimo aggiornamento: 2026-04-19
 | [docs/native-launch.md](./native-launch.md) | Avvio rapido app macOS via script/launcher. | Per esecuzione operativa locale. |
 | [docs/local-api-tls.md](./local-api-tls.md) | TLS proxy locale e trasporto sicuro per native API. | Per debug networking/certificate pinning. |
 | [docs/native-testing.md](./native-testing.md) | Strategia canonica test macOS (SwiftPM/XCTest/Xcode). | Per piani test e parity sweep. |
+| [docs/mobile-home-base-smoke.md](./mobile-home-base-smoke.md) | Runbook smoke iPhone/iPad contro `home-base` reale con pairing temporaneo e sessione operatore. | Per verifiche mobili `home-base` paired su simulatori Apple. |
 | [docs/icd-local-setup.md](./icd-local-setup.md) | Setup locale container ICD-11. | Quando si lavora su diagnostica ICD. |
 
 ## Prodotto, compliance e contesto clinico
@@ -51,16 +53,17 @@ Ultimo aggiornamento: 2026-04-19
 | --- | --- | --- |
 | [docs/ROADMAP.md](./ROADMAP.md) | Roadmap prodotto canonica. | Per direzione prodotto/release narrative. |
 | [docs/product_roadmap.md](./product_roadmap.md) | Roadmap storica (deprecata). | Solo per contesto storico. |
-| [docs/FAQ.md](./FAQ.md) | FAQ sintetiche pubbliche: salto `v0.3 -> v0.5`, boundary dichiarati, preview profiles e stato Apple/SISS. | Per onboarding rapido o lettura pubblica del progetto. |
+| [docs/FAQ.md](./FAQ.md) | FAQ sintetiche pubbliche: stato attuale del prodotto, boundary dichiarati e orientamento rapido. | Per onboarding rapido o lettura pubblica del progetto. |
 | [docs/COMPLIANCE.md](./COMPLIANCE.md) | Quadro compliance GDPR/FHIR e interoperabilità. | Per requisiti normativi e policy operative. |
 | [docs/FSE2-terminology-roadmap.md](./FSE2-terminology-roadmap.md) | Roadmap codifiche cliniche FSE/EDS. | Per sviluppo terminologie e export documentale. |
 | [docs/fse-gtw-baseline-alignment.md](./fse-gtw-baseline-alignment.md) | Matrice di allineamento tra baseline ufficiale GTW/FSE e stato MediFlow. | Per gap analysis ministeriale, priorità FSE e anti-drift tecnico. |
 | [docs/siss-baseline.md](./siss-baseline.md) | Baseline canonica SISS: stato attuale, fonti ufficiali, matrice del prototipo contestuale, gap e sequenza di consegna. | Quando si lavora su `WUL-43`, `WUL-44`, `WUL-45`, `WUL-178` e `WUL-180`. |
 | [docs/siss-ssi-a2a-feasibility.md](./siss-ssi-a2a-feasibility.md) | Mappa canonica di fattibilità ufficiale oltre il `portal-handoff`: separa ciò che il SISS rende tecnicamente possibile da ciò che MediFlow può fare davvero solo dopo `SSI`, scenari approvati e onboarding regionale. | Quando si lavora su `WUL-180` o si valuta prescrittivo/FSE/SGDT/Anagrafe oltre l'handoff attuale. |
 | [docs/siss-modulo-prescrittivo-regionale.md](./siss-modulo-prescrittivo-regionale.md) | Nota canonica `WUL-181` sul Modulo Prescrittivo Regionale: fissa il boundary tra richiamo della webapp ufficiale, possibile supporto WS/API e re-implementazione UI non ancora dimostrata. | Quando si lavora sul prescrittivo regionale oltre il launcher attuale. |
+| [docs/siss-fse-docs-corpus.md](./siss-fse-docs-corpus.md) | Runbook canonico del corpus documentale locale SISS/FSE: manifest sorgenti, fetch/sync fuori Git, placeholder `manual-import` e report di freshness. | Quando si lavora su `WUL-176`, `WUL-179` o sulla base documentale delle integrazioni regionali. |
 | [docs/MANUALE.md](./MANUALE.md) | Manuale utente medico. | Per supporto operativo lato clinico. |
 
-## Tracciabilità agent e metadoc
+## Indici e contratti tecnici
 
 | File | Scopo | Quando consultarlo |
 | --- | --- | --- |
@@ -100,6 +103,10 @@ Ultimo aggiornamento: 2026-04-19
 | [docs/adr/0025-siss-local-adapter-contract-and-error-taxonomy.md](./adr/0025-siss-local-adapter-contract-and-error-taxonomy.md) | Introduce il foundation layer locale SISS con azioni tipizzate, error taxonomy stabile, retry sui transienti e metadata audit PHI-safe. |
 | [docs/adr/0045-siss-native-integration-boundary-requires-qualified-ssi.md](./adr/0045-siss-native-integration-boundary-requires-qualified-ssi.md) | Fissa il boundary ufficiale del filone `WUL-180`: oltre il `portal-handoff`, la vera integrazione nativa SISS/FSE richiede scenari approvati e un percorso coerente con `SSI` qualificata/provisioning ARIA. |
 | [docs/adr/0046-modulo-prescrittivo-regionale-first-slice-webapp-assisted.md](./adr/0046-modulo-prescrittivo-regionale-first-slice-webapp-assisted.md) | Fissa la decisione `WUL-181`: il primo step credibile sul prescrittivo regionale oltre l'handoff e `webapp-assisted`, non la riscrittura della UI prescrittiva dentro MediFlow. |
+| [docs/adr/0047-graphite-workbench-single-official-web-shell.md](./adr/0047-graphite-workbench-single-official-web-shell.md) | Fissa `WUL-196`: la shell web Graphite/Clinical Workbench diventa il solo runtime UI supportato su `main`, senza shell concorrenti o chooser visuali persistiti. |
+| [docs/adr/0050-functional-preview-profiles-retired-on-mainline.md](./adr/0050-functional-preview-profiles-retired-on-mainline.md) | Fissa `WUL-199`: i preview profiles funzionali vengono ritirati da `main`, con AI e Smart Import gia live e il contesto paziente SISS promosso a parte stabile della scheda paziente. |
+| [docs/adr/0048-apple-shared-client-architecture-and-home-base-runtime.md](./adr/0048-apple-shared-client-architecture-and-home-base-runtime.md) | Formalizza `WUL-188`: family Apple ricostruita con core Swift condiviso, shell distinte per macOS/iPhone/iPad, Mac packaged come `home-base` autorevole e mobile paired senza accesso diretto a SQLite. |
+| [docs/adr/0049-siss-fse-document-corpus-and-local-mcp-layer.md](./adr/0049-siss-fse-document-corpus-and-local-mcp-layer.md) | Formalizza `WUL-176`: corpus documentale locale SISS/FSE con manifest versionato, fetch/sync fuori Git e futuro MCP ammesso solo sopra un corpus approvato. |
 | [docs/adr/0026-pin-rotation-via-client-side-rewrap.md](./adr/0026-pin-rotation-via-client-side-rewrap.md) | Definisce la rotazione zero-knowledge del PIN tramite re-wrap client-side della master key, senza ricifrare i dati clinici. |
 | [docs/adr/0034-local-only-default-and-network-home-base-opt-in.md](./adr/0034-local-only-default-and-network-home-base-opt-in.md) | Formalizza `WUL-117`: `local-only` resta il default, `network home-base` diventa una modalita esplicita su LAN fidata con nodo paired autorevole e thin slice iniziale read-only prima di replica, sync e identity model. |
 | [docs/adr/0035-network-replica-thin-slice-snapshot-mirror.md](./adr/0035-network-replica-thin-slice-snapshot-mirror.md) | Formalizza `WUL-120`: la replica iniziale `network home-base` resta uno snapshot mirror governato con fallback locale, stato deferred e manual review prima di qualsiasi sync record-level. |

--- a/docs/openapi/README.md
+++ b/docs/openapi/README.md
@@ -65,7 +65,7 @@ Se la risposta e `si`, la spec va aggiornata.
 4. Nella PR scrivi cosa e cambiato:
    - spec aggiornata
    - oppure `no contract impact`
-5. Se il cambio e breaking o deprecante, aggiorna prima ADR/PLANS/Linear.
+5. Se il cambio e breaking o deprecante, aggiorna prima ADR e piano di lavoro.
 6. Esegui `npm run check:openapi:drift` per verificare coverage, drift e breaking.
 
 ## Registro eccezioni e override
@@ -74,7 +74,7 @@ Se la risposta e `si`, la spec va aggiornata.
   fuori dalla slice OpenAPI pubblicata; una nuova operation `/api/v1` deve stare
   o nella spec o in questo registro
 - `breakingOverrides` nello stesso file e il punto unico per deroghe intenzionali:
-  ogni voce deve citare il change esatto bloccato dal guard e il Linear issue che
+  ogni voce deve citare il change esatto bloccato dal guard e la motivazione che
   la giustifica
 
 ## Versioning semplice

--- a/docs/siss-modulo-prescrittivo-regionale.md
+++ b/docs/siss-modulo-prescrittivo-regionale.md
@@ -169,7 +169,7 @@ La prossima slice runtime, se e quando verra aperta, dovrebbe essere:
 
 Forma:
 
-- MediFlow resta orchestratore locale del contesto paziente
+- MediFlow resta coordinatore locale del contesto paziente
 - l'atto prescrittivo vero avviene nel `Modulo Prescrittivo Regionale`
   ufficiale
 - l'operatore continua a usare credenziale/sessione SISS ufficiale
@@ -210,7 +210,7 @@ Una futura implementazione runtime dovra dimostrare almeno questo:
 3. non assume prefill di dati non esplicitamente supportato dalla
    documentazione/scenario raccolti
 4. preserva il boundary della credenziale operatore e del contesto funzionale
-5. mantiene audit locale PHI-safe del solo handoff/orchestrazione MediFlow
+5. mantiene audit locale PHI-safe del solo handoff/coordinamento MediFlow
 6. non dichiara `prescrittivo nativo MediFlow` se l'atto prescrittivo resta
    dentro la webapp regionale
 

--- a/docs/system_architecture.md
+++ b/docs/system_architecture.md
@@ -6,6 +6,7 @@
 > Il walkthrough operativo canonico resta [docs/walkthrough.md](./walkthrough.md).
 
 Panoramica tecnica rapida aggiornata allo stato reale di `main`.
+Per la lettura completa e trasversale usa [docs/STATE_OF_THE_SYSTEM.md](./STATE_OF_THE_SYSTEM.md).
 Per il dettaglio completo usa [docs/walkthrough.md](./walkthrough.md).
 Per la mappa documentale completa usa [docs/README.md](./README.md) e [docs/markdown-index.md](./markdown-index.md).
 
@@ -22,11 +23,14 @@ Per la mappa documentale completa usa [docs/README.md](./README.md) e [docs/mark
 4. **Document intelligence prudente**: `documentInsights` resta compat layer,
    mentre gli allegati possono gia persistere un artifact `parse/evidence`
    cifrato consumato in priorita da `AI Patient Insight`.
-5. **Direzione Apple piu chiara**: web app primaria oggi, shell macOS storica
+5. **Clinical Workbench unico**: Graphite e la shell web ufficiale su `main`;
+   AI, Smart Import e contesto paziente SISS/FSE non dipendono piu da preview
+   profiles runtime.
+6. **Direzione Apple piu chiara**: web app primaria oggi, shell macOS storica
    congelata per rebuild e filone iPadOS/iOS ricondotto allo stesso boundary
    `home-base + /api/v1`.
-6. **Preview profiles locali**: alcune fette UI/AI/import/SISS sono verificabili
-   come preview locali senza cambiare il checkout stabile.
+7. **SISS/FSE documentale governato**: il corpus locale con sync/freshness
+   prepara integrazioni future senza dichiarare una catena regionale certificata.
 
 ---
 
@@ -34,7 +38,7 @@ Per la mappa documentale completa usa [docs/README.md](./README.md) e [docs/mark
 
 | Componente | Stato attuale | Note |
 | --- | --- | --- |
-| Web app Next.js | Superficie primaria | UI, `/api/*`, `/api/v1/*`, overview `home-base`, orchestrazione AI locale |
+| Web app Next.js | Superficie primaria | UI, `/api/*`, `/api/v1/*`, overview `home-base`, coordinamento AI locale |
 | SQLite + Drizzle | Storage autorevole | `medical.db`, schema in `lib/schema.ts` |
 | Ollama | Runtime AI/OCR locale | Default text-only `qwen3.5:35b-a3b`, OCR locale separato |
 | ICD-11 Docker | Servizio locale opzionale | Resolver diagnostico OMS |
@@ -109,6 +113,8 @@ clinica quando diagnosi/terapie sono gia presenti.
   branch/revision/worktree.
 - `Start_MediFlow.command` puo resettare `.next` quando cambia il fingerprint
   della sorgente locale.
+- Il `Clinical Workbench` e l'unico runtime UI supportato su `main`; nuove
+  sperimentazioni non vivono come selector persistito in Settings.
 - I benchmark/shadow lane (`OpenMed`, comparator cloud, NER benchmark-only)
   restano separati dal runtime clinico.
 
@@ -123,7 +129,10 @@ clinica quando diagnosi/terapie sono gia presenti.
 - [docs/adr/0034-local-only-default-and-network-home-base-opt-in.md](./adr/0034-local-only-default-and-network-home-base-opt-in.md)
 - [docs/adr/0038-network-readonly-data-plane-auth-boundary.md](./adr/0038-network-readonly-data-plane-auth-boundary.md)
 - [docs/adr/0042-document-driven-new-patient-review-and-prudent-therapy-persistence.md](./adr/0042-document-driven-new-patient-review-and-prudent-therapy-persistence.md)
+- [docs/adr/0047-graphite-workbench-single-official-web-shell.md](./adr/0047-graphite-workbench-single-official-web-shell.md)
+- [docs/adr/0050-functional-preview-profiles-retired-on-mainline.md](./adr/0050-functional-preview-profiles-retired-on-mainline.md)
+- [docs/adr/0049-siss-fse-document-corpus-and-local-mcp-layer.md](./adr/0049-siss-fse-document-corpus-and-local-mcp-layer.md)
 
 ---
 
-*Ultimo aggiornamento: 2026-04-07 — main post-v0.5.0*
+*Ultimo aggiornamento: 2026-05-01 — main corrente*

--- a/docs/topologia-dati-flussi.md
+++ b/docs/topologia-dati-flussi.md
@@ -13,6 +13,7 @@ Questo documento mappa in modo operativo:
 - quali controlli di sicurezza lo proteggono
 
 Riferimenti rapidi:
+- [docs/STATE_OF_THE_SYSTEM.md](./STATE_OF_THE_SYSTEM.md)
 - [docs/walkthrough.md](./walkthrough.md)
 - [docs/README.md](./README.md)
 - [docs/markdown-index.md](./markdown-index.md)

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -26,6 +26,7 @@ Serve per onboarding tecnico, manutenzione e verifica rapida dei flussi principa
 - Riassumere sicurezza, cifratura e trasporto locale.
 
 Se serve il dettaglio di singoli moduli, consulta anche:
+- [docs/STATE_OF_THE_SYSTEM.md](./STATE_OF_THE_SYSTEM.md)
 - [docs/topologia-dati-flussi.md](./topologia-dati-flussi.md)
 - [docs/system_architecture.md](./system_architecture.md)
 - [docs/native-setup.md](./native-setup.md)
@@ -118,30 +119,75 @@ graph TB
 | `native/` | app macOS SwiftUI |
 | `scripts/` | avvio, TLS proxy, build native |
 
-## Preview profiles locali
+## Shell ufficiale e superfici integrate
 
-Su checkout non-production MediFlow espone anche una registry locale di
-`Preview Profiles`, selezionabile dalle `Impostazioni`.
+Nel checkout web esiste oggi una sola shell ufficiale del prodotto:
 
-Obiettivo: provare fette sperimentali senza cambiare branch o worktree e senza
-spostare per errore il profilo stabile.
+1. `Clinical Workbench / Graphite`: runtime stabile del checkout corrente.
 
-Profili attuali:
+Le superfici AI, Smart Import e contesto paziente SISS non vivono piu dietro un
+selector locale di preview: quando sono considerate mature per `main`, vengono
+integrate direttamente nel workbench ufficiale.
 
-- `Base`: nessun toggle sperimentale
-- `Liquid Glass UI`: direzione visiva piu liquida e piu separata dal contenuto clinico
-- `AI Stack Preview`: superfici locali dedicate a stack AI e diagnostica
-- `Smart Import Review v2`: percorsi review-first dell'import operatore
-- `SISS Context Preview`: pannello contestuale SISS/FSE sul paziente
+In pratica:
+
+- `AI`: resta parte della shell ufficiale come stack locale governato;
+- `Smart Import`: resta reviewable dentro i flussi normali del paziente;
+- `SISS`: il pannello contestuale paziente e parte stabile della scheda
+  clinica, mantenendo il boundary `webapp-assisted` verso i moduli regionali.
+- `Protesica`: la scheda paziente include un diario locale delle prescrizioni
+  protesiche e un handoff `Protesica-RL` con codice fiscale pronto da incollare.
 
 Implementazione principale:
 
-- `lib/preview-profiles.ts`
-- `components/preview-profile-chrome.tsx`
+- `app/patients/[id]/page.tsx`
+- `components/siss-patient-context-panel.tsx`
+- `components/prosthetic-prescription-manager.tsx`
 - `app/settings/page.tsx`
 
-Questi profili non cambiano i boundary canonici: servono a verificare fette
-locali, non a dichiararle automaticamente come parte consolidata del prodotto.
+Questo non cambia i boundary canonici: AI, import e contesto SISS sono integrati
+nel runtime ufficiale, ma non dichiarano scorciatoie architetturali oltre quelle
+gia formalizzate nelle ADR e nei documenti SISS. Il diario protesico resta un
+registro locale document-backed: non invia prescrizioni al sistema regionale e
+non dichiara un canale certificato.
+
+### Diario protesico da documenti Assistente RL
+
+Quando l'operatore produce un pacchetto documentale `Protesica-RL`, MediFlow lo
+tratta come fonte documentale per una bozza revisionabile del diario protesico,
+non come scrittura automatica certificata verso il sistema regionale.
+
+Fonti attese:
+
+- `PRESCRIZIONE DI PROTESICA`: analisi funzionale, diagnosi/razionale, tabella
+  dei presidi ISO prescritti, significato terapeutico-riabilitativo e tempi
+  d'impiego.
+- `MODELLO 03`: numero pratica/domanda, data presentazione, diritto, area
+  fornitore/prezzi, requisito di collaudo e sezione consegna.
+- `SchedaTecnica`: conferma tecnica della fornitura, data prescrizione, codice
+  ISO, quantita, descrizione del presidio, prescrittore e struttura.
+
+Regole di import reviewable:
+
+- una voce `prosthetic_prescriptions` per ogni presidio ISO documentato;
+- `regionalPrescriptionId` da `NUMERO PRESCRIZIONE` / `NUMERO PRATICA`;
+- `prescribedAt` da `DATA PRESCRIZIONE`, conservando eventuale data domanda
+  nelle note se diversa;
+- `status=prescribed` quando esiste solo la prescrizione clinica,
+  `status=submitted` quando il modello regionale documenta la domanda
+  presentata, e stati `authorized`, `delivered`, `tested` solo con evidenza
+  esplicita;
+- `collaudoAt` solo con data di collaudo effettiva; `Prescrizione soggetta a
+  collaudo: NO` e una informazione di requisito, non un collaudo completato;
+- `measures` solo per misure, configurazioni, quantita o tempi d'impiego
+  espliciti, senza inventare dettagli tecnici dalla narrativa;
+- `clinicalReason` solo da diagnosi, analisi funzionale e significato
+  terapeutico-riabilitativo documentati.
+
+Il matching resta paziente-scoped: codice fiscale prima, poi nome/data di
+nascita come controllo secondario. Se i documenti del pacchetto divergono su
+identita, numero pratica o data, l'import deve fermarsi e lasciare una bozza da
+revisione operatore.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds the public-safe `docs/STATE_OF_THE_SYSTEM.md` current-state guide.
- Refreshes OSS entrypoints and public documentation maps around the same product/runtime boundary.
- Cleans residual public references to internal planning/tracker language in touched docs.

## Verification
- `git diff --check`
- `rg -n "Codex|Linear|AGENTS|PLANS|repo privata|orchestr|docs/private" README.md docs ARCHITECTURE.md SECURITY.md CONTRIBUTING.md CHANGELOG.md` returned no matches.
- `find . -maxdepth 2 \( -name 'medical.db' -o -name '*.sqlite' -o -name '*.sqlite3' -o -name 'tmp-*' -o -name '.next' \) -print` returned no files.

## Private Pair
- Private PR: https://github.com/Wulfgardr/mediflow_private/pull/84
- WUL-203
