### PR TITLE
fix: guardia sealed su tutti i campi sensibili dell'update paziente paired

### DIFF
--- a/docs/openapi/mediflow-v1.yaml
+++ b/docs/openapi/mediflow-v1.yaml
@@ -1457,7 +1457,7 @@ paths:
               updateNetworkPhone:
                 value:
                   version: 7
-                  phone: "+39 333 1234567"
+                  phone: ENC:opaque-phone
               archiveNetworkPatient:
                 value:
                   version: 7
@@ -3966,22 +3966,27 @@ components:
           type:
             - string
             - 'null'
+          description: Sealed opaque address beginning with `ENC:`; the paired network boundary rejects plaintext.
         phone:
           type:
             - string
             - 'null'
+          description: Sealed opaque phone beginning with `ENC:`; the paired network boundary rejects plaintext.
         caregiver:
           type:
             - string
             - 'null'
+          description: Sealed opaque caregiver beginning with `ENC:`; the paired network boundary rejects plaintext.
         exemptions:
           type:
             - string
             - 'null'
+          description: Sealed opaque exemptions payload beginning with `ENC:`; the paired network boundary rejects plaintext.
         diagnoses:
           type:
             - string
             - 'null'
+          description: Sealed opaque diagnoses payload beginning with `ENC:`; the paired network boundary rejects plaintext.
         monitoringProfile:
           type:
             - string
@@ -3990,20 +3995,22 @@ components:
           type:
             - string
             - 'null'
+          description: Sealed opaque status reason beginning with `ENC:`; the paired network boundary rejects plaintext.
         archiveReason:
           type:
             - string
             - 'null'
-          description: Sealed opaque archive reason beginning with `ENC:`.
+          description: Sealed opaque archive reason beginning with `ENC:`; the paired network boundary rejects plaintext.
         archiveNote:
           type:
             - string
             - 'null'
-          description: Sealed optional archive note beginning with `ENC:`.
+          description: Sealed optional archive note beginning with `ENC:`; the paired network boundary rejects plaintext.
         notes:
           type:
             - string
             - 'null'
+          description: Sealed opaque notes beginning with `ENC:`; the paired network boundary rejects plaintext.
         aiSummary:
           type:
             - string
@@ -4833,22 +4840,27 @@ components:
           type:
             - string
             - 'null'
+          description: Sealed opaque address beginning with `ENC:`; the paired network boundary rejects plaintext.
         phone:
           type:
             - string
             - 'null'
+          description: Sealed opaque phone beginning with `ENC:`; the paired network boundary rejects plaintext.
         caregiver:
           type:
             - string
             - 'null'
+          description: Sealed opaque caregiver beginning with `ENC:`; the paired network boundary rejects plaintext.
         exemptions:
           type:
             - string
             - 'null'
+          description: Sealed opaque exemptions payload beginning with `ENC:`; the paired network boundary rejects plaintext.
         diagnoses:
           type:
             - string
             - 'null'
+          description: Sealed opaque diagnoses payload beginning with `ENC:`; the paired network boundary rejects plaintext.
         monitoringProfile:
           type:
             - string
@@ -4857,20 +4869,22 @@ components:
           type:
             - string
             - 'null'
+          description: Sealed opaque status reason beginning with `ENC:`; the paired network boundary rejects plaintext.
         archiveReason:
           type:
             - string
             - 'null'
-          description: Sealed opaque archive reason beginning with `ENC:`.
+          description: Sealed opaque archive reason beginning with `ENC:`; the paired network boundary rejects plaintext.
         archiveNote:
           type:
             - string
             - 'null'
-          description: Sealed optional archive note beginning with `ENC:`.
+          description: Sealed optional archive note beginning with `ENC:`; the paired network boundary rejects plaintext.
         notes:
           type:
             - string
             - 'null'
+          description: Sealed opaque notes beginning with `ENC:`; the paired network boundary rejects plaintext.
         aiSummary:
           type:
             - string

--- a/lib/network-patient-lifecycle.test.ts
+++ b/lib/network-patient-lifecycle.test.ts
@@ -45,6 +45,25 @@ test('validateNetworkPatientCreateBody rejects plaintext sensitive create fields
     assert.deepEqual(result.value, { error: 'Network create requires sealed sensitive fields' });
 });
 
