### PR TITLE
docs(parity): definisci il closeout Wave 6

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -55,7 +55,8 @@ MediFlow è un **sistema ibrido locale**:
 Il default resta **local-only sul singolo computer**. Se l'operatore attiva la
 modalita `network-home-base`, lo stesso nodo espone anche `/api/v1/network/*`
 con pairing esplicito, data plane pazienti read-only-first e write limitati a
-profilo/status paziente, diario clinico, terapie, checkup e osservazioni per client trusted su LAN.
+lifecycle/profilo paziente, moduli clinici non-AI, prestazioni, protesica e
+create documentale manuale per client trusted su LAN.
 
 ### Porte locali (default)
 
@@ -99,7 +100,8 @@ MediFlow espone due superfici API:
 - **Network API** (`/api/v1/network/*`):
   - si attiva solo in modalita `network-home-base`
   - resta read-only-first, con write versionati su ciclo di vita paziente (creazione, cestino, ripristino), profilo/status, diario clinico, terapie, checkup, osservazioni, prestazioni e protesica, piu export FHIR generato lato client (nodo keyless), validazione FSE, guardia di revisione e discovery capabilities/identity/node in dual-auth
-  - i cataloghi (farmaci, esenzioni, terminologia, prestazioni) sono esposti in sola lettura; restano esclusi hard delete remoto, attachment remoti, sync, cache offline e campi AI/documentali
+  - i cataloghi (farmaci, esenzioni, terminologia, prestazioni) sono esposti in sola lettura
+  - il dominio documentale consente lettura e create manuale cifrato, riferimenti allegato sigillati e compute deterministici senza persistenza; restano esclusi PUT/DELETE paired degli allegati, artifact document-derived, invocazione AI, hard delete remoto, sync e write offline (ADR 0076)
   - disattivare la modalita non revoca i pairing: i token dei client paired
     diventano inerti e il data plane risponde `403 NETWORK_MODE_DISABLED`
     finche la modalita non viene riattivata
@@ -171,7 +173,7 @@ flowchart TB
   - versionato
   - documentato
   - retrocompatibile all'interno della stessa major
-- `local-only` come default e `network-home-base` come opt-in paired/read-only-first con write paziente, diario, terapie, checkup e osservazioni limitati/versionati.
+- `local-only` come default e `network-home-base` come opt-in paired/read-only-first con write versionati e capability-scoped; le eccezioni documentali seguono ADR 0076.
 - Cancellazione clinica reversibile: il DELETE di pazienti e delle
   sotto-risorse cliniche e un tombstone soft-delete version-guarded; la
   cancellazione fisica passa solo da strumenti amministrativi espliciti e

--- a/README.md
+++ b/README.md
@@ -148,10 +148,15 @@ Il dettaglio completo è nel [CHANGELOG](./CHANGELOG.md).
 MediFlow non vuole raccontare più di quanto possa dimostrare.
 
 - **Nessun cloud obbligatorio**: il default resta locale.
-- **Nessuna app iPad/iPhone dichiarata come già completa**: la direzione multi-device esiste, ma il perimetro operativo attuale è `home-base + paired client`, con approccio read-only-first, cache cifrata e write online limitati a profilo/status, diario, terapie, checkup e osservazioni.
+- **Nessuna app iPad/iPhone dichiarata come già completa**: il perimetro operativo è `home-base + paired client`; lifecycle paziente, moduli clinici non-AI, cataloghi, prestazioni/protesica e upload documentale manuale hanno workflow online governati, mentre cache offline, click-map UI e superfici document-derived restano parziali o host-only.
 - **Nessuna parity Windows/Linux dichiarata oggi**: la 0.7.2 prova il core tri-OS e il runtime di base, non app complete su ogni piattaforma.
 - **Nessuna integrazione SISS/FSE certificata dichiarata senza prove**: il percorso attuale è contestuale e `webapp-assisted`, usando i canali ufficiali; MediFlow non dichiara sincronizzazione FSE, writeback regionale o invio prescrittivo diretto.
 - **Nessuna delega cieca all'AI**: l'AI locale può aiutare, ma non sostituisce revisione, giudizio clinico e responsabilità professionale.
+
+La fotografia post-Wave 5 è versionata in
+[docs/parity-matrix.md](./docs/parity-matrix.md): 30 delle 43 capability per cui
+la parity è un obiettivo sono complete; 13 restano parziali e 21 ulteriori
+capability sono intenzionalmente host-only.
 
 ## Perché open source
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ read_when:
 
 Questo file è il punto di ingresso unico: dove leggere, cosa aggiornare e quale documento prevale.
 
-Ultimo aggiornamento: 2026-07-09
+Ultimo aggiornamento: 2026-07-11
 
 ## 📚 Policy di consultazione (agent)
 
@@ -32,7 +32,7 @@ Approfondimenti utili:
 - Lettura completa dello stato corrente: [docs/STATE_OF_THE_SYSTEM.md](./STATE_OF_THE_SYSTEM.md)
 - FAQ pubbliche e stato sintetico del prodotto: [docs/FAQ.md](./FAQ.md)
 - Walkthrough operativo end-to-end: [docs/walkthrough.md](./walkthrough.md)
-- Parity web/macOS: [docs/parity-matrix.md](./parity-matrix.md)
+- Parity localhost/Apple: [docs/parity-matrix.md](./parity-matrix.md), [docs/apple-parity-matrix.json](./apple-parity-matrix.json) e [docs/apple-wide-qa-manifest.json](./apple-wide-qa-manifest.json)
 - Contratto OpenAPI `/api/v1`: [docs/openapi/mediflow-v1.yaml](./openapi/mediflow-v1.yaml), [docs/openapi/README.md](./openapi/README.md), [docs/adr/0010-openapi-spec-first-for-api-v1.md](./adr/0010-openapi-spec-first-for-api-v1.md), [docs/adr/0052-network-patient-profile-write-boundary.md](./adr/0052-network-patient-profile-write-boundary.md), [docs/adr/0053-network-diary-entry-write-boundary.md](./adr/0053-network-diary-entry-write-boundary.md), [docs/adr/0054-network-therapy-write-boundary.md](./adr/0054-network-therapy-write-boundary.md), [docs/adr/0055-network-checkup-write-boundary.md](./adr/0055-network-checkup-write-boundary.md), [docs/adr/0056-network-observation-write-boundary.md](./adr/0056-network-observation-write-boundary.md)
 - Corpus documentale SISS/FSE 2.0: [docs/siss-fse-docs-corpus.md](./siss-fse-docs-corpus.md)
 - Integrazione ATHENA-style treatment reasoning: [docs/treatment-reasoning-athena-integration.md](./treatment-reasoning-athena-integration.md), [docs/adr/0073-treatment-reasoning-athena-boundary.md](./adr/0073-treatment-reasoning-athena-boundary.md)
@@ -77,7 +77,7 @@ Approfondimenti utili:
 | Write paired checkup | [docs/adr/0055-network-checkup-write-boundary.md](./adr/0055-network-checkup-write-boundary.md) | `CANONICAL` | Slice per read/create/update/soft-delete checkup su `/api/v1/network/patients/{id}/checkups*` con `checkups.version`, capability dedicate, audit PHI-safe e hard delete/AI/documenti fuori scope. |
 | Write paired osservazioni | [docs/adr/0056-network-observation-write-boundary.md](./adr/0056-network-observation-write-boundary.md) | `CANONICAL` | Slice per read/create/update/soft-delete osservazioni su `/api/v1/network/patients/{id}/observations*` con `observations.version`, capability dedicate, audit PHI-safe e hard delete/AI/documenti fuori scope. |
 | Runbook manutenzione OpenAPI | [docs/openapi/README.md](./openapi/README.md) | `SECONDARY` | Workflow operativo per mantenere aggiornata la spec durante lo sviluppo. |
-| Matrice parity web/macOS | [docs/parity-matrix.md](./parity-matrix.md) | `CANONICAL` | Gate capability-by-capability (funzioni/campi/flessibilita/autonomia). |
+| Parity localhost/client Apple | [docs/parity-matrix.md](./parity-matrix.md) | `CANONICAL` | Sintesi post-Wave 5, 64 capability machine-readable, manifest QA e piano Wave 6/closeout. |
 | FAQ pubbliche | [docs/FAQ.md](./FAQ.md) | `SECONDARY` | Sintesi rapida per capire cosa fa oggi MediFlow, quali sono i boundary dichiarati e come orientarsi nel progetto. |
 | Roadmap terminologie/FSE | [docs/FSE2-terminology-roadmap.md](./FSE2-terminology-roadmap.md) | `CANONICAL` | Evoluzione codifiche cliniche e compliance documentale (coerente con ADR 0006). |
 | Matrice baseline ufficiale GTW/FSE | [docs/fse-gtw-baseline-alignment.md](./fse-gtw-baseline-alignment.md) | `CANONICAL` | Gap analysis versionata tra artifact ministeriali `it-fse-support` e stato reale MediFlow. |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,7 +1,14 @@
+---
+summary: "Canonical MediFlow product roadmap and current delivery horizons."
+read_when:
+  - "Changing product direction, release narrative, or Apple parity priorities."
+  - "Separating shipped capabilities from future or policy-gated work."
+---
+
 # 🧭 Roadmap MediFlow
 
 > **Dove siamo e dove vogliamo andare.**
-> v0.7.2 (release corrente, chiude la parità del boundary paired sopra il ramo Apple/native). Ultimo aggiornamento: 2026-07-09.
+> v0.7.2 (release corrente, chiude le Wave 1-5 del boundary/client Apple senza dichiarare parity UI completa). Ultimo aggiornamento: 2026-07-11.
 > Fonte roadmap prodotto canonica (vedi anche [docs/STATE_OF_THE_SYSTEM.md](./STATE_OF_THE_SYSTEM.md) per la lettura completa corrente e [docs/README.md](./README.md) per mappa completa documenti).
 
 > [!NOTE]
@@ -29,8 +36,9 @@ Base tecnica più solida, con flussi documentali e contratti locali molto più e
 * **Compliance locale piu esplicita**: terminology registry locale, baseline GTW/FSE, baseline SISS e pannello prescrizione con handoff controllato.
 * **Stabilizzazione web/core**: `typecheck` canonico, normalizzazione condivisa dei payload paziente e riduzione del carico nei file piu densi.
 
-> Nota: il filone `macOS/parity` non prosegue come delivery incrementale oltre `v0.4.0`.
-> Entra in **riscrittura controllata** della shell nativa, preservando `/api/v1`, TLS locale, cifratura e regole security/local-first.
+> Nota storica: dopo `v0.4.0` il vecchio filone `macOS/parity` è entrato in
+> **riscrittura controllata**. Le Wave 1-5 successive lavorano sul nuovo client
+> universale Apple/home-base, non sullo snapshot legacy.
 
 ---
 
@@ -146,7 +154,7 @@ repository pubblica.
 
 ### Modalita network home-base
 
-* **Nodo centrale locale**: pairing esplicito, capability discovery, data plane read-only e primi write versionati per profilo/status, diario, terapie, checkup e osservazioni sono gia entrati su `main`; restano da estendere UX, replica e altri moduli clinici senza rompere il boundary.
+* **Nodo centrale locale**: pairing esplicito, capability discovery, lifecycle paziente, moduli clinici non-AI, prestazioni/protesica, cataloghi read-only e create documentale manuale sono su `main`; restano da chiudere UX, offline e superfici policy-gated senza rompere il boundary.
 * **Replica e fallback offline**: continuita operativa tra dispositivi con riconciliazione esplicita ancora da promuovere oltre il mirror/snapshot governato.
 * **Runtime AI centralizzabile**: opzione locale di studio per client meno potenti, senza egress cloud e ancora separata dal data plane clinico.
 
@@ -160,6 +168,10 @@ repository pubblica.
 
 * **Apple/native su mainline**: macOS resta il fronte nativo piu avanzato;
   iPhone/iPad proseguono come client paired sopra contratti locali versionati.
+* **Wave 6 / closeout parity**: `WUL-479` governa la matrice canonica; `WUL-401`
+  chiude click-map P6 e convergenza dei moduli core, `WUL-403` rende onesto
+  l'offline degradato, mentre il workflow documentale nativo resta condizionato
+  da ADR 0076 e dagli spike `WUL-417`/`WUL-383`.
 * **Stack voice visit**: `WUL-419`, `WUL-421` e `WUL-422` mantengono transcript e
   bozze sintetiche review-first, separati dall'audio reale e dalla promozione
   runtime.

--- a/docs/STATE_OF_THE_SYSTEM.md
+++ b/docs/STATE_OF_THE_SYSTEM.md
@@ -18,7 +18,7 @@ read_when:
 > prevalgono [AGENTS.md](../AGENTS.md) e
 > [docs/repository-topology.md](./repository-topology.md).
 
-Ultimo aggiornamento: 2026-07-09 (`v0.7.2` mainline)
+Ultimo aggiornamento: 2026-07-11 (`v0.7.2`, closeout parity `WUL-479`)
 
 ---
 
@@ -141,10 +141,12 @@ Il disegno Apple non e "tre app con tre store dati". E una family architecture:
 - client mobili paired, con cache derivata e riconciliazione esplicita quando
   quella parte verra implementata.
 
-Oggi la slice resta read-only-first nel disegno generale: il read pazienti e
-stabile e i write remoti sono limitati/versionati a profilo/status paziente,
-diario clinico, terapie, checkup e osservazioni. Hard delete remoto, cataloghi, sync
-record-level, replica automatica e multi-master sono fuori scope corrente.
+Oggi la slice resta read-only-first nel disegno generale, ma non è più limitata
+ai primi cinque moduli: lifecycle paziente, diario, terapie, checkup,
+osservazioni, prestazioni e protesica hanno write versionati; i cataloghi sono
+read-only e il dominio documentale ammette create manuale cifrato. Hard delete,
+PUT/DELETE paired degli allegati, artifact document-derived, invocazione AI,
+write offline, sync record-level e multi-master restano fuori scope.
 
 Documenti/ADR principali:
 
@@ -280,8 +282,9 @@ Documenti/ADR principali:
    limitato a profilo/status paziente, richiede
    `network.replica.write-patient-profile` e `version`.
 7. `/api/v1/network/patients/{id}/entries*` pubblica read/create/update/soft-delete
-   del diario con capability diary dedicate e `entries.version`, bloccando hard
-   delete, attachment remoti, sync e campi AI/documentali.
+   del diario con capability diary dedicate e `entries.version`; i riferimenti
+   allegato sono ammessi solo sigillati e validati dal client, mentre hard
+   delete, sync e campi AI/document-derived restano bloccati.
 8. Le sotto-risorse cliniche locali condivise `/api/v1/patients/{id}/entries*`,
    `/api/v1/patients/{id}/therapies*`, `/api/v1/patients/{id}/checkups*` e
    `/api/v1/patients/{id}/observations*` mantengono per web/native la stessa
@@ -517,10 +520,20 @@ Disponibile:
 - client iPhone/iPad paired non-AI con cache cifrata degradabile e primi
   workflow online versionati sui moduli core.
 
+Fotografia parity post-Wave 5:
+
+- 64 capability censite: 30 full, 13 partial, 21 host-only, 0 missing-both;
+- tra le 43 capability per cui la parity è un obiettivo, 30 sono full (70%);
+- click-map P6 e convergenza UI macOS restano in `WUL-401`;
+- offline degradato onesto resta in `WUL-403`;
+- Smart Import e invocazione AI paired restano host-only per ADR 0076.
+
+La fonte canonica è [docs/parity-matrix.md](./parity-matrix.md).
+
 Direzione:
 
 - app Windows/Linux e launcher dedicati oltre il core;
-- parity non-AI tramite API;
+- closeout parity tramite `WUL-401`/`WUL-403` e decisione separata per i quattro residui documentali;
 - cache locale cifrata derivata e riconciliazione esplicita.
 
 Fuori scope corrente:

