### PR TITLE
fix: versione paziente nelle scritture dell'Archivio Intelligente

### DIFF
--- a/components/document-insights-panel.tsx
+++ b/components/document-insights-panel.tsx
@@ -2,12 +2,14 @@
 
 import { useEffect, useState } from 'react';
 import { FileText, ChevronDown, ChevronUp, Calendar, Sparkles, AlertTriangle, Trash2, Loader2 } from 'lucide-react';
-import { db, DocumentInsight, Patient } from '@/lib/db';
+import { ApiConflictError, db, DocumentInsight, Patient } from '@/lib/db';
 import ReactMarkdown from 'react-markdown';
 import PrivacyBlur from '@/components/privacy-blur';
 import { refreshPatientSummaryIfEnabled, getAiModelLabels } from '@/lib/ai-summary-service';
 import { qualityLabel, documentClassLabel } from '@/lib/ai-labels';
 import { parsePatientDatedRecords } from '@/lib/patient-structured-fields';
+import { notifyDbChange } from '@/lib/live-query';
+import { persistDocumentInsightsArchive } from '@/lib/domain/documents/document-insights-archive';
 import { useToast } from '@/components/ui/toast-provider';
 import { useConfirm } from '@/components/ui/confirm-dialog';
 
@@ -52,13 +54,21 @@ export default function DocumentInsightsPanel({ patient }: DocumentInsightsPanel
 
     /* @Codex */
     const persistArchive = async (nextInsights: DocumentInsight[], action: string | 'all') => {
+        if (typeof patient.version !== 'number') {
+            showToast({
+                tone: 'error',
+                title: 'Versione paziente non disponibile',
+                description: 'Ricarica la pagina e riprova.'
+            });
+            return;
+        }
+
         setBusyAction(action);
 
         try {
-            await db.patients.update(patient.id, {
-                documentInsights: nextInsights,
-                updatedAt: new Date()
-            });
+            await persistDocumentInsightsArchive({
+                updatePatient: db.patients.update.bind(db.patients),
+            }, patient, nextInsights);
 
             setExpandedId((current) => nextInsights.some((insight) => insight.id === current) ? current : null);
 
@@ -74,6 +84,15 @@ export default function DocumentInsightsPanel({ patient }: DocumentInsightsPanel
             }
         } catch (error) {
             console.error('[DocumentInsightsPanel] Archive update failed', error);
+            if (error instanceof ApiConflictError) {
+                notifyDbChange('patients');
+                showToast({
+                    tone: 'error',
+                    title: 'Archivio non aggiornato',
+                    description: 'Il paziente è stato aggiornato altrove. La scheda viene ricaricata, poi riprova.'
+                });
+                return;
+            }
             showToast({
                 tone: 'error',
                 title: 'Aggiornamento non riuscito',

--- a/lib/domain/documents/document-insights-archive.test.ts
+++ b/lib/domain/documents/document-insights-archive.test.ts
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { persistDocumentInsightsArchive } from './document-insights-archive';
+
+test('document insights archive persists with the patient version', async () => {
+    let receivedChanges: Record<string, unknown> | undefined;
+
+    await persistDocumentInsightsArchive({
+        updatePatient: async (_patientId, changes) => {
+            receivedChanges = changes;
+            if (typeof changes.version !== 'number') {
+                throw new Error('Missing required version for patient update');
+            }
+        },
+        now: () => new Date('2026-07-10T10:00:00.000Z'),
+    }, {
+        id: 'patient-document-insights',
+        version: 7,
+    }, []);
+
+    assert.deepEqual(receivedChanges, {
+        documentInsights: [],
+        updatedAt: new Date('2026-07-10T10:00:00.000Z'),
+        version: 7,
+    });
+});

--- a/lib/domain/documents/document-insights-archive.ts
+++ b/lib/domain/documents/document-insights-archive.ts
@@ -1,0 +1,23 @@
+import type { DocumentInsight, Patient } from '../../db';
+
+type DocumentInsightsArchivePatient = Pick<Patient, 'id' | 'version'>;
+
+type DocumentInsightsArchiveDependencies = {
+    updatePatient: (
+        patientId: string,
+        changes: Pick<Partial<Patient>, 'documentInsights' | 'updatedAt' | 'version'>,
+    ) => Promise<void>;
+    now?: () => Date;
+};
+
+export async function persistDocumentInsightsArchive(
+    dependencies: DocumentInsightsArchiveDependencies,
+    patient: DocumentInsightsArchivePatient,
+    nextInsights: DocumentInsight[],
+): Promise<void> {
+    await dependencies.updatePatient(patient.id, {
+        documentInsights: nextInsights,
+        version: patient.version,
+        updatedAt: (dependencies.now ?? (() => new Date()))(),
+    });
+}


### PR DESCRIPTION
Il pannello Archivio Intelligente aggiornava il paziente senza `version`, ma `patients` richiede la scrittura versionata: eliminare un singolo insight o svuotare l'archivio falliva sempre con `Missing required version for patient update`.

Contenuto:
- persistenza estratta in `lib/domain/documents/document-insights-archive.ts`, che invia `version: patient.version` (stesso pattern del percorso gia' corretto di Smart Import);
- gestione del conflitto 409 (`ApiConflictError`): la scheda si riallinea via `notifyDbChange('patients')` e l'utente riceve un toast onesto;
- guardia difensiva se la versione non e' disponibile nel record in memoria;
- test unitario che fissa il contratto (la scrittura porta la versione) e riproduce il fallimento del vecchio payload.

Verifica indipendente sul worktree: 1/1 unit col runner del repo, typecheck pulito, ESLint zero warning, `check:never-regress` verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)