### PR TITLE
docs(repo): rendi pubblica la fonte operativa

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,85 @@
+# AGENTS.md: MediFlow
+
+## Missione
+
+MediFlow e una cartella clinica territoriale local-first. Gli agent devono
+preservare privacy, sicurezza, semplicita e verificabilita, con diff piccoli e
+revisionabili.
+
+## Avvio obbligatorio
+
+Prima di ogni attivita nel repository, leggere nell'ordine:
+
+1. `AGENTS.md`
+2. `README.md`
+3. `docs/README.md`
+4. `docs/markdown-index.md`
+5. `ARCHITECTURE.md`
+6. `CONTRIBUTING.md`
+7. `SECURITY.md`
+8. gli ADR piu recenti in `docs/adr/`
+9. `docs/walkthrough.md` quando serve una vista end-to-end
+
+Non dedurre intenti architetturali dal solo codice quando esiste una fonte
+documentale canonica.
+
+## Repository canonica
+
+- `https://github.com/Wulfgardr/mediflow` e l'unica repository operativa e
+  canonica del progetto.
+- La precedente repository privata `Wulfgardr/mediflow_private` e archiviata e
+  non e una fonte di sviluppo, pianificazione o rilascio.
+- Non esiste piu un flusso private-to-OSS, una doppia mainline o un passaggio di
+  export prima della pubblicazione.
+- Branch, commit, pull request, issue, tag e release appartengono alla
+  repository pubblica.
+- Database, PHI/PII, credenziali, output runtime, corpus autenticati e altri
+  artefatti riservati restano fuori da Git; non vanno spostati nella vecchia
+  repository privata.
+
+La fonte canonica per questa decisione e
+[`docs/repository-topology.md`](./docs/repository-topology.md).
+
+## Sicurezza e privacy
+
+- Non committare PHI/PII, database reali, screenshot o log con dati clinici.
+- Usare solo fixture sintetiche.
+- Nessun cloud, telemetria o egress dati e attivo per default.
+- Le modifiche a confini di sicurezza, dati o architettura richiedono un ADR
+  prima dell'implementazione.
+
+## Disciplina operativa
+
+- Un workstream usa un issue, un branch `codex/<issue>-<slug>` e un worktree
+  dedicato.
+- La checkout primaria e una superficie di coordinamento, non di sviluppo.
+- Preferire un solo cambiamento logico per commit e nessun refactor laterale.
+- Se la modifica supera circa 300 LOC o coinvolge piu confini architetturali,
+  fermarsi e proporre una suddivisione.
+- Prima del commit verificare branch corrente, scope del diff e stato del
+  worktree.
+
+## Igiene documentale
+
+- Se un file Markdown viene aggiunto, rimosso o rinominato, aggiornare
+  `docs/markdown-index.md`.
+- Se cambia la fonte autorevole di un tema, aggiornare `docs/README.md`.
+- Allineare prima la fonte canonica, poi le sintesi secondarie.
+- Stato reale, direzione e fuori-scope devono restare distinguibili.
+
+## Verifica minima
+
+Per modifiche solo documentali:
+
+```bash
+git diff --check
+rg --files -g '*.md' | sort
+```
+
+Per modifiche runtime, seguire i comandi e la Definition of Done in
+`CONTRIBUTING.md`. Dichiarare sempre cosa e stato verificato e cosa non lo e.
+
+## Attribuzione Codex
+
+Il codice specificamente prodotto da Codex usa `/* @Codex */` per i blocchi o
+`// @Codex` inline. La regola non richiede marcatori nei soli documenti.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,12 +13,14 @@ Prima di ogni attivita nel repository, leggere nell'ordine:
 1. `AGENTS.md`
 2. `README.md`
 3. `docs/README.md`