+test('validateNetworkPatientCreateBody rejects plaintext archive fields', () => {
+    for (const field of ['archiveReason', 'archiveNote']) {
+        const result = validateNetworkPatientCreateBody(
+            {
+                firstName: 'Ada',
+                lastName: 'Lovelace',
+                taxCode: 'LVLDAA',
+                [field]: 'valore in chiaro',
+            },
+            'amb-1',
+        );
+
+        assert.equal(result.ok, false);
+        if (result.ok) return;
+        assert.equal(result.status, 400);
+        assert.deepEqual(result.value, { error: 'Network create requires sealed sensitive fields' });
+    }
+});
+
 test('validateNetworkPatientCreateBody rejects AI and server-controlled fields', () => {
     const aiResult = validateNetworkPatientCreateBody(
         {

--- a/lib/network-patient-lifecycle.ts
+++ b/lib/network-patient-lifecycle.ts
@@ -50,6 +50,8 @@ const NETWORK_CREATE_SENSITIVE_FIELDS = [
     'diagnoses',
     'statusReason',
     'notes',
+    'archiveReason',
+    'archiveNote',
 ] as const;
 
 const NETWORK_CREATE_SERVER_CONTROLLED_FIELDS = [

--- a/lib/network-patient-write.test.ts
+++ b/lib/network-patient-write.test.ts
@@ -66,26 +66,36 @@ function resetDatabase(): void {
     dbServer.insert(patientsToAmbulatories).values([{ patientId: PATIENT_ID, ambulatoryId: SCOPE_AMBULATORY }]).run();
 }
 
-test('network update rejects plaintext archive reason and note', async () => {
+test('network update rejects plaintext sensitive fields', async () => {
     resetDatabase();
-    for (const body of [
-        { version: 3, archiveReason: 'motivo in chiaro' },
-        { version: 3, archiveNote: 'nota in chiaro' },
+    for (const field of [
+        'address',
+        'phone',
+        'caregiver',
+        'exemptions',
+        'diagnoses',
+        'notes',
+        'statusReason',
+        'archiveReason',
+        'archiveNote',
     ]) {
+        const body = { version: 3, [field]: 'valore in chiaro' };
         const result = await updateNetworkScopedPatient(makeContext(), body);
         assert.equal(result.status, 400);
-        assert.deepEqual(result.value, { error: 'Network update requires sealed archive fields' });
+        assert.deepEqual(result.value, { error: 'Network update requires sealed sensitive fields' });
     }
     const row = dbServer.select().from(patients).all()[0];
     assert.equal(row.archiveReason, 'ENC:iv:previous-reason');
     assert.equal(row.version, 3);
 });
 
-test('network update accepts sealed archive fields and null clearing', async () => {
+test('network update accepts sealed sensitive fields and null clearing', async () => {
     resetDatabase();
     const sealed = await updateNetworkScopedPatient(makeContext(), {
         version: 3,
         isArchived: true,
+        phone: 'ENC:iv:new-phone',
+        diagnoses: 'ENC:iv:new-diagnoses',
         archiveReason: 'ENC:iv:new-reason',
         archiveNote: 'ENC:iv:new-note',
     });
@@ -93,6 +103,8 @@ test('network update accepts sealed archive fields and null clearing', async () 
     let row = dbServer.select().from(patients).all()[0];
     assert.equal(row.archiveReason, 'ENC:iv:new-reason');
     assert.equal(row.archiveNote, 'ENC:iv:new-note');
+    assert.equal(row.phone, 'ENC:iv:new-phone');
+    assert.equal(row.diagnoses, 'ENC:iv:new-diagnoses');
     assert.equal(row.version, 4);
 
     const cleared = await updateNetworkScopedPatient(makeContext(), {

--- a/lib/network-patient-write.ts
+++ b/lib/network-patient-write.ts
@@ -32,9 +32,19 @@ export const NETWORK_PATIENT_WRITE_CAPABILITY = 'network.replica.write-patient-p
 /* @Codex */
 export const NETWORK_FORBIDDEN_PATIENT_WRITE_FIELDS = new Set(['aiSummary', 'documentInsights']);
 
-// I campi motivazione arrivano sigillati dal client (ENC:); l'host non li
+// I campi sensibili arrivano sigillati dal client (ENC:); l'host non li
 // decodifica e non deve accettarli in chiaro da un client paired.
-export const NETWORK_UPDATE_SEALED_PATIENT_FIELDS = ['archiveReason', 'archiveNote'] as const;
+export const NETWORK_UPDATE_SEALED_PATIENT_FIELDS = [
+    'address',
+    'phone',
+    'caregiver',
+    'exemptions',
+    'diagnoses',
+    'notes',
+    'statusReason',
+    'archiveReason',
+    'archiveNote',
+] as const;
 
 type NetworkPatientMutationResponse =
     | { status: 200; value: { success: true } }
@@ -92,7 +102,7 @@ function validateNetworkPatientMutationBoundary(
         if (value !== undefined && value !== null && !isSealedValue(value)) {
             return {
                 status: 400,
-                value: { error: 'Network update requires sealed archive fields' },
+                value: { error: 'Network update requires sealed sensitive fields' },
             };
         }
     }

--- a/scripts/network-home-base-write.test.mjs
+++ b/scripts/network-home-base-write.test.mjs
@@ -56,7 +56,7 @@ test('paired patient profile write requires write capability, session, scope, an
             },
             body: {
                 version: 1,
-                phone: '+39 333 0000001',
+                phone: 'ENC:smoke:phone-1',
             },
         });
         assert.equal(readOnlyWrite.response.status, 403);
@@ -65,7 +65,7 @@ test('paired patient profile write requires write capability, session, scope, an
             headers: pairedHeaders(writeClient),
             body: {
                 version: 1,
-                phone: '+39 333 0000001',
+                phone: 'ENC:smoke:phone-1',
             },
         });
         assert.equal(missingSession.response.status, 401);
@@ -77,7 +77,7 @@ test('paired patient profile write requires write capability, session, scope, an
             },
             body: {
                 version: 1,
-                phone: '+39 333 0000001',
+                phone: 'ENC:smoke:phone-1',
                 isArchived: true,
             },
         });
@@ -91,7 +91,7 @@ test('paired patient profile write requires write capability, session, scope, an
             },
         });
         assert.equal(detail.response.status, 200);
-        assert.equal(detail.json?.phone, '+39 333 0000001');
+        assert.equal(detail.json?.phone, 'ENC:smoke:phone-1');
         assert.equal(detail.json?.isArchived, true);
         assert.equal(detail.json?.version, 2);
 
@@ -102,7 +102,7 @@ test('paired patient profile write requires write capability, session, scope, an
             },
             body: {
                 version: 1,
-                phone: '+39 333 0000002',
+                phone: 'ENC:smoke:phone-2',
             },
         });
         assert.equal(conflict.response.status, 409);
@@ -181,7 +181,7 @@ test('disabling home-base mode makes paired-client tokens inert until re-enabled
             },
             body: {
                 version: 1,
-                phone: '+39 333 0000009',
+                phone: 'ENC:smoke:phone-9',
             },
         });
         assert.equal(gatedWrite.response.status, 403);
@@ -205,7 +205,7 @@ test('disabling home-base mode makes paired-client tokens inert until re-enabled
             },
             body: {
                 version: 1,
-                phone: '+39 333 0000009',
+                phone: 'ENC:smoke:phone-9',
             },
         });
         assert.equal(update.response.status, 200);


### PR DESCRIPTION
## Chiusura del gap zero-knowledge sull'update paired

Emerso durante la review di #11: il PUT paired `/api/v1/network/patients/{id}` applicava il controllo sealed solo ai campi archivio introdotti li'. I campi cifrati PRE-esistenti (`address`, `phone`, `caregiver`, `exemptions`, `diagnoses`, `notes`, `statusReason`) passavano dal normalizzatore condiviso senza verifica: un client paired poteva persistirli in chiaro, rompendo l'invariante zero-knowledge at-rest.

### Cosa cambia
- La guardia dell'update copre ora tutti i campi cifrati scrivibili (9 in totale, inclusa `diagnoses` che il normalizzatore accetta), con la stessa semantica del create: 400 sul plaintext, null ammesso per l'azzeramento, blob `ENC:` persistiti opachi.
- Verificato che il client Apple paired sigilla gia' ogni campo che invia (`encryptedStringPatchValue` e affini): nessun impatto sul client reale.
- Lo smoke di write inviava un telefono in chiaro sulle PUT paired: corretto lo smoke con valori sigillati, la guardia non si indebolisce.

### Verifica (run reali, rieseguiti in verifica indipendente)
564 unit TS; test dedicato con DB reale sui 9 campi (plaintext respinto senza toccare riga ne' version, sealed persistito, null azzera); smoke `test:network:home-base-write` 2/2; typecheck, contract guard con `--base-ref`, never-regress e claims guard verdi.

**Impilata su #11** (base `fix/patient-archive-delete-reasons`): ordine di merge #10, #11, questa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)