--- a/docs/apple-parity-matrix.json
+++ b/docs/apple-parity-matrix.json
@@ -1,0 +1,657 @@
+{
+  "generated": "2026-07-08",
+  "source": "WUL-479 reconciliation of the 2026-07-08 capability map against Wulfgardr/mediflow public/main",
+  "rows": [
+    {
+      "area": "pazienti",
+      "feature": "Anagrafica paziente: lista, ricerca, view, create, update",
+      "web": "Lista/ricerca/CRUD completo + assign/unassign/move/duplicate/soft-delete/archivia/ripristina (list/create: app/api/patients/route.ts; azioni bulk: app/api/patients/{assign,unassign,move,duplicate}/route.ts, MA il consumer web e' un hook orfano non cablato a UI e move non ha consumer: escluse da W2-finale finche' la web non le espone, decisione spec W2-finale)",
+      "native": "partial: lista+ricerca+view+update+create ANCHE via wire dietro capability lifecycle (HomeBasePatientsClient.createPatient POST network/patients; stub 405 rimosso); soft-delete/archivia/ripristina ora flussi dedicati (vedi riga archivia); mancano assign/unassign/move/duplicate",
+      "boundary": "partial: GET list (+includeDeleted gated), GET/PUT [id], POST create con guardia ENC sui sensibili, DELETE soft-delete, POST restore (app/api/v1/network/patients/route.ts; [id]/route.ts; [id]/restore/route.ts; lib/network-patient-lifecycle.ts); mancano assign/unassign/move/duplicate",
+      "gap": "partial",
+      "wave": "W1-mobile-core",
+      "evidence": "wave2b commits 984f16474; smoke scripts/network-home-base-patient-lifecycle-write.test.mjs (crypto round-trip byte-identico); residuo: assign/unassign/move/duplicate"
+    },
+    {
+      "area": "pazienti",
+      "feature": "Archivia / soft-delete / ripristina paziente (stato scheda)",
+      "web": "Archivia(MMG/decesso/altro), soft-delete verso cestino con motivazione ripristinabile 30gg, ripristina (components/patient-action-modal.tsx; edit/page.tsx:117-219)",
+      "native": "full: sheet dedicate archivia/riattiva (PUT minimale version+isArchived) ed elimina con motivazione facoltativa sigillata; vista Cestino (PatientListViewMode.trash) su includeDeleted con Ripristina; guardie can* sul model (PairedPatientArchiveSheet.swift; PairedPatientDeleteSheet.swift; PatientsFiltering.swift; PairedPatientsWorkspaceModel lifecycle)",
+      "boundary": "full: DELETE [id] con version+deletionReason sigillata (default paired-delete), POST [id]/restore con version check, GET ?includeDeleted=true gated dalla capability lifecycle (lib/network-patient-lifecycle.ts; OpenAPI 1.15.0)",
+      "gap": "full-parity",
+      "wave": "W2-boundary",
+      "evidence": "wave2b commits 984f16474; smoke lifecycle 1/1 pass; swift test 94 Core + 242 AppleShared 0 failure. Nota: il branch fix/patient-archive-delete-reasons fara' persistere archiveReason/archiveNote sulla web; il client nativo per scelta (spec D7) non li raccoglie finche' quel fix non atterra"
+    },
+    {
+      "area": "diario",
+      "feature": "Diario clinico: view/list, create, update, soft-delete+restore, filtri",
+      "web": "list+add+soft-delete con motivazione+restore da cestino+toggle eliminati+view allegati+metadata scala (components/timeline.tsx; entries/new/page.tsx)",
+      "native": "partial(quasi-piena): list+create+update+soft-delete con motivazione libera+restore+toggle mostra eliminate+filtro tipo (PairedDiaryDeleteSheet.swift; PairedPatientsWorkspaceModel.restoreEntry; EntryFiltering includeDeleted). Residuo: view allegati (W5)",
+      "boundary": "partial: GET/POST/PUT su .../entries; manca DELETE paired (capability write-clinical-diary esclude hard delete/AI/document-derived) (app/api/v1/network/patients/[id]/entries)",
+      "gap": "partial",
+      "wave": "W1-mobile-core",
+      "evidence": "web-scheda.diario; native-ui.diario; api-boundary.entries | wave1 slice1 commit 984f16474; residuo allegati -> W5"
+    },
+    {
+      "area": "diario",
+      "feature": "Nuova voce clinica avanzata (S/O/A/P, allegati OCR, sessione visita, elabora bozza AI)",
+      "web": "editor rich-text S/O/A/P, upload allegati con OCR+sintesi, transcript dettato, POST /api/visit-session/draft per ripulire+estrarre farmaci (entries/new/page.tsx)",
+      "native": "partial: editor WYSIWYG a blocchi bindato al transcoder ClinicalRichText (grassetto/corsivo/sottolineato/barrato, heading, liste, blockquote, template S/O/A/P), content sigillato = render del transcoder (parita byte-esatta col sanitizer web su 40 fixture); allegati referenziati in voce con validazione ownership client-side prima del sigillo; flusso bozza visita (dettatura, compute deterministico, revisione obbligatoria). Residuo: OCR/sintesi inline degli allegati resta host (Classe C); stile misto inline non creabile (fallback a blocchi)",
+      "boundary": "partial: POST /api/v1/network/visit-draft compute-only (capability network.compute.visit-draft, lib condivisa con la route web); entries.attachments accetta valori sigillati ENC (guardia sigillo al posto del 403). OCR/sintesi document-derived restano host (ADR 0076 Classe C)",
+      "gap": "partial",
+      "wave": "W5-ai-avanzate",
+      "evidence": "PR #16 (Wave 5) + PR #17 (gate XCUITest), CI GitHub pubblica; ClinicalRichText round-trip + PairedPatientsWorkspaceModelS7Tests"
+    },
+    {
+      "area": "diario",
+      "feature": "Editor rich-text clinico (formattazione S/O/A/P)",
+      "web": "toolbar contentEditable completa (grassetto/liste/indent/paste sanitize) (components/clinical-rich-text-editor.tsx)",
+      "native": "partial: resa formattata HTML in lettura (ClinicalContentRendering, fallback testo piano) + template S/O/A/P identico allo skeleton web alla creazione. Residuo: editing WYSIWYG (in modifica il contenuto resta testo grezzo, markup mai degradato)",
+      "boundary": "n-a: contenuto è testo già supportato dal boundary entries",
+      "gap": "partial",
+      "wave": "W1-mobile-core",
+      "evidence": "web-scheda.diario(editor); native-ui.diario | wave1 slice2 commit 984f16474"
+    },
+    {
+      "area": "scale",
+      "feature": "Somministrazione scale cliniche (runner + salvataggio come voce diario)",
+      "web": "catalogo scale (/scales), runner domanda-per-domanda con score+interpretazione, salva come entry type 'scale' (components/scale-engine.tsx)",
+      "native": "full-parity: menu 'Valutazione' con ClinicalScales.all, form binario/multi-opzione, score live, crea entry type:'scale' stesso shape (ClinicalScaleFormView.swift)",
+      "boundary": "exposed: passa dal boundary entries (create clinical-diary)",
+      "gap": "full-parity",
+      "wave": "W1-mobile-core",
+      "evidence": "web-global.scales; native-ui.diario(scale); native-core.ClinicalScales"
+    },
+    {
+      "area": "scale",
+      "feature": "Libreria/catalogo scale standalone con storico e scorciatoie",
+      "web": "griglia SCALES per area + scorciatoie rapide in scheda + pagina /scales dedicata (app/patients/[id]/scales/page.tsx; app/scales/page.tsx)",
+      "native": "full-parity: modulo Scale per-paziente con libreria per area, avvio runner riusato e storico somministrazioni da entries type=scale; catalogo globale fuori scheda aggiunto in ClinicalScalesWorkspaceView con selezione paziente e riuso di ClinicalScaleFormView (PairedScalesSection.swift; ScaleHistoryPresentation.swift; ClinicalWorkspaceViews.swift)",
+      "boundary": "exposed: entries boundary sufficiente",
+      "gap": "full-parity",
+      "wave": "W1-mobile-core",
+      "evidence": "web-global.scales; web-scheda.scale; native-ui.scale(standalone) | wave1 slice3 commit 984f16474; W3 S5 f01346656 ClinicalScalesWorkspaceView; test esistenziale ClinicalWorkspaceViewsTests.testAnalyticsLoadsDecryptedDiagnosesAndScaleCatalogLoadsPatients"
+    },
+    {
+      "area": "terapie",
+      "feature": "Gestione terapie farmacologiche (CRUD + stato + collegamento diagnosi)",
+      "web": "add/edit/soft-delete/status transition, autocomplete AIFA, principio attivo, posologia, collegamento diagnosi, campi AIC/ATC (components/therapy-manager.tsx)",
+      "native": "partial: CRUD+soft-delete+stato+collegamento diagnosi+export testo+campi AIC/ATC in create/edit/dettaglio. Residuo: catalogo AIFA con autocomplete e validazione prontuario (W2 boundary drugs)",
+      "boundary": "partial: GET/POST/PUT therapies; manca DELETE (write-therapies esclude hard delete/AI/document-derived)",
+      "gap": "partial",
+      "wave": "W1-mobile-core",
+      "evidence": "web-scheda.terapie; native-ui.terapie; api-boundary.therapies | wave1 slice4 commit 984f16474; boundary aic/atc whitelist verificata (lib/api-v1-clinical-write-normalization.ts:534-617)"
+    },
+    {
+      "area": "terapie",
+      "feature": "Ragionamento terapeutico AI (Treatment Reasoning, review-only)",
+      "web": "pannello AI genera bozza (raccomandazione/evidenze/flag sicurezza/writePolicy), gated kill switch AI_TREATMENT_REASONING (components/treatment-reasoning-panel.tsx)",
+      "native": "missing: nessuna superficie AI reasoning lato Apple",
+      "boundary": "missing: nessuna route paired; /api/system/treatment-reasoning/athena-mlx host-only",
+      "gap": "host-only",
+      "wave": "W5-ai-avanzate",
+      "evidence": "PR #16 (Wave 5) + PR #17 (gate XCUITest), CI GitHub pubblica; docs-plan(AI plane separato)"
+    },
+    {
+      "area": "controlli",
+      "feature": "Controlli/checkup follow-up (CRUD + stato)",
+      "web": "view lista pending, gestione via edit form (date/title/notes/status/source) + suggerimenti follow-up da documenti (modules/page.tsx:727-769; followup-suggestions.tsx)",
+      "native": "partial(più ricca su CRUD): list+create+update+soft-delete+filtro stato+note operative; no suggerimenti da documenti (PairedPatientsWorkspaceView.swift:1349-1429)",
+      "boundary": "partial: GET/POST/PUT checkups; manca DELETE (write-checkups esclude hard delete/AI/document-derived)",
+      "gap": "partial",
+      "wave": "W1-mobile-core",
+      "evidence": "web-scheda.follow-up; native-ui.controlli; api-boundary.checkups; docs-plan.gap-legacy(checkups asimmetria)"
+    },
+    {
+      "area": "controlli",
+      "feature": "Suggerimenti follow-up proiettati da documenti",
+      "web": "view excerpt/citazione fonte + form rapido per crearli come checkup (components/followup-suggestions.tsx)",
+      "native": "full: suggerimenti follow-up proiettati dai fact insight (dedup + filtro sui controlli esistenti, semantica web 1:1) che precompilano il form controlli nativo (source ai_suggestion, provenance excerpt+nome file nelle note sigillate); revisione obbligatoria, nessun salvataggio automatico",
+      "boundary": "full: scrittura via capability write-checkups esistente (form_prefill_only, ADR 0076 Classe E); nessuna nuova estrazione document-derived",
+      "gap": "full-parity",
+      "wave": "W5-ai-avanzate",
+      "evidence": "PR #16 (Wave 5) + PR #17 (gate XCUITest), CI GitHub pubblica; PatientFollowupProjection port + DocumentInsightsCodecTests"
+    },
+    {
+      "area": "parametri",
+      "feature": "Osservazioni/parametri clinici (CRUD LOINC/UCUM + trend/sparkline)",
+      "web": "add LOINC+UCUM+range+note, delete, view per parametro/data, sparkline+trend+badge fuori-range (components/observation-manager.tsx)",
+      "native": "full-parity(non-AI): CRUD+trend freccia+sparkline Chart+LOINC/UCUM manuali; no estrazione automatica/HealthKit (PairedPatientsWorkspaceView.swift:1432-1495)",
+      "boundary": "partial: GET/POST/PUT observations; manca DELETE (write-observations esclude hard delete/AI)",
+      "gap": "partial",
+      "wave": "W1-mobile-core",
+      "evidence": "web-scheda.parametri; native-ui.osservazioni; api-boundary.observations; native-core.ObservationTrend"
+    },
+    {
+      "area": "prestazioni",
+      "feature": "Prestazioni prescritte (Service Prescriptions, CRUD ricco + stato)",
+      "web": "form ricco con voci multiple/classe priorità/erogatore/date/allegati, status transitions, delete, matching repertorio (components/service-prescription-manager.tsx)",
+      "native": "full: modulo prestazioni nativo con parita' di campi (21 campi incl. voci multilinea CODICE NOME, priorita' RAO, quesito clinico, riferimenti documento), transizioni con guardie speculari alla web e propagazione stato+data a ogni item con la propria version; niente edit post-create ne' delete, come la web reale (il delete resta host-only per postura no-hard-delete)",
+      "boundary": "full: GET/POST/PUT service-prescriptions e items con capability readonly/write dedicate, concurrency ottimistica nuova (migrazione 0017), scope membership 404, nessuna DELETE (vincolo 4)",
+      "gap": "full-parity",
+      "wave": "W2-boundary",
+      "evidence": "w2-final commits 984f16474; smoke prescriptions-write e discovery-read verdi; swift 110 Core + 257 AppleShared 0 failure"
+    },
+    {
+      "area": "protesica",
+      "feature": "Diario ausili e prescrizioni protesiche (CRUD + collaudo)",
+      "web": "add + azione Collaudo + delete con stato/categoria/ISO/pratica/fornitore/collaudo (components/prosthetic-prescription-manager.tsx; nessun edit post-create nella UI web reale)",
+      "native": "full: modulo protesica nativo con parita' di campi completa e azione Collaudo (stringhe identiche alla web); niente delete (postura no-hard-delete)",
+      "boundary": "full: GET/POST/PUT prosthetic-prescriptions con capability dedicate e version (0017)",
+      "gap": "full-parity",
+      "wave": "W2-boundary",
+      "evidence": "w2-final commits 984f16474; smoke prescriptions-write e discovery-read verdi; swift 110 Core + 257 AppleShared 0 failure"
+    },
+    {
+      "area": "documenti",
+      "feature": "Upload documenti + OCR + sintesi clinica (Archivio documenti)",
+      "web": "drag&drop multi-file, OCR automatico, sintesi, coda OCR-needed, riprova OCR, preview, delete (components/document-upload.tsx)",
+      "native": "partial: upload nativo (fileImporter + PhotosPicker) con sigillo ENC client-side e precheck dimensione wire onesto, archivio allegati con etichette coda OCR, dettaglio on-demand, preview in-memory PDFKit/immagini, condivisione. Residuo: OCR e sintesi clinica restano host/web (Classe C); gli upload paired entrano in coda pending con reason paired_upload",
+      "boundary": "partial: famiglia documenti network (capability readonly-documents/write-documents), create Classe A con name/path/data sigillati ENC e limite wire condiviso; PUT/DELETE e OCR restano host (ADR 0076 Classi A/C)",
+      "gap": "partial",
+      "wave": "W5-ai-avanzate",
+      "evidence": "PR #16 (Wave 5) + PR #17 (gate XCUITest), CI GitHub pubblica; lib/network-attachment-{read,write} + smoke home-base-documents-write"
+    },
+    {
+      "area": "documenti",
+      "feature": "Archivio Intelligente / Document Insights (view estrazioni + delete)",
+      "web": "view/expand diagnosi/terapie estratte, quality reason, sintesi markdown, delete/svuota (components/document-insights-panel.tsx)",
+      "native": "partial: Archivio Intelligente nativo completo in lettura (lista insight, expand diagnosi/terapie estratte, quality reason, sintesi). Residuo: delete/svuota resta web (ADR 0076 Classe C: curation document-derived host-only)",
+      "boundary": "partial: lettura insight via detail paziente esistente; curation (delete) resta host (Classe C)",
+      "gap": "partial",
+      "wave": "W5-ai-avanzate",
+      "evidence": "PR #16 (Wave 5) + PR #17 (gate XCUITest), CI GitHub pubblica; DocumentInsightsCodec + fix web insights version (PR #15)"
+    },
+    {
+      "area": "documenti",
+      "feature": "Smart Import (candidati diagnosi/terapie da documenti, applica in scheda)",
+      "web": "analisi AI candidati ICD-11/AIFA, select/edit/scarta, preview resolver, applica scrittura, kill switch AI_SMART_IMPORT (components/patient-smart-import-panel.tsx)",
+      "native": "missing: nessuna superficie Smart Import lato Apple",
+      "boundary": "missing: document-derived/AI writes esclusi dalle capability",
+      "gap": "missing-both",
+      "wave": "W5-ai-avanzate",
+      "evidence": "PR #16 (Wave 5) + PR #17 (gate XCUITest), CI GitHub pubblica; native-ui.documenti"
+    },
+    {
+      "area": "documenti",
+      "feature": "Referti recenti (Evidence Stack tile, view sintesi)",
+      "web": "card riassuntiva ultimi 4 document insight (components/evidence-stack-tile.tsx)",
+      "native": "full: Evidence Stack nativo (card ultimi 4 insight) in sola lettura, dai documentInsights decifrati",
+      "boundary": "full: nessun boundary aggiuntivo necessario (lettura da detail paziente esistente)",
+      "gap": "full-parity",
+      "wave": "W5-ai-avanzate",
+      "evidence": "PR #16 (Wave 5) + PR #17 (gate XCUITest), CI GitHub pubblica; smoke documenti+diario reali verdi"
+    },
+    {
+      "area": "insight",
+      "feature": "AI Patient Insight (sintesi/follow-up/alert generati)",
+      "web": "generate/regenerate insight, stop, badge stale, dettagli fonti/limiti, kill switch AI_PATIENT_INSIGHT (components/ai-patient-insight.tsx)",
+      "native": "missing (view-only): aiSummary mostrato read-only, nessuna generazione lato client",
+      "boundary": "missing: conversations/messages/AI writes esclusi; solo output già persistiti eventualmente leggibili",
+      "gap": "host-only",
+      "wave": "W5-ai-avanzate",
+      "evidence": "PR #16 (Wave 5) + PR #17 (gate XCUITest), CI GitHub pubblica; docs-plan(AI plane separato)"
+    },
+    {
+      "area": "cockpit",
+      "feature": "Foglio sinottico / Identity Lens / Review Queue (viste sintetiche cockpit)",
+      "web": "synoptic sheet, identity lens, review queue summary, clinical river timeline (patient-synoptic-sheet.tsx; patient-identity-lens.tsx; clinical-river-timeline.tsx)",
+      "native": "partial: segnali clinici calcolati su liste piene fino al limite boundary (100, costante condivisa) con resa onesta N+ al cap (ClinicalSignalCount). Residuo: review queue e aggregati server-side (W2)",
+      "boundary": "partial: dati grezzi via boundary, ma nessun aggregate server-side dedicato",
+      "gap": "partial",
+      "wave": "W1-mobile-core",
+      "evidence": "web-scheda.cockpit; web-scheda.timeline; native-ui.pazienti(segnali clinici) | wave1 slice6 commit 984f16474"
+    },
+    {
+      "area": "scheda",
+      "feature": "Export FHIR paziente (con pre-check validazione FSE)",
+      "web": "pre-check /api/fse/validate-patient, blocco errori/conferma warning, genera bundle FHIR JSON, download (modules/page.tsx:388-434; edit/page.tsx)",
+      "native": "full: flusso identico alla web (conferma, pre-check FSE via boundary con blocco errori e conferma warning, bundle generato on-device da FHIRBundleGenerator, condivisione file); equivalenza col mapper web garantita dal golden contract fhir-golden-bundle.v1.json (confronto strutturale)",
+      "boundary": "full: GET /api/v1/network/fse/validate-patient sotto capability network.fse.validate; il bundle NON passa dal server (zero-knowledge: host keyless)",
+      "gap": "full-parity",
+      "wave": "W2-boundary",
+      "evidence": "w2-final commits 984f16474; smoke prescriptions-write e discovery-read verdi; swift 110 Core + 257 AppleShared 0 failure"
+    },
+    {
+      "area": "scheda",
+      "feature": "Report PDF paziente",
+      "web": "generatePatientReport (dati/diario/scale/terapie/osservazioni), download client (modules/page.tsx:462-474)",
+      "native": "full-parity: report PDF client-side multipagina (PatientReportDocument builder puro + renderer CoreGraphics/CoreText, ShareLink), sezioni oneste se vuote, esclusione rigorosa ciphertext ENC:",
+      "boundary": "n-a: generazione client-side su dati già disponibili via boundary",
+      "gap": "full-parity",
+      "wave": "W1-mobile-core",
+      "evidence": "web-scheda.scheda(report PDF); native-ui.terapie(export testo) | wave1 slice5 commit 984f16474; PatientReportDocumentTests"
+    },
+    {
+      "area": "esenzioni",
+      "feature": "Esenzioni paziente (selezione/gestione codici cifrati)",
+      "web": "ExemptionSelector multi-code cifrati con lookup/validazione, catalogo /api/exemptions (components/exemption-selector.tsx)",
+      "native": "full-parity: chip add/remove + lookup catalogo esenzioni (ricerca codice/descrizione, selezione aggiunge chip), fallback manuale se capability assente",
+      "boundary": "exposed: GET /api/v1/network/exemptions con capability network.catalogs.readonly",
+      "gap": "full-parity",
+      "wave": "W2-boundary",
+      "evidence": "web-scheda.scheda(edit esenzioni); native-ui.esenzioni; api-boundary.exemptions; native-core.ExemptionCodesCodec | wave2a commit 984f16474"
+    },
+    {
+      "area": "farmaci",
+      "feature": "Catalogo farmaci AIFA (ricerca/validazione prontuario)",
+      "web": "autocomplete AIFA nel therapy manager, /api/drugs ricerca (components/therapy-manager.tsx; /api/drugs)",
+      "native": "full-parity(ricerca): autocomplete AIFA as-you-type nel form terapie (debounce, min 2 char, selezione compila drugName/AIC/ATC/principio attivo), fallback manuale onesto se capability assente. Import/clear repertorio restano host-only per disegno",
+      "boundary": "exposed: GET /api/v1/network/drugs con capability network.catalogs.readonly, stessa forma risposta della route host",
+      "gap": "full-parity",
+      "wave": "W2-boundary",
+      "evidence": "native-ui.farmaci; api-boundary.drugs; api-boundary.boundary(catalogs.sync planned) | wave2a commit 984f16474; smoke test:network:home-base-catalog-read"
+    },
+    {
+      "area": "diagnosi/icd",
+      "feature": "Ricerca ICD in-app per codifica diagnosi",
+      "web": "ICDAutocomplete nel patient-form/edit (systems ICD-9/10/11), /api/v1/terminology + /api/icd/proxy (components/patient-form.tsx)",
+      "native": "full-parity: ricerca ICD in-app (ICDCatalog, A14 in-app table) nel form edit diagnosi (PairedPatientsWorkspaceView.swift:627-753)",
+      "boundary": "n-a: catalogo ICD in-app on-device, non richiede boundary; terminology non esposta ma non necessaria",
+      "gap": "full-parity",
+      "wave": "W1-mobile-core",
+      "evidence": "native-core.ICDCatalog; native-ui.pazienti(update diagnosi); api-boundary.terminology"
+    },
+    {
+      "area": "terminologia",
+      "feature": "Ricerca terminologica generale (ICD/systems oltre in-app)",
+      "web": "/api/v1/terminology/search/resolve/systems + /api/icd/proxy verso ICD-11 API",
+      "native": "full: autocomplete LOINC/UCUM nel form osservazioni via boundary terminology con fallback manuale; copre e supera il consumo web reale (libreria statica in-memory, nessuna chiamata HTTP dalla web UI)",
+      "boundary": "exposed: GET /api/v1/network/terminology/search|resolve|systems con capability network.catalogs.readonly",
+      "gap": "full-parity",
+      "wave": "W2-boundary",
+      "evidence": "w2-final commits 984f16474; smoke prescriptions-write e discovery-read verdi; swift 110 Core + 257 AppleShared 0 failure; web usa lib/terminology statica (nessun consumer HTTP)"
+    },
+    {
+      "area": "ambulatori",
+      "feature": "Selezione scope ambulatorio attivo",
+      "web": "filtri scope + selezione contesto ambulatorio (kree8 incarico-area; ambulatories)",
+      "native": "full-parity(scope): campo+menu 'Ambulatorio attivo' via fetchNetworkAmbulatories, selectAmbulatory ricarica lista (PairedPatientsWorkspaceView.swift:226-240)",
+      "boundary": "exposed: GET /api/v1/network/ambulatories (solo lista)",
+      "gap": "full-parity",
+      "wave": "W1-mobile-core",
+      "evidence": "native-ui.ambulatori; api-boundary.ambulatories"
+    },
+    {
+      "area": "ambulatori",
+      "feature": "Gestione anagrafica ambulatori (create/update/predefinita/svuota/elimina)",
+      "web": "CRUD sedi, albero gerarchico, usa come predefinita, svuota test, elimina (app/settings/ambulatories/page.tsx)",
+      "native": "full-parity: CRUD anagrafica ambulatori, promozione predefinita, svuota test ed elimina nel hub Impostazioni paired (SettingsWorkspaceView.swift)",
+      "boundary": "full: create/update/promozione/elimina/svuota sul boundary network versionato con capability network.ambulatories.write",
+      "gap": "full-parity",
+      "wave": "W4-settings",
+      "evidence": "commit 80e05c427 (boundary+capability) + cd8c05c42 (hub nativo); npm run test:network:home-base-ambulatory-write verde"
+    },
+    {
+      "area": "analytics",
+      "feature": "Cruscotto analytics locale (popolazione, età, diagnosi, ADI)",
+      "web": "slider età, 4 indicatori, distribuzione fasce, top 10 diagnosi (app/analytics/page.tsx:105-238)",
+      "native": "full: vista Analytics nativa con slider eta, metriche popolazione/ADI/diagnosi, distribuzione fasce e top diagnosi decifrate lato client (PopulationAnalyticsWorkspaceView; PopulationAnalytics.swift). Sezione Audit esclusa: web-admin-only, nessun percorso paired.",
+      "boundary": "exposed: GET /api/v1/network/patients?include=diagnoses usa la scope-list paired con capability network.replica.readonly-patients; diagnosi restano ciphertext passthrough e vengono decifrate lato client",
+      "gap": "full-parity",
+      "wave": "W3-macos-clinical-shell",
+      "evidence": "web-global.analytics; W3 S1 828468c02 boundary include=diagnoses/ADR 0074; S3 f01346656 data-plane; S4 f01346656 PopulationAnalytics.swift; S5 f01346656 PopulationAnalyticsWorkspaceView; test esistenziale ClinicalWorkspaceViewsTests.testAnalyticsLoadsDecryptedDiagnosesAndScaleCatalogLoadsPatients"
+    },
+    {
+      "area": "analytics",
+      "feature": "Pannello audit operativo locale",
+      "web": "finestra 7/30/90gg, GET /api/system/audit, card eventi/attori/esiti, gestione 403 admin (app/analytics/page.tsx:193-229)",
+      "native": "missing: nessun pannello audit lato Apple",
+      "boundary": "missing: /api/system/audit host-only, solo network-overview aggregato read-only lato host",
+      "gap": "host-only",
+      "wave": "HOST-ONLY",
+      "evidence": "web-global.analytics(audit); api-boundary.analytics/system; codex-fetch-map./api/system/audit"
+    },
+    {
+      "area": "siss",
+      "feature": "Apertura portali regionali SISS/FSE (context panel + handoff diary)",
+      "web": "apre portali con CF via clipboard/handoff, stato accesso regionale, pre-check FSE, diario handoff SISS CRUD (components/siss-patient-context-panel.tsx; siss-handoff-diary.tsx)",
+      "native": "missing: nessuna superficie SISS/FSE lato Apple",
+      "boundary": "missing: nessuna route paired SISS; integrazione regionale host-only (claim freeze zero-knowledge) (app/api/siss/*)",
+      "gap": "host-only",
+      "wave": "HOST-ONLY",
+      "evidence": "web-scheda.siss; api-boundary.SISS; codex-fetch-map./api/siss/context"
+    },
+    {
+      "area": "shell-globale",
+      "feature": "Cockpit shell / rail navigazione globale + toolbar + deep-link",
+      "web": "Kree8 cockpit shell con 5 aree, toolbar ricerca/filtri, deep-link query string, sub-area tabs (components/kree8/kree8-clinical-cockpit.tsx)",
+      "native": "partial: NavigationSplitView (macOS/iPad) / TabView (iPhone) con sezioni cliniche Pazienti/Agenda/Diario/Analytics/Scale e gruppo Progetto separato, piu master-detail pazienti (AppleFoundationViews.swift:210-292). Residuo ristretto: nessun deep-link/URL scheme nativo equivalente alla query string web ?area=&paziente=. Ricerca globale non conteggiata come residuo di parita: non esiste nemmeno come ricerca globale unica sulla web.",
+      "boundary": "n-a: chrome UI locale",
+      "gap": "partial",
+      "wave": "W3-macos-clinical-shell",
+      "evidence": "web-global.shell query string in components/kree8/kree8-clinical-cockpit.tsx:204-219; native-ui.navigazione; W3 S5 f01346656 AppleFoundationViews.swift"
+    },
+    {
+      "area": "turno",
+      "feature": "Agenda di oggi / turno + bridge candidati agenda clinica",
+      "web": "agenda odierna, stat card, filtri, GET /api/clinical-agenda/candidates read-only (components/kree8/areas/turno-area.tsx)",
+      "native": "full: vista Agenda nativa con statistiche visite oggi/pianificate/pazienti attivi, lista prossime visite e pill di stato, caricata da AgendaWorkspaceView/AgendaWorkspaceModel e logica AgendaPresentation.swift. Bridge candidati esterni da mail escluso: sorgenti host-local, non paired, e AI_QUEUE web mock.",
+      "boundary": "exposed: GET /api/v1/network/checkups con capability network.replica.readonly-agenda, scope ambulatoriale, filtri plaintext e limit cap",
+      "gap": "full-parity",
+      "wave": "W3-macos-clinical-shell",
+      "evidence": "web-global.turno; W3 S1 boundary 828468c02 /api/v1/network/checkups + ADR 0074; S2 smoke f01346656 scripts/network-home-base-aggregate-read.test.mjs; S3 data-plane f01346656 HomeBasePatientsClient.fetchScopedCheckups; S5 UI f01346656 AgendaWorkspaceView; test esistenziale ClinicalWorkspaceViewsTests.testAgendaLoadsScopedRowsAndStatistics. Bridge mail escluso e dati host-local; AI_QUEUE web mock in turno-area.tsx:25-51"
+    },
+    {
+      "area": "diario-globale",
+      "feature": "Diario clinico globale cross-paziente (ultime 50 voci)",
+      "web": "timeline cross-paziente virtualizzata, route /diary dedicata (components/kree8/areas/diario-area.tsx)",
+      "native": "full: vista Diario globale nativa con ultime 50 voci cross-paziente, nome/codice paziente, preview decifrata, stato Eliminata e conteggio allegati (GlobalDiaryWorkspaceView/GlobalDiaryWorkspaceModel; GlobalDiaryPresentation.swift)",
+      "boundary": "exposed: GET /api/v1/network/entries con capability network.replica.readonly-clinical-diary-global, default limit 50, scope ambulatoriale e tombstone soft-delete incluse come la web",
+      "gap": "full-parity",
+      "wave": "W3-macos-clinical-shell",
+      "evidence": "web-global.diario(globale); W3 S1 boundary 828468c02 /api/v1/network/entries + ADR 0074; S2 smoke f01346656 aggregate-read include soft-deleted entries; S3 data-plane f01346656 HomeBasePatientsClient.fetchScopedEntries; S5 UI f01346656 GlobalDiaryWorkspaceView; test esistenziale ClinicalWorkspaceViewsTests.testDiaryDecryptsClinicalFieldsWithTestMasterKey"
+    },
+    {
+      "area": "repertori",
+      "feature": "Cruscotto repertori clinici (AIFA/esenzioni/ICD freschezza)",
+      "web": "card freschezza, conteggi drugs/exemptions, stato ICD locale, link import/diagnostica (components/kree8/areas/repertori-area.tsx)",
+      "native": "missing: nessun cruscotto repertori (solo ICD in-app usato silenziosamente)",
+      "boundary": "missing: drugs/exemptions non esposti al paired; catalogs.sync planned",
+      "gap": "host-only",
+      "wave": "W4-settings",
+      "evidence": "web-global.repertori; api-boundary.drugs/exemptions; web-settings.repertori"
+    },
+    {
+      "area": "pazienti-nuovo",
+      "feature": "Wizard nuova scheda da documento (PdfImporter + review + form)",
+      "web": "3 sezioni: PdfImporter OCR, review import, PatientForm, check duplicato CF (app/patients/new/page.tsx:99-350)",
+      "native": "partial: create paziente solo anagrafica base (local authority), nessun import documento/OCR/review",
+      "boundary": "partial: POST create paziente ora presente sul boundary con guardia ENC (era 405); document import assente (W5)",
+      "gap": "partial",
+      "wave": "W2-boundary",
+      "evidence": "web-global.pazienti-nuovo; wave2b commit 984f16474; residuo import documento -> W5"
+    },
+    {
+      "area": "auth",
+      "feature": "Pairing + login operatore + PIN (deriva master key)",
+      "web": "login/logout/check/setup + change-pin lato web session locale (app/api/auth/*)",
+      "native": "full-parity(paired model): card pairing HTTPS+fingerprint+Bonjour+client ID/token, login operatore, PIN deriva KEK RAM-only, dissocia (PairedPatientsWorkspaceView.swift:201-306)",
+      "boundary": "exposed(modello paired): pairing intent/confirm + token headers + sessionCookie; NON usa /api/auth/* (lib/network-contract; network-paired-client-auth)",
+      "gap": "full-parity",
+      "wave": "W4-settings",
+      "evidence": "native-ui.auth; api-boundary.auth; api-boundary.boundary(pairing)"
+    },
+    {
+      "area": "accesso",
+      "feature": "Cambio PIN / gestione ciclo di vita chiave (rewrap/reset)",
+      "web": "changePin (3 campi), rewrap-master-key, reset (app/settings/accesso/page.tsx; /api/auth/change-pin,/reset,/rewrap-master-key)",
+      "native": "full-parity: cambio PIN paired con re-wrap client-of-origin, KDF v2 e salt ruotato; reset escluso come superficie host/web-admin cripto-distruttiva",
+      "boundary": "exposed: famiglia auth condivisa, session-auth; nessuna route network replicata e vincolo master key client-of-origin rispettato",
+      "gap": "full-parity",
+      "wave": "W4-settings",
+      "evidence": "commit 1f9a9cc64 (UPDATE condizionale anti-race) + bf4f64dfc (client paired) + cd8c05c42 (UI); npm run test:network:home-base-account-pin verde"
+    },
+    {
+      "area": "accesso",
+      "feature": "Blocco sessione immediato / stato sessione",
+      "web": "mostra operatore/ambulatorio, 'Blocca sessione adesso' lock() (app/settings/accesso/page.tsx:148-179)",
+      "native": "full-parity: bottone Blocca sessione adesso, logout e azzeramento locale di cookie e master key",
+      "boundary": "n-a: gestione sessione locale al client",
+      "gap": "full-parity",
+      "wave": "W4-settings",
+      "evidence": "commit bf4f64dfc (logout+lockSessionNow) + cd8c05c42 (UI); Core e AppleShared Swift verdi nella wave"
+    },
+    {
+      "area": "profilo",
+      "feature": "Profilo medico/ambulatorio (nome mostrato su documenti)",
+      "web": "2 campi doctorName/clinicName, PUT /api/auth/profile (app/settings/profilo/page.tsx)",
+      "native": "full-parity: modifica nome medico e ambulatorio nel hub Impostazioni paired",
+      "boundary": "exposed: PUT /api/auth/profile nella famiglia auth condivisa con session-auth, senza route network replicata",
+      "gap": "full-parity",
+      "wave": "W4-settings",
+      "evidence": "commit 1f9a9cc64 (profilo transazionale) + 07ca88ae5 (identita operatore) + cd8c05c42 (UI); Core e AppleShared Swift verdi nella wave"
+    },
+    {
+      "area": "aspetto",
+      "feature": "Preferenze UI: tema light/dark/system, riduci movimento",
+      "web": "ThemeToggle + reduceMotion + privacy pointer (app/settings/aspetto/page.tsx)",
+      "native": "full-parity: tema system/light/dark e riduci movimento nel hub Impostazioni su iOS e macOS; riduci movimento e per-device e non sincronizzato col server, come la preferenza tema web",
+      "boundary": "n-a: preferenza UI puramente locale",
+      "gap": "full-parity",
+      "wave": "W4-settings",
+      "evidence": "commit 61e89f6ce; test AppleAppearanceStore verdi nella wave"
+    },
+    {
+      "area": "privacy",
+      "feature": "Modalità Privacy / redazione dati",
+      "web": "PrivacyModeToggle persistente header, blur/mascheramento dati (kree8-clinical-cockpit; PrivacyProvider)",
+      "native": "full-parity: toggle Privacy mode persistito e simmetrico su iOS e macOS, separato dal seam di test",
+      "boundary": "n-a: comportamento UI locale",
+      "gap": "full-parity",
+      "wave": "W4-settings",
+      "evidence": "commit 61e89f6ce; PrivacyShieldTests verdi nella wave"
+    },
+    {
+      "area": "conversazioni-ai",
+      "feature": "Conversazioni AI e messaggi",
+      "web": "GET/POST/PUT/DELETE /api/conversations e /api/messages",
+      "native": "missing: nessuna superficie conversazioni AI lato Apple",
+      "boundary": "missing: nessuna route paired conversations/messages (AI writes esclusi)",
+      "gap": "host-only",
+      "wave": "W5-ai-avanzate",
+      "evidence": "PR #16 (Wave 5) + PR #17 (gate XCUITest), CI GitHub pubblica; web-global.boundary(no consumer)"
+    },
+    {
+      "area": "ai-runtime",
+      "feature": "Configurazione/invocazione runtime AI (Ollama/modelli/kill switch)",
+      "web": "selezione modelli per ruolo, connessione Ollama, profilo hardware, kill switch funzioni AI, budget contesto (app/settings/ai/*)",
+      "native": "missing (view-only): pannello runtime mostra stato Ollama/Docker come diagnostica, mai avviato/configurato; nessuna inferenza via boundary",
+      "boundary": "partial/host-only: GET /api/v1/network/ai-runtime solo stato; central-runtime 'gated by benchmark/rollout', nessuna route chat/generate paired",
+      "gap": "host-only",
+      "wave": "W5-ai-avanzate",
+      "evidence": "PR #16 (Wave 5) + PR #17 (gate XCUITest), CI GitHub pubblica; native-ui.boundary(runtime status)"
+    },
+    {
+      "area": "cache-offline",
+      "feature": "Cache pazienti cifrata offline (consultazione degradata)",
+      "web": "n-a (web è online contro DB locale)",
+      "native": "partial: snapshot cifrato AES-GCM lista pazienti (Keychain, TTL 24h, scoping server+ambulatorio), restore offline-degraded; SOLO lista, no dettaglio/sotto-risorse, NO write queue (HomeBasePatientCacheStore.swift)",
+      "boundary": "n-a: derivata dal boundary, mai autorevole (vincolo docs-plan: no seconda source of truth)",
+      "gap": "partial",
+      "wave": "W1-mobile-core",
+      "evidence": "native-ui.cache offline; gap corrente WUL-403; nessuna offline write queue"
+    },
+    {
+      "area": "settings-host",
+      "feature": "Backup: schedulazione automatica + ripristino manuale",
+      "web": "BackupSchedulerUI + BackupRestoreUI su filesystem/cron host (app/settings/backup/page.tsx)",
+      "native": "host-only (view): capability local.backup.artifact.v1/scheduler.macos; runtime status osservabile, nessuna gestione da client paired remoto",
+      "boundary": "host-only: opera su filesystem/DB del nodo host, non esposto al client paired",
+      "gap": "host-only",
+      "wave": "HOST-ONLY",
+      "evidence": "web-settings.backup; api-boundary.analytics/system; api-boundary.boundary(local.backup capability)"
+    },
+    {
+      "area": "settings-host",
+      "feature": "Diagnostica: architettura servizi + Diagnostic Hub + service health",
+      "web": "ServiceArchitecturePanel + DiagnosticHub introspezione servizi host (app/settings/diagnostica/page.tsx)",
+      "native": "host-only (view): HomeBaseRuntimeStatusView mostra stato componenti; start/stop backend/proxy solo macOS, iOS solo view (HomeBaseRuntimeStatusView.swift)",
+      "boundary": "host-only: introspezione servizi del nodo host",
+      "gap": "host-only",
+      "wave": "HOST-ONLY",
+      "evidence": "web-settings.diagnostica; native-ui.boundary(runtime home-base)"
+    },
+    {
+      "area": "settings-host",
+      "feature": "Update Awareness (aggiornamenti software)",
+      "web": "UpdateAwarenessPanel, GET /api/system/update-awareness (app/settings/diagnostica/page.tsx)",
+      "native": "missing: nessun pannello update; update del client Apple gestito via App Store/canale nativo separato",
+      "boundary": "host-only: pannello controlla update backend/host",
+      "gap": "host-only",
+      "wave": "HOST-ONLY",
+      "evidence": "web-settings.diagnostica(update); codex-fetch-map./api/system/update-awareness"
+    },
+    {
+      "area": "settings-host",
+      "feature": "Repertori: import CSV AIFA + gestione DB esenzioni",
+      "web": "importAifaCsv con progress, clearDrugDatabase, ExemptionDbManager (app/settings/repertori/page.tsx)",
+      "native": "missing: nessun import repertori lato Apple",
+      "boundary": "host-only: import massivo alimenta il boundary lato host, non ripetuto su ogni client paired",
+      "gap": "host-only",
+      "wave": "HOST-ONLY",
+      "evidence": "web-settings.repertori; api-boundary.drugs/exemptions"
+    },
+    {
+      "area": "settings-host",
+      "feature": "Modelli AI: pull modello Ollama + profilo hardware + governance",
+      "web": "/api/ai/pull, applyHardwareProfile, AiModelParliamentPanel, AiRolloutReadinessPanel (app/settings/ai/modelli,funzioni)",
+      "native": "host-only: hardware/RAM e runtime Ollama sono del nodo host; nessuna gestione client paired",
+      "boundary": "host-only: configurazione runtime AI del nodo host",
+      "gap": "host-only",
+      "wave": "HOST-ONLY",
+      "evidence": "web-settings.ai/modelli(pull,hardware,parliament); codex-fetch-map./api/ai/pull,ai-parliament,ai-rollout-readiness"
+    },
+    {
+      "area": "settings-host",
+      "feature": "Kill switch funzioni AI (stato read-only rilevante al client)",
+      "web": "4 toggle Patient Insight/Document Synthesis/Smart Import/Treatment Reasoning, saveAiConfig (app/settings/ai/funzioni/page.tsx:162-349)",
+      "native": "full: sezione Funzioni AI nei settings, stato dei 4 kill switch (Attivo/Disattivato) e del runtime AI in sola lettura, nota onesta di governance host, fail-closed quando lo stato non e leggibile",
+      "boundary": "full: GET /api/v1/network/ai-runtime in dual-auth espone killSwitches (4 chiavi fail-closed) e la surface treatment-reasoning (ADR 0076 Classe D: stato leggibile, invocazione esclusa)",
+      "gap": "full-parity",
+      "wave": "W5-ai-avanzate",
+      "evidence": "PR #16 (Wave 5) + PR #17 (gate XCUITest), CI GitHub pubblica; lib/network-ai-runtime + SettingsAiFunctionsModel + settings-write-policy registry"
+    },
+    {
+      "area": "settings-host",
+      "feature": "Network Operating Mode (gestione modalità boundary)",
+      "web": "NetworkOperatingModePanel, POST /api/settings/network.mode, /api/system/network-overview (components/settings/network-operating-mode-panel.tsx)",
+      "native": "host-only: riguarda il nodo che espone il boundary, non il client paired",
+      "boundary": "host-only: settings network scritti solo home-base (lib/network-home-base-server.ts)",
+      "gap": "host-only",
+      "wave": "HOST-ONLY",
+      "evidence": "web-settings.settings(network mode); api-boundary.settings; codex-fetch-map./api/settings/network.mode,network-overview"
+    },
+    {
+      "area": "settings-host",
+      "feature": "Zona pericolo: reset onboarding + sviluppo (seeder, apri app nativa, DB repair/purge)",
+      "web": "reset onboarding, DataSeeder, POST /api/system/native, repair-db/purge/migrate (app/settings/zona-pericolo, sviluppo)",
+      "native": "host-only: reset chiavi/onboarding + tool sviluppo agiscono sul nodo host, non replicati sul client paired (che avrebbe semmai 'scollega/pairing reset', già presente via Dissocia)",
+      "boundary": "host-only: nessuna operazione di sistema raggiungibile dal client paired",
+      "gap": "host-only",
+      "wave": "HOST-ONLY",
+      "evidence": "web-settings.zona-pericolo,sviluppo; api-boundary.analytics/system; native-ui.auth(Dissocia)"
+    },
+    {
+      "area": "governance",
+      "feature": "Hub Impostazioni / governance (dashboard navigazione settings)",
+      "web": "hub link a /settings/* con card stato sessione/audit/backup (components/kree8/areas/live-governance-area.tsx)",
+      "native": "full-parity per il target nativo: hub Impostazioni con Accesso, Profilo, Ambulatori, Aspetto e Privacy",
+      "boundary": "host-only per la maggior parte dei target; hub in sé è chrome",
+      "gap": "host-only",
+      "wave": "W4-settings",
+      "evidence": "commit cd8c05c42 (hub nativo) + 61e89f6ce (aspetto/privacy); SettingsWorkspaceTests verdi nella wave; residuo host-only dichiarato"
+    },
+    {
+      "area": "Contesto ambulatorio",
+      "feature": "POST/GET /api/context (imposta/legge ambulatory_id come cookie di sessione)",
+      "web": "app/api/context/route.ts — set/read cookie 'ambulatory_id' lato server, session-gated (requireSession)",
+      "native": "full per equivalenza stateless: il client seleziona l'ambulatorio per richiesta (picker esistente + cookie per-request) e legge lo scope effettivo risolto dal server via identity.scope (ramo paired onora il cookie ambulatory_id, smoke discovery-read lo asserisce); un POST context server-side non ha senso per un client stateless (decisione D7 spec W2-finale)",
+      "boundary": "full per equivalenza: identity dual-auth con scope dal cookie; nessuna route context dedicata per design",
+      "gap": "full-parity",
+      "wave": "W2-boundary",
+      "evidence": "w2-final commits 984f16474; smoke prescriptions-write e discovery-read verdi; swift 110 Core + 257 AppleShared 0 failure; spec D7"
+    },
+    {
+      "area": "FSE / conformità",
+      "feature": "Validazione documento FSE singolo (profilo->payload) via v1",
+      "web": "app/api/v1/fse/validate-document/route.ts — POST {profile, document|payload} -> validateProfileDocument(), auth locale (requireLocalApiToken), DISTINTO da /api/fse/validate-patient (batch validazione retrospettiva paziente, session-auth, cita PROFILE_OBSERVATION_VITALS/PROFILE_THERAPY_MEDICATION su tutte le risorse del paziente)",
+      "native": "full: azione Verifica FSE nell area documenti che invoca validateFseDocument sui record terapia/osservazione e mostra l esito per profilo; client method e boundary gia pronti (W2), UI aggiunta in W5",
+      "boundary": "full: POST /api/v1/network/fse/validate-document sotto capability network.fse.validate (logica condivisa con la route v1 locale)",
+      "gap": "full-parity",
+      "wave": "W2-boundary+W5-ui",
+      "evidence": "PR #16 (Wave 5) + PR #17 (gate XCUITest), CI GitHub pubblica; smoke documenti+diario reali verdi"
+    },
+    {
+      "area": "Repertorio prestazioni",
+      "feature": "GET /api/service-catalog (catalogo prestazioni) + famiglie distinte /api/service-prescriptions e /api/service-prescription-items",
+      "web": "app/api/service-catalog/route.ts (catalogo/ricerca), app/api/service-prescriptions/* (prescrizioni), app/api/service-prescription-items/* (righe/item) — tre famiglie API separate, non un'unica 'matching repertorio'",
+      "native": "full a livello API: fetchServiceCatalog(+count) nel client paired; il matching repertorio in UI non esiste su NESSUNA superficie (la web crea item con matchStatus manual/unmatched senza consultare il catalogo), quindi non e' un gap di parita'",
+      "boundary": "full: GET /api/v1/network/service-catalog sotto readonly-service-prescriptions",
+      "gap": "full-parity",
+      "wave": "W2-boundary",
+      "evidence": "w2-final commits 984f16474; smoke prescriptions-write e discovery-read verdi; swift 110 Core + 257 AppleShared 0 failure; DEDUP: le famiglie prescriptions/items sono coperte dalla riga 'Prestazioni prescritte' (W2-boundary); questa riga resta per il solo catalogo; retag da W1-mobile-core a W2-boundary"
+    },
+    {
+      "area": "AI conversazionale",
+      "feature": "POST /api/proxy/ai/chat (proxy invocazione modello AI per chat), distinto da /api/conversations e /api/messages (CRUD storico)",
+      "web": "app/api/proxy/ai/chat/route.ts — endpoint proxy che inoltra la richiesta di generazione al runtime AI configurato (Ollama/MLX/cloud); /api/conversations e /api/messages gestiscono solo persistenza CRUD dello storico, non l'invocazione del modello",
+      "native": "missing — nessun riferimento a proxy/ai/chat nel codice nativo; il client Apple non ha superficie per invocare la generazione AI stessa (solo eventuale lettura storico se già coperta altrove)",
+      "boundary": "missing — non esiste sotto /api/v1/network; il proxy AI chat non è raggiungibile dal client paired tramite boundary consentito",
+      "gap": "missing-both",
+      "wave": "W5-ai-avanzate",
+      "evidence": "PR #16 (Wave 5) + PR #17 (gate XCUITest), CI GitHub pubblica; app/api/proxy/ai/chat/route.ts vs app/api/conversations/route.ts, app/api/messages/route.ts"
+    },
+    {
+      "area": "AI runtime locale",
+      "feature": "GET /api/system/mlx (stato/gestione generico runtime MLX via PM2, admin-only, solo macOS), distinto da /api/system/treatment-reasoning/athena-mlx (generazione ragionamento terapeutico specifico, kill-switch dedicato)",
+      "web": "app/api/system/mlx/route.ts — stato PM2Manager del runtime MLX generico (501 strutturato su non-macOS), requireSessionOrLocalToken + admin only; athena-mlx è un consumer applicativo separato del runtime, con proprio kill-switch AI_TREATMENT_REASONING_KILL_SWITCH_KEY",
+      "native": "missing — nessuna evidenza di consumo di /api/system/mlx (generico) nel codice nativo, solo eventualmente della funzione applicativa athena-mlx se già mappata altrove",
+      "boundary": "n/a — non è sotto /api/v1/network; è un endpoint di sistema admin, HOST-ONLY per natura (richiede PM2/macOS Apple Silicon)",
+      "gap": "host-only",
+      "wave": "HOST-ONLY",
+      "evidence": "app/api/system/mlx/route.ts:14-16,29-36 vs app/api/system/treatment-reasoning/athena-mlx/route.ts:1-13"
+    },
+    {
+      "area": "Privacy / de-identificazione",
+      "feature": "GET /api/system/redaction (stato/health provider OpenMed per redazione PII)",
+      "web": "app/api/system/redaction/route.ts — verifica endpoint OpenMed configurato e relativo health check, requireSessionOrLocalToken",
+      "native": "host-only: stato e health di OpenMed locale, senza pertinenza per il client paired remoto",
+      "boundary": "host-only: non è sotto /api/v1/network; dipende da OpenMed locale e usa requireSessionOrLocalToken con validateLocalTarget",
+      "gap": "host-only",
+      "wave": "W4-settings",
+      "evidence": "spec W4 D14; app/api/system/redaction/route.ts:1-33"
+    },
+    {
+      "area": "Diagnostica applicazione",
+      "feature": "GET /api/system/revision (fingerprint/branch/revisione build corrente, usato per rilevare mismatch versione)",
+      "web": "app/api/system/revision/route.ts — espone revision/sourceFingerprint/fingerprint sempre, branch/worktreeHash solo se autenticato; consumato da components/app-revision-guard.tsx per forzare reload su drift versione",
+      "native": "full: guard revisione attivo su connect e ritorno in foreground (fetchNetworkRevision, refetch + notice non bloccante su fingerprint cambiato)",
+      "boundary": "full: GET /api/v1/network/revision paired-auth espone SOLO revision/sourceFingerprint/fingerprint (branch/worktreeHash mai, asserito da smoke)",
+      "gap": "full-parity",
+      "wave": "W2-boundary",
+      "evidence": "w2-final commits 984f16474; smoke prescriptions-write e discovery-read verdi; swift 110 Core + 257 AppleShared 0 failure"
+    },
+    {
+      "area": "Zona pericolo / manutenzione DB",
+      "feature": "POST/GET /api/system/fix-orphans (conteggio+riparazione righe cliniche orfane, admin-only) e POST /api/system/migrate-m2m (migrazione relazione paziente-ambulatorio da 1:1 a many-to-many, admin-only) — DISTINTI dal generico /api/system/migrate (setup ambulatorio di default) e da repair-db/purge",
+      "web": "app/api/system/fix-orphans/route.ts — countOrphanedClinicalRows/purgeOrphanedClinicalRows su cascata paziente; app/api/system/migrate-m2m/route.ts — backfill patientsToAmbulatories da patients.ambulatoryId legacy; entrambi isWebAdminSession/role admin, azioni una-tantum di manutenzione dati distinte da 'migrate' semplice e da 'repair-db'",
+      "native": "missing — la riga attuale 'zona pericolo: repair-db/purge/migrate' non nomina questi due endpoint specifici; nessuna evidenza di superficie nativa equivalente",
+      "boundary": "n/a — non sono sotto /api/v1/network; operazioni web-admin dirette sul DB server, per natura HOST-ONLY (rischio di corruzione se esposte a un client remoto paired)",
+      "gap": "host-only",
+      "wave": "HOST-ONLY",
+      "evidence": "app/api/system/fix-orphans/route.ts:1-38; app/api/system/migrate-m2m/route.ts:1-20; cfr. app/api/system/migrate/route.ts:1-16 (endpoint generico distinto)"
+    },
+    {
+      "area": "Network boundary — discovery/pairing",
+      "feature": "GET /api/v1/network/capabilities, /api/v1/network/identity, /api/v1/network/node (negoziazione capability host, identità di rete, sommario nodo) — famiglie boundary distinte da pairing-intents/confirm e session",
+      "web": "app/api/v1/network/capabilities/route.ts (getNetworkCapabilities), app/api/v1/network/identity/route.ts (getNetworkIdentitySummary, session-aware), app/api/v1/network/node/route.ts (getNetworkNodeSummary) — tutte con requireLocalApiToken, GET-only, servono a un client paired per scoprire cosa il nodo host supporta prima/durante il pairing",
+      "native": "full: fetchNetworkCapabilities/Identity/Node nel client paired con test; identity consumata per lo scope, revision guard attivo; nessuna superficie UI diagnostica dedicata su nessuno dei due lati (parita' a livello di consumo API)",
+      "boundary": "full: dual-auth local-token O paired (helper resolveNetworkDiscoveryAuth; ramo local-token invariato, asserito da smoke)",
+      "gap": "full-parity",
+      "wave": "W2-boundary",
+      "evidence": "w2-final commits 984f16474; smoke prescriptions-write e discovery-read verdi; swift 110 Core + 257 AppleShared 0 failure"
+    },
+    {
+      "area": "Impostazioni AI",
+      "feature": "/settings/ai (hub) — in realtà un semplice redirect a /settings/ai/modelli, non una vista distinta",
+      "web": "app/settings/ai/page.tsx — 'export default function SettingsAiIndexPage() { redirect(\"/settings/ai/modelli\"); }' (commento: WUL-297, /settings/ai defaults to models surface); le viste reali sono /settings/ai/modelli e /settings/ai/funzioni",
+      "native": "n/a — non è un gap: non esiste una terza superficie UI da coprire, la riga 'ai-runtime' che copre modelli+funzioni è già esaustiva",
+      "boundary": "n/a",
+      "gap": "full-parity",
+      "wave": "W4-settings",
+      "evidence": "app/settings/ai/page.tsx:1-5"
+    }
+  ],
+  "critique_residua": [],
+  "updated": "2026-07-11 WUL-479 closeout: evidence reconciled to public/main after Wave 5; residual gaps assigned to Wave 6 or host-only policy",
+  "version": 1,
+  "summary": {
+    "total": 64,
+    "fullParity": 31,
+    "partial": 13,
+    "missing": 2,
+    "hostOnly": 18,
+    "openNonHost": 15
+  }
+}

--- a/docs/apple-parity-matrix.json
+++ b/docs/apple-parity-matrix.json
@@ -76,7 +76,7 @@
       "area": "terapie",
       "feature": "Gestione terapie farmacologiche (CRUD + stato + collegamento diagnosi)",
       "web": "add/edit/soft-delete/status transition, autocomplete AIFA, principio attivo, posologia, collegamento diagnosi, campi AIC/ATC (components/therapy-manager.tsx)",
-      "native": "partial: CRUD+soft-delete+stato+collegamento diagnosi+export testo+campi AIC/ATC in create/edit/dettaglio. Residuo: catalogo AIFA con autocomplete e validazione prontuario (W2 boundary drugs)",
+      "native": "partial: CRUD+soft-delete+stato+campi AIC/ATC/principio attivo, autocomplete AIFA e fallback manuale onesto. Residuo: equivalenza completa del collegamento diagnosi e validazione manuale P6 della flessibilita del form",
       "boundary": "partial: GET/POST/PUT therapies; manca DELETE (write-therapies esclude hard delete/AI/document-derived)",
       "gap": "partial",
       "wave": "W1-mobile-core",
@@ -166,9 +166,9 @@
       "area": "documenti",
       "feature": "Smart Import (candidati diagnosi/terapie da documenti, applica in scheda)",
       "web": "analisi AI candidati ICD-11/AIFA, select/edit/scarta, preview resolver, applica scrittura, kill switch AI_SMART_IMPORT (components/patient-smart-import-panel.tsx)",
-      "native": "missing: nessuna superficie Smart Import lato Apple",
-      "boundary": "missing: document-derived/AI writes esclusi dalle capability",
-      "gap": "missing-both",
+      "native": "host-only per la policy corrente: nessuna superficie Smart Import lato Apple; WUL-409 resta una lane review-first separata, non un requisito automatico di parity",
+      "boundary": "host-only: ADR 0076 esclude scritture document-derived/AI dal client paired finche una nuova decisione non ne ridefinisce il boundary",
+      "gap": "host-only",
       "wave": "W5-ai-avanzate",
       "evidence": "PR #16 (Wave 5) + PR #17 (gate XCUITest), CI GitHub pubblica; native-ui.documenti"
     },
@@ -576,9 +576,9 @@
       "area": "AI conversazionale",
       "feature": "POST /api/proxy/ai/chat (proxy invocazione modello AI per chat), distinto da /api/conversations e /api/messages (CRUD storico)",
       "web": "app/api/proxy/ai/chat/route.ts — endpoint proxy che inoltra la richiesta di generazione al runtime AI configurato (Ollama/MLX/cloud); /api/conversations e /api/messages gestiscono solo persistenza CRUD dello storico, non l'invocazione del modello",
-      "native": "missing — nessun riferimento a proxy/ai/chat nel codice nativo; il client Apple non ha superficie per invocare la generazione AI stessa (solo eventuale lettura storico se già coperta altrove)",
-      "boundary": "missing — non esiste sotto /api/v1/network; il proxy AI chat non è raggiungibile dal client paired tramite boundary consentito",
-      "gap": "missing-both",
+      "native": "host-only per la policy corrente: il client Apple non invoca la generazione AI e puo al massimo leggere output gia persistiti nelle superfici consentite",
+      "boundary": "host-only: il proxy AI chat non appartiene a /api/v1/network e ADR 0076 esclude l'invocazione AI paired",
+      "gap": "host-only",
       "wave": "W5-ai-avanzate",
       "evidence": "PR #16 (Wave 5) + PR #17 (gate XCUITest), CI GitHub pubblica; app/api/proxy/ai/chat/route.ts vs app/api/conversations/route.ts, app/api/messages/route.ts"
     },
@@ -636,10 +636,10 @@
       "area": "Impostazioni AI",
       "feature": "/settings/ai (hub) — in realtà un semplice redirect a /settings/ai/modelli, non una vista distinta",
       "web": "app/settings/ai/page.tsx — 'export default function SettingsAiIndexPage() { redirect(\"/settings/ai/modelli\"); }' (commento: WUL-297, /settings/ai defaults to models surface); le viste reali sono /settings/ai/modelli e /settings/ai/funzioni",
-      "native": "n/a — non è un gap: non esiste una terza superficie UI da coprire, la riga 'ai-runtime' che copre modelli+funzioni è già esaustiva",
-      "boundary": "n/a",
-      "gap": "full-parity",
-      "wave": "W4-settings",
+      "native": "n/a — redirect e configurazione del runtime AI restano superfici del nodo Mac autorevole, non un target di parity del client paired",
+      "boundary": "host-only: nessun boundary paired richiesto per un redirect verso impostazioni AI locali",
+      "gap": "host-only",
+      "wave": "HOST-ONLY",
       "evidence": "app/settings/ai/page.tsx:1-5"
     }
   ],
@@ -648,10 +648,10 @@
   "version": 1,
   "summary": {
     "total": 64,
-    "fullParity": 31,
+    "fullParity": 30,
     "partial": 13,
-    "missing": 2,
-    "hostOnly": 18,
-    "openNonHost": 15
+    "missing": 0,
+    "hostOnly": 21,
+    "openNonHost": 13
   }
 }

--- a/docs/apple-wide-qa-manifest.json
+++ b/docs/apple-wide-qa-manifest.json
@@ -360,7 +360,7 @@
         "iPad"
       ],
       "status": "gap",
-      "acceptance": "Mobile clients keep encrypted derived cache, show paired-offline-degraded state and reconcile writes explicitly when the home-base returns.",
+      "acceptance": "Mobile clients keep encrypted derived cache, expose cache age, TTL and stale state, remain read-only while offline, and make the absence of an offline write queue explicit.",
       "gapIssue": "WUL-403",
       "evidence": [
         {
@@ -540,7 +540,7 @@
         },
         {
           "type": "command",
-          "value": "npm run check:openapi:drift -- --base-ref public/main"
+          "value": "npm run check:openapi:drift -- --base-ref origin/main"
         },
         {
           "type": "adr",
@@ -569,7 +569,7 @@
         },
         {
           "type": "command",
-          "value": "npm run check:openapi:drift -- --base-ref public/main"
+          "value": "npm run check:openapi:drift -- --base-ref origin/main"
         },
         {
           "type": "adr",
@@ -590,7 +590,7 @@
         "iPad"
       ],
       "status": "gap",
-      "acceptance": "Eseguire la click-map manuale P6 sul bundle macOS home-base per Pazienti, Diario, Terapie, Checkup e Osservazioni; i probe automatici restano evidenza preparatoria, non certificazione di parity UI piena.",
+      "acceptance": "Eseguire la click-map manuale P6 sul bundle macOS home-base per Pazienti, Diario base, editor rich text, Terapie, Checkup, Osservazioni, cockpit e shell/deep-link; i probe automatici restano evidenza preparatoria, non certificazione di parity UI piena.",
       "evidence": [
         {
           "type": "command",
@@ -614,4 +614,3 @@
   ],
   "originIssue": "WUL-194"
 }
-

--- a/docs/apple-wide-qa-manifest.json
+++ b/docs/apple-wide-qa-manifest.json
@@ -1,0 +1,617 @@
+{
+  "version": 2,
+  "updatedAt": "2026-07-11",
+  "issue": "WUL-479",
+  "networkCapabilityContract": {
+    "activeNetworkKeys": [
+      "network.pairing.bootstrap",
+      "network.ambulatories.write",
+      "network.replica.readonly-patients",
+      "network.replica.readonly-clinical-diary",
+      "network.replica.write-patient-profile",
+      "network.replica.write-patient-lifecycle",
+      "network.replica.write-clinical-diary",
+      "network.replica.readonly-therapies",
+      "network.replica.write-therapies",
+      "network.replica.readonly-checkups",
+      "network.replica.readonly-agenda",
+      "network.replica.readonly-clinical-diary-global",
+      "network.replica.write-checkups",
+      "network.replica.readonly-observations",
+      "network.replica.write-observations",
+      "network.replica.readonly-service-prescriptions",
+      "network.replica.write-service-prescriptions",
+      "network.replica.readonly-prosthetic-prescriptions",
+      "network.replica.write-prosthetic-prescriptions",
+      "network.fse.validate",
+      "network.catalogs.readonly",
+      "network.ai.central-runtime",
+      "network.replica.readonly-documents",
+      "network.replica.write-documents",
+      "network.compute.visit-draft"
+    ],
+    "plannedNetworkKeys": [
+      "network.replica.sync",
+      "network.catalogs.sync"
+    ],
+    "localOnlyKeys": [
+      "local.backup.artifact.v1",
+      "local.backup.scheduler.macos"
+    ],
+    "note": "Runtime, TypeScript, and OpenAPI enumerate these 29 keys. The 24 QA acceptance records are separate from the key enum; add each future active network key to every contract surface and its QA coverage together."
+  },
+  "capabilities": [
+    {
+      "id": "macos-packaged-home-base-runtime",
+      "title": "macOS packaged home-base runtime",
+      "surfaces": [
+        "macOS"
+      ],
+      "status": "covered",
+      "acceptance": "The built macOS bundle opens the Apple/home-base shell, includes the web runtime, manages backend/proxy explicitly, and supports local signing.",
+      "evidence": [
+        {
+          "type": "command",
+          "value": "MEDIFLOW_CODESIGN_IDENTITY=- bash scripts/build-native-app.sh"
+        },
+        {
+          "type": "command",
+          "value": "codesign -dv native/MediFlowMac/Build/MediFlowMac.app"
+        },
+        {
+          "type": "manual",
+          "value": "MediFlow v0.7.2 public release: https://github.com/Wulfgardr/mediflow/releases/tag/v0.7.2"
+        }
+      ]
+    },
+    {
+      "id": "shared-apple-core-contracts",
+      "title": "Shared Apple core contracts",
+      "surfaces": [
+        "macOS",
+        "iPhone",
+        "iPad"
+      ],
+      "status": "covered",
+      "acceptance": "Shared Swift code has repeatable tests for pairing store, encrypted patient-list cache, patients client, launch overrides, Bonjour discovery, runtime status and optional service diagnostics.",
+      "evidence": [
+        {
+          "type": "command",
+          "value": "swift test --package-path native/MediFlowMac"
+        }
+      ]
+    },
+    {
+      "id": "mobile-paired-bootstrap-read",
+      "title": "Mobile paired bootstrap and read",
+      "surfaces": [
+        "iPhone",
+        "iPad",
+        "home-base"
+      ],
+      "status": "covered",
+      "acceptance": "A booted iPhone/iPad simulator can receive temporary paired credentials, authenticate as operator, read network patients, launch MediFlowMobile and capture an artifact.",
+      "evidence": [
+        {
+          "type": "runbook",
+          "value": "docs/mobile-home-base-smoke.md"
+        },
+        {
+          "type": "command",
+          "value": "MEDIFLOW_MOBILE_SMOKE_OPERATOR_PIN=<PIN> bash scripts/mobile-home-base-paired-smoke.sh"
+        }
+      ]
+    },
+    {
+      "id": "paired-ambulatory-write",
+      "title": "Paired ambulatory write boundary",
+      "surfaces": [
+        "iPhone",
+        "iPad",
+        "home-base"
+      ],
+      "status": "covered",
+      "acceptance": "The paired client can create, update, promote, delete, and clear a test ambulatory through the versioned network boundary with paired-client audit attribution.",
+      "evidence": [
+        {
+          "type": "command",
+          "value": "npm run test:network:home-base-ambulatory-write"
+        }
+      ]
+    },
+    {
+      "id": "paired-account-pin-rotation",
+      "title": "Paired account PIN rotation",
+      "surfaces": [
+        "iPhone",
+        "iPad",
+        "home-base"
+      ],
+      "status": "covered",
+      "acceptance": "The paired client rotates its PIN through the shared auth family using client-of-origin re-wrap, a versioned KDF, rotated salt, and conditional server persistence.",
+      "evidence": [
+        {
+          "type": "command",
+          "value": "npm run test:network:home-base-account-pin"
+        },
+        {
+          "type": "adr",
+          "value": "docs/adr/0075-paired-account-operations-and-pin-rotation.md"
+        }
+      ]
+    },
+    {
+      "id": "paired-profile-write",
+      "title": "Paired patient profile write",
+      "surfaces": [
+        "iPhone",
+        "iPad",
+        "home-base"
+      ],
+      "status": "covered",
+      "acceptance": "Network paired write for patient profile/status requires paired credentials, operator session, capability and version conflict handling.",
+      "evidence": [
+        {
+          "type": "command",
+          "value": "npm run test:network:home-base-write"
+        },
+        {
+          "type": "adr",
+          "value": "docs/adr/0052-network-patient-profile-write-boundary.md"
+        }
+      ]
+    },
+    {
+      "id": "paired-diary-write",
+      "title": "Paired diary write",
+      "surfaces": [
+        "iPhone",
+        "iPad",
+        "home-base"
+      ],
+      "status": "covered",
+      "acceptance": "Network paired diary create/update/soft-delete requires paired credentials, operator session, capability and entry version handling.",
+      "evidence": [
+        {
+          "type": "command",
+          "value": "npm run test:network:home-base-diary-write"
+        },
+        {
+          "type": "adr",
+          "value": "docs/adr/0053-network-diary-entry-write-boundary.md"
+        }
+      ]
+    },
+    {
+      "id": "paired-therapy-write",
+      "title": "Paired therapy write",
+      "surfaces": [
+        "iPhone",
+        "iPad",
+        "home-base"
+      ],
+      "status": "covered",
+      "acceptance": "Network paired therapy create/update/soft-delete requires paired credentials, operator session, capability and therapy version handling.",
+      "evidence": [
+        {
+          "type": "command",
+          "value": "npm run test:network:home-base-therapy-write"
+        },
+        {
+          "type": "adr",
+          "value": "docs/adr/0054-network-therapy-write-boundary.md"
+        }
+      ]
+    },
+    {
+      "id": "paired-checkup-write",
+      "title": "Paired checkup write",
+      "surfaces": [
+        "iPhone",
+        "iPad",
+        "home-base"
+      ],
+      "status": "covered",
+      "acceptance": "Network paired checkup create/update/soft-delete requires paired credentials, operator session, capability and checkup version handling.",
+      "evidence": [
+        {
+          "type": "command",
+          "value": "npm run test:network:home-base-checkup-write"
+        },
+        {
+          "type": "adr",
+          "value": "docs/adr/0055-network-checkup-write-boundary.md"
+        }
+      ]
+    },
+    {
+      "id": "paired-observation-write",
+      "title": "Paired observation write",
+      "surfaces": [
+        "iPhone",
+        "iPad",
+        "home-base"
+      ],
+      "status": "covered",
+      "acceptance": "Network paired observation create/update/soft-delete requires paired credentials, operator session, capability and observation version handling.",
+      "evidence": [
+        {
+          "type": "command",
+          "value": "npm run test:network:home-base-observation-write"
+        },
+        {
+          "type": "adr",
+          "value": "docs/adr/0056-network-observation-write-boundary.md"
+        }
+      ]
+    },
+    {
+      "id": "paired-catalog-read",
+      "title": "Paired catalog read",
+      "surfaces": [
+        "iPhone",
+        "iPad",
+        "home-base"
+      ],
+      "status": "covered",
+      "acceptance": "Network paired read-only catalog lookup exposes drugs, exemptions and terminology through /api/v1/network/* only for paired clients with operator session and network.catalogs.readonly; catalog sync remains planned separately.",
+      "evidence": [
+        {
+          "type": "command",
+          "value": "npm run test:network:home-base-catalog-read"
+        }
+      ]
+    },
+    {
+      "id": "paired-cross-patient-agenda-read",
+      "title": "Paired cross-patient agenda read",
+      "surfaces": [
+        "iPhone",
+        "iPad",
+        "home-base"
+      ],
+      "status": "covered",
+      "acceptance": "Network paired agenda reads use a distinct capability, mandatory capped limit, plaintext date and status filters, and ambulatory membership scope that excludes patients outside the active ambulatory.",
+      "evidence": [
+        {
+          "type": "command",
+          "value": "npm run test:unit"
+        },
+        {
+          "type": "adr",
+          "value": "docs/adr/0074-network-cross-patient-read-boundary.md"
+        }
+      ]
+    },
+    {
+      "id": "paired-cross-patient-diary-read",
+      "title": "Paired cross-patient clinical diary read",
+      "surfaces": [
+        "iPhone",
+        "iPad",
+        "home-base"
+      ],
+      "status": "covered",
+      "acceptance": "Network paired global diary reads use a distinct capability, mandatory capped limit, plaintext filters, ambulatory membership scope, and preserve sealed fields plus soft-delete tombstones for client-side rendering.",
+      "evidence": [
+        {
+          "type": "command",
+          "value": "npm run test:unit"
+        },
+        {
+          "type": "adr",
+          "value": "docs/adr/0074-network-cross-patient-read-boundary.md"
+        }
+      ]
+    },
+    {
+      "id": "mobile-core-crud-ui",
+      "title": "Mobile core CRUD UI",
+      "surfaces": [
+        "iPhone",
+        "iPad"
+      ],
+      "status": "covered",
+      "acceptance": "iPhone/iPad expose usable native list/detail/create/edit flows for the non-AI core modules.",
+      "evidence": [
+        {
+          "type": "command",
+          "value": "swift test --package-path native/MediFlowMac --filter HomeBasePatientsClientTests"
+        },
+        {
+          "type": "command",
+          "value": "npm run test:network:home-base-diary-write"
+        },
+        {
+          "type": "command",
+          "value": "npm run test:network:home-base-therapy-write"
+        },
+        {
+          "type": "command",
+          "value": "npm run test:network:home-base-checkup-write"
+        },
+        {
+          "type": "command",
+          "value": "npm run test:network:home-base-observation-write"
+        },
+        {
+          "type": "issue",
+          "value": "WUL-206"
+        },
+        {
+          "type": "issue",
+          "value": "WUL-208"
+        },
+        {
+          "type": "issue",
+          "value": "WUL-209"
+        },
+        {
+          "type": "issue",
+          "value": "WUL-210"
+        }
+      ]
+    },
+    {
+      "id": "mobile-offline-cache-reconciliation",
+      "title": "Mobile offline cache and explicit reconciliation",
+      "surfaces": [
+        "iPhone",
+        "iPad"
+      ],
+      "status": "gap",
+      "acceptance": "Mobile clients keep encrypted derived cache, show paired-offline-degraded state and reconcile writes explicitly when the home-base returns.",
+      "gapIssue": "WUL-403",
+      "evidence": [
+        {
+          "type": "command",
+          "value": "swift test --package-path native/MediFlowMac --filter HomeBasePatientCacheStoreTests"
+        },
+        {
+          "type": "issue",
+          "value": "WUL-403"
+        }
+      ]
+    },
+    {
+      "id": "paired-patient-lifecycle-boundary",
+      "title": "Paired patient lifecycle boundary",
+      "surfaces": [
+        "iPhone",
+        "iPad",
+        "home-base"
+      ],
+      "status": "covered",
+      "acceptance": "Network paired patient create, soft-delete, restore and tombstone listing are documented in OpenAPI and guarded by the lifecycle capability, sealed sensitive-field checks and optimistic concurrency.",
+      "evidence": [
+        {
+          "type": "command",
+          "value": "npm run test:unit"
+        },
+        {
+          "type": "command",
+          "value": "npm run check:openapi:drift -- --base-ref origin/main"
+        },
+        {
+          "type": "manual",
+          "value": "Lifecycle smoke V2 remains the next slice and is not implemented by this boundary slice."
+        }
+      ]
+    },
+    {
+      "id": "paired-service-prescriptions-boundary",
+      "title": "Paired service prescriptions boundary",
+      "surfaces": [
+        "iPhone",
+        "iPad",
+        "home-base"
+      ],
+      "status": "covered",
+      "acceptance": "Network paired service prescriptions and items can be listed, created and updated through scoped capability checks, parent membership checks and optimistic concurrency; paired DELETE is intentionally absent.",
+      "evidence": [
+        {
+          "type": "command",
+          "value": "npm run test:unit"
+        },
+        {
+          "type": "command",
+          "value": "npm run check:openapi:drift -- --base-ref origin/main"
+        },
+        {
+          "type": "manual",
+          "value": "S1 W2-finale excludes smoke S3 and native changes."
+        }
+      ]
+    },
+    {
+      "id": "paired-prosthetic-prescriptions-boundary",
+      "title": "Paired prosthetic prescriptions boundary",
+      "surfaces": [
+        "iPhone",
+        "iPad",
+        "home-base"
+      ],
+      "status": "covered",
+      "acceptance": "Network paired prosthetic prescriptions can be listed, created and updated through scoped capability checks and optimistic concurrency; paired DELETE is intentionally absent.",
+      "evidence": [
+        {
+          "type": "command",
+          "value": "npm run test:unit"
+        },
+        {
+          "type": "command",
+          "value": "npm run check:openapi:drift -- --base-ref origin/main"
+        },
+        {
+          "type": "manual",
+          "value": "S1 W2-finale excludes smoke S3 and native changes."
+        }
+      ]
+    },
+    {
+      "id": "paired-network-discovery-dual-auth",
+      "title": "Paired network discovery dual auth",
+      "surfaces": [
+        "iPhone",
+        "iPad",
+        "home-base"
+      ],
+      "status": "covered",
+      "acceptance": "Network capabilities, identity and node discovery accept either the local API token or paired credentials; paired identity additionally requires an operator session and resolves the cookie-selected ambulatory scope.",
+      "evidence": [
+        {
+          "type": "command",
+          "value": "npm run test:unit"
+        },
+        {
+          "type": "command",
+          "value": "npm run check:openapi:drift -- --base-ref origin/main"
+        },
+        {
+          "type": "manual",
+          "value": "S2 W2-finale excludes native and smoke changes."
+        }
+      ]
+    },
+    {
+      "id": "paired-network-revision-boundary",
+      "title": "Paired network revision boundary",
+      "surfaces": [
+        "iPhone",
+        "iPad",
+        "home-base"
+      ],
+      "status": "covered",
+      "acceptance": "GET /api/v1/network/revision is paired-authenticated, mode-gated, no-store, and exposes only revision, sourceFingerprint and fingerprint.",
+      "evidence": [
+        {
+          "type": "command",
+          "value": "npm run test:unit"
+        },
+        {
+          "type": "command",
+          "value": "npm run check:openapi:drift -- --base-ref origin/main"
+        },
+        {
+          "type": "manual",
+          "value": "S2 W2-finale excludes native guard consumption."
+        }
+      ]
+    },
+    {
+      "id": "paired-fse-validation-boundary",
+      "title": "Paired FSE validation boundary",
+      "surfaces": [
+        "iPhone",
+        "iPad",
+        "home-base"
+      ],
+      "status": "covered",
+      "acceptance": "Network paired FSE validate-patient and validate-document require paired credentials, operator session and network.fse.validate; validate-patient returns 404 for patients outside scope.",
+      "evidence": [
+        {
+          "type": "command",
+          "value": "npm run test:unit"
+        },
+        {
+          "type": "command",
+          "value": "npm run check:openapi:drift -- --base-ref origin/main"
+        },
+        {
+          "type": "manual",
+          "value": "S2 W2-finale excludes smoke S3 and Swift FHIR generation."
+        }
+      ]
+    },
+    {
+      "id": "paired-document-domain-boundary",
+      "title": "Paired document domain boundary",
+      "surfaces": [
+        "iPhone",
+        "iPad",
+        "home-base"
+      ],
+      "status": "covered",
+      "acceptance": "Network paired attachment list (metadata only, no data), single-attachment read (with data, 404 cross-patient) and create are guarded by distinct read/write capabilities, an active-and-scoped patient check, sealed name/path/data enforcement, rejection by presence of every document-derived and server-controlled field, and the shared host wire size limit; created attachments enter the OCR queue as pending/paired_upload. Paired update and delete are intentionally absent (ADR 0076, Classe A).",
+      "evidence": [
+        {
+          "type": "command",
+          "value": "npm run test:unit"
+        },
+        {
+          "type": "command",
+          "value": "npm run check:openapi:drift -- --base-ref public/main"
+        },
+        {
+          "type": "adr",
+          "value": "docs/adr/0076-paired-document-domain-write-policy.md"
+        },
+        {
+          "type": "manual",
+          "value": "S1 W5 excludes smoke S3 and native changes."
+        }
+      ]
+    },
+    {
+      "id": "paired-visit-draft-and-ai-runtime-status",
+      "title": "Paired visit-draft compute and AI runtime status",
+      "surfaces": [
+        "iPhone",
+        "iPad",
+        "home-base"
+      ],
+      "status": "covered",
+      "acceptance": "The paired client can compute a deterministic review-first visit draft without patient scope, persistence, or mutation audit, and can read fail-closed AI kill-switch status through discovery dual-auth.",
+      "evidence": [
+        {
+          "type": "command",
+          "value": "npm run test:unit"
+        },
+        {
+          "type": "command",
+          "value": "npm run check:openapi:drift -- --base-ref public/main"
+        },
+        {
+          "type": "adr",
+          "value": "docs/adr/0076-paired-document-domain-write-policy.md"
+        },
+        {
+          "type": "manual",
+          "value": "S2 W5 excludes smoke S3 and native changes."
+        }
+      ]
+    },
+    {
+      "id": "apple-wide-click-map",
+      "title": "Current Apple-wide click-map evidence",
+      "surfaces": [
+        "macOS",
+        "iPhone",
+        "iPad"
+      ],
+      "status": "gap",
+      "acceptance": "Eseguire la click-map manuale P6 sul bundle macOS home-base per Pazienti, Diario, Terapie, Checkup e Osservazioni; i probe automatici restano evidenza preparatoria, non certificazione di parity UI piena.",
+      "evidence": [
+        {
+          "type": "command",
+          "value": "npm run test:native:clickmap:probe"
+        },
+        {
+          "type": "command",
+          "value": "MEDIFLOW_MOBILE_SMOKE_OPERATOR_PIN=<PIN> MEDIFLOW_MOBILE_SMOKE_AUTOLOAD_PATIENTS=0 bash scripts/mobile-home-base-paired-smoke.sh"
+        },
+        {
+          "type": "command",
+          "value": "npm run test:network:home-base-write"
+        },
+        {
+          "type": "issue",
+          "value": "WUL-401"
+        }
+      ],
+      "gapIssue": "WUL-401"
+    }
+  ],
+  "originIssue": "WUL-194"
+}
+

--- a/docs/markdown-index.md
+++ b/docs/markdown-index.md
@@ -11,7 +11,7 @@ read_when:
 > GitHub mostra in alto solo alcuni file speciali (`README`, `CONTRIBUTING`, `SECURITY`, ecc.).
 > Questo file elenca invece **tutti** i `.md` tracciati nella repository con una sintesi rapida d'uso.
 
-Ultimo aggiornamento: 2026-07-09
+Ultimo aggiornamento: 2026-07-11
 
 ## 📚 Come usare questo indice
 
@@ -42,7 +42,7 @@ Ultimo aggiornamento: 2026-07-09
 | [docs/STATE_OF_THE_SYSTEM.md](./STATE_OF_THE_SYSTEM.md) | Stato canonico complessivo del sistema, pensato come lettura unica per onboarding profondo e review trasversale. | Quando devi capire cosa esiste davvero oggi, cosa e direzione e quali confini non vanno superati. |
 | [docs/topologia-dati-flussi.md](./topologia-dati-flussi.md) | Topologia dati, trust boundaries, cifratura e percorsi digitali, inclusi artifact documentali cifrati e boundary `network-home-base`. | Per analisi data flow e impatti sicurezza. |
 | [docs/repository-topology.md](./repository-topology.md) | Fonte canonica per repository operativa, confine Git/fuori-Git e aree top-level: runtime clinico, publication/site e tooling. | Quando devi scegliere repository, branch o collocazione di codice, asset e artefatti locali. |
-| [docs/parity-matrix.md](./parity-matrix.md) | Stato parity web/macOS su moduli core e gap operativi. | Per steering parity e release readiness. |
+| [docs/parity-matrix.md](./parity-matrix.md) | Stato canonico post-Wave 5 tra localhost e client Apple, conteggi della matrice a 64 capability e piano Wave 6/closeout. | Per steering parity, click-map P6 e release readiness Apple. |
 | [docs/ARCHITETTURA.md](./ARCHITETTURA.md) | Deep dive tecnico esteso dell'architettura MediFlow. | Per approfondimenti implementativi. |
 | [docs/system_architecture.md](./system_architecture.md) | Sintesi rapida dell'architettura operativa aggiornata al `main` corrente: Clinical Workbench unico, home-base, document intelligence, OCR platform boundary, SISS/FSE e guardrail locali. | Per overview veloce in onboarding/review. |
 

--- a/docs/parity-matrix.md
+++ b/docs/parity-matrix.md
@@ -1,117 +1,142 @@
-# Matrice Parity Web <-> macOS (Core)
-
-Stato documento: CANONICAL (parity operativa web/native)  
-Ultimo aggiornamento: 2026-06-16
-
+---
+summary: "Canonical feature-parity status between the localhost web app and the universal Apple client."
+read_when:
+  - "Planning or reviewing macOS, iPhone, or iPad parity work."
+  - "Checking which localhost capabilities are full, partial, host-only, or policy-gated."
 ---
 
-## 🎯 Obiettivo vincolante
+# Matrice parity localhost ↔ client Apple
 
-Nei moduli core, web app e app macOS devono avere:
+Stato documento: `CANONICAL`
+Ultimo aggiornamento: 2026-07-11 (`WUL-479`, post-Wave 5)
 
-1. le stesse funzioni
-2. gli stessi campi clinici rilevanti
-3. la stessa flessibilita operativa
-4. capacita di lavorare in modo indipendente (stesso DB condiviso, nessun storage duplicato)
+## Perimetro
 
-Riferimenti:
-- [docs/adr/0005-web-native-functional-parity.md](./adr/0005-web-native-functional-parity.md)
-- [docs/adr/0008-web-first-with-parity-sweeps.md](./adr/0008-web-first-with-parity-sweeps.md)
-- [docs/adr/0009-native-testing-strategy-xcode-xctest.md](./adr/0009-native-testing-strategy-xcode-xctest.md)
+Questa matrice confronta:
 
-## ⚙️ Cadenza operativa
+- **localhost**: la web app locale sul Mac, superficie clinica di riferimento;
+- **macOS**: il bundle Apple/home-base con shell clinica condivisa;
+- **iPhone/iPad**: client paired sul boundary `/api/v1/network/*`.
 
-- Modalita ordinaria: `web-first` (sviluppo principale sulla web app).
-- Modalita convergenza: `parity sweep` dedicati su macOS.
-- Regola: il gap puo esistere temporaneamente, ma deve essere tracciato qui e chiuso nelle wave di parity.
+La fonte machine-readable è
+[docs/apple-parity-matrix.json](./apple-parity-matrix.json). Il manifest
+[docs/apple-wide-qa-manifest.json](./apple-wide-qa-manifest.json) verifica invece
+24 acceptance record tecnici e i contratti di rete: una capability QA
+`covered` non equivale automaticamente a feature parity completa.
 
-## 📚 Legenda
+Riferimenti architetturali:
 
-| Stato | Significato |
-| --- | --- |
-| `FULL` | allineato |
-| `PARTIAL` | parzialmente allineato |
-| `MISSING` | assente |
+- [ADR 0005](./adr/0005-web-native-functional-parity.md)
+- [ADR 0008](./adr/0008-web-first-with-parity-sweeps.md)
+- [ADR 0048](./adr/0048-apple-shared-client-architecture-and-home-base-runtime.md)
+- [ADR 0076](./adr/0076-paired-document-domain-write-policy.md)
 
----
+## Fotografia post-Wave 5
 
-## 🧩 Baseline corrente (frozen native snapshot)
+| Classe | Righe | Significato |
+| --- | ---: | --- |
+| `full-parity` | 30 | Il workflow equivalente è disponibile sulle superfici target previste. |
+| `partial` | 13 | Esiste una superficie utile, ma manca equivalenza di funzione, campo, flessibilità o verifica manuale. |
+| `missing-both` | 0 | Nessuna capability resta priva sia di boundary sia di UI senza una decisione esplicita. |
+| `host-only` | 21 | La funzione resta sul Mac/localhost per autorità, filesystem, runtime AI o policy. |
+| **Totale** | **64** | Capability censite. |
 
-> [!NOTE]
-> Snapshot legacy congelato: nessun modulo core e ancora `FULL` e la click-map
-> manuale `P6` non e stata eseguita. La promessa Apple-wide si verifica nella
-> matrice separata, non in questa tabella.
+Escludendo le 21 righe intenzionalmente host-only, 30 capability su 43 sono
+`full-parity` (**70%**); 13 su 43 restano parziali (**30%**). Sul totale
+grezzo, le righe full sono 30/64 (**47%**).
 
-Il run strict `WUL-21` del 2026-05-02 ha validato la lane automatizzata
-web+native (`web 2/2`, Xcode native `45/45`), ma non cambia gli stati modulo:
-la click-map manuale `P6` non e stata eseguita e nessun modulo core e ancora
-`FULL`. Le esenzioni in create/edit paziente risultano code-satisfied in
-`WUL-22`, la semantica delete del diario e stata riallineata in `WUL-24`, le
-osservazioni native LOINC/UCUM risultano code-satisfied in `WUL-23` e i
-cataloghi farmaci/esenzioni sono ora operabili da Settings macOS in `WUL-25`.
-La parita campi/flex delle terapie native e code-satisfied in `WUL-76`.
-La parita campi/flex dei checkups/appuntamenti nativi e code-satisfied in
-`WUL-77`.
+Questi numeri non autorizzano il claim “parity completa”: la click-map manuale
+P6 del bundle macOS è ancora aperta in `WUL-401`.
 
-Il closeout `WUL-26` del 2026-05-02 ha rieseguito lo strict smoke automatizzato
-post-moduli con esito `PASS` (`web PASS`, `native xcode PASS`) in
-`tmp-parity-smoke/wul-26-20260502-post-module-closeout-rerun/summary.md` (private).
-Questo chiude la track legacy come evidenza documentale/code-satisfied, non come
-dichiarazione di UI parity piena del vecchio bundle macOS. Il primo slice
-`WUL-192` sposta l'entrypoint compilato su Apple Foundation/home-base e aggiunge
-osservabilita runtime, supervisione app-managed di backend/proxy e packaging
-firmabile; non riapre la vecchia shell clinica come UI ufficiale. La verifica
-capability-by-capability Apple-wide parte da
+## Stato per area
 
-| Modulo core | Contratto `/api/v1` | Web UI | macOS UI | Parity campi | Parity flessibilita | Indipendenza macOS | Stato |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| Pazienti | FULL (GET/POST/PUT/DELETE) | FULL | PARTIAL (view/add/edit/delete/archive/search/sort + filtri stato + esenzioni create/edit code-satisfied) | PARTIAL (click-map P6 non ancora eseguita) | FULL | FULL | PARTIAL |
-| Diario clinico (entries) | FULL | PARTIAL (add + soft-delete/restore) | FULL (add/edit/soft-delete/restore + filtri eliminati) | PARTIAL | PARTIAL | FULL | PARTIAL |
-| Terapie | FULL | FULL | FULL (CRUD + AIFA/manuale, principio attivo, motivazione, indicazione, date/stato) | PARTIAL (click-map P6 non ancora eseguita) | FULL | FULL | PARTIAL |
-| Appuntamenti (checkups) | FULL | PARTIAL (form paziente con date/title/notes/status/source manuale) | FULL (CRUD + note operative, status, source manuale, metadata contratto) | PARTIAL (click-map P6 non ancora eseguita) | FULL | FULL | PARTIAL |
-| Farmaci (catalogo/search) | FULL | FULL (search + import/clear) | FULL (search + status/import JSON/clear in Settings) | PARTIAL (click-map P6 non ancora eseguita) | FULL | FULL | PARTIAL |
-| Esenzioni (catalogo + patient mapping) | FULL | FULL | FULL (patient mapping create/edit + status/import JSON/clear in Settings) | PARTIAL (click-map P6 non ancora eseguita) | FULL | FULL | PARTIAL |
+| Area | Stato | Cosa è già disponibile | Residuo reale |
+| --- | --- | --- | --- |
+| Pazienti | `PARTIAL` | lista, ricerca, dettaglio, create/update, archivio, cestino e ripristino | operazioni bulk non esposte e click-map P6 |
+| Diario | `PARTIAL` | CRUD versionato, restore, filtri, S/O/A/P, rich text, allegati e bozza visita deterministica | equivalenza completa allegati/editor e verifica P6 |
+| Terapie | `PARTIAL` | CRUD, stato, AIC/ATC/principio attivo, autocomplete AIFA e fallback manuale | collegamento diagnosi e flessibilità del form da verificare |
+| Checkup | `PARTIAL` | CRUD, status/source, conflitti versione | equivalenza campi/flussi e P6 |
+| Osservazioni | `PARTIAL` | CRUD LOINC/UCUM e trend | equivalenza visuale/flessibilità e P6 |
+| Cataloghi AIFA/esenzioni | `FULL` per lookup | ricerca AIFA ed esenzioni dal boundary paired | import/clear repertori resta host-only |
+| Prestazioni e protesica | `FULL` nel perimetro paired | read/write versionati e UI nativa | nessun invio regionale o generazione NRE |
+| Export FHIR/FSE pre-check | `FULL` nel perimetro locale | bundle on-device e validazione boundary | nessun writeback FSE |
+| Viste globali | `MIXED` | agenda, diario globale e analytics di popolazione | shell/deep-link e cockpit sintetico restano partial |
+| Documenti | `PARTIAL` e policy-limited | upload manuale cifrato, archivio, insight read-only, follow-up e allegati nel diario | OCR/curation/document-derived write richiedono policy dedicata |
+| Offline mobile | `PARTIAL` | cache cifrata derivata e stato degradato read-only | TTL/freschezza visibili e riconciliazione onesta (`WUL-403`) |
+| AI generativa | `HOST-ONLY` | stato runtime/kill switch leggibile | nessuna invocazione AI paired per ADR 0076 |
+| Backup, diagnostica, repertori, update | `HOST-ONLY` | gestiti dal nodo Mac autorevole | non sono gap di parity client |
 
-### Runtime home-base Apple
+## Wave completate
 
-`WUL-192` introduce una prima superficie osservabile nel bundle macOS:
+1. **Wave 1 — core mobile**: diario, rich text, scale, terapie, report e cockpit.
+2. **Wave 2 — boundary paired**: lifecycle paziente, cataloghi, prestazioni,
+   protesica, FHIR, terminologie, discovery e revision guard.
+3. **Wave 3 — viste globali**: agenda, diario globale, analytics e shell clinica.
+4. **Wave 4 — settings e chiavi**: ambulatori, profilo, aspetto, privacy,
+   session lock e cambio PIN.
+5. **Wave 5 — documenti e superfici AI-adiacenti**: allegati manuali, archivio,
+   rich text, bozza visita deterministica, insight/follow-up read-only e stato AI.
+   Consegnata con [PR #16](https://github.com/Wulfgardr/mediflow/pull/16) e
+   follow-up [PR #17](https://github.com/Wulfgardr/mediflow/pull/17).
 
-- finestra primaria Apple Foundation/home-base invece del prototipo oncologico;
-- pannello runtime con config nativa, presenza token, PID backend/proxy,
-  modalita rete, fingerprint TLS e start/stop esplicito di backend web
-  production + proxy TLS inclusi nel bundle, con stop bounded/escalation;
-- health diagnostico read-only per Ollama e Docker/ICD se gia attivi, senza
-  installazione, avvio, arresto o supervisione app-managed.
+Wave 5 è una tranche consegnata, non la chiusura della parity complessiva.
 
-Questa non modifica gli stati dei moduli core nella tabella legacy: e la base
-per la track Apple-wide successiva, non una nuova certificazione di parity UI.
+## Wave 6 / closeout proposto
 
-## 🧪 QA Apple-wide (WUL-194)
+### W6-A — convergenza UI macOS e click-map P6
 
-La matrice legacy sopra resta la fonte per il vecchio confronto web/macOS core.
-Dal momento in cui il bundle macOS usa la shell Apple/home-base, la promessa
-Apple-wide si verifica invece con una matrice separata:
+Owner: `WUL-401`.
 
-La matrice Apple-wide distingue esplicitamente capability `covered` con
-comando/runbook ripetibile, gap `WUL-193` per CRUD UI mobile e cache/offline, e
-click-map `WUL-194` coperto sulle superfici oggi disponibili: macOS home-base
-shell, smoke mobile paired e write paired non-AI.
+Copre otto residui: pazienti, diario base, editor rich text, terapie, checkup,
+osservazioni, cockpit e shell/deep-link. L’uscita richiede una click-map manuale
+reale sul bundle home-base; i probe automatici non bastano.
 
-> [!IMPORTANT]
-> Nessuna riga `covered` nella matrice Apple-wide equivale da sola a parity
-> piena del prodotto.
+### W6-B — offline degradato onesto
 
-## ⚠️ Gap principali da chiudere
+Owner: `WUL-403`.
 
-1. Nessun gap modulo-specifico legacy resta aperto nella track `WUL-75`: pazienti, esenzioni, osservazioni, diario, cataloghi, terapie e checkups sono code-satisfied sui rispettivi thin slice.
-2. La parity UI piena non va dichiarata sul bundle macOS corrente finche l'entrypoint compilato non torna a una shell clinica MediFlow. Questo lavoro passa alla track Apple-native/home-base (`WUL-187`/`WUL-194`).
+Rende visibili età/TTL della cache, stato stale, read-only e assenza di write
+queue. Non introduce sync multi-master né scritture offline.
 
-## ✅ Regole di uscita (parity gate)
+### W6-C — decisione sul workflow documentale nativo
 
-Un modulo core e considerato `FULL` solo se:
+Dipendenze: `WUL-417` (OCR Apple on-device), `WUL-383` (degradazione OCR) e
+`WUL-409` (Smart Import review-first).
 
-1. funzioni `view/add/edit/delete/filter` equivalenti nei due client
-2. campi principali equivalenti in create/edit/detail
-3. filtri/stati/ricerca/ordinamento equivalenti
-4. workflow completabile end-to-end su entrambi i client
-5. nessuna deviazione dati (stesso schema SQLite e stesso contratto `/api/v1`)
+Copre quattro residui partial: nuova voce avanzata, OCR/sintesi dell’archivio,
+curation degli insight e wizard nuova scheda da documento. Prima di estendere
+scritture document-derived o invocazione AI paired serve una nuova decisione
+che aggiorni ADR 0076. In sua assenza, queste superfici restano read-only o
+host-assisted.
+
+### Fuori Wave 6
+
+- chat/generazione AI paired;
+- gestione modelli, backup, diagnostica e import repertori dal client;
+- hard delete remoto;
+- writeback SISS/FSE;
+- coda di scrittura offline o sync multi-master;
+- parity applicativa Windows/Linux.
+
+Il catalogo AIFA nativo non è un residuo: autocomplete, AIC/ATC e fallback
+manuale sono già presenti; `WUL-476` è assorbita dallo stato corrente.
+
+## Gate di uscita
+
+Una capability può diventare `full-parity` solo con:
+
+1. funzioni equivalenti nel perimetro dichiarato;
+2. stessi campi clinici significativi;
+3. equivalente ricerca, filtri, stati e gestione conflitti;
+4. workflow completabile end-to-end;
+5. test o runbook ripetibile;
+6. click-map manuale quando la promessa riguarda l’esperienza UI;
+7. nessuna violazione dei boundary local-first, zero-knowledge o review-first.
+
+## Verifica
+
+```bash
+npm run check:apple-wide-qa
+npm run check:claims
+npm run check:never-regress
+```

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -382,8 +382,9 @@ Boundary attuale:
   `network.replica.write-checkups` e `checkups.version`
 - le osservazioni paired usano capability `network.replica.readonly-observations` /
   `network.replica.write-observations` e `observations.version`
-- hard delete remoto, attachment remoti, cataloghi, sync record-level,
-  campi AI/document-derived e fallback automatico restano fuori scope
+- hard delete remoto, PUT/DELETE paired degli allegati, sync record-level,
+  invocazione AI, campi document-derived e fallback automatico restano fuori;
+  cataloghi read-only e create manuale allegati sono disponibili
 
 ### Backup e restore artifact v1
 
@@ -651,10 +652,10 @@ sequenceDiagram
 
 ## ⚠️ Limitazioni attuali
 
-- `home-base` e ancora read-only-first: esistono solo i primi write versionati
-  per profilo/status paziente, diario clinico, terapie, checkup e osservazioni; hard delete
-  remoto, attachment remoti, cataloghi, sync record-level e
-  fallback automatico promotable restano fuori.
+- `home-base` resta read-only-first come autorita, ma include write versionati
+  su lifecycle paziente, moduli clinici, prestazioni/protesica e create manuale
+  degli allegati. Hard delete, curation document-derived, invocazione AI,
+  write offline e sync record-level restano fuori.
 - `documentInsights` resta un compat layer: il `document evidence ledger` ha
   ora una base runtime con artifact e prime ancore sezionali, ma i decision
   layer completi restano incrementali.
@@ -667,18 +668,19 @@ sequenceDiagram
   smoke web+native `PASS`, gap modulo-specifici chiusi, nessuna dichiarazione
   di UI parity piena della vecchia shell clinica. La prossima click-map
   capability-by-capability appartiene al filone Apple-native/home-base.
-- Il pairing multi-device e la UX iPhone/iPad sono ancora workstream aperti.
+- Il closeout parity e tracciato da `WUL-479`: click-map P6 (`WUL-401`), offline
+  degradato (`WUL-403`) e decisione documentale condizionata da ADR 0076.
 
 ---
 
 ## 🧭 Prossimi passi suggeriti
 
-1) Estendere la UX `home-base`: pairing guidato, replica governata e fallback
-   dichiarato senza rompere il local-first
+1) Eseguire la Wave 6/closeout definita in `docs/parity-matrix.md`, iniziando
+   dalla click-map P6 e dai residui UI realmente azionabili
 2) Portare altri consumer sul `parse/evidence artifact` prima di cambiare i
    contratti persistiti piu ampi
 3) Riavviare il filone native sul nuovo shell, non su quello storico; quando
    serve un riferimento visuale esterno, confrontarlo esplicitamente con
    OncoBackboneMac senza confonderlo con MediFlow
-4) Aprire i target iPhone/iPad coerenti con il boundary paired/read-only-first
-   e con i write paziente/diario/terapie/checkup/osservazioni limitati e versionati
+4) Rendere visibile TTL/freschezza della cache mobile senza introdurre write
+   offline o sync multi-master

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "check:schema-drift": "node scripts/check-schema-drift.mjs",
     "check:standalone-runtime-bundle": "node scripts/check-standalone-runtime-bundle.mjs",
     "check:mlx-operational-parity": "node scripts/check-mlx-operational-parity.mjs",
+    "check:apple-wide-qa": "node scripts/check-apple-wide-qa-manifest.mjs",
     "check:claims": "node scripts/check-claims-guard.mjs",
     "rehearse:api-v1-compatibility": "node scripts/api-v1-compatibility-rehearsal.mjs",
     "check:never-regress": "node scripts/check-never-regress.mjs",

--- a/scripts/check-apple-wide-qa-manifest.mjs
+++ b/scripts/check-apple-wide-qa-manifest.mjs
@@ -15,12 +15,16 @@ const allowedEvidenceTypes = new Set(['command', 'runbook', 'adr', 'issue', 'pr'
 const allowedParityGaps = new Set(['full-parity', 'partial', 'missing-both', 'host-only']);
 const expectedParitySummary = {
   total: 64,
-  fullParity: 31,
+  fullParity: 30,
   partial: 13,
-  missing: 2,
-  hostOnly: 18,
-  openNonHost: 15,
+  missing: 0,
+  hostOnly: 21,
+  openNonHost: 13,
 };
+const expectedManifestGaps = new Map([
+  ['mobile-offline-cache-reconciliation', 'WUL-403'],
+  ['apple-wide-click-map', 'WUL-401'],
+]);
 const requiredCapabilities = [
   'macos-packaged-home-base-runtime',
   'shared-apple-core-contracts',
@@ -143,6 +147,9 @@ if (!Array.isArray(parityMatrix.critique_residua) || parityMatrix.critique_resid
 if (JSON.stringify(parityMatrix).includes('mediflow_private')) {
   fail('parity matrix must reference only the public operational repository.');
 }
+if (JSON.stringify(manifest).includes('mediflow_private')) {
+  fail('QA manifest must reference only the public operational repository.');
+}
 
 if (!networkCapabilityContract || typeof networkCapabilityContract !== 'object') {
   fail('manifest.networkCapabilityContract is required.');
@@ -217,6 +224,22 @@ for (const capability of capabilities) {
     if ((item.type === 'runbook' || item.type === 'adr') && !pathExists(item.value)) {
       fail(`${capability.id}: evidence path does not exist: ${item.value}.`);
     }
+  }
+}
+
+const actualManifestGaps = capabilities.filter((capability) => capability.status !== 'covered');
+if (actualManifestGaps.length !== expectedManifestGaps.size) {
+  fail(`manifest must contain exactly ${expectedManifestGaps.size} non-covered capabilities.`);
+}
+for (const [capabilityId, gapIssue] of expectedManifestGaps) {
+  const capability = capabilities.find((candidate) => candidate.id === capabilityId);
+  if (!capability || capability.status !== 'gap' || capability.gapIssue !== gapIssue) {
+    fail(`${capabilityId} must be the gap owned by ${gapIssue}.`);
+  }
+}
+for (const capability of actualManifestGaps) {
+  if (!expectedManifestGaps.has(capability.id)) {
+    fail(`${capability.id}: unexpected non-covered capability.`);
   }
 }
 

--- a/scripts/check-apple-wide-qa-manifest.mjs
+++ b/scripts/check-apple-wide-qa-manifest.mjs
@@ -1,0 +1,227 @@
+#!/usr/bin/env node
+// @Codex
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const rootDir = process.cwd();
+const manifestPath = path.join(rootDir, 'docs/apple-wide-qa-manifest.json');
+const parityMatrixPath = path.join(rootDir, 'docs/apple-parity-matrix.json');
+const runtimeContractPath = path.join(rootDir, 'lib/network-contract.ts');
+const typeContractPath = path.join(rootDir, 'lib/api/v1/types.ts');
+const openApiContractPath = path.join(rootDir, 'docs/openapi/mediflow-v1.yaml');
+const allowedStatuses = new Set(['covered', 'gap', 'blocked']);
+const allowedEvidenceTypes = new Set(['command', 'runbook', 'adr', 'issue', 'pr', 'manual']);
+const allowedParityGaps = new Set(['full-parity', 'partial', 'missing-both', 'host-only']);
+const expectedParitySummary = {
+  total: 64,
+  fullParity: 31,
+  partial: 13,
+  missing: 2,
+  hostOnly: 18,
+  openNonHost: 15,
+};
+const requiredCapabilities = [
+  'macos-packaged-home-base-runtime',
+  'shared-apple-core-contracts',
+  'mobile-paired-bootstrap-read',
+  'paired-ambulatory-write',
+  'paired-account-pin-rotation',
+  'paired-profile-write',
+  'paired-diary-write',
+  'paired-therapy-write',
+  'paired-checkup-write',
+  'paired-observation-write',
+  'paired-patient-lifecycle-boundary',
+  'paired-catalog-read',
+  'paired-cross-patient-agenda-read',
+  'paired-cross-patient-diary-read',
+  'paired-service-prescriptions-boundary',
+  'paired-prosthetic-prescriptions-boundary',
+  'paired-network-discovery-dual-auth',
+  'paired-network-revision-boundary',
+  'paired-fse-validation-boundary',
+  'paired-document-domain-boundary',
+  'paired-visit-draft-and-ai-runtime-status',
+  'mobile-core-crud-ui',
+  'mobile-offline-cache-reconciliation',
+  'apple-wide-click-map'
+];
+
+function fail(message) {
+  console.error(`check:apple-wide-qa failed: ${message}`);
+  process.exitCode = 1;
+}
+
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function pathExists(relativePath) {
+  return fs.existsSync(path.join(rootDir, relativePath));
+}
+
+function uniqueStrings(value, label) {
+  if (!Array.isArray(value) || value.some((item) => !isNonEmptyString(item))) {
+    fail(`${label} must be an array of non-empty strings.`);
+    return [];
+  }
+
+  if (new Set(value).size !== value.length) {
+    fail(`${label} must not contain duplicate keys.`);
+  }
+
+  return value;
+}
+
+function extractRuntimeKeys(source) {
+  const fseCapability = source.match(/const NETWORK_FSE_VALIDATE_CAPABILITY = '([^']+)'/)?.[1];
+  return [...source.matchAll(/capability\(\s*(?:'([^']+)'|NETWORK_FSE_VALIDATE_CAPABILITY)/g)]
+    .map((match) => match[1] ?? fseCapability)
+    .filter(Boolean);
+}
+
+function extractTypeKeys(source) {
+  const block = source.match(/export type NetworkCapabilityKey =[\s\S]*?;/)?.[0] ?? '';
+  return [...block.matchAll(/'([^']+)'/g)].map((match) => match[1]);
+}
+
+function extractOpenApiKeys(source) {
+  const block = source.match(/    NetworkCapability:\n[\s\S]*?(?=    NetworkCapabilitiesResponse:)/)?.[0] ?? '';
+  return [...block.matchAll(/^            - ((?:network|local)\.[\w.-]+)$/gm)].map((match) => match[1]);
+}
+
+function sameKeySet(actual, expected, label) {
+  const actualSet = new Set(actual);
+  const expectedSet = new Set(expected);
+  const missing = expected.filter((key) => !actualSet.has(key));
+  const unexpected = actual.filter((key) => !expectedSet.has(key));
+  if (missing.length > 0 || unexpected.length > 0 || actual.length !== actualSet.size) {
+    fail(`${label} must match the manifest network capability contract; missing: ${missing.join(', ') || 'none'}; unexpected: ${unexpected.join(', ') || 'none'}.`);
+  }
+}
+
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+const parityMatrix = JSON.parse(fs.readFileSync(parityMatrixPath, 'utf8'));
+const capabilities = Array.isArray(manifest.capabilities) ? manifest.capabilities : [];
+const ids = new Set();
+const networkCapabilityContract = manifest.networkCapabilityContract;
+
+if (manifest.issue !== 'WUL-479' || manifest.originIssue !== 'WUL-194') {
+  fail('manifest must identify WUL-479 as closeout issue and WUL-194 as origin issue.');
+}
+
+const parityRows = Array.isArray(parityMatrix.rows) ? parityMatrix.rows : [];
+const parityRowIds = new Set();
+const parityCounts = { total: parityRows.length, fullParity: 0, partial: 0, missing: 0, hostOnly: 0 };
+
+for (const row of parityRows) {
+  const rowId = `${row.area}::${row.feature}`;
+  if (!isNonEmptyString(row.area) || !isNonEmptyString(row.feature)) {
+    fail('parity rows require non-empty area and feature.');
+  }
+  if (parityRowIds.has(rowId)) fail(`duplicate parity row ${rowId}.`);
+  parityRowIds.add(rowId);
+  if (!allowedParityGaps.has(row.gap)) fail(`${rowId}: invalid parity gap ${row.gap}.`);
+  if (!isNonEmptyString(row.evidence)) fail(`${rowId}: evidence is required.`);
+
+  if (row.gap === 'full-parity') parityCounts.fullParity += 1;
+  if (row.gap === 'partial') parityCounts.partial += 1;
+  if (row.gap === 'missing-both') parityCounts.missing += 1;
+  if (row.gap === 'host-only') parityCounts.hostOnly += 1;
+}
+
+parityCounts.openNonHost = parityCounts.partial + parityCounts.missing;
+for (const [key, expected] of Object.entries(expectedParitySummary)) {
+  if (parityCounts[key] !== expected || parityMatrix.summary?.[key] !== expected) {
+    fail(`parity summary ${key} must be ${expected}.`);
+  }
+}
+if (!Array.isArray(parityMatrix.critique_residua) || parityMatrix.critique_residua.length !== 0) {
+  fail('parity matrix must not retain unresolved critique items.');
+}
+if (JSON.stringify(parityMatrix).includes('mediflow_private')) {
+  fail('parity matrix must reference only the public operational repository.');
+}
+
+if (!networkCapabilityContract || typeof networkCapabilityContract !== 'object') {
+  fail('manifest.networkCapabilityContract is required.');
+} else {
+  const activeNetworkKeys = uniqueStrings(networkCapabilityContract.activeNetworkKeys, 'networkCapabilityContract.activeNetworkKeys');
+  const plannedNetworkKeys = uniqueStrings(networkCapabilityContract.plannedNetworkKeys, 'networkCapabilityContract.plannedNetworkKeys');
+  const localOnlyKeys = uniqueStrings(networkCapabilityContract.localOnlyKeys, 'networkCapabilityContract.localOnlyKeys');
+  const expectedKeys = [...activeNetworkKeys, ...plannedNetworkKeys, ...localOnlyKeys];
+
+  if (activeNetworkKeys.length !== 25 || plannedNetworkKeys.length !== 2 || localOnlyKeys.length !== 2) {
+    fail('networkCapabilityContract must contain 25 active network keys, 2 planned network keys, and 2 local-only keys.');
+  }
+  if (new Set(expectedKeys).size !== expectedKeys.length) {
+    fail('networkCapabilityContract key categories must not overlap.');
+  }
+  if (!isNonEmptyString(networkCapabilityContract.note)) {
+    fail('networkCapabilityContract.note is required.');
+  }
+
+  sameKeySet(extractRuntimeKeys(fs.readFileSync(runtimeContractPath, 'utf8')), expectedKeys, 'lib/network-contract.ts');
+  sameKeySet(extractTypeKeys(fs.readFileSync(typeContractPath, 'utf8')), expectedKeys, 'lib/api/v1/types.ts');
+  sameKeySet(extractOpenApiKeys(fs.readFileSync(openApiContractPath, 'utf8')), expectedKeys, 'docs/openapi/mediflow-v1.yaml');
+}
+
+for (const requiredId of requiredCapabilities) {
+  if (!capabilities.some((capability) => capability.id === requiredId)) {
+    fail(`missing required capability ${requiredId}.`);
+  }
+}
+
+if (capabilities.length !== 24) {
+  fail('manifest.capabilities must contain 24 QA acceptance records.');
+}
+
+for (const capability of capabilities) {
+  if (!isNonEmptyString(capability.id)) fail('capability id is required.');
+  if (ids.has(capability.id)) fail(`duplicate capability id ${capability.id}.`);
+  ids.add(capability.id);
+
+  if (!isNonEmptyString(capability.title)) fail(`${capability.id}: title is required.`);
+  if (!Array.isArray(capability.surfaces) || capability.surfaces.length === 0) {
+    fail(`${capability.id}: at least one surface is required.`);
+  }
+  if (!allowedStatuses.has(capability.status)) {
+    fail(`${capability.id}: invalid status ${capability.status}.`);
+  }
+  if (!isNonEmptyString(capability.acceptance)) {
+    fail(`${capability.id}: acceptance is required.`);
+  }
+  if (!Array.isArray(capability.evidence) || capability.evidence.length === 0) {
+    fail(`${capability.id}: evidence is required.`);
+  }
+
+  if (capability.status === 'covered') {
+    const hasRepeatableEvidence = capability.evidence.some((item) => item.type === 'command' || item.type === 'runbook');
+    if (!hasRepeatableEvidence) {
+      fail(`${capability.id}: covered capability requires command or runbook evidence.`);
+    }
+  }
+
+  if ((capability.status === 'gap' || capability.status === 'blocked') && !isNonEmptyString(capability.gapIssue)) {
+    fail(`${capability.id}: ${capability.status} capability requires gapIssue.`);
+  }
+
+  for (const item of capability.evidence) {
+    if (!allowedEvidenceTypes.has(item.type)) {
+      fail(`${capability.id}: invalid evidence type ${item.type}.`);
+    }
+    if (!isNonEmptyString(item.value)) {
+      fail(`${capability.id}: evidence value is required.`);
+    }
+    if ((item.type === 'runbook' || item.type === 'adr') && !pathExists(item.value)) {
+      fail(`${capability.id}: evidence path does not exist: ${item.value}.`);
+    }
+  }
+}
+
+if (process.exitCode) {
+  process.exit(process.exitCode);
+}
+
+console.log(`check:apple-wide-qa passed (${capabilities.length} capabilities).`);


### PR DESCRIPTION
## Summary
- consolida la matrice canonica post-Wave 5 in 64 capability: 30 full, 13 partial, 21 host-only e 0 missing-both
- aggiunge un manifest QA da 24 record e il guardrail `check:apple-wide-qa`
- allinea README, roadmap, architettura, stato del sistema, walkthrough e indice documentale
- assegna il closeout Wave 6 a WUL-401, WUL-403 e alla decisione documentale vincolata da ADR 0076

## Verification
- `npm run check:openapi:drift -- --base-ref origin/main`
- `npm run check:apple-wide-qa`
- `npm run check:claims`
- `npm run check:never-regress`
- `git diff --check`
- verifica indipendente read-only sul commit `292131b82`: PASS

## Risk / Notes
- Modifica documentale e di guardrail: non cambia runtime, schema o API.
- Il lavoro di design locale e stato escluso dal branch.
- Nessuna PHI/PII o dato paziente reale incluso.

## Ticket
Refs WUL-479