-4. `docs/markdown-index.md`
-5. `ARCHITECTURE.md`
-6. `CONTRIBUTING.md`
-7. `SECURITY.md`
-8. gli ADR piu recenti in `docs/adr/`
-9. `docs/walkthrough.md` quando serve una vista end-to-end
+4. `docs/STATE_OF_THE_SYSTEM.md`
+5. `docs/repository-topology.md`
+6. `docs/markdown-index.md`
+7. `ARCHITECTURE.md`
+8. `CONTRIBUTING.md`
+9. `SECURITY.md`
+10. gli ADR piu recenti in `docs/adr/`
+11. `docs/walkthrough.md` quando serve una vista end-to-end
 
 Non dedurre intenti architetturali dal solo codice quando esiste una fonte
 documentale canonica.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,7 +180,7 @@ e questo progetto aderisce al [Semantic Versioning](https://semver.org/spec/v2.0
 
 ### 📚 Documentazione
 
-- **Lettura completa dello stato sistema**: aggiunto `docs/STATE_OF_THE_SYSTEM.md` come punto canonico unico per prodotto, runtime, dati, sicurezza, AI/document intelligence, home-base, SISS/FSE, Apple clients e split private/OSS.
+- **Lettura completa dello stato sistema**: aggiunto `docs/STATE_OF_THE_SYSTEM.md` come punto canonico unico per prodotto, runtime, dati, sicurezza, AI/document intelligence, home-base, SISS/FSE e Apple clients; il riferimento allora presente allo split private/OSS e stato poi superato da `WUL-477`.
 - **Repo/GitHub riallineati al runtime reale**: README, piani, walkthrough, topologia dati, roadmap e sintesi architetturale descrivono ora `home-base` read-only, artifact `parse/evidence`, comparator/shadow lane e guard di revisione della shell locale.
 - **Narrativa `v0.6` piu chiara**: README, FAQ, roadmap, architettura e mappe documentali raccontano lo stato corrente senza confronti interni, con Clinical Workbench unico, boundary SISS attuale, `home-base` packaged e client Apple paired.
 - **Sweep WUL-203**: riferimento, supporto e overview docs riallineati allo stato corrente di `main`, con rimozione dei residui che presentavano i preview profiles come runtime disponibile.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,7 +180,7 @@ e questo progetto aderisce al [Semantic Versioning](https://semver.org/spec/v2.0
 
 ### 📚 Documentazione
 
-- **Lettura completa dello stato sistema**: aggiunto `docs/STATE_OF_THE_SYSTEM.md` come punto canonico unico per prodotto, runtime, dati, sicurezza, AI/document intelligence, home-base, SISS/FSE e Apple clients; il riferimento allora presente allo split private/OSS e stato poi superato da `WUL-477`.
+- **Lettura completa dello stato sistema**: aggiunto `docs/STATE_OF_THE_SYSTEM.md` come punto canonico unico per prodotto, runtime, dati, sicurezza, AI/document intelligence, home-base, SISS/FSE e Apple clients; il riferimento allora presente allo split private/OSS è stato poi superato da `WUL-477`.
 - **Repo/GitHub riallineati al runtime reale**: README, piani, walkthrough, topologia dati, roadmap e sintesi architetturale descrivono ora `home-base` read-only, artifact `parse/evidence`, comparator/shadow lane e guard di revisione della shell locale.
 - **Narrativa `v0.6` piu chiara**: README, FAQ, roadmap, architettura e mappe documentali raccontano lo stato corrente senza confronti interni, con Clinical Workbench unico, boundary SISS attuale, `home-base` packaged e client Apple paired.
 - **Sweep WUL-203**: riferimento, supporto e overview docs riallineati allo stato corrente di `main`, con rimozione dei residui che presentavano i preview profiles come runtime disponibile.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,16 @@ Qui si lavora su **dati sanitari**: privacy e sicurezza non sono opzionali.
 > [!IMPORTANT]
 > Se vuoi cambiare confini di sicurezza, scrivi prima un ADR (vedi sotto).
 
+## Repository e consegna
+
+La repository pubblica
+[`Wulfgardr/mediflow`](https://github.com/Wulfgardr/mediflow) e l'unica fonte
+operativa. Issue, branch, pull request, tag e release devono nascere qui; la
+precedente repository privata e archiviata e non va usata come mirror o
+destinazione di export. Dati e artifact sensibili restano fuori da Git secondo
+[`SECURITY.md`](./SECURITY.md) e
+[`docs/repository-topology.md`](./docs/repository-topology.md).
+
 ---
 
 ## ⚙️ Prerequisiti

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,9 +19,9 @@ Qui si lavora su **dati sanitari**: privacy e sicurezza non sono opzionali.
 ## Repository e consegna
 
 La repository pubblica
-[`Wulfgardr/mediflow`](https://github.com/Wulfgardr/mediflow) e l'unica fonte
+[`Wulfgardr/mediflow`](https://github.com/Wulfgardr/mediflow) è l'unica fonte
 operativa. Issue, branch, pull request, tag e release devono nascere qui; la
-precedente repository privata e archiviata e non va usata come mirror o
+precedente repository privata è archiviata e non va usata come mirror o
 destinazione di export. Dati e artifact sensibili restano fuori da Git secondo
 [`SECURITY.md`](./SECURITY.md) e
 [`docs/repository-topology.md`](./docs/repository-topology.md).

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ lavoro clinico di tutti i giorni.
 Lo sviluppo di MediFlow avviene interamente in questa repository pubblica.
 Branch, pull request, issue, tag e release fanno capo a
 [`Wulfgardr/mediflow`](https://github.com/Wulfgardr/mediflow); la precedente
-repository privata e archiviata e non costituisce piu una fonte operativa.
+repository privata è archiviata e non costituisce più una fonte operativa.
 Gli artefatti sensibili o locali restano fuori da Git secondo
 [`SECURITY.md`](./SECURITY.md) e
 [`docs/repository-topology.md`](./docs/repository-topology.md).

--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ Non nasce per sostituire i canali istituzionali, né per promettere integrazioni
 che non sono ancora dimostrate. Nasce per dare ordine, continuità e controllo al
 lavoro clinico di tutti i giorni.
 
+## Repository canonica
+
+Lo sviluppo di MediFlow avviene interamente in questa repository pubblica.
+Branch, pull request, issue, tag e release fanno capo a
+[`Wulfgardr/mediflow`](https://github.com/Wulfgardr/mediflow); la precedente
+repository privata e archiviata e non costituisce piu una fonte operativa.
+Gli artefatti sensibili o locali restano fuori da Git secondo
+[`SECURITY.md`](./SECURITY.md) e
+[`docs/repository-topology.md`](./docs/repository-topology.md).
+
 ## Come si presenta
 
 <img src="./screenshots/01-worklist.png" alt="Cockpit Kree8: lista di lavoro con pazienti dimostrativi sintetici" width="820" loading="lazy" decoding="async"/>

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ Per orientarti rapidamente:
 Approfondimenti utili:
 
 - Mappa completa markdown: [docs/markdown-index.md](./markdown-index.md)
-- Topologia repository (runtime clinico vs publication/site): [docs/repository-topology.md](./repository-topology.md)
+- Governance repository e topologia runtime/publication: [docs/repository-topology.md](./repository-topology.md)
 - Lettura completa dello stato corrente: [docs/STATE_OF_THE_SYSTEM.md](./STATE_OF_THE_SYSTEM.md)
 - FAQ pubbliche e stato sintetico del prodotto: [docs/FAQ.md](./FAQ.md)
 - Walkthrough operativo end-to-end: [docs/walkthrough.md](./walkthrough.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,25 +2,27 @@
 summary: "Canonical MediFlow documentation entrypoint and precedence map."
 read_when:
   - "Starting any MediFlow task and deciding which docs are authoritative."
-  - "Updating documentation structure, canonical indices, or OSS/private doc boundaries."
+  - "Updating documentation structure, canonical indices, or repository governance."
 ---
 
 # Documentazione MediFlow: Indice Canonico
 
 Questo file è il punto di ingresso unico: dove leggere, cosa aggiornare e quale documento prevale.
 
-Ultimo aggiornamento: 2026-07-03
+Ultimo aggiornamento: 2026-07-09
 
 ## 📚 Policy di consultazione (agent)
 
 Per orientarti rapidamente:
 
 1. [README.md](../README.md)
+2. [AGENTS.md](../AGENTS.md)
 3. [docs/README.md](./README.md) (questo file)
 4. [docs/STATE_OF_THE_SYSTEM.md](./STATE_OF_THE_SYSTEM.md)
 5. [ARCHITECTURE.md](../ARCHITECTURE.md)
 6. [SECURITY.md](../SECURITY.md)
 7. [CONTRIBUTING.md](../CONTRIBUTING.md)
+8. [docs/repository-topology.md](./repository-topology.md)
 9. [docs/adr/](./adr/README.md) (partendo dai più recenti)
 
 Approfondimenti utili:
@@ -38,11 +40,13 @@ Approfondimenti utili:
 ## 🧭 Ordine di lettura consigliato
 
 1. [README.md](../README.md)
+2. [AGENTS.md](../AGENTS.md)
 3. [docs/STATE_OF_THE_SYSTEM.md](./STATE_OF_THE_SYSTEM.md)
 4. [ARCHITECTURE.md](../ARCHITECTURE.md)
 5. [SECURITY.md](../SECURITY.md)
 6. [CONTRIBUTING.md](../CONTRIBUTING.md)
-7. [docs/adr/](./adr/README.md) (partendo dai più recenti)
+7. [docs/repository-topology.md](./repository-topology.md)
+8. [docs/adr/](./adr/README.md) (partendo dai più recenti)
 9. [docs/walkthrough.md](./walkthrough.md)
 10. [docs/markdown-index.md](./markdown-index.md)
 
@@ -57,7 +61,9 @@ Approfondimenti utili:
 | Tema | File canonico | Stato | Note |
 | --- | --- | --- | --- |
 | Onboarding progetto | [README.md](../README.md) | `CANONICAL` | Punto di ingresso generale. |
-| Stato completo del sistema | [docs/STATE_OF_THE_SYSTEM.md](./STATE_OF_THE_SYSTEM.md) | `CANONICAL` | Lettura unificata corrente: prodotto, runtime, boundary, AI/document intelligence, Apple clients e split private/OSS. |
+| Regole operative per agent | [AGENTS.md](../AGENTS.md) | `CANONICAL` | Boot sequence, repository canonica, privacy, disciplina di branch/worktree e verifica. |
+| Governance e topologia repository | [docs/repository-topology.md](./repository-topology.md) | `CANONICAL` | Fissa la repository pubblica come unica fonte operativa e separa runtime, publication/site e artefatti locali fuori Git. |
+| Stato completo del sistema | [docs/STATE_OF_THE_SYSTEM.md](./STATE_OF_THE_SYSTEM.md) | `CANONICAL` | Lettura unificata corrente: prodotto, runtime, boundary, AI/document intelligence, Apple clients e governance della repository pubblica. |
 | Visione architetturale stabile | [ARCHITECTURE.md](../ARCHITECTURE.md) | `CANONICAL` | Confini e principi che cambiano raramente. |
 | Sicurezza e redazione dati | [SECURITY.md](../SECURITY.md) | `CANONICAL` | Policy di sicurezza, threat model, logging rules. |
 | Intended purpose e claims guard clinico | [docs/adr/0065-intended-purpose-and-claims-guard.md](./adr/0065-intended-purpose-and-claims-guard.md) | `CANONICAL` | Fissa `WUL-279`: claim consentiti/esclusi su AI, SISS/FSE, cloud, diagnosi, triage, prescrizione e automazione, con guard `check:claims`. |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -134,9 +134,6 @@ testato anche su Linux/Windows.
   superato da `WUL-477`; la repository pubblica e ora l'unica fonte operativa,
   mentre materiali sensibili e artifact temporanei restano fuori da Git.
 
-> [!WARNING]
-> La 0.7.1 va taggata solo dopo merge del ramo Apple/native, CI verde sul
-
 ---
 
 ## 🚧 In corso (post-v0.7.2)
@@ -161,15 +158,16 @@ repository pubblica.
 
 ### Esperienza nativa
 
-* **Merge train Apple/native**: chiudere PR #271, far girare CI sul `main`
-  risultante e poi promuovere la release docs 0.7.1.
-* **Stack voice visit**: riconciliare #272, #273 e #274 in ordine, partendo
-  dall'ADR boundary e poi dalle superfici UI/backend sintetiche.
-* **Windows/Linux oltre il core**: trasformare il vecchio branch #266 in slice
-  piu piccole per launcher, floor hardware e distribuzione tri-OS, senza
-  promettere parity applicativa prima delle prove.
-* **Provider locali Apple**: rivalutare #259 dentro WUL-417/WUL-418, recuperando
-  solo kill-switch, test e decisioni compatibili con il gate benchmark-first.
+* **Apple/native su mainline**: macOS resta il fronte nativo piu avanzato;
+  iPhone/iPad proseguono come client paired sopra contratti locali versionati.
+* **Stack voice visit**: `WUL-419`, `WUL-421` e `WUL-422` mantengono transcript e
+  bozze sintetiche review-first, separati dall'audio reale e dalla promozione
+  runtime.
+* **Windows/Linux oltre il core**: procedere per slice piccole su launcher,
+  floor hardware e distribuzione tri-OS, senza promettere parity applicativa
+  prima delle prove.
+* **Provider locali Apple**: `WUL-417` e `WUL-418` restano benchmark-first, con
+  kill-switch, test e decisioni esplicite prima di qualunque promozione runtime.
 
 ### Shell ufficiale e sperimentazioni controllate
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -130,9 +130,9 @@ testato anche su Linux/Windows.
 * **Gate tri-OS**: Linux, macOS e Windows costruiscono e testano il core
   condiviso in CI. Questo prova la direzione di portabilita, ma non equivale a
   parity applicativa Windows/Linux.
-* **OSS export piu disciplinato**: l'export pubblico resta applicativo e
-  prodotto-centrico; materiali di coordinamento, analisi interne, workspace
-  privati e artifact temporanei restano esclusi.
+* **Convergenza pubblica completata**: questo punto storico sull'export OSS e
+  superato da `WUL-477`; la repository pubblica e ora l'unica fonte operativa,
+  mentre materiali sensibili e artifact temporanei restano fuori da Git.
 
 > [!WARNING]
 > La 0.7.1 va taggata solo dopo merge del ramo Apple/native, CI verde sul
@@ -144,7 +144,8 @@ testato anche su Linux/Windows.
 La lettura operativa piu completa del ciclo post-v0.7.2 e ora
 [docs/STATE_OF_THE_SYSTEM.md](./STATE_OF_THE_SYSTEM.md): questo file resta la
 roadmap prodotto, mentre lo stato del sistema tiene insieme runtime effettivo,
-boundary, document intelligence, home-base, Apple clients e split private/OSS.
+boundary, document intelligence, home-base, Apple clients e governance della
+repository pubblica.
 
 ### Modalita network home-base
 

--- a/docs/STATE_OF_THE_SYSTEM.md
+++ b/docs/STATE_OF_THE_SYSTEM.md
@@ -14,8 +14,9 @@ read_when:
 >
 > Per i principi stabili prevalgono sempre [ARCHITECTURE.md](../ARCHITECTURE.md)
 > e [SECURITY.md](../SECURITY.md). Per il flusso operativo end-to-end prevale
-> [docs/walkthrough.md](./walkthrough.md). Le priorita operative a breve restano
-> nel piano engineering del workspace sorgente.
+> [docs/walkthrough.md](./walkthrough.md). Per la governance della repository
+> prevalgono [AGENTS.md](../AGENTS.md) e
+> [docs/repository-topology.md](./repository-topology.md).
 
 Ultimo aggiornamento: 2026-07-09 (`v0.7.2` mainline)
 
@@ -43,6 +44,9 @@ La fotografia corrente e questa:
   descrivere l'intero file SQLite come completamente zero-knowledge finché
   identificativi, metadati e backup non sono coperti dallo stesso perimetro
   verificato.
+- **Repository operativa**: `Wulfgardr/mediflow` pubblica e l'unica fonte per
+  sviluppo e release; la precedente repository privata e archiviata e gli
+  artefatti sensibili restano fuori da Git.
 - **Contratto condiviso**: `/api/v1/*` per client native/locali; OpenAPI come
   riferimento anti-drift per la parte stabile.
 - **Home-base**: modalita opt-in in cui il Mac espone `/api/v1/network/*`
@@ -360,46 +364,39 @@ non scrive dati paziente e non cambia il default local-first.
 ### 6.1 Percorso consigliato per capire tutto
 
 1. [README.md](../README.md): ingresso prodotto.
-2. [docs/STATE_OF_THE_SYSTEM.md](./STATE_OF_THE_SYSTEM.md): lettura completa
+2. [AGENTS.md](../AGENTS.md): regole operative e repository canonica.
+3. [docs/STATE_OF_THE_SYSTEM.md](./STATE_OF_THE_SYSTEM.md): lettura completa
    dello stato corrente.
-3. [ARCHITECTURE.md](../ARCHITECTURE.md): principi stabili.
-4. [SECURITY.md](../SECURITY.md): threat model, privacy, logging e redazione.
-5. [docs/walkthrough.md](./walkthrough.md): flusso end-to-end.
-6. [docs/topologia-dati-flussi.md](./topologia-dati-flussi.md): percorsi dati
+4. [ARCHITECTURE.md](../ARCHITECTURE.md): principi stabili.
+5. [SECURITY.md](../SECURITY.md): threat model, privacy, logging e redazione.
+6. [docs/walkthrough.md](./walkthrough.md): flusso end-to-end.
+7. [docs/topologia-dati-flussi.md](./topologia-dati-flussi.md): percorsi dati
    e trust boundaries.
-7. [docs/README.md](./README.md): mappa canonica e fonti autorevoli per tema.
-8. [docs/markdown-index.md](./markdown-index.md): inventario completo.
-9. [docs/adr/README.md](./adr/README.md): decisioni architetturali.
-10. Piano engineering privato: priorita operative a breve, disponibile solo nel
-    workspace sorgente quando presente.
+8. [docs/repository-topology.md](./repository-topology.md): governance della
+   repository e confine Git/fuori-Git.
+9. [docs/README.md](./README.md): mappa canonica e fonti autorevoli per tema.
+10. [docs/markdown-index.md](./markdown-index.md): inventario completo.
+11. [docs/adr/README.md](./adr/README.md): decisioni architetturali.
 
-### 6.2 Documenti pubblici vs documenti privati
+### 6.2 Repository pubblica e artefatti locali
 
-Il workspace sorgente puo contenere:
-
-- piani operativi a breve;
-- attribution agentica;
-- playbook interni di delivery e tracciabilita;
-- runbook interni di benchmark e shadow evaluation;
-- riferimenti a vault o workspace locali privati, sempre senza PHI in Git.
-
-La repo OSS deve contenere:
+La repository pubblica `Wulfgardr/mediflow` contiene tutto cio che serve allo
+sviluppo e al rilascio del progetto:
 
 - prodotto e installazione;
 - architettura e sicurezza;
 - roadmap pubblica;
 - FAQ;
-- walkthrough e documenti canonici non interni;
-- ADR pubblicabili;
-- script runtime necessari alla app nuda.
+- walkthrough, ADR e documenti canonici;
+- regole agentiche, workflow contributivo e script necessari allo sviluppo.
 
-La repo OSS non deve contenere:
+Restano fuori da Git, senza usare la repository privata archiviata come
+destinazione alternativa:
 
 - database reali o runtime artifacts;
 - `medical.db`, `.sqlite`, `.sqlite3`, `.next`, `tmp-*`;
-- piani interni e attribution agentica;
-- riferimenti a tracker interni, branch interni, coordinamento agentico o materiali non
-  esportabili;
+- PHI/PII, credenziali, log o screenshot con dati clinici;
+- note personali di account, billing o limiti di spesa;
 - documenti riservati o fonti autenticate del corpus SISS/FSE.
 
 ---
@@ -567,7 +564,7 @@ Quando cambia una feature runtime:
 - aggiorna [docs/README.md](./README.md) se cambia la fonte autorevole;
 - aggiorna [docs/markdown-index.md](./markdown-index.md) se aggiungi, rimuovi o
   rinomini Markdown;
-- aggiorna il piano engineering privato se cambia priorita operativa.
+- aggiorna issue e roadmap pubbliche se cambia una priorita operativa.
 
 Quando cambia un boundary:
 
@@ -576,11 +573,14 @@ Quando cambia un boundary:
 - verifica impatto OpenAPI se riguarda `/api/v1`;
 - dichiara esplicitamente cosa resta fuori scope.
 
-Quando esporti OSS:
+Quando cambia la topologia della repository:
 
-  destinazione di prova;
-- verifica che non compaiano DB, runtime artifacts o documenti interni;
-- cerca termini interni e riferimenti privati;
+- aggiorna [AGENTS.md](../AGENTS.md) e
+  [docs/repository-topology.md](./repository-topology.md);
+- verifica che remote, branch, PR, tag e release puntino alla repository
+  pubblica canonica;
+- verifica che DB, runtime artifact, credenziali e materiali riservati restino
+  fuori da Git.
 
 ---
 

--- a/docs/STATE_OF_THE_SYSTEM.md
+++ b/docs/STATE_OF_THE_SYSTEM.md
@@ -77,10 +77,9 @@ La fotografia corrente e questa:
 - **SISS/FSE**: handoff contestuale e flussi `webapp-assisted`; nessuna
   integrazione regionale nativa certificata dichiarata senza `SSI/A2A` e scenari
   approvati.
-- **OSS**: la repo pubblica deve restare prodotto-centrica, senza materiale
-  interno di coordinamento, analisi, piani privati o runtime data. I crediti
-  pubblici agli strumenti di sviluppo assistito restano ammessi se separati dai
-  materiali operativi interni.
+- **Repository pubblica**: contiene prodotto, documentazione e governance di
+  sviluppo. PHI/PII, credenziali, runtime data, corpus autenticati e note
+  personali di account restano fuori da Git.
 
 ---
 
@@ -637,5 +636,6 @@ Fermati e apri/spezza workstream se:
 
 - il diff supera un singolo tema;
 - una doc pubblica richiede materiale privato per restare comprensibile;
-- una modifica OSS trascina riferimenti interni;
+- una modifica alla repository trascina dati o artefatti che devono restare
+  fuori da Git;
 - il worktree contiene cambi non correlati.

--- a/docs/markdown-index.md
+++ b/docs/markdown-index.md
@@ -11,7 +11,7 @@ read_when:
 > GitHub mostra in alto solo alcuni file speciali (`README`, `CONTRIBUTING`, `SECURITY`, ecc.).
 > Questo file elenca invece **tutti** i `.md` tracciati nella repository con una sintesi rapida d'uso.
 
-Ultimo aggiornamento: 2026-07-07
+Ultimo aggiornamento: 2026-07-09
 
 ## 📚 Come usare questo indice
 
@@ -23,9 +23,10 @@ Ultimo aggiornamento: 2026-07-07
 
 | File | Scopo | Quando consultarlo |
 | --- | --- | --- |
+| [AGENTS.md](../AGENTS.md) | Regole operative: boot sequence, repository pubblica canonica, privacy, branch/worktree e verifica. | Sempre, prima di iniziare un task. |
 | [README.md](../README.md) | Onboarding generale progetto e punti di accesso documentazione. | Sempre, in fase di avvio. |
 | [docs/README.md](./README.md) | Mappa canonica della documentazione (fonte autorevole per tema). | Sempre, per decidere precedenze. |
-| [docs/STATE_OF_THE_SYSTEM.md](./STATE_OF_THE_SYSTEM.md) | Lettura completa dello stato corrente: prodotto, runtime, dati, AI/document intelligence, OCR macOS-only fallback, home-base, SISS/FSE, Apple clients e split private/OSS. | Sempre, quando serve una vista unica e aggiornata senza ricostruire il quadro da piu documenti. |
+| [docs/STATE_OF_THE_SYSTEM.md](./STATE_OF_THE_SYSTEM.md) | Lettura completa dello stato corrente: prodotto, runtime, dati, AI/document intelligence, OCR macOS-only fallback, home-base, SISS/FSE, Apple clients e governance della repository pubblica. | Sempre, quando serve una vista unica e aggiornata senza ricostruire il quadro da piu documenti. |
 | [ARCHITECTURE.md](../ARCHITECTURE.md) | Visione architetturale stabile, confini e non-obiettivi. | Sempre, per cambi tecnici non banali. |
 | [SECURITY.md](../SECURITY.md) | Policy sicurezza, threat model e regole redazione/logging. | Sempre, per qualunque cambio dati/API. |
 | [CONTRIBUTING.md](../CONTRIBUTING.md) | Workflow contributivo e Definition of Done. | Sempre, prima di chiudere un task. |
@@ -40,7 +41,7 @@ Ultimo aggiornamento: 2026-07-07
 | [docs/walkthrough.md](./walkthrough.md) | Walkthrough canonico end-to-end (web + native + servizi locali), con stato reale di `home-base`, document intelligence, fallback OCR macOS-only e shell locale. | Per capire flussi completi e integrazione moduli. |
 | [docs/STATE_OF_THE_SYSTEM.md](./STATE_OF_THE_SYSTEM.md) | Stato canonico complessivo del sistema, pensato come lettura unica per onboarding profondo e review trasversale. | Quando devi capire cosa esiste davvero oggi, cosa e direzione e quali confini non vanno superati. |
 | [docs/topologia-dati-flussi.md](./topologia-dati-flussi.md) | Topologia dati, trust boundaries, cifratura e percorsi digitali, inclusi artifact documentali cifrati e boundary `network-home-base`. | Per analisi data flow e impatti sicurezza. |
-| [docs/repository-topology.md](./repository-topology.md) | Mappa concisa delle aree top-level del repo: runtime clinico vs publication/site (`whitepaper/`) vs tooling. | Quando devi capire dove collocare codice/asset o se una cartella è clinical runtime. |
+| [docs/repository-topology.md](./repository-topology.md) | Fonte canonica per repository operativa, confine Git/fuori-Git e aree top-level: runtime clinico, publication/site e tooling. | Quando devi scegliere repository, branch o collocazione di codice, asset e artefatti locali. |
 | [docs/parity-matrix.md](./parity-matrix.md) | Stato parity web/macOS su moduli core e gap operativi. | Per steering parity e release readiness. |
 | [docs/ARCHITETTURA.md](./ARCHITETTURA.md) | Deep dive tecnico esteso dell'architettura MediFlow. | Per approfondimenti implementativi. |
 | [docs/system_architecture.md](./system_architecture.md) | Sintesi rapida dell'architettura operativa aggiornata al `main` corrente: Clinical Workbench unico, home-base, document intelligence, OCR platform boundary, SISS/FSE e guardrail locali. | Per overview veloce in onboarding/review. |

--- a/docs/repository-topology.md
+++ b/docs/repository-topology.md
@@ -1,10 +1,29 @@
+---
+summary: "Canonical MediFlow repository ownership, publication boundary, and top-level directory map."
+read_when:
+  - "Deciding which repository, branch, or worktree is authoritative."
+  - "Placing code, documentation, publication assets, or private local artifacts."
+---
+
 # Repository Topology: MediFlow
 
-Ultimo aggiornamento: 2026-06-16
+Ultimo aggiornamento: 2026-07-09 (`WUL-477`)
 
 Mappa concisa delle aree top-level del repository, pensata per orientare agent e
 contributor: distingue il **runtime clinico** (codice che gira con dati paziente)
 dagli **artefatti di pubblicazione/sito** e dagli **strumenti di sviluppo**.
+
+## Repository operativa
+
+[`Wulfgardr/mediflow`](https://github.com/Wulfgardr/mediflow) e l'unica
+repository canonica per sviluppo, issue, branch, pull request, tag e release.
+La precedente repository privata `Wulfgardr/mediflow_private` e archiviata: non
+e una seconda mainline e non riceve piu lavoro operativo.
+
+Non esiste un flusso di export private-to-OSS. Tutto cio che puo essere
+pubblicato nasce e viene revisionato qui; database, PHI/PII, credenziali,
+runtime artifact e fonti riservate restano fuori da Git secondo
+[`SECURITY.md`](../SECURITY.md).
 
 > [!IMPORTANT]
 > Le directory di **publication/site** non vanno trattate come parte del runtime
@@ -26,7 +45,7 @@ dagli **artefatti di pubblicazione/sito** e dagli **strumenti di sviluppo**.
 | `public/` | runtime clinico (asset) | Asset statici serviti dall'app. |
 | `docs/` | documentazione | Documentazione canonica del progetto. |
 | **`whitepaper/`** | **publication/site** | **Whitepaper/sito di pubblicazione. Non è runtime clinico, non importare da `app/`, `components/`, `lib/`.** |
-| `oss-assets/` | publication/site | Asset per la repo OSS. |
+| `oss-assets/` | publication/site | Asset pubblici storicamente raccolti per la distribuzione open source. |
 | `tmp-*/` | tooling effimero | Output di test e build temporanei (in `.gitignore` o esclusi dal typecheck). |
 | `tmp/` | tooling effimero | Scratchpad locale. |
 | `Farmaci/` | dati di riferimento | Dataset farmaceutici di riferimento. |
@@ -39,5 +58,9 @@ dagli **artefatti di pubblicazione/sito** e dagli **strumenti di sviluppo**.
 - Codice in `app/`, `components/`, `lib/`, `hooks/` non deve importare da
   `whitepaper/` o `oss-assets/`.
 - I path `tmp-*/` sono esclusi da `tsconfig.typecheck.json` (vedi `exclude`).
+- Non creare mirror operativi o pipeline di export verso la repository privata
+  archiviata.
+- Un clone storico puo mantenere remote locali differenti, ma il remote usato
+  per branch, push e release deve puntare alla repository pubblica canonica.
 - Per la lista completa dei `.md` tracciati, vedi
   [docs/markdown-index.md](./markdown-index.md).


### PR DESCRIPTION
## Summary
- dichiara Wulfgardr/mediflow come unica repository operativa e la precedente repository privata come archivio storico;
- aggiunge AGENTS.md pubblico e riallinea boot sequence, topologia e fonti documentali canoniche;
- rimuove dalla roadmap riferimenti a PR private, tagging obsoleto e istruzioni del vecchio export private-to-OSS;
- mantiene PHI/PII, credenziali, runtime artifact e note account fuori da Git.

## Verification
- git diff --check
- controllo esistenza link relativi sui documenti modificati
- npm run check:claims — 268 file, 0 claim ad alto rischio
- grep dei residui private/OSS e dei vecchi riferimenti PR/tag
- review indipendente Fable 5; finding sostanziali recepiti nel commit 86f6e9c30
- review finale Opus 4.8 sul delta; nessun rilievo sostanziale residuo

## Risk / Notes
- modifica solo documentale: nessun runtime, schema, dipendenza o workflow CI modificato;
- il nome e lo stato archived della repository precedente sono stati verificati live;
- i dettagli GitHub Pro, billing e limiti di spesa restano in una nota locale non tracciata;
- la normalizzazione globale degli accenti nei documenti tecnici non appartiene a questa PR.

## Ticket
Refs WUL-477
https://linear.app/wulfgardr/issue/WUL-477/rendere-la-repository-pubblica-lunica-fonte-operativa-di-mediflow