### PR TITLE
fix(api): uniforma il lifecycle clinico di terapie e osservazioni

### DIFF
--- a/app/api/checkups/route.ts
+++ b/app/api/checkups/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { dbServer } from '@/lib/db-server';
-import { checkups } from '@/lib/schema';
+import { checkups, patients } from '@/lib/schema';
 import { and, asc, desc, eq, isNull, type SQL } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
 /* @Codex */
@@ -15,6 +15,7 @@ import { parseListParams } from '@/lib/list-query-params';
 import { checkupCreateSchema } from '@/lib/api-schemas/clinical-writes';
 /* @Codex */
 import { parseApiBody } from '@/lib/api-schemas/parse';
+import { activePatients } from '@/lib/patient-lifecycle';
 
 // Only plaintext columns are sortable server-side (notes is ENC:, not sortable).
 const CHECKUP_SORT_COLUMNS = {
@@ -112,7 +113,7 @@ export async function POST(request: Request) {
 
         const newId = body.id || uuidv4();
 
-        await dbServer.insert(checkups).values({
+        const checkupValues = {
             id: newId,
             patientId: body.patientId,
             date: checkupDate,
@@ -127,7 +128,19 @@ export async function POST(request: Request) {
             updatedAt: new Date(),
             deletedAt: null,
             deletionReason: null,
+        };
+        const created = dbServer.transaction((tx) => {
+            const patient = tx.select({ id: patients.id })
+                .from(patients)
+                .where(and(eq(patients.id, body.patientId), activePatients()))
+                .get();
+            if (!patient) return false;
+            tx.insert(checkups).values(checkupValues).run();
+            return true;
         });
+        if (!created) {
+            return NextResponse.json({ error: 'Patient not found' }, { status: 404 });
+        }
 
         /* @Codex */
         await safeWriteAuditEventFromRequest(

--- a/app/api/entries/route.ts
+++ b/app/api/entries/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { dbServer } from '@/lib/db-server';
-import { entries } from '@/lib/schema';
+import { entries, patients } from '@/lib/schema';
 import { and, asc, desc, eq, isNull, type SQL } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
 /* @Codex */
@@ -11,6 +11,7 @@ import { listChangedFields, safeWriteAuditEventFromRequest } from '@/lib/securit
 import { normalizeEntryCreateInput } from '@/lib/api-v1-clinical-write-normalization';
 /* STREAM B: server-side list params (whitelisted, plaintext columns only). */
 import { parseListParams } from '@/lib/list-query-params';
+import { activePatients } from '@/lib/patient-lifecycle';
 
 // Only plaintext columns are sortable server-side (ENC: columns are opaque).
 const ENTRY_SORT_COLUMNS = {
@@ -79,7 +80,18 @@ export async function POST(request: Request) {
             return NextResponse.json({ error: normalized.error }, { status: 400 });
         }
 
-        await dbServer.insert(entries).values(normalized.values);
+        const created = dbServer.transaction((tx) => {
+            const patient = tx.select({ id: patients.id })
+                .from(patients)
+                .where(and(eq(patients.id, patientId), activePatients()))
+                .get();
+            if (!patient) return false;
+            tx.insert(entries).values(normalized.values).run();
+            return true;
+        });
+        if (!created) {
+            return NextResponse.json({ error: 'Patient not found' }, { status: 404 });
+        }
 
         /* @Codex */
         await safeWriteAuditEventFromRequest(

--- a/app/api/observations/[id]/route.ts
+++ b/app/api/observations/[id]/route.ts
@@ -2,12 +2,28 @@
 import { NextResponse } from 'next/server';
 import { dbServer } from '@/lib/db-server';
 import { observations } from '@/lib/schema';
-import { eq, sql } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { requireSession, unauthorizedResponse } from '@/lib/security/server-auth';
 /* @Codex */
 import { listChangedFields, safeWriteAuditEventFromRequest } from '@/lib/security/audit';
 /* @Codex */
 import { normalizeObservationUpdateInput } from '@/lib/api-v1-clinical-write-normalization';
+import { buildObservationVersionConflictPayload, parseObservationExpectedVersion } from '@/lib/observation-concurrency';
+import { parseClinicalDeleteBody } from '@/lib/api-v1-clinical-lifecycle';
+
+async function selectObservationConflictSnapshot(observationId: string) {
+    return await dbServer
+        .select({
+            id: observations.id,
+            patientId: observations.patientId,
+            version: observations.version,
+            updatedAt: observations.updatedAt,
+            deletedAt: observations.deletedAt,
+        })
+        .from(observations)
+        .where(eq(observations.id, observationId))
+        .get() ?? null;
+}
 
 export async function PUT(
     request: Request,
@@ -19,6 +35,10 @@ export async function PUT(
     try {
         const { id } = await params;
         const body = await request.json() as Record<string, unknown>;
+        const expectedVersion = parseObservationExpectedVersion(body.version);
+        if (expectedVersion === null) {
+            return NextResponse.json({ error: 'Version is required' }, { status: 400 });
+        }
 
         const existing = await dbServer
             .select({ id: observations.id })
@@ -34,17 +54,23 @@ export async function PUT(
             return NextResponse.json({ error: normalized.error }, { status: 400 });
         }
 
-        await dbServer.update(observations)
+        const updateResult = await dbServer.update(observations)
             .set({
                 ...normalized.values,
-                version: sql`${observations.version} + 1`,
+                version: expectedVersion + 1,
             })
-            .where(eq(observations.id, id));
-        const current = await dbServer
-            .select({ version: observations.version })
-            .from(observations)
-            .where(eq(observations.id, id))
-            .get();
+            .where(and(eq(observations.id, id), eq(observations.version, expectedVersion)))
+            .run();
+        if (updateResult.changes === 0) {
+            return NextResponse.json(
+                buildObservationVersionConflictPayload(
+                    expectedVersion,
+                    id,
+                    await selectObservationConflictSnapshot(id),
+                ),
+                { status: 409 },
+            );
+        }
 
         /* @Codex */
         await safeWriteAuditEventFromRequest(
@@ -56,7 +82,7 @@ export async function PUT(
                 subjectRef: id,
                 redactedMetadata: {
                     changedFields: listChangedFields(body, ['version']),
-                    resourceVersion: current?.version ?? undefined,
+                    resourceVersion: expectedVersion + 1,
                 },
             },
             '[MediFlow] Observation audit write failed:',
@@ -78,8 +104,23 @@ export async function DELETE(
 
     try {
         const { id } = await params;
+        const parsedBody = await parseClinicalDeleteBody(request, 'web-delete');
+        if (!parsedBody.ok) {
+            return NextResponse.json({ error: parsedBody.error }, { status: 400 });
+        }
+        const expectedVersion = parseObservationExpectedVersion(parsedBody.values.version);
+        if (expectedVersion === null) {
+            return NextResponse.json({ error: 'Version is required' }, { status: 400 });
+        }
+        const normalized = normalizeObservationUpdateInput({
+            deletedAt: parsedBody.values.deletedAt,
+            deletionReason: parsedBody.values.deletionReason,
+        });
+        if (!normalized.ok) {
+            return NextResponse.json({ error: normalized.error }, { status: 400 });
+        }
         const existing = await dbServer
-            .select({ id: observations.id, version: observations.version })
+            .select({ id: observations.id })
             .from(observations)
             .where(eq(observations.id, id))
             .get();
@@ -87,7 +128,23 @@ export async function DELETE(
             return NextResponse.json({ error: 'Not found' }, { status: 404 });
         }
 
-        await dbServer.delete(observations).where(eq(observations.id, id));
+        const updateResult = await dbServer.update(observations)
+            .set({
+                ...normalized.values,
+                version: expectedVersion + 1,
+            })
+            .where(and(eq(observations.id, id), eq(observations.version, expectedVersion)))
+            .run();
+        if (updateResult.changes === 0) {
+            return NextResponse.json(
+                buildObservationVersionConflictPayload(
+                    expectedVersion,
+                    id,
+                    await selectObservationConflictSnapshot(id),
+                ),
+                { status: 409 },
+            );
+        }
 
         /* @Codex */
         await safeWriteAuditEventFromRequest(
@@ -98,8 +155,8 @@ export async function DELETE(
                 subjectType: 'observation',
                 subjectRef: id,
                 redactedMetadata: {
-                    changedFields: ['deleted'],
-                    resourceVersion: existing.version,
+                    changedFields: ['deletedAt', 'deletionReason'],
+                    resourceVersion: expectedVersion + 1,
                 },
             },
             '[MediFlow] Observation audit write failed:',

--- a/app/api/observations/route.ts
+++ b/app/api/observations/route.ts
@@ -1,7 +1,7 @@
 /* @Codex */
 import { NextResponse } from 'next/server';
 import { dbServer } from '@/lib/db-server';
-import { observations } from '@/lib/schema';
+import { observations, patients } from '@/lib/schema';
 import { and, asc, desc, eq, isNull, type SQL } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
 import { requireSession, unauthorizedResponse } from '@/lib/security/server-auth';
@@ -11,6 +11,7 @@ import { listChangedFields, safeWriteAuditEventFromRequest } from '@/lib/securit
 import { normalizeObservationCreateInput } from '@/lib/api-v1-clinical-write-normalization';
 /* STREAM B: server-side list params (whitelisted, plaintext columns only). */
 import { parseListParams } from '@/lib/list-query-params';
+import { activePatients } from '@/lib/patient-lifecycle';
 
 // notes is ENC:, not sortable. Only plaintext columns here.
 const OBSERVATION_SORT_COLUMNS = {
@@ -78,7 +79,18 @@ export async function POST(request: Request) {
             return NextResponse.json({ error: normalized.error }, { status: 400 });
         }
 
-        await dbServer.insert(observations).values(normalized.values);
+        const created = dbServer.transaction((tx) => {
+            const patient = tx.select({ id: patients.id })
+                .from(patients)
+                .where(and(eq(patients.id, patientId), activePatients()))
+                .get();
+            if (!patient) return false;
+            tx.insert(observations).values(normalized.values).run();
+            return true;
+        });
+        if (!created) {
+            return NextResponse.json({ error: 'Patient not found' }, { status: 404 });
+        }
 
         /* @Codex */
         await safeWriteAuditEventFromRequest(

--- a/app/api/patients/[id]/smart-import/route.ts
+++ b/app/api/patients/[id]/smart-import/route.ts
@@ -1,0 +1,104 @@
+/* @Codex */
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { therapyCreateSchema } from '@/lib/api-schemas/clinical-writes';
+import { parseApiBody } from '@/lib/api-schemas/parse';
+import { normalizeTherapyCreateInput } from '@/lib/api-v1-clinical-write-normalization';
+import { dbServer } from '@/lib/db-server';
+import { isSealedValue } from '@/lib/network-patient-lifecycle';
+import {
+    commitPatientSmartImport,
+    type PatientSmartImportTherapyValues,
+} from '@/lib/patient-smart-import-apply';
+import { listChangedFields, safeWriteAuditEventFromRequest } from '@/lib/security/audit';
+import { requireSession, unauthorizedResponse } from '@/lib/security/server-auth';
+
+const smartImportApplySchema = z.object({
+    version: z.number().int().positive(),
+    diagnoses: z.string().optional(),
+    therapies: z.array(therapyCreateSchema),
+}).refine(
+    (value) => value.diagnoses !== undefined || value.therapies.length > 0,
+    { message: 'No changes to apply' },
+);
+
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+    const session = await requireSession();
+    if (!session) return unauthorizedResponse();
+
+    let rawBody: unknown;
+    try {
+        rawBody = await request.json();
+    } catch {
+        return NextResponse.json({ error: 'Payload non valido' }, { status: 400 });
+    }
+
+    const parsed = parseApiBody(smartImportApplySchema, rawBody);
+    if (!parsed.ok) return parsed.response;
+
+    const { id: patientId } = await params;
+    if (parsed.data.diagnoses !== undefined && !isSealedValue(parsed.data.diagnoses)) {
+        return NextResponse.json({ error: 'Diagnoses must be sealed' }, { status: 400 });
+    }
+
+    const now = new Date();
+    const normalizedTherapies: PatientSmartImportTherapyValues[] = [];
+    for (const therapy of parsed.data.therapies) {
+        if (therapy.patientId !== patientId) {
+            return NextResponse.json({ error: 'Therapy patient mismatch' }, { status: 400 });
+        }
+        if (typeof therapy.motivation === 'string' && therapy.motivation.length > 0 && !isSealedValue(therapy.motivation)) {
+            return NextResponse.json({ error: 'Therapy motivation must be sealed' }, { status: 400 });
+        }
+
+        const normalized = normalizeTherapyCreateInput(therapy, {
+            id: therapy.id ?? crypto.randomUUID(),
+            patientId,
+            now,
+        });
+        if (!normalized.ok) {
+            return NextResponse.json({ error: normalized.error }, { status: 400 });
+        }
+        normalizedTherapies.push(normalized.values);
+    }
+
+    try {
+        const result = commitPatientSmartImport(dbServer, {
+            patientId,
+            expectedVersion: parsed.data.version,
+            diagnoses: parsed.data.diagnoses,
+            therapies: normalizedTherapies,
+            now,
+        });
+        if (result.status !== 200) {
+            return NextResponse.json(result.value, { status: result.status });
+        }
+
+        if (parsed.data.diagnoses !== undefined) {
+            await safeWriteAuditEventFromRequest(request, session, {
+                eventType: 'patient.updated',
+                subjectType: 'patient',
+                subjectRef: patientId,
+                redactedMetadata: {
+                    changedFields: ['diagnoses'],
+                    resourceVersion: result.value.patientVersion,
+                },
+            });
+        }
+        for (const [index, therapyId] of result.value.therapyIds.entries()) {
+            await safeWriteAuditEventFromRequest(request, session, {
+                eventType: 'therapy.created',
+                subjectType: 'therapy',
+                subjectRef: therapyId,
+                redactedMetadata: {
+                    changedFields: listChangedFields(parsed.data.therapies[index] as Record<string, unknown>, ['id']),
+                    resourceVersion: 1,
+                },
+            });
+        }
+
+        return NextResponse.json(result.value);
+    } catch {
+        return NextResponse.json({ error: 'Smart Import apply failed' }, { status: 500 });
+    }
+}

--- a/app/api/therapies/[id]/route.ts
+++ b/app/api/therapies/[id]/route.ts
@@ -2,7 +2,7 @@
 import { NextResponse } from 'next/server';
 import { dbServer } from '@/lib/db-server';
 import { therapies } from '@/lib/schema';
-import { eq, sql } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { requireSession, unauthorizedResponse } from '@/lib/security/server-auth';
 /* @Codex */
 import { parseTherapyStatus } from '@/lib/status-normalization';
@@ -12,6 +12,23 @@ import { listChangedFields, safeWriteAuditEventFromRequest } from '@/lib/securit
 import { therapyUpdateSchema } from '@/lib/api-schemas/clinical-writes';
 /* @Codex */
 import { parseApiBody } from '@/lib/api-schemas/parse';
+import { normalizeTherapyUpdateInput } from '@/lib/api-v1-clinical-write-normalization';
+import { buildTherapyVersionConflictPayload, parseTherapyExpectedVersion } from '@/lib/therapy-concurrency';
+import { parseClinicalDeleteBody } from '@/lib/api-v1-clinical-lifecycle';
+
+async function selectTherapyConflictSnapshot(therapyId: string) {
+    return await dbServer
+        .select({
+            id: therapies.id,
+            patientId: therapies.patientId,
+            version: therapies.version,
+            updatedAt: therapies.updatedAt,
+            deletedAt: therapies.deletedAt,
+        })
+        .from(therapies)
+        .where(eq(therapies.id, therapyId))
+        .get() ?? null;
+}
 
 function parseDate(value: unknown): Date | undefined {
     if (value === null || value === undefined || value === '') return undefined;
@@ -29,6 +46,10 @@ export async function PUT(
     try {
         const { id } = await params;
         const rawBody = await request.json() as Record<string, unknown>;
+        const expectedVersion = parseTherapyExpectedVersion(rawBody.version);
+        if (expectedVersion === null) {
+            return NextResponse.json({ error: 'Version is required' }, { status: 400 });
+        }
         const parsedBody = parseApiBody(therapyUpdateSchema, rawBody);
         if (!parsedBody.ok) return parsedBody.response;
         const body = parsedBody.data;
@@ -126,18 +147,24 @@ export async function PUT(
             return NextResponse.json({ error: 'No valid fields to update' }, { status: 400 });
         }
 
-        await dbServer.update(therapies)
+        const updateResult = await dbServer.update(therapies)
             .set({
                 ...updateData,
-                version: sql`${therapies.version} + 1`,
+                version: expectedVersion + 1,
                 updatedAt: new Date(),
             })
-            .where(eq(therapies.id, id));
-        const current = await dbServer
-            .select({ version: therapies.version })
-            .from(therapies)
-            .where(eq(therapies.id, id))
-            .get();
+            .where(and(eq(therapies.id, id), eq(therapies.version, expectedVersion)))
+            .run();
+        if (updateResult.changes === 0) {
+            return NextResponse.json(
+                buildTherapyVersionConflictPayload(
+                    expectedVersion,
+                    id,
+                    await selectTherapyConflictSnapshot(id),
+                ),
+                { status: 409 },
+            );
+        }
 
         /* @Codex */
         await safeWriteAuditEventFromRequest(
@@ -149,7 +176,7 @@ export async function PUT(
                 subjectRef: id,
                 redactedMetadata: {
                     changedFields: listChangedFields(body),
-                    resourceVersion: current?.version ?? undefined,
+                    resourceVersion: expectedVersion + 1,
                 },
             },
             '[MediFlow] Therapy audit write failed:',
@@ -171,11 +198,42 @@ export async function DELETE(
 
     try {
         const { id } = await params;
-        const existing = await dbServer.select({ id: therapies.id, version: therapies.version }).from(therapies).where(eq(therapies.id, id)).get();
+        const parsedBody = await parseClinicalDeleteBody(request, 'web-delete');
+        if (!parsedBody.ok) {
+            return NextResponse.json({ error: parsedBody.error }, { status: 400 });
+        }
+        const expectedVersion = parseTherapyExpectedVersion(parsedBody.values.version);
+        if (expectedVersion === null) {
+            return NextResponse.json({ error: 'Version is required' }, { status: 400 });
+        }
+        const normalized = normalizeTherapyUpdateInput({
+            deletedAt: parsedBody.values.deletedAt,
+            deletionReason: parsedBody.values.deletionReason,
+        });
+        if (!normalized.ok) {
+            return NextResponse.json({ error: normalized.error }, { status: 400 });
+        }
+        const existing = await dbServer.select({ id: therapies.id }).from(therapies).where(eq(therapies.id, id)).get();
         if (!existing) {
             return NextResponse.json({ error: 'Not found' }, { status: 404 });
         }
-        await dbServer.delete(therapies).where(eq(therapies.id, id));
+        const updateResult = await dbServer.update(therapies)
+            .set({
+                ...normalized.values,
+                version: expectedVersion + 1,
+            })
+            .where(and(eq(therapies.id, id), eq(therapies.version, expectedVersion)))
+            .run();
+        if (updateResult.changes === 0) {
+            return NextResponse.json(
+                buildTherapyVersionConflictPayload(
+                    expectedVersion,
+                    id,
+                    await selectTherapyConflictSnapshot(id),
+                ),
+                { status: 409 },
+            );
+        }
 
         /* @Codex */
         await safeWriteAuditEventFromRequest(
@@ -186,8 +244,8 @@ export async function DELETE(
                 subjectType: 'therapy',
                 subjectRef: id,
                 redactedMetadata: {
-                    changedFields: ['deleted'],
-                    resourceVersion: existing.version,
+                    changedFields: ['deletedAt', 'deletionReason'],
+                    resourceVersion: expectedVersion + 1,
                 },
             },
             '[MediFlow] Therapy audit write failed:',

--- a/app/api/therapies/route.ts
+++ b/app/api/therapies/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { dbServer } from '@/lib/db-server';
-import { therapies } from '@/lib/schema';
+import { patients, therapies } from '@/lib/schema';
 import { and, asc, desc, eq, isNull, type SQL } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
 /* @Codex */
@@ -15,6 +15,7 @@ import { parseListParams } from '@/lib/list-query-params';
 import { therapyCreateSchema } from '@/lib/api-schemas/clinical-writes';
 /* @Codex */
 import { parseApiBody } from '@/lib/api-schemas/parse';
+import { activePatients } from '@/lib/patient-lifecycle';
 
 // motivation is ENC:, so it is not sortable. Only plaintext columns here.
 const THERAPY_SORT_COLUMNS = {
@@ -83,7 +84,7 @@ export async function POST(request: Request) {
         }
 
         const newId = body.id || uuidv4(); // Consistent ID handling
-        await dbServer.insert(therapies).values({
+        const therapyValues = {
             id: newId,
             patientId: body.patientId,
             drugName: body.drugName,
@@ -108,7 +109,19 @@ export async function POST(request: Request) {
             updatedAt: new Date(),
             deletedAt: null,
             deletionReason: null,
+        };
+        const created = dbServer.transaction((tx) => {
+            const patient = tx.select({ id: patients.id })
+                .from(patients)
+                .where(and(eq(patients.id, body.patientId), activePatients()))
+                .get();
+            if (!patient) return false;
+            tx.insert(therapies).values(therapyValues).run();
+            return true;
         });
+        if (!created) {
+            return NextResponse.json({ error: 'Patient not found' }, { status: 404 });
+        }
 
         /* @Codex */
         await safeWriteAuditEventFromRequest(

--- a/app/api/v1/patients/[id]/checkups/route.ts
+++ b/app/api/v1/patients/[id]/checkups/route.ts
@@ -1,7 +1,7 @@
 // Codex: created 2026-02-01
 import { NextResponse } from 'next/server';
 import { dbServer } from '@/lib/db-server';
-import { checkups } from '@/lib/schema';
+import { checkups, patients } from '@/lib/schema';
 import { and, desc, eq, gte, inArray, isNull, lte } from 'drizzle-orm';
 import { requireLocalApiToken } from '@/lib/security/local-api-auth';
 import { requireLocalApiActorSession } from '@/lib/security/server-auth';
@@ -16,6 +16,7 @@ import {
 } from '@/lib/status-normalization';
 /* @Codex */
 import { listChangedFields, safeWriteAuditEventFromRequest } from '@/lib/security/audit';
+import { activePatients } from '@/lib/patient-lifecycle';
 
 function toIsoString(value: unknown): string | null {
     if (!value) return null;
@@ -111,7 +112,18 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
             return NextResponse.json({ error: normalized.error }, { status: 400 });
         }
 
-        await dbServer.insert(checkups).values(normalized.values);
+        const created = dbServer.transaction((tx) => {
+            const patient = tx.select({ id: patients.id })
+                .from(patients)
+                .where(and(eq(patients.id, id), activePatients()))
+                .get();
+            if (!patient) return false;
+            tx.insert(checkups).values(normalized.values).run();
+            return true;
+        });
+        if (!created) {
+            return NextResponse.json({ error: 'Patient not found' }, { status: 404 });
+        }
 
         /* @Codex */
         await safeWriteAuditEventFromRequest(

--- a/app/api/v1/patients/[id]/entries/route.ts
+++ b/app/api/v1/patients/[id]/entries/route.ts
@@ -1,7 +1,7 @@
 // Codex: created 2026-02-01
 import { NextResponse } from 'next/server';
 import { dbServer } from '@/lib/db-server';
-import { entries } from '@/lib/schema';
+import { entries, patients } from '@/lib/schema';
 import { and, desc, eq, gte, isNull, lte } from 'drizzle-orm';
 import { requireLocalApiToken } from '@/lib/security/local-api-auth';
 import { requireLocalApiActorSession } from '@/lib/security/server-auth';
@@ -9,6 +9,7 @@ import type { EntrySummary } from '@/lib/api/v1/types';
 import { v4 as uuidv4 } from 'uuid';
 /* @Codex */
 import { normalizeEntryCreateInput } from '@/lib/api-v1-clinical-write-normalization';
+import { activePatients } from '@/lib/patient-lifecycle';
 /* @Codex */
 import { listChangedFields, safeWriteAuditEventFromRequest } from '@/lib/security/audit';
 
@@ -105,7 +106,18 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
             return NextResponse.json({ error: normalized.error }, { status: 400 });
         }
 
-        await dbServer.insert(entries).values(normalized.values);
+        const created = dbServer.transaction((tx) => {
+            const patient = tx.select({ id: patients.id })
+                .from(patients)
+                .where(and(eq(patients.id, id), activePatients()))
+                .get();
+            if (!patient) return false;
+            tx.insert(entries).values(normalized.values).run();
+            return true;
+        });
+        if (!created) {
+            return NextResponse.json({ error: 'Patient not found' }, { status: 404 });
+        }
 
         /* @Codex */
         await safeWriteAuditEventFromRequest(

--- a/app/api/v1/patients/[id]/observations/route.ts
+++ b/app/api/v1/patients/[id]/observations/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from 'next/server';
 import { and, desc, eq, gte, isNull, lte } from 'drizzle-orm';
 import { v4 as uuidv4 } from 'uuid';
 import { dbServer } from '@/lib/db-server';
-import { observations } from '@/lib/schema';
+import { observations, patients } from '@/lib/schema';
 import { requireLocalApiToken } from '@/lib/security/local-api-auth';
 import { requireLocalApiActorSession } from '@/lib/security/server-auth';
 import type { ObservationSummary } from '@/lib/api/v1/types';
@@ -11,6 +11,7 @@ import type { ObservationSummary } from '@/lib/api/v1/types';
 import { listChangedFields, safeWriteAuditEventFromRequest } from '@/lib/security/audit';
 /* @Codex */
 import { normalizeObservationCreateInput } from '@/lib/api-v1-clinical-write-normalization';
+import { activePatients } from '@/lib/patient-lifecycle';
 
 /* @Codex */
 function toIsoString(value: unknown): string | null {
@@ -111,7 +112,18 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
             return NextResponse.json({ error: normalized.error }, { status: 400 });
         }
 
-        await dbServer.insert(observations).values(normalized.values);
+        const created = dbServer.transaction((tx) => {
+            const patient = tx.select({ id: patients.id })
+                .from(patients)
+                .where(and(eq(patients.id, id), activePatients()))
+                .get();
+            if (!patient) return false;
+            tx.insert(observations).values(normalized.values).run();
+            return true;
+        });
+        if (!created) {
+            return NextResponse.json({ error: 'Patient not found' }, { status: 404 });
+        }
 
         /* @Codex */
         await safeWriteAuditEventFromRequest(

--- a/app/api/v1/patients/[id]/therapies/route.ts
+++ b/app/api/v1/patients/[id]/therapies/route.ts
@@ -1,7 +1,7 @@
 // Codex: created 2026-02-01
 import { NextResponse } from 'next/server';
 import { dbServer } from '@/lib/db-server';
-import { therapies } from '@/lib/schema';
+import { patients, therapies } from '@/lib/schema';
 import { and, desc, eq, gte, inArray, isNull, lte } from 'drizzle-orm';
 import { requireLocalApiToken } from '@/lib/security/local-api-auth';
 import { requireLocalApiActorSession } from '@/lib/security/server-auth';
@@ -16,6 +16,7 @@ import {
 } from '@/lib/status-normalization';
 /* @Codex */
 import { listChangedFields, safeWriteAuditEventFromRequest } from '@/lib/security/audit';
+import { activePatients } from '@/lib/patient-lifecycle';
 
 function toIsoString(value: unknown): string | null {
     if (!value) return null;
@@ -119,7 +120,18 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
             return NextResponse.json({ error: normalized.error }, { status: 400 });
         }
 
-        await dbServer.insert(therapies).values(normalized.values);
+        const created = dbServer.transaction((tx) => {
+            const patient = tx.select({ id: patients.id })
+                .from(patients)
+                .where(and(eq(patients.id, id), activePatients()))
+                .get();
+            if (!patient) return false;
+            tx.insert(therapies).values(normalized.values).run();
+            return true;
+        });
+        if (!created) {
+            return NextResponse.json({ error: 'Patient not found' }, { status: 404 });
+        }
 
         /* @Codex */
         await safeWriteAuditEventFromRequest(

--- a/app/api/v1/patients/route.ts
+++ b/app/api/v1/patients/route.ts
@@ -110,15 +110,17 @@ export async function POST(request: Request) {
             return NextResponse.json({ error: normalized.error }, { status: 400 });
         }
 
-        await dbServer.insert(patients).values(normalized.values);
+        dbServer.transaction((tx) => {
+            tx.insert(patients).values(normalized.values).run();
 
-        if (normalized.values.ambulatoryId) {
-            await dbServer.insert(patientsToAmbulatories).values({
-                patientId: normalized.values.id,
-                ambulatoryId: normalized.values.ambulatoryId,
-                assignedAt: new Date()
-            }).onConflictDoNothing();
-        }
+            if (normalized.values.ambulatoryId) {
+                tx.insert(patientsToAmbulatories).values({
+                    patientId: normalized.values.id,
+                    ambulatoryId: normalized.values.ambulatoryId,
+                    assignedAt: new Date(),
+                }).onConflictDoNothing().run();
+            }
+        });
 
         /* @Codex */
         await recordPatientAuditEvent(request, 'patient.created', normalized.values.id, {

--- a/components/observation-manager.tsx
+++ b/components/observation-manager.tsx
@@ -5,7 +5,8 @@ import { useMemo, useRef, useState } from 'react';
 import { useLiveQuery } from '@/lib/live-query';
 import { v4 as uuidv4 } from 'uuid';
 import { Activity, ChevronDown, Minus, Plus, Trash2, TrendingDown, TrendingUp } from 'lucide-react';
-import { db } from '@/lib/db';
+import { ApiConflictError, db } from '@/lib/db';
+import { notifyDbChange } from '@/lib/live-query';
 import { searchStaticTerminology } from '@/lib/terminology';
 import { classifyObservationRange, formatReferenceRange } from '@/lib/observation-range';
 import { useToast } from '@/components/ui/toast-provider';
@@ -242,6 +243,11 @@ export default function ObservationManager({ patientId, embedded = false }: { pa
     };
 
     const deleteObservation = async (id: string) => {
+        const observation = observations?.find((item) => item.id === id);
+        if (!observation || typeof observation.version !== 'number') {
+            showToast({ tone: 'error', title: 'Versione osservazione non disponibile', description: 'Ricarica la pagina e riprova.' });
+            return;
+        }
         const { confirmed } = await confirm({
             title: 'Eliminare questa misura?',
             message: 'La misura verra rimossa dai parametri clinici del paziente.',
@@ -250,9 +256,14 @@ export default function ObservationManager({ patientId, embedded = false }: { pa
         });
         if (!confirmed) return;
         try {
-            await db.observations.delete(id);
+            await db.observations.delete(id, { version: observation.version });
         } catch (error) {
             console.error('Failed to delete observation', error);
+            if (error instanceof ApiConflictError) {
+                notifyDbChange('observations');
+                showToast({ tone: 'error', title: 'Osservazione aggiornata altrove', description: 'I dati sono stati ricaricati. Controlla e riprova.' });
+                return;
+            }
             showToast({ tone: 'error', title: 'Eliminazione misura fallita' });
         }
     };

--- a/components/therapy-manager.tsx
+++ b/components/therapy-manager.tsx
@@ -2,7 +2,8 @@
 
 import { useState } from 'react';
 import { useLiveQuery } from '@/lib/live-query';
-import { db, Therapy } from '@/lib/db';
+import { ApiConflictError, db, Therapy } from '@/lib/db';
+import { notifyDbChange } from '@/lib/live-query';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
@@ -111,6 +112,11 @@ export default function TherapyManager({ patientId, embedded = false }: { patien
         setIsSaving(true);
         try {
             if (editingId) {
+                const therapy = visibleTherapies.find((item) => item.id === editingId);
+                if (!therapy || typeof therapy.version !== 'number') {
+                    showToast({ tone: 'error', title: 'Versione terapia non disponibile', description: 'Ricarica la pagina e riprova.' });
+                    return;
+                }
                 // UPDATE EXISTING
                 await db.therapies.update(editingId, {
                     ...data,
@@ -118,7 +124,8 @@ export default function TherapyManager({ patientId, embedded = false }: { patien
                     diagnosisCode: selectedDiagnosis?.code as any,
                     // eslint-disable-next-line @typescript-eslint/no-explicit-any
                     diagnosisName: selectedDiagnosis?.title as any,
-                    updatedAt: new Date()
+                    updatedAt: new Date(),
+                    version: therapy.version,
                 });
             } else {
                 // CREATE NEW
@@ -163,6 +170,11 @@ export default function TherapyManager({ patientId, embedded = false }: { patien
             cancelEditing();
         } catch (error) {
             console.error("Failed to save therapy", error);
+            if (error instanceof ApiConflictError) {
+                notifyDbChange('therapies');
+                showToast({ tone: 'error', title: 'Terapia aggiornata altrove', description: 'I dati sono stati ricaricati. Controlla e riprova.' });
+                return;
+            }
             showToast({ tone: 'error', title: 'Salvataggio terapia fallito', description: 'Controlla i dati e riprova.' });
         } finally {
             setIsSaving(false);
@@ -170,6 +182,11 @@ export default function TherapyManager({ patientId, embedded = false }: { patien
     };
 
     const updateStatus = async (id: string, status: Therapy['status']) => {
+        const therapy = visibleTherapies.find((item) => item.id === id);
+        if (!therapy || typeof therapy.version !== 'number') {
+            showToast({ tone: 'error', title: 'Versione terapia non disponibile', description: 'Ricarica la pagina e riprova.' });
+            return;
+        }
         const patch: { status: Therapy['status']; updatedAt: Date; endDate?: Date | null } = { status, updatedAt: new Date() };
         /* @Codex WUL-UIUX: endDate esiste in schema ma non veniva mai valorizzata;
            la conclusione la registra. Alla riattivazione va azzerata con null
@@ -177,18 +194,45 @@ export default function TherapyManager({ patientId, embedded = false }: { patien
            non lo cancellerebbe (la route pulisce endDate solo su null o ''). */
         if (status === 'completed') patch.endDate = new Date();
         if (status === 'active') patch.endDate = null;
-        await db.therapies.update(id, patch as Partial<Therapy>);
+        try {
+            await db.therapies.update(id, { ...patch, version: therapy.version });
+        } catch (error) {
+            console.error('Failed to update therapy status', error);
+            if (error instanceof ApiConflictError) {
+                notifyDbChange('therapies');
+                showToast({ tone: 'error', title: 'Terapia aggiornata altrove', description: 'I dati sono stati ricaricati. Controlla e riprova.' });
+                return;
+            }
+            showToast({ tone: 'error', title: 'Aggiornamento terapia fallito' });
+        }
     };
 
     const handleSoftDelete = async (id: string) => {
-        const { confirmed } = await confirm({
+        const therapy = visibleTherapies.find((item) => item.id === id);
+        if (!therapy || typeof therapy.version !== 'number') {
+            showToast({ tone: 'error', title: 'Versione terapia non disponibile', description: 'Ricarica la pagina e riprova.' });
+            return;
+        }
+        const { confirmed, reason } = await confirm({
             title: 'Eliminare questo farmaco dalla cartella?',
             message: 'Usa Elimina solo per errori di inserimento; per una terapia interrotta scegli Sospendi o Concludi.',
             confirmLabel: 'Elimina',
-            tone: 'danger'
+            tone: 'danger',
+            requireReason: true,
+            reasonLabel: 'Motivazione dell\'eliminazione',
+            reasonPlaceholder: 'Es. inserimento duplicato',
         });
-        if (confirmed) {
-            await db.therapies.delete(id);
+        if (!confirmed || !reason) return;
+        try {
+            await db.therapies.delete(id, { version: therapy.version, deletionReason: reason });
+        } catch (error) {
+            console.error('Failed to delete therapy', error);
+            if (error instanceof ApiConflictError) {
+                notifyDbChange('therapies');
+                showToast({ tone: 'error', title: 'Terapia aggiornata altrove', description: 'I dati sono stati ricaricati. Controlla e riprova.' });
+                return;
+            }
+            showToast({ tone: 'error', title: 'Eliminazione terapia fallita' });
         }
     };
 

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -558,6 +558,8 @@ class ApiTable<T> {
             || this.tableName === 'ambulatories'
             || this.tableName === 'entries'
             || this.tableName === 'checkups'
+            || this.tableName === 'therapies'
+            || this.tableName === 'observations'
             || this.tableName === 'service_prescriptions'
             || this.tableName === 'service_prescription_items'
             || this.tableName === 'prosthetic_prescriptions';
@@ -569,6 +571,8 @@ class ApiTable<T> {
         if (this.tableName === 'ambulatories') return 'ambulatory';
         if (this.tableName === 'entries') return 'entry';
         if (this.tableName === 'checkups') return 'checkup';
+        if (this.tableName === 'therapies') return 'therapy';
+        if (this.tableName === 'observations') return 'observation';
         if (this.tableName === 'service_prescriptions') return 'service prescription';
         if (this.tableName === 'service_prescription_items') return 'service prescription item';
         if (this.tableName === 'prosthetic_prescriptions') return 'prosthetic prescription';
@@ -920,6 +924,10 @@ export interface Observation {
     observedAt: Date;
     source?: 'manual' | 'ai_suggestion';
     createdAt: Date;
+    version?: number;
+    updatedAt?: Date;
+    deletedAt?: Date | null;
+    deletionReason?: string | null;
 }
 
 export interface Attachment {
@@ -1095,9 +1103,10 @@ export interface Therapy {
     /* @Codex */
     status: 'active' | 'suspended' | 'completed';
     startDate: Date;
-    endDate?: Date;
+    endDate?: Date | null;
     createdAt: Date;
     updatedAt?: Date;
+    version?: number;
     /* @Codex */
     deletedAt?: Date | null;
     /* @Codex */

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -406,6 +406,11 @@ class ApiTable<T> {
         return data.id;
     }
 
+    /* @Codex */
+    async prepareWritePayload(item: Partial<T>, isPartial = false): Promise<Partial<T>> {
+        return this.encryptItem(item, isPartial);
+    }
+
     // Alias for Dexie compatibility (Upsert-like behavior)
     /* @Codex */
     async put(item: T, options?: { suppressNotify?: boolean }): Promise<string> {
@@ -792,6 +797,43 @@ class MedicalApiClient {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         this.settings = new ApiTable<any>('/api/settings', 'settings', getKey);
         this.patientsToAmbulatories = new ApiTable<PatientAmbulatory>('/api/patients/assign', 'patients_to_ambulatories', getKey);
+    }
+
+    /* @Codex */
+    async applyPatientSmartImport(
+        patientId: string,
+        input: {
+            version: number;
+            diagnoses?: Diagnosis[];
+            therapies: Therapy[];
+        },
+    ): Promise<void> {
+        const patientPayload = input.diagnoses === undefined
+            ? undefined
+            : await this.patients.prepareWritePayload({ diagnoses: input.diagnoses }, true);
+        const therapyPayloads = await Promise.all(
+            input.therapies.map((therapy) => this.therapies.prepareWritePayload(therapy)),
+        );
+
+        const response = await fetch(`/api/patients/${encodeURIComponent(patientId)}/smart-import`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                version: input.version,
+                ...(patientPayload?.diagnoses !== undefined ? { diagnoses: patientPayload.diagnoses } : {}),
+                therapies: therapyPayloads,
+            }),
+        });
+        if (!response.ok) {
+            const payload = await response.json().catch(() => null);
+            if (response.status === 409 && isApiVersionConflictPayload(payload)) {
+                throw new ApiConflictError(payload);
+            }
+            throw new Error('Failed to apply Smart Import selection');
+        }
+
+        if (input.diagnoses !== undefined) notifyDbChange('patients');
+        if (input.therapies.length > 0) notifyDbChange('therapies');
     }
 
     /* @Codex */

--- a/lib/domain/documents/patient-smart-import-service.ts
+++ b/lib/domain/documents/patient-smart-import-service.ts
@@ -1035,7 +1035,7 @@ export async function applyPatientSmartImportSelection(
         }
     } catch (error) {
         for (const therapyId of createdTherapyIds) {
-            await db.therapies.delete(therapyId, { suppressNotify: true }).catch(() => null);
+            await db.therapies.delete(therapyId, { suppressNotify: true, version: 1 }).catch(() => null);
         }
         if (createdTherapyIds.length > 0) {
             notifyDbChange();

--- a/lib/domain/documents/patient-smart-import-service.ts
+++ b/lib/domain/documents/patient-smart-import-service.ts
@@ -17,7 +17,6 @@ import { dedupeDocumentInsightsForContext } from './document-insight-context';
 /* @Codex */
 import { renderDocumentEvidencePackContext } from './document-evidence-pack';
 import { searchICDHybrid, type ICDSearchResult } from '../../icd-service';
-import { notifyDbChange } from '../../live-query';
 import {
     buildDiagnosisSearchQueries,
     classifyExtractedTherapyState,
@@ -1017,30 +1016,12 @@ export async function applyPatientSmartImportSelection(
         appliedTherapyIds.push(suggestion.id);
     }
 
-    const createdTherapyIds: string[] = [];
-    try {
-        for (const therapyItem of therapyItems) {
-            await db.therapies.add(therapyItem, { suppressNotify: true });
-            createdTherapyIds.push(therapyItem.id);
-        }
-
-        if (appliedDiagnosisIds.length > 0) {
-            await db.patients.update(patientId, {
-                diagnoses: nextDiagnoses,
-                version: patient.version,
-                updatedAt: new Date(),
-            });
-        } else if (createdTherapyIds.length > 0) {
-            notifyDbChange();
-        }
-    } catch (error) {
-        for (const therapyId of createdTherapyIds) {
-            await db.therapies.delete(therapyId, { suppressNotify: true, version: 1 }).catch(() => null);
-        }
-        if (createdTherapyIds.length > 0) {
-            notifyDbChange();
-        }
-        throw error;
+    if (appliedDiagnosisIds.length > 0 || therapyItems.length > 0) {
+        await db.applyPatientSmartImport(patientId, {
+            version: patient.version,
+            diagnoses: appliedDiagnosisIds.length > 0 ? nextDiagnoses : undefined,
+            therapies: therapyItems,
+        });
     }
 
     if (appliedDiagnosisIds.length > 0 || appliedTherapyIds.length > 0) {

--- a/lib/fhir/types.ts
+++ b/lib/fhir/types.ts
@@ -40,7 +40,7 @@ export interface FhirTherapyInput {
     motivation?: string;
     status: 'active' | 'suspended' | 'completed';
     startDate: Date | string;
-    endDate?: Date | string;
+    endDate?: Date | string | null;
 }
 
 export interface FhirCheckupInput {

--- a/lib/patient-smart-import-apply.test.ts
+++ b/lib/patient-smart-import-apply.test.ts
@@ -1,0 +1,131 @@
+/* @Codex */
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { eq } from 'drizzle-orm';
+import {
+    commitPatientSmartImport,
+    type PatientSmartImportTherapyValues,
+} from './patient-smart-import-apply';
+import { patients, therapies } from './schema';
+
+function makeDatabase() {
+    const sqlite = new Database(':memory:');
+    sqlite.exec(`
+        CREATE TABLE patients (
+            id TEXT PRIMARY KEY NOT NULL,
+            first_name TEXT NOT NULL,
+            last_name TEXT NOT NULL,
+            tax_code TEXT NOT NULL,
+            diagnoses TEXT,
+            is_archived INTEGER DEFAULT 0,
+            deleted_at INTEGER,
+            version INTEGER NOT NULL DEFAULT 1,
+            updated_at INTEGER
+        );
+        CREATE TABLE therapies (
+            id TEXT PRIMARY KEY NOT NULL,
+            patient_id TEXT NOT NULL,
+            drug_name TEXT NOT NULL,
+            aic TEXT,
+            atc TEXT,
+            active_principle TEXT,
+            dosage TEXT NOT NULL,
+            motivation TEXT,
+            diagnosis_code TEXT,
+            diagnosis_name TEXT,
+            status TEXT NOT NULL,
+            start_date INTEGER NOT NULL,
+            end_date INTEGER,
+            version INTEGER NOT NULL DEFAULT 1,
+            created_at INTEGER,
+            updated_at INTEGER,
+            deleted_at INTEGER,
+            deletion_reason TEXT
+        );
+    `);
+    const database = drizzle(sqlite);
+    sqlite.prepare(`
+        INSERT INTO patients (id, first_name, last_name, tax_code, diagnoses, version, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run(
+        'patient-synthetic',
+        'Paziente',
+        'Sintetico',
+        'SYNTHETIC0000000',
+        'ENC:b2xk:dmFsdWU=',
+        3,
+        1783800000,
+    );
+    return { sqlite, database };
+}
+
+function therapy(id: string): PatientSmartImportTherapyValues {
+    const now = new Date('2026-07-11T20:01:00.000Z');
+    return {
+        id,
+        patientId: 'patient-synthetic',
+        drugName: 'Farmaco sintetico',
+        aic: null,
+        atc: null,
+        activePrinciple: null,
+        dosage: '1 compressa',
+        motivation: 'ENC:bW90:aXZhemlvbmU=',
+        diagnosisCode: null,
+        diagnosisName: null,
+        status: 'active',
+        startDate: now,
+        endDate: null,
+        version: 1,
+        createdAt: now,
+        updatedAt: now,
+        deletedAt: null,
+        deletionReason: null,
+    };
+}
+
+test('Smart Import rolls back diagnoses and created therapies when a later insert fails', () => {
+    const { sqlite, database } = makeDatabase();
+    try {
+        assert.throws(() => commitPatientSmartImport(database, {
+            patientId: 'patient-synthetic',
+            expectedVersion: 3,
+            diagnoses: 'ENC:bmV3:dmFsdWU=',
+            therapies: [therapy('therapy-duplicate'), therapy('therapy-duplicate')],
+        }));
+
+        const patient = database.select({
+            diagnoses: patients.diagnoses,
+            version: patients.version,
+        }).from(patients).where(eq(patients.id, 'patient-synthetic')).get();
+        const therapyRows = database.select().from(therapies).all();
+
+        assert.deepEqual(patient, { diagnoses: 'ENC:b2xk:dmFsdWU=', version: 3 });
+        assert.equal(therapyRows.length, 0);
+    } finally {
+        sqlite.close();
+    }
+});
+
+test('Smart Import commits the patient update and therapy inserts together', () => {
+    const { sqlite, database } = makeDatabase();
+    try {
+        const result = commitPatientSmartImport(database, {
+            patientId: 'patient-synthetic',
+            expectedVersion: 3,
+            diagnoses: 'ENC:bmV3:dmFsdWU=',
+            therapies: [therapy('therapy-created')],
+        });
+
+        assert.equal(result.status, 200);
+        const patient = database.select({
+            diagnoses: patients.diagnoses,
+            version: patients.version,
+        }).from(patients).where(eq(patients.id, 'patient-synthetic')).get();
+        assert.deepEqual(patient, { diagnoses: 'ENC:bmV3:dmFsdWU=', version: 4 });
+        assert.equal(database.select().from(therapies).all().length, 1);
+    } finally {
+        sqlite.close();
+    }
+});

--- a/lib/patient-smart-import-apply.ts
+++ b/lib/patient-smart-import-apply.ts
@@ -1,0 +1,99 @@
+/* @Codex */
+import { and, eq } from 'drizzle-orm';
+import type { dbServer } from './db-server';
+import { activePatients } from './patient-lifecycle';
+import {
+    buildPatientVersionConflictPayload,
+    type PatientVersionConflictPayload,
+} from './patient-concurrency';
+import { patients, therapies } from './schema';
+
+export type PatientSmartImportTherapyValues = typeof therapies.$inferInsert;
+
+type PatientSmartImportApplyInput = {
+    patientId: string;
+    expectedVersion: number;
+    diagnoses?: string;
+    therapies: PatientSmartImportTherapyValues[];
+    now?: Date;
+};
+
+export type PatientSmartImportApplyResult =
+    | {
+        status: 200;
+        value: {
+            success: true;
+            patientVersion: number;
+            therapyIds: string[];
+        };
+    }
+    | { status: 404; value: { error: 'Not found' } }
+    | { status: 409; value: PatientVersionConflictPayload };
+
+type TransactionDatabase = Pick<typeof dbServer, 'transaction'>;
+
+export function commitPatientSmartImport(
+    database: TransactionDatabase,
+    input: PatientSmartImportApplyInput,
+): PatientSmartImportApplyResult {
+    return database.transaction((tx): PatientSmartImportApplyResult => {
+        const current = tx.select({
+            id: patients.id,
+            version: patients.version,
+            updatedAt: patients.updatedAt,
+            isArchived: patients.isArchived,
+        })
+            .from(patients)
+            .where(and(eq(patients.id, input.patientId), activePatients()))
+            .get();
+
+        if (!current) {
+            return { status: 404, value: { error: 'Not found' } };
+        }
+        if (current.version !== input.expectedVersion) {
+            return {
+                status: 409,
+                value: buildPatientVersionConflictPayload(input.expectedVersion, input.patientId, current),
+            };
+        }
+
+        const patientVersion = input.diagnoses === undefined
+            ? current.version
+            : current.version + 1;
+
+        if (input.diagnoses !== undefined) {
+            const updated = tx.update(patients)
+                .set({
+                    diagnoses: input.diagnoses,
+                    version: patientVersion,
+                    updatedAt: input.now ?? new Date(),
+                })
+                .where(and(
+                    eq(patients.id, input.patientId),
+                    eq(patients.version, input.expectedVersion),
+                    activePatients(),
+                ))
+                .run();
+
+            if (updated.changes === 0) {
+                return {
+                    status: 409,
+                    value: buildPatientVersionConflictPayload(input.expectedVersion, input.patientId, current),
+                };
+            }
+        }
+
+        for (const therapy of input.therapies) {
+            tx.insert(therapies).values(therapy).run();
+        }
+
+        return {
+            status: 200,
+            value: {
+                success: true,
+                patientVersion,
+                therapyIds: input.therapies.map((therapy) => therapy.id),
+            },
+        };
+    });
+}

--- a/scripts/network-home-base-observation-write.test.mjs
+++ b/scripts/network-home-base-observation-write.test.mjs
@@ -253,6 +253,119 @@ test('paired observation write requires capability, session, scope, version, and
     }
 });
 
+test('web clinical lifecycle rejects stale writes, preserves observation tombstones, and refuses creates for deleted patients', async () => {
+    await assertServerReady();
+
+    const ambulatoryId = await resolveDefaultAmbulatoryId();
+    const patientId = await createSeedPatient(ambulatoryId);
+    const login = await request('POST', '/api/auth/login', {
+        body: { username: USERNAME, password: PIN },
+    });
+    assert.equal(login.response.status, 200);
+    const sessionCookie = extractSessionCookie(login.response);
+
+    try {
+        const therapy = await request('POST', '/api/therapies', {
+            headers: { Cookie: sessionCookie },
+            body: {
+                patientId,
+                drugName: 'Lifecycle test therapy',
+                dosage: '1 compressa',
+                startDate: '2026-05-02T09:00:00.000Z',
+            },
+        });
+        assert.equal(therapy.response.status, 201);
+
+        const therapyUpdate = await request('PUT', `/api/therapies/${therapy.json.id}`, {
+            headers: { Cookie: sessionCookie },
+            body: { version: 1, status: 'suspended' },
+        });
+        assert.equal(therapyUpdate.response.status, 200);
+
+        const staleTherapyUpdate = await request('PUT', `/api/therapies/${therapy.json.id}`, {
+            headers: { Cookie: sessionCookie },
+            body: { version: 1, status: 'completed' },
+        });
+        assert.equal(staleTherapyUpdate.response.status, 409);
+        assert.equal(staleTherapyUpdate.json?.code, 'VERSION_CONFLICT');
+        assert.equal(staleTherapyUpdate.json?.entity, 'therapy');
+        assert.equal(staleTherapyUpdate.json?.currentVersion, 2);
+
+        const observation = await request('POST', '/api/observations', {
+            headers: { Cookie: sessionCookie },
+            body: {
+                patientId,
+                codeSystem: 'LOINC',
+                code: '8480-6',
+                display: 'Systolic blood pressure',
+                unitSystem: 'UCUM',
+                unitCode: 'mm[Hg]',
+                value: 128,
+                observedAt: '2026-05-02T09:00:00.000Z',
+                source: 'manual',
+            },
+        });
+        assert.equal(observation.response.status, 201);
+
+        const observationDelete = await request('DELETE', `/api/observations/${observation.json.id}`, {
+            headers: { Cookie: sessionCookie },
+            body: { version: 1 },
+        });
+        assert.equal(observationDelete.response.status, 200);
+
+        const deletedObservations = await request('GET', `/api/observations?patientId=${patientId}&includeDeleted=true`, {
+            headers: { Cookie: sessionCookie },
+        });
+        assert.equal(deletedObservations.response.status, 200);
+        const deletedObservation = deletedObservations.json.find((item) => item.id === observation.json.id);
+        assert.ok(deletedObservation, 'Soft-deleted observation must remain recoverable');
+        assert.ok(deletedObservation.deletedAt, 'Soft-deleted observation must have deletedAt');
+        assert.equal(deletedObservation.version, 2);
+
+        const patient = await request('GET', `/api/v1/patients/${patientId}`, {
+            headers: localApiHeaders(),
+        });
+        assert.equal(patient.response.status, 200);
+        const patientDelete = await request('DELETE', `/api/v1/patients/${patientId}`, {
+            headers: localApiHeaders(),
+            body: { version: patient.json.version },
+        });
+        assert.equal(patientDelete.response.status, 200);
+
+        const webCreates = [
+            ['/api/entries', { patientId, type: 'note', date: '2026-05-02T09:00:00.000Z', content: 'blocked' }],
+            ['/api/therapies', { patientId, drugName: 'Blocked therapy', dosage: '1 compressa', startDate: '2026-05-02T09:00:00.000Z' }],
+            ['/api/checkups', { patientId, title: 'Blocked checkup', date: '2026-05-02T09:00:00.000Z' }],
+            ['/api/observations', { patientId, codeSystem: 'LOINC', code: '8480-6', display: 'Systolic blood pressure', unitSystem: 'UCUM', unitCode: 'mm[Hg]', value: 128, observedAt: '2026-05-02T09:00:00.000Z', source: 'manual' }],
+        ];
+        for (const [pathname, body] of webCreates) {
+            const response = await request('POST', pathname, { headers: { Cookie: sessionCookie }, body });
+            assert.equal(response.response.status, 404, `Expected deleted patient create guard for ${pathname}`);
+        }
+
+        const v1Creates = [
+            [`/api/v1/patients/${patientId}/entries`, { type: 'note', date: '2026-05-02T09:00:00.000Z', content: 'blocked' }],
+            [`/api/v1/patients/${patientId}/therapies`, { drugName: 'Blocked therapy', dosage: '1 compressa', startDate: '2026-05-02T09:00:00.000Z' }],
+            [`/api/v1/patients/${patientId}/checkups`, { title: 'Blocked checkup', date: '2026-05-02T09:00:00.000Z' }],
+            [`/api/v1/patients/${patientId}/observations`, { codeSystem: 'LOINC', code: '8480-6', display: 'Systolic blood pressure', unitSystem: 'UCUM', unitCode: 'mm[Hg]', value: 128, observedAt: '2026-05-02T09:00:00.000Z', source: 'manual' }],
+        ];
+        for (const [pathname, body] of v1Creates) {
+            const response = await request('POST', pathname, { headers: localApiHeaders(), body });
+            assert.equal(response.response.status, 404, `Expected deleted patient create guard for ${pathname}`);
+        }
+
+        scenarioResults.push({
+            name: 'web clinical lifecycle',
+            patientId,
+            staleTherapyStatus: staleTherapyUpdate.response.status,
+            observationDeleteStatus: observationDelete.response.status,
+            deletedPatientCreateStatus: 404,
+        });
+    } finally {
+        await cleanupPatient(patientId);
+    }
+});
+
 async function findAuditEvent(eventType, subjectRef, sessionCookie) {
     const audit = await request('GET', `/api/system/audit?eventType=${eventType}&subjectType=observation&limit=20`, {
         headers: {


### PR DESCRIPTION
## Summary

- Rende versionati update e soft-delete di terapie e osservazioni, mantenendo risposte 409 PHI-safe e audit coerenti.
- Rifiuta le create cliniche su pazienti tombstoned e rende atomica la creazione paziente/membership.
- Sostituisce la compensazione Smart Import basata su DELETE con una singola transazione server-side per diagnosi e terapie.
- Aggiunge una regressione sintetica che prova rollback completo e commit positivo.

## Verification

- `npm run typecheck`
- `npm run lint`
- `node scripts/run-strip-types.mjs --test lib/patient-smart-import-apply.test.ts lib/domain/documents/patient-smart-import-service.test.ts` con Node 24.18.0: 21/21
- `npm run test:unit` con Node 24.18.0: 606/606
- `git diff --check origin/main..HEAD`
- Verifica indipendente read-only: APPROVA, nessun finding

## Risk / Notes

- Il nuovo endpoint e interno alla superficie web autenticata; non modifica il contratto `/api/v1`.
- La transazione conserva il guard di versione e il filtro sui pazienti attivi; un errore in qualunque inserimento annulla tutte le scritture Smart Import.
- Il worktree con dipendenze condivise richiede Node 24 per l'ABI locale di `better-sqlite3`; nessuna dipendenza e stata ricompilata.
- Nessuna PHI/PII o fixture clinica reale inclusa.

## Ticket

Refs WUL-483