### PR TITLE
fix: persisti le motivazioni di archiviazione ed eliminazione paziente

### DIFF
--- a/app/api/patients/[id]/route.ts
+++ b/app/api/patients/[id]/route.ts
@@ -23,6 +23,13 @@ import {
 } from '@/lib/security/audit';
 
 /* @Codex */
+function parsePatientDeletionReason(body: Record<string, unknown>, fallback: string): string | null {
+    if (!Object.prototype.hasOwnProperty.call(body, 'deletionReason')) return fallback;
+    if (typeof body.deletionReason !== 'string' || body.deletionReason.trim().length === 0) return null;
+    return body.deletionReason;
+}
+
+/* @Codex */
 async function recordPatientAuditEvent(
     request: Request,
     session: Awaited<ReturnType<typeof requireSession>>,
@@ -151,6 +158,10 @@ export async function DELETE(request: Request, { params }: { params: Promise<{ i
         if (expectedVersion === null) {
             return NextResponse.json({ error: 'Version is required' }, { status: 400 });
         }
+        const deletionReason = parsePatientDeletionReason(body, 'web-delete');
+        if (deletionReason === null) {
+            return NextResponse.json({ error: 'Invalid deletionReason' }, { status: 400 });
+        }
 
         const existing = await dbServer.select({ id: patients.id }).from(patients).where(and(eq(patients.id, id), activePatients())).get();
         if (!existing) {
@@ -161,7 +172,7 @@ export async function DELETE(request: Request, { params }: { params: Promise<{ i
         // stay linked for the audited admin purge. Wire contract unchanged.
         const deleteResult = await dbServer
             .update(patients)
-            .set(buildPatientTombstoneValues(expectedVersion, 'web-delete'))
+            .set(buildPatientTombstoneValues(expectedVersion, deletionReason))
             .where(and(eq(patients.id, id), eq(patients.version, expectedVersion), activePatients()))
             .run();
 

--- a/app/api/v1/patients/[id]/route.ts
+++ b/app/api/v1/patients/[id]/route.ts
@@ -23,6 +23,13 @@ import {
     writeAuditEvent,
 } from '@/lib/security/audit';
 
+/* @Codex */
+function parsePatientDeletionReason(body: Record<string, unknown>, fallback: string): string | null {
+    if (!Object.prototype.hasOwnProperty.call(body, 'deletionReason')) return fallback;
+    if (typeof body.deletionReason !== 'string' || body.deletionReason.trim().length === 0) return null;
+    return body.deletionReason;
+}
+
 function toIsoString(value: unknown): string | null {
     if (!value) return null;
     const date = value instanceof Date ? value : new Date(value as string | number);
@@ -84,6 +91,10 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
             monitoringProfile: patient.monitoringProfile ?? null,
             /* @Codex */
             statusReason: patient.statusReason ?? null,
+            /* @Codex */
+            archiveReason: patient.archiveReason ?? null,
+            /* @Codex */
+            archiveNote: patient.archiveNote ?? null,
             notes: patient.notes ?? null,
             /* @Codex */
             aiSummary: patient.aiSummary ?? null,
@@ -197,6 +208,10 @@ export async function DELETE(request: Request, { params }: { params: Promise<{ i
         if (expectedVersion === null) {
             return NextResponse.json({ error: 'Version is required' }, { status: 400 });
         }
+        const deletionReason = parsePatientDeletionReason(body, 'api-v1-delete');
+        if (deletionReason === null) {
+            return NextResponse.json({ error: 'Invalid deletionReason' }, { status: 400 });
+        }
 
         const existing = await dbServer.select({ id: patients.id }).from(patients).where(and(eq(patients.id, id), activePatients())).get();
         if (!existing) {
@@ -207,7 +222,7 @@ export async function DELETE(request: Request, { params }: { params: Promise<{ i
         // stay linked for the audited admin purge. Wire contract unchanged.
         const deleteResult = await dbServer
             .update(patients)
-            .set(buildPatientTombstoneValues(expectedVersion, 'api-v1-delete'))
+            .set(buildPatientTombstoneValues(expectedVersion, deletionReason))
             .where(and(eq(patients.id, id), eq(patients.version, expectedVersion), activePatients()))
             .run();
 

--- a/app/patients/[id]/edit/page.tsx
+++ b/app/patients/[id]/edit/page.tsx
@@ -174,7 +174,10 @@ export default function EditPatientPage() {
 
         if (actionType === 'delete') {
             try {
-                await db.patients.delete(id, { version: patientVersion });
+                await db.patients.delete(id, {
+                    version: patientVersion,
+                    deletionReason: data.deletionReason,
+                });
                 router.push('/'); // Redirect to dashboard
             } catch (error) {
                 showToast({ tone: 'error', title: 'Eliminazione non riuscita', description: messageFromError(error, "Errore durante l'eliminazione.") });
@@ -183,6 +186,8 @@ export default function EditPatientPage() {
             try {
                 await db.patients.update(id, {
                     isArchived: true,
+                    archiveReason: data.archiveReason,
+                    archiveNote: data.archiveNote ?? null,
                     version: patientVersion,
                     updatedAt: new Date()
                 });
@@ -259,6 +264,16 @@ export default function EditPatientPage() {
                             <p className="mt-1 text-sm font-medium leading-relaxed" style={{ color: 'var(--mf-muted)' }}>
                                 Questa scheda è attualmente in sola lettura per l&apos;agenda corrente. Ripristina per tornare alle operazioni standard.
                             </p>
+                            {patient.archiveReason && (
+                                <p className="mt-3 text-sm font-semibold" style={{ color: 'var(--mf-ink)' }}>
+                                    Motivo: {patient.archiveReason === 'assigned_mmg' ? 'Assegnato a MMG' : patient.archiveReason === 'deceased' ? 'Decesso' : 'Altro'}
+                                </p>
+                            )}
+                            {patient.archiveNote && (
+                                <p className="mt-1 text-sm leading-relaxed" style={{ color: 'var(--mf-muted)' }}>
+                                    {patient.archiveNote}
+                                </p>
+                            )}
                             <button
                                 onClick={handleRestore}
                                 className="mf-btn-secondary mt-4 !text-[color:var(--mf-warning)]"

--- a/components/patient-action-modal.tsx
+++ b/components/patient-action-modal.tsx
@@ -79,8 +79,7 @@ export default function PatientActionModal({ isOpen, onClose, onConfirm, patient
                         <div className="mf-alert mf-alert-critical">
                             <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0" />
                             <p>
-                                Il paziente verrà spostato nel <strong>Cestino</strong>.
-                                Potrai ripristinarlo entro 30 giorni, dopodiché verrà eliminato definitivamente.
+                                Il paziente verrà spostato nel <strong>Cestino</strong> e potrà essere ripristinato da lì.
                             </p>
                         </div>
                         <div>

--- a/docs/openapi/contract-policy.json
+++ b/docs/openapi/contract-policy.json
@@ -172,6 +172,11 @@
       "change": "PUT /api/v1/network/patients/{id}/observations/{observationId} request changed",
       "trackingIssue": "WUL-40",
       "reason": "Additive optional reference-range fields accepted on observation update (S6): existing payloads remain valid."
+    },
+    {
+      "change": "DELETE /api/v1/patients/{id} request changed",
+      "trackingIssue": "WUL-306",
+      "reason": "Additive optional deletionReason accepted on patient soft-delete tombstones; existing version-only payloads remain valid."
     }
   ]
 }

--- a/docs/openapi/mediflow-v1.yaml
+++ b/docs/openapi/mediflow-v1.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: MediFlow Local API v1
-  version: 1.17.0
+  version: 1.18.0
   summary: Stable patient contract plus executable home-base network slice with explicit pairing review, paired-client auth boundary, ambulatory scope options, scoped remote patient, cross-patient agenda and diary reads, therapy, checkup, observation, and catalog read boundaries, replica planning state, explicit identity summary, and declarative AI runtime summary for the local `/api/v1` surface.
   description: |
     OpenAPI contract for the client-facing local API defined by ADR 0010.
@@ -126,6 +126,7 @@ paths:
                 value:
                   version: 7
                   isArchived: true
+                  archiveReason: ENC:opaque-archive-reason
               updateDemographics:
                 value:
                   version: 7
@@ -180,6 +181,7 @@ paths:
               deletePatient:
                 value:
                   version: 7
+                  deletionReason: ENC:opaque-deletion-reason
       responses:
         '200':
           description: Patient deleted.
@@ -1460,6 +1462,7 @@ paths:
                 value:
                   version: 7
                   isArchived: true
+                  archiveReason: ENC:opaque-archive-reason
       responses:
         '200':
           description: Patient updated through the paired boundary.
@@ -3987,6 +3990,16 @@ components:
           type:
             - string
             - 'null'
+        archiveReason:
+          type:
+            - string
+            - 'null'
+          description: Sealed opaque archive reason beginning with `ENC:`.
+        archiveNote:
+          type:
+            - string
+            - 'null'
+          description: Sealed optional archive note beginning with `ENC:`.
         notes:
           type:
             - string
@@ -4844,6 +4857,16 @@ components:
           type:
             - string
             - 'null'
+        archiveReason:
+          type:
+            - string
+            - 'null'
+          description: Sealed opaque archive reason beginning with `ENC:`.
+        archiveNote:
+          type:
+            - string
+            - 'null'
+          description: Sealed optional archive note beginning with `ENC:`.
         notes:
           type:
             - string
@@ -4945,6 +4968,10 @@ components:
         version:
           type: integer
           minimum: 1
+        deletionReason:
+          type: string
+          minLength: 1
+          description: Sealed optional deletion reason beginning with `ENC:`.
     NetworkPatientDeleteRequest:
       allOf:
         - $ref: '#/components/schemas/PatientDeleteRequest'

--- a/docs/openapi/mediflow-v1.yaml
+++ b/docs/openapi/mediflow-v1.yaml
@@ -176,7 +176,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatientDeleteRequest'
+              $ref: '#/components/schemas/PatientSoftDeleteRequest'
             examples:
               deletePatient:
                 value:
@@ -4968,10 +4968,16 @@ components:
         version:
           type: integer
           minimum: 1
-        deletionReason:
-          type: string
-          minLength: 1
-          description: Sealed optional deletion reason beginning with `ENC:`.
+    PatientSoftDeleteRequest:
+      allOf:
+        - $ref: '#/components/schemas/PatientDeleteRequest'
+        - type: object
+          additionalProperties: false
+          properties:
+            deletionReason:
+              type: string
+              minLength: 1
+              description: Sealed optional deletion reason beginning with `ENC:`.
     NetworkPatientDeleteRequest:
       allOf:
         - $ref: '#/components/schemas/PatientDeleteRequest'

--- a/drizzle/0019_patient_archive_reasons.sql
+++ b/drizzle/0019_patient_archive_reasons.sql
@@ -1,0 +1,3 @@
+/* @Codex */
+ALTER TABLE `patients` ADD COLUMN `archive_reason` text;
+ALTER TABLE `patients` ADD COLUMN `archive_note` text;

--- a/lib/api/v1/types.ts
+++ b/lib/api/v1/types.ts
@@ -36,6 +36,10 @@ export type PatientDetail = {
     monitoringProfile: string | null;
     /* @Codex */
     statusReason: string | null;
+    /* @Codex */
+    archiveReason: string | null;
+    /* @Codex */
+    archiveNote: string | null;
     notes: string | null;
     /* @Codex */
     aiSummary: string | null;

--- a/lib/db-server.ts
+++ b/lib/db-server.ts
@@ -122,6 +122,8 @@ function applySchemaGuards() {
         // WUL-306 (ADR 0066): soft-delete tombstone columns, additive and idempotent
         ensureColumn('patients', 'deleted_at', 'deleted_at INTEGER');
         ensureColumn('patients', 'deletion_reason', 'deletion_reason TEXT');
+        ensureColumn('patients', 'archive_reason', 'archive_reason TEXT');
+        ensureColumn('patients', 'archive_note', 'archive_note TEXT');
         // S1: ciclo di vita insight (staleness). Additive e idempotenti.
         ensureColumn('patients', 'ai_summary_generated_at', 'ai_summary_generated_at INTEGER');
         ensureColumn('patients', 'ai_summary_context_hash', 'ai_summary_context_hash TEXT');

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -111,6 +111,8 @@ export interface Patient {
     createdAt: Date;
     deletedAt?: Date;
     deletionReason?: string;
+    archiveReason?: string | null;
+    archiveNote?: string | null;
     aiSummary?: string;
     // Ciclo di vita dell'insight: quando e stato generato e hash deterministico del
     // contesto clinico su cui poggia. Non PHI (id + timestamp), quindi non cifrati.
@@ -192,7 +194,7 @@ export interface SissHandoffEvent {
 // Fields that should be encrypted for each table
 const ENCRYPTED_FIELDS: Record<string, string[]> = {
     /* @Codex */
-    patients: ['address', 'phone', 'caregiver', 'exemptions', 'diagnoses', 'statusReason', 'notes', 'aiSummary', 'documentInsights', 'archiveNote', 'deletionReason'],
+    patients: ['address', 'phone', 'caregiver', 'exemptions', 'diagnoses', 'statusReason', 'notes', 'aiSummary', 'documentInsights', 'archiveReason', 'archiveNote', 'deletionReason'],
     entries: ['title', 'content', 'metadata', 'attachments', 'deletionReason'],
     therapies: ['motivation', 'deletionReason'],
     checkups: ['notes'],
@@ -441,10 +443,13 @@ class ApiTable<T> {
 
         const init: RequestInit = { method: 'DELETE' };
         if (typeof options?.version === 'number' || typeof options?.deletionReason === 'string') {
+            const deletionReason = typeof options?.deletionReason === 'string'
+                ? await this.encryptDeleteField('deletionReason', options.deletionReason)
+                : undefined;
             init.headers = { 'Content-Type': 'application/json' };
             init.body = JSON.stringify({
                 ...(typeof options?.version === 'number' ? { version: options.version } : {}),
-                ...(typeof options?.deletionReason === 'string' ? { deletionReason: options.deletionReason } : {}),
+                ...(typeof deletionReason === 'string' ? { deletionReason } : {}),
             });
         }
 
@@ -628,6 +633,16 @@ class ApiTable<T> {
     }
 
     // --- Encryption Helpers ---
+
+    /* @Codex */
+    private async encryptDeleteField(field: string, value: string): Promise<string> {
+        const fields = ENCRYPTED_FIELDS[this.tableName];
+        const key = this.getMasterKey();
+        if (!fields?.includes(field) || !key || !value) return value;
+
+        const { iv, data } = await encryptData(value, key);
+        return `ENC:${iv}:${data}`;
+    }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private async encryptItem(item: any, isPartial = false): Promise<any> {

--- a/lib/network-patient-lifecycle.ts
+++ b/lib/network-patient-lifecycle.ts
@@ -64,7 +64,7 @@ function hasOwn(input: Record<string, unknown>, key: string): boolean {
     return Object.prototype.hasOwnProperty.call(input, key);
 }
 
-function isSealedValue(value: unknown): boolean {
+export function isSealedValue(value: unknown): boolean {
     return typeof value === 'string' && value.startsWith('ENC:');
 }
 

--- a/lib/network-patient-read.ts
+++ b/lib/network-patient-read.ts
@@ -46,6 +46,8 @@ function toPatientDetail(patient: typeof patients.$inferSelect): PatientDetail {
         diagnoses: patient.diagnoses ?? null,
         monitoringProfile: patient.monitoringProfile ?? null,
         statusReason: patient.statusReason ?? null,
+        archiveReason: patient.archiveReason ?? null,
+        archiveNote: patient.archiveNote ?? null,
         notes: patient.notes ?? null,
         aiSummary: patient.aiSummary ?? null,
         aiSummaryGeneratedAt: toIsoString(patient.aiSummaryGeneratedAt),

--- a/lib/network-patient-write.test.ts
+++ b/lib/network-patient-write.test.ts
@@ -1,0 +1,108 @@
+/* @Codex */
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import Database from 'better-sqlite3';
+
+import { ambulatories, patients, patientsToAmbulatories } from './schema';
+
+const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'mediflow-network-patient-write-'));
+process.env.MEDIFLOW_DATA_DIR = DATA_DIR;
+
+function bootstrapDatabase(): void {
+    const sqlite = new Database(path.join(DATA_DIR, 'medical.db'));
+    try {
+        const migrationsDir = path.join(ROOT_DIR, 'drizzle');
+        const migrationFiles = fs
+            .readdirSync(migrationsDir)
+            .filter((file) => file.endsWith('.sql'))
+            .sort((left, right) => left.localeCompare(right));
+        for (const fileName of migrationFiles) {
+            const sql = fs
+                .readFileSync(path.join(migrationsDir, fileName), 'utf8')
+                .replace(/^-->\s+statement-breakpoint\s*$/gm, '');
+            if (sql.trim().length > 0) sqlite.exec(sql);
+        }
+    } finally {
+        sqlite.close();
+    }
+}
+
+bootstrapDatabase();
+
+const { dbServer } = await import('./db-server.ts');
+const { updateNetworkScopedPatient } = await import('./network-patient-write.ts');
+
+const SCOPE_AMBULATORY = 'amb-write-scope';
+const PATIENT_ID = 'patient-write-1';
+
+function makeContext() {
+    return {
+        request: new Request('https://localhost/api/v1/network/patients/' + PATIENT_ID),
+        patientId: PATIENT_ID,
+        scopeAmbulatoryId: SCOPE_AMBULATORY,
+        pairedClient: { clientId: 'client-test' } as never,
+        session: { userId: 'user-test' } as never,
+    };
+}
+
+function resetDatabase(): void {
+    dbServer.delete(patientsToAmbulatories).run();
+    dbServer.delete(patients).run();
+    dbServer.delete(ambulatories).run();
+    dbServer.insert(ambulatories).values([{ id: SCOPE_AMBULATORY, name: 'Ambulatorio Write', type: 'live' }]).run();
+    dbServer.insert(patients).values([{
+        id: PATIENT_ID,
+        firstName: 'Ada',
+        lastName: 'Sealed',
+        taxCode: 'ADASEALED01',
+        archiveReason: 'ENC:iv:previous-reason',
+        version: 3,
+    }]).run();
+    dbServer.insert(patientsToAmbulatories).values([{ patientId: PATIENT_ID, ambulatoryId: SCOPE_AMBULATORY }]).run();
+}
+
+test('network update rejects plaintext archive reason and note', async () => {
+    resetDatabase();
+    for (const body of [
+        { version: 3, archiveReason: 'motivo in chiaro' },
+        { version: 3, archiveNote: 'nota in chiaro' },
+    ]) {
+        const result = await updateNetworkScopedPatient(makeContext(), body);
+        assert.equal(result.status, 400);
+        assert.deepEqual(result.value, { error: 'Network update requires sealed archive fields' });
+    }
+    const row = dbServer.select().from(patients).all()[0];
+    assert.equal(row.archiveReason, 'ENC:iv:previous-reason');
+    assert.equal(row.version, 3);
+});
+
+test('network update accepts sealed archive fields and null clearing', async () => {
+    resetDatabase();
+    const sealed = await updateNetworkScopedPatient(makeContext(), {
+        version: 3,
+        isArchived: true,
+        archiveReason: 'ENC:iv:new-reason',
+        archiveNote: 'ENC:iv:new-note',
+    });
+    assert.equal(sealed.status, 200);
+    let row = dbServer.select().from(patients).all()[0];
+    assert.equal(row.archiveReason, 'ENC:iv:new-reason');
+    assert.equal(row.archiveNote, 'ENC:iv:new-note');
+    assert.equal(row.version, 4);
+
+    const cleared = await updateNetworkScopedPatient(makeContext(), {
+        version: 4,
+        isArchived: false,
+        archiveReason: null,
+        archiveNote: null,
+    });
+    assert.equal(cleared.status, 200);
+    row = dbServer.select().from(patients).all()[0];
+    assert.equal(row.archiveReason, null);
+    assert.equal(row.archiveNote, null);
+});

--- a/lib/network-patient-write.ts
+++ b/lib/network-patient-write.ts
@@ -11,6 +11,8 @@ import {
 } from './security/audit';
 /* @Codex */
 import { dbServer } from './db-server';
+import { isSealedValue } from './network-patient-lifecycle';
+
 import { upsertPrimaryAmbulatoryMembership } from './patient-ambulatory-membership';
 /* @Codex */
 import { buildPatientVersionConflictPayload, parseExpectedVersion } from './patient-concurrency';
@@ -29,6 +31,10 @@ import type { ServerSession } from './security/server-session';
 export const NETWORK_PATIENT_WRITE_CAPABILITY = 'network.replica.write-patient-profile';
 /* @Codex */
 export const NETWORK_FORBIDDEN_PATIENT_WRITE_FIELDS = new Set(['aiSummary', 'documentInsights']);
+
+// I campi motivazione arrivano sigillati dal client (ENC:); l'host non li
+// decodifica e non deve accettarli in chiaro da un client paired.
+export const NETWORK_UPDATE_SEALED_PATIENT_FIELDS = ['archiveReason', 'archiveNote'] as const;
 
 type NetworkPatientMutationResponse =
     | { status: 200; value: { success: true } }
@@ -79,6 +85,16 @@ function validateNetworkPatientMutationBoundary(
                 error: 'Network scope violation',
             },
         };
+    }
+
+    for (const field of NETWORK_UPDATE_SEALED_PATIENT_FIELDS) {
+        const value = body[field];
+        if (value !== undefined && value !== null && !isSealedValue(value)) {
+            return {
+                status: 400,
+                value: { error: 'Network update requires sealed archive fields' },
+            };
+        }
     }
 
     return null;

--- a/lib/patient-lifecycle.test.ts
+++ b/lib/patient-lifecycle.test.ts
@@ -194,3 +194,35 @@ test('deletedAt and deletionReason are not forgeable through the PUT whitelist',
     assert.equal('deletedAt' in normalized.values, false, 'PUT must never write deletedAt');
     assert.equal('deletionReason' in normalized.values, false, 'PUT must never write deletionReason');
 });
+
+test('archive reason fields are writeable and cleared on restore from archive', () => {
+    const archived = normalizePatientUpdateInput(
+        {
+            version: 4,
+            isArchived: true,
+            archiveReason: 'deceased',
+            archiveNote: null,
+        },
+        { expectedVersion: 4 }
+    );
+
+    assert.equal(archived.ok, true);
+    if (!archived.ok) return;
+    assert.equal(archived.values.archiveReason, 'deceased');
+    assert.equal(archived.values.archiveNote, null);
+
+    const restored = normalizePatientUpdateInput(
+        {
+            version: 5,
+            isArchived: false,
+            archiveReason: 'deceased',
+            archiveNote: 'stale',
+        },
+        { expectedVersion: 5 }
+    );
+
+    assert.equal(restored.ok, true);
+    if (!restored.ok) return;
+    assert.equal(restored.values.archiveReason, null);
+    assert.equal(restored.values.archiveNote, null);
+});

--- a/lib/patient-write-normalization.test.ts
+++ b/lib/patient-write-normalization.test.ts
@@ -115,6 +115,8 @@ test('normalizePatientUpdateInput clears nullable string fields when null is sen
         documentInsights: null,
         monitoringProfile: null,
         statusReason: null,
+        archiveReason: null,
+        archiveNote: null,
         ambulatoryId: null,
     }, {
         expectedVersion: 5,
@@ -131,8 +133,44 @@ test('normalizePatientUpdateInput clears nullable string fields when null is sen
     assert.equal(result.values.documentInsights, null);
     assert.equal(result.values.monitoringProfile, null);
     assert.equal(result.values.statusReason, null);
+    assert.equal(result.values.archiveReason, null);
+    assert.equal(result.values.archiveNote, null);
     assert.equal(result.values.ambulatoryId, null);
     assert.equal(result.values.version, 6);
+});
+
+test('normalizePatientUpdateInput accepts archive reason fields', () => {
+    const result = normalizePatientUpdateInput({
+        version: 5,
+        isArchived: true,
+        archiveReason: 'assigned_mmg',
+        archiveNote: 'Cambio medico',
+    }, {
+        expectedVersion: 5,
+    });
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+
+    assert.equal(result.values.isArchived, true);
+    assert.equal(result.values.archiveReason, 'assigned_mmg');
+    assert.equal(result.values.archiveNote, 'Cambio medico');
+});
+
+test('normalizePatientUpdateInput clears archive reason fields on unarchive', () => {
+    const result = normalizePatientUpdateInput({
+        version: 5,
+        isArchived: false,
+    }, {
+        expectedVersion: 5,
+    });
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+
+    assert.equal(result.values.isArchived, false);
+    assert.equal(result.values.archiveReason, null);
+    assert.equal(result.values.archiveNote, null);
 });
 
 test('normalizePatientUpdateInput leaves omitted nullable fields untouched', () => {

--- a/lib/patient-write-normalization.ts
+++ b/lib/patient-write-normalization.ts
@@ -152,6 +152,8 @@ export function normalizePatientUpdateInput(
         notes: normalizeNullableStringField(body.notes),
         monitoringProfile: normalizeNullableStringField(body.monitoringProfile),
         statusReason: normalizeNullableStringField(body.statusReason),
+        archiveReason: normalizeNullableStringField(body.archiveReason),
+        archiveNote: normalizeNullableStringField(body.archiveNote),
         aiSummary: normalizeNullableStringField(body.aiSummary),
         aiSummaryGeneratedAt: normalizeOptionalTimestampField(body.aiSummaryGeneratedAt),
         aiSummaryContextHash: normalizeNullableStringField(body.aiSummaryContextHash),
@@ -174,6 +176,11 @@ export function normalizePatientUpdateInput(
     const normalizedDiagnoses = normalizeStructuredPatientField(body.diagnoses, { allowUndefined: true });
     if (normalizedDiagnoses !== undefined) {
         updateValues.diagnoses = normalizedDiagnoses;
+    }
+
+    if (body.isArchived === false) {
+        updateValues.archiveReason = null;
+        updateValues.archiveNote = null;
     }
 
     if (!hasPatientUpdatableField(updateValues)) {

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -58,6 +58,10 @@ export const patients = sqliteTable('patients', {
     documentInsights: text('document_insights'), // JSON array of DocumentInsight
     isAdi: integer('is_adi', { mode: 'boolean' }).default(false),
     isArchived: integer('is_archived', { mode: 'boolean' }).default(false),
+    /* @Codex */
+    archiveReason: text('archive_reason'),
+    /* @Codex */
+    archiveNote: text('archive_note'),
     // WUL-306 (ADR 0066): soft-delete tombstone, same lifecycle as entries/therapies/checkups
     deletedAt: integer('deleted_at', { mode: 'timestamp' }),
     deletionReason: text('deletion_reason'),

--- a/scripts/patient-soft-delete.test.mjs
+++ b/scripts/patient-soft-delete.test.mjs
@@ -30,7 +30,8 @@ test('patient DELETE routes write a version-guarded tombstone instead of a hard 
         assert.doesNotMatch(source, /\.delete\(patients\)/, `${route.file} must not hard-delete patients`);
 
         const deleteBlock = handlerSource(source, 'DELETE');
-        assert.match(deleteBlock, new RegExp(`buildPatientTombstoneValues\\(expectedVersion, '${route.deletionReason}'\\)`), `${route.file} DELETE must tombstone with reason ${route.deletionReason}`);
+        assert.match(deleteBlock, new RegExp(`const deletionReason = parsePatientDeletionReason\\(body, '${route.deletionReason}'\\)`), `${route.file} DELETE must parse the optional delete reason with default ${route.deletionReason}`);
+        assert.match(deleteBlock, /buildPatientTombstoneValues\(expectedVersion, deletionReason\)/, `${route.file} DELETE must tombstone with the parsed reason`);
         assert.match(deleteBlock, /eq\(patients\.version, expectedVersion\)/, `${route.file} DELETE must stay version-guarded`);
         assert.match(deleteBlock, /activePatients\(\)/, `${route.file} DELETE must not re-delete tombstones`);
         assert.match(deleteBlock, /buildPatientVersionConflictPayload\(/, `${route.file} DELETE must keep the 409 payload`);


### PR DESCRIPTION
## Motivazioni di archiviazione ed eliminazione persistite davvero

Il modal paziente raccoglieva archiveReason, archiveNote e deletionReason e poi li scartava. Questo fix chiude il giro:

- **Archivia**: motivo e nota persistiti nelle colonne nuove `archive_reason` e `archive_note`, cifrate client-side, azzerate alla de-archiviazione.
- **Soft-delete**: la deletionReason scritta dall'operatore viene cifrata dal client e persistita al posto della costante `web-delete` (fallback invariato quando il body manca); `ApiTable.delete` cifra la reason prima dell'invio.
- **Copy onesta**: il cestino non promette piu i 30 giorni che nessuna purge automatica mantiene.
- **Contratto**: migrazione `0019`, guard runtime idempotenti per le colonne nuove, OpenAPI 1.18.0 con i campi documentati come blob sigillati `ENC:` che il server persiste senza decodificare.

**Impilata su #10** (base `feat/apple-parity-wave3`): al merge di quella GitHub ritargetta questa su `main`. Ordine di merge: #10 prima, questa dopo.

### Verifica (run reali, rieseguiti in verifica indipendente)
562 unit TS; `patient-lifecycle` 5/5; `patient-soft-delete` 15/15 e 10/10; typecheck, contract guard OpenAPI, never-regress e claims guard verdi. Il lavoro nasce dal ledger locale verificato (commit 8bf098b60) e viene ri-applicato concettualmente sullo stato corrente del contratto, non copiato alla cieca.

🤖 Generated with [Claude Code](https://claude.com/claude-code)