### PR TITLE
fix(backup): rende ripristinabile e sicuro il backup schedulato

### DIFF
--- a/app/api/system/backup-restore/route.ts
+++ b/app/api/system/backup-restore/route.ts
@@ -34,6 +34,7 @@ import {
     type BackupDataset,
     serializeBackupArtifact,
 } from '@/lib/backup-artifact';
+import { derivePatientAmbulatoryLinks } from '@/lib/backup-patient-ambulatory-links';
 import { runBackupRestorePreflight } from '@/lib/backup-restore-preflight';
 
 /* @Codex */
@@ -192,44 +193,25 @@ function filterRowsByReference<T extends Record<string, unknown>>(
 }
 
 /* @Codex */
-async function buildBackupDataset(): Promise<BackupDataset> {
-    const [
-        ambulatoriesRows,
-        attachmentsRows,
-        conversationsRows,
-        drugsRows,
-        entriesRows,
-        exemptionsRows,
-        messagesRows,
-        observationsRows,
-        patientsRows,
-        prostheticPrescriptionRows,
-        serviceCatalogRows,
-        servicePrescriptionItemRows,
-        servicePrescriptionRows,
-        sissHandoffRows,
-        checkupsRows,
-        therapiesRows,
-        patientAmbulatoryRows,
-    ] = await Promise.all([
-        dbServer.select().from(ambulatories),
-        dbServer.select().from(attachments),
-        dbServer.select().from(conversations),
-        dbServer.select().from(drugs),
-        dbServer.select().from(entries),
-        dbServer.select().from(exemptions),
-        dbServer.select().from(messages),
-        dbServer.select().from(observations),
-        dbServer.select().from(patients),
-        dbServer.select().from(prostheticPrescriptions),
-        dbServer.select().from(serviceCatalogEntries),
-        dbServer.select().from(servicePrescriptionItems),
-        dbServer.select().from(servicePrescriptions),
-        dbServer.select().from(sissHandoffEvents),
-        dbServer.select().from(checkups),
-        dbServer.select().from(therapies),
-        dbServer.select().from(patientsToAmbulatories),
-    ]);
+function buildBackupDataset(): BackupDataset {
+    return dbServer.transaction((tx): BackupDataset => {
+        const ambulatoriesRows = tx.select().from(ambulatories).all();
+        const attachmentsRows = tx.select().from(attachments).all();
+        const conversationsRows = tx.select().from(conversations).all();
+        const drugsRows = tx.select().from(drugs).all();
+        const entriesRows = tx.select().from(entries).all();
+        const exemptionsRows = tx.select().from(exemptions).all();
+        const messagesRows = tx.select().from(messages).all();
+        const observationsRows = tx.select().from(observations).all();
+        const patientsRows = tx.select().from(patients).all();
+        const prostheticPrescriptionRows = tx.select().from(prostheticPrescriptions).all();
+        const serviceCatalogRows = tx.select().from(serviceCatalogEntries).all();
+        const servicePrescriptionItemRows = tx.select().from(servicePrescriptionItems).all();
+        const servicePrescriptionRows = tx.select().from(servicePrescriptions).all();
+        const sissHandoffRows = tx.select().from(sissHandoffEvents).all();
+        const checkupsRows = tx.select().from(checkups).all();
+        const therapiesRows = tx.select().from(therapies).all();
+        const patientAmbulatoryRows = tx.select().from(patientsToAmbulatories).all();
 
     const normalizedPatientAmbulatoryRows = sortBackupRows(patientAmbulatoryRows);
     const enrichedPatients = patientsRows.map((patient) => {
@@ -249,24 +231,25 @@ async function buildBackupDataset(): Promise<BackupDataset> {
             .filter((value): value is string => typeof value === 'string' && value.trim().length > 0),
     );
 
-    return {
-        ambulatories: sortBackupRows(ambulatoriesRows),
-        attachments: sortBackupRows(filterRowsByReference(attachmentsRows, 'patientId', patientIds)),
-        conversations: sortBackupRows(conversationsRows),
-        drugs: sortBackupRows(drugsRows),
-        entries: sortBackupRows(filterRowsByReference(entriesRows, 'patientId', patientIds)),
-        exemptions: sortBackupRows(exemptionsRows),
-        messages: sortBackupRows(filterRowsByReference(messagesRows, 'conversationId', conversationIds)),
-        observations: sortBackupRows(filterRowsByReference(observationsRows, 'patientId', patientIds)),
-        patients: sortBackupRows(enrichedPatients),
-        prostheticPrescriptions: sortBackupRows(filterRowsByReference(prostheticPrescriptionRows, 'patientId', patientIds)),
-        serviceCatalogEntries: sortBackupRows(serviceCatalogRows),
-        servicePrescriptionItems: sortBackupRows(filterRowsByReference(servicePrescriptionItemRows, 'patientId', patientIds)),
-        servicePrescriptions: sortBackupRows(filterRowsByReference(servicePrescriptionRows, 'patientId', patientIds)),
-        sissHandoffs: sortBackupRows(filterRowsByReference(sissHandoffRows, 'patientId', patientIds)),
-        checkups: sortBackupRows(filterRowsByReference(checkupsRows, 'patientId', patientIds)),
-        therapies: sortBackupRows(filterRowsByReference(therapiesRows, 'patientId', patientIds)),
-    };
+        return {
+            ambulatories: sortBackupRows(ambulatoriesRows),
+            attachments: sortBackupRows(filterRowsByReference(attachmentsRows, 'patientId', patientIds)),
+            conversations: sortBackupRows(conversationsRows),
+            drugs: sortBackupRows(drugsRows),
+            entries: sortBackupRows(filterRowsByReference(entriesRows, 'patientId', patientIds)),
+            exemptions: sortBackupRows(exemptionsRows),
+            messages: sortBackupRows(filterRowsByReference(messagesRows, 'conversationId', conversationIds)),
+            observations: sortBackupRows(filterRowsByReference(observationsRows, 'patientId', patientIds)),
+            patients: sortBackupRows(enrichedPatients),
+            prostheticPrescriptions: sortBackupRows(filterRowsByReference(prostheticPrescriptionRows, 'patientId', patientIds)),
+            serviceCatalogEntries: sortBackupRows(serviceCatalogRows),
+            servicePrescriptionItems: sortBackupRows(filterRowsByReference(servicePrescriptionItemRows, 'patientId', patientIds)),
+            servicePrescriptions: sortBackupRows(filterRowsByReference(servicePrescriptionRows, 'patientId', patientIds)),
+            sissHandoffs: sortBackupRows(filterRowsByReference(sissHandoffRows, 'patientId', patientIds)),
+            checkups: sortBackupRows(filterRowsByReference(checkupsRows, 'patientId', patientIds)),
+            therapies: sortBackupRows(filterRowsByReference(therapiesRows, 'patientId', patientIds)),
+        };
+    });
 }
 
 /* @Codex */
@@ -328,48 +311,13 @@ function insertRows<T extends Record<string, unknown>>(runner: InsertRunner, tab
 }
 
 /* @Codex */
-function parseAssignedAmbulatoryIds(value: unknown): string[] {
-    if (!Array.isArray(value)) return [];
-    return Array.from(new Set(
-        value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
-    ));
-}
-
-function derivePatientLinks(patientsPayload: BackupArtifact['payload']['patients']): Array<{ patientId: string; ambulatoryId: string; assignedAt: Date }> {
-    return patientsPayload.flatMap((patient) => {
-        if (typeof patient.id !== 'string') {
-            return [];
-        }
-        const patientId = patient.id;
-
-        const assignedAt = typeof patient.updatedAt === 'string'
-            ? new Date(patient.updatedAt)
-            : typeof patient.createdAt === 'string'
-                ? new Date(patient.createdAt)
-                : new Date();
-
-        const normalizedAssignedAt = Number.isNaN(assignedAt.getTime()) ? new Date() : assignedAt;
-        const ambulatoryIds = new Set(parseAssignedAmbulatoryIds(patient.assignedAmbulatoryIds));
-        if (typeof patient.ambulatoryId === 'string' && patient.ambulatoryId.trim().length > 0) {
-            ambulatoryIds.add(patient.ambulatoryId);
-        }
-
-        return Array.from(ambulatoryIds).map((ambulatoryId) => ({
-            patientId,
-            ambulatoryId,
-            assignedAt: normalizedAssignedAt,
-        }));
-    });
-}
-
-/* @Codex */
 export async function GET() {
     const session = await requireSession();
     if (!session) return unauthorizedResponse();
     if (!isWebAdminSession(session)) return forbiddenResponse();
 
     try {
-        const payload = await buildBackupDataset();
+        const payload = buildBackupDataset();
         const serialized = await serializeBackupArtifact(payload);
         return new NextResponse(serialized, {
             status: 200,
@@ -487,7 +435,7 @@ export async function POST(request: Request) {
                 }
             }
 
-            const patientLinks = derivePatientLinks(artifact.payload.patients);
+            const patientLinks = derivePatientAmbulatoryLinks(artifact.payload.patients);
             insertRows(tx, TABLES.patientsToAmbulatories, patientLinks);
         });
 

--- a/lib/backup-patient-ambulatory-links.ts
+++ b/lib/backup-patient-ambulatory-links.ts
@@ -1,0 +1,41 @@
+/* @Codex */
+import type { BackupArtifact } from './backup-artifact';
+
+export type RestoredPatientAmbulatoryLink = {
+    patientId: string;
+    ambulatoryId: string;
+    assignedAt: Date;
+};
+
+function parseAssignedAmbulatoryIds(value: unknown): string[] {
+    if (!Array.isArray(value)) return [];
+    return Array.from(new Set(
+        value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0),
+    ));
+}
+
+export function derivePatientAmbulatoryLinks(
+    patientsPayload: BackupArtifact['payload']['patients'],
+): RestoredPatientAmbulatoryLink[] {
+    return patientsPayload.flatMap((patient) => {
+        if (typeof patient.id !== 'string') return [];
+        const patientId = patient.id;
+
+        const assignedAt = typeof patient.updatedAt === 'string'
+            ? new Date(patient.updatedAt)
+            : typeof patient.createdAt === 'string'
+                ? new Date(patient.createdAt)
+                : new Date();
+        const normalizedAssignedAt = Number.isNaN(assignedAt.getTime()) ? new Date() : assignedAt;
+        const ambulatoryIds = new Set(parseAssignedAmbulatoryIds(patient.assignedAmbulatoryIds));
+        if (typeof patient.ambulatoryId === 'string' && patient.ambulatoryId.trim().length > 0) {
+            ambulatoryIds.add(patient.ambulatoryId);
+        }
+
+        return Array.from(ambulatoryIds).map((ambulatoryId) => ({
+            patientId,
+            ambulatoryId,
+            assignedAt: normalizedAssignedAt,
+        }));
+    });
+}

--- a/lib/backup-scheduler.test.ts
+++ b/lib/backup-scheduler.test.ts
@@ -80,6 +80,8 @@ test('previews only scheduler-owned backup artifacts beyond keep-last-N plus orp
     await fs.promises.writeFile(newerArtifact, 'newer');
     await fs.promises.writeFile(orphanTemp, 'temp');
     await fs.promises.writeFile(unrelated, 'keep');
+    const staleAt = new Date(Date.now() - (16 * 60 * 1000));
+    await fs.promises.utimes(orphanTemp, staleAt, staleAt);
 
     const preview = previewBackupRetention({
         destinationDir: tempDir,
@@ -111,6 +113,8 @@ test('applies retention and tracks the last cleanup state', async () => {
     await fs.promises.writeFile(preservedArtifact, 'latest');
     await fs.promises.writeFile(orphanTemp, 'temp');
     await fs.promises.writeFile(unrelated, 'keep');
+    const staleAt = new Date(Date.now() - (16 * 60 * 1000));
+    await fs.promises.utimes(orphanTemp, staleAt, staleAt);
 
     const result = applyBackupRetention(
         {
@@ -148,6 +152,31 @@ test('applies retention and tracks the last cleanup state', async () => {
     assert.equal(trackedState.run.lastRetentionDeletedCount, 2);
     assert.equal(trackedState.run.lastRetentionAt, '2026-03-18T12:00:00.000Z');
     assert.equal(trackedState.run.lastArtifactPath, preservedArtifact);
+
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+});
+
+test('retention preserves recent temp files and all temps while a runner lock is active', async () => {
+    const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'mediflow-backup-lock-'));
+    const recentTemp = path.join(tempDir, 'mediflow-backup-v1-recent.mediflow.tmp');
+    const staleTemp = path.join(tempDir, 'mediflow-backup-v1-stale.mediflow.tmp');
+    const lockPath = path.join(tempDir, '.mediflow-backup.lock');
+
+    await fs.promises.writeFile(recentTemp, 'recent');
+    await fs.promises.writeFile(staleTemp, 'stale');
+    const staleAt = new Date(Date.now() - (16 * 60 * 1000));
+    await fs.promises.utimes(staleTemp, staleAt, staleAt);
+    await fs.promises.writeFile(lockPath, 'active');
+
+    const whileLocked = previewBackupRetention({ destinationDir: tempDir, retentionKeepArtifacts: 1 });
+    assert.equal(whileLocked.items.some((item) => item.path === recentTemp), false);
+    assert.equal(whileLocked.items.some((item) => item.path === staleTemp), false);
+
+    const staleLockAt = new Date(Date.now() - (7 * 60 * 60 * 1000));
+    await fs.promises.utimes(lockPath, staleLockAt, staleLockAt);
+    const afterStaleLock = previewBackupRetention({ destinationDir: tempDir, retentionKeepArtifacts: 1 });
+    assert.equal(afterStaleLock.items.some((item) => item.path === recentTemp), false);
+    assert.equal(afterStaleLock.items.some((item) => item.path === staleTemp), true);
 
     await fs.promises.rm(tempDir, { recursive: true, force: true });
 });

--- a/lib/backup-scheduler.ts
+++ b/lib/backup-scheduler.ts
@@ -12,6 +12,9 @@ export const DEFAULT_BACKUP_RETENTION_KEEP_ARTIFACTS = 14 as const;
 const BACKUP_ARTIFACT_FILE_PREFIX = 'mediflow-backup-v1-';
 const BACKUP_ARTIFACT_FILE_SUFFIX = '.mediflow';
 const BACKUP_ARTIFACT_TEMP_SUFFIX = '.mediflow.tmp';
+const BACKUP_LOCK_FILE_NAME = '.mediflow-backup.lock';
+const BACKUP_LOCK_STALE_MS = 6 * 60 * 60 * 1000;
+const BACKUP_TEMP_MIN_AGE_MS = 15 * 60 * 1000;
 
 export type BackupSchedulerRunStatus = 'success' | 'error';
 export type BackupRetentionMode = 'auto' | 'manual';
@@ -257,16 +260,32 @@ function sortManagedBackupFiles(files: ManagedBackupFile[]): ManagedBackupFile[]
     });
 }
 
+function isRecentTemp(file: ManagedBackupFile, nowMs: number): boolean {
+    return file.kind === 'temp' && nowMs - file.modifiedAtMs < BACKUP_TEMP_MIN_AGE_MS;
+}
+
+function hasActiveBackupLock(destinationDir: string, nowMs: number): boolean {
+    try {
+        return nowMs - fs.statSync(path.join(destinationDir, BACKUP_LOCK_FILE_NAME)).mtimeMs < BACKUP_LOCK_STALE_MS;
+    } catch {
+        return false;
+    }
+}
+
 export function previewBackupRetention(
     config: Pick<BackupSchedulerConfig, 'destinationDir' | 'retentionKeepArtifacts'>,
-    options?: { preservePaths?: string[] },
+    options?: { preservePaths?: string[]; nowMs?: number },
 ): BackupRetentionPreview {
     const preservePaths = new Set((options?.preservePaths ?? []).map((value) => path.resolve(value)));
+    const nowMs = options?.nowMs ?? Date.now();
+    const activeBackupLock = hasActiveBackupLock(config.destinationDir, nowMs);
     const managedFiles = sortManagedBackupFiles(listManagedBackupFiles(config.destinationDir));
     const artifacts = managedFiles.filter((file) => file.kind === 'artifact');
     const orphanTemps = managedFiles
         .filter((file) => file.kind === 'temp')
-        .filter((file) => !preservePaths.has(path.resolve(file.path)));
+        .filter((file) => !preservePaths.has(path.resolve(file.path)))
+        .filter((file) => !isRecentTemp(file, nowMs))
+        .filter(() => !activeBackupLock);
     const staleArtifacts = artifacts
         .slice(clampRetentionKeepArtifacts(config.retentionKeepArtifacts))
         .filter((file) => !preservePaths.has(path.resolve(file.path)));
@@ -301,7 +320,7 @@ export function previewBackupRetention(
 
 export function applyBackupRetention(
     config: Pick<BackupSchedulerConfig, 'destinationDir' | 'retentionKeepArtifacts'>,
-    options?: { preservePaths?: string[] },
+    options?: { preservePaths?: string[]; nowMs?: number },
 ): BackupRetentionApplyResult {
     const preview = previewBackupRetention(config, options);
 

--- a/lib/scheduled-backup-membership-roundtrip.test.ts
+++ b/lib/scheduled-backup-membership-roundtrip.test.ts
@@ -1,0 +1,102 @@
+/* @Codex */
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import Database from 'better-sqlite3';
+import { parseBackupArtifact } from './backup-artifact';
+import { derivePatientAmbulatoryLinks } from './backup-patient-ambulatory-links';
+
+test('scheduled backup roundtrip restores both ambulatory memberships for one patient', async () => {
+    const root = process.cwd();
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mediflow-scheduled-membership-'));
+    const sourceDataDir = path.join(workDir, 'source');
+    const targetDataDir = path.join(workDir, 'target');
+    const backupDir = path.join(workDir, 'backups');
+
+    try {
+        for (const dataDir of [sourceDataDir, targetDataDir]) {
+            execFileSync(process.execPath, ['scripts/prepare-e2e-db.mjs'], {
+                cwd: root,
+                env: { ...process.env, MEDIFLOW_E2E_DATA_DIR: dataDir },
+                stdio: 'pipe',
+            });
+        }
+
+        const sourceDb = new Database(path.join(sourceDataDir, 'medical.db'));
+        let primaryAmbulatoryId: string;
+        try {
+            primaryAmbulatoryId = (sourceDb.prepare('SELECT id FROM ambulatories WHERE is_default = 1 LIMIT 1').get() as { id: string }).id;
+            sourceDb.prepare('INSERT INTO ambulatories (id, name, type, is_default, created_at) VALUES (?, ?, ?, ?, ?)')
+                .run('roundtrip-amb-secondary', 'Ambulatorio sintetico secondario', 'synthetic', 0, 1_700_000_000);
+            sourceDb.prepare('INSERT INTO patients (id, first_name, last_name, tax_code, ambulatory_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)')
+                .run('roundtrip-patient', 'Synthetic', 'Membership', 'SYNTHETIC-ONLY', primaryAmbulatoryId, 1_700_000_000, 1_700_000_000);
+            sourceDb.prepare('INSERT INTO patients_to_ambulatories (patient_id, ambulatory_id, assigned_at) VALUES (?, ?, ?)')
+                .run('roundtrip-patient', primaryAmbulatoryId, 1_700_000_000);
+            sourceDb.prepare('INSERT INTO patients_to_ambulatories (patient_id, ambulatory_id, assigned_at) VALUES (?, ?, ?)')
+                .run('roundtrip-patient', 'roundtrip-amb-secondary', 1_700_000_000);
+        } finally {
+            sourceDb.close();
+        }
+
+        fs.mkdirSync(backupDir, { recursive: true });
+        const runnerResult = JSON.parse(execFileSync(process.execPath, ['scripts/run-scheduled-backup.mjs'], {
+            cwd: root,
+            env: {
+                ...process.env,
+                MEDIFLOW_DATA_DIR: sourceDataDir,
+                MEDIFLOW_BACKUP_DEST_DIR: backupDir,
+                MEDIFLOW_BACKUP_FORCE: '1',
+            },
+            encoding: 'utf8',
+        })) as { ok: boolean; artifactPath?: string; message?: string };
+        assert.equal(runnerResult.ok, true, runnerResult.message);
+        assert.ok(runnerResult.artifactPath);
+
+        const artifact = await parseBackupArtifact(JSON.parse(fs.readFileSync(runnerResult.artifactPath, 'utf8')));
+        const patient = artifact.payload.patients.find((row) => row.id === 'roundtrip-patient');
+        assert.deepEqual(patient?.assignedAmbulatoryIds, [primaryAmbulatoryId, 'roundtrip-amb-secondary'].sort());
+
+        const targetDb = new Database(path.join(targetDataDir, 'medical.db'));
+        try {
+            targetDb.transaction(() => {
+                targetDb.prepare('DELETE FROM patients_to_ambulatories').run();
+                targetDb.prepare('DELETE FROM patients').run();
+                targetDb.prepare('DELETE FROM ambulatories').run();
+                for (const ambulatory of artifact.payload.ambulatories) {
+                    targetDb.prepare('INSERT INTO ambulatories (id, name, type, is_default, created_at) VALUES (?, ?, ?, ?, ?)')
+                        .run(
+                            ambulatory.id,
+                            ambulatory.name,
+                            ambulatory.type ?? null,
+                            ambulatory.isDefault ?? null,
+                            ambulatory.createdAt ?? null,
+                        );
+                }
+                targetDb.prepare('INSERT INTO patients (id, first_name, last_name, tax_code, ambulatory_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)')
+                    .run(
+                        patient?.id ?? null,
+                        patient?.firstName ?? null,
+                        patient?.lastName ?? null,
+                        patient?.taxCode ?? null,
+                        patient?.ambulatoryId ?? null,
+                        patient?.createdAt ?? null,
+                        patient?.updatedAt ?? null,
+                    );
+                for (const link of derivePatientAmbulatoryLinks(artifact.payload.patients)) {
+                    targetDb.prepare('INSERT INTO patients_to_ambulatories (patient_id, ambulatory_id, assigned_at) VALUES (?, ?, ?)')
+                        .run(link.patientId, link.ambulatoryId, Math.floor(link.assignedAt.getTime() / 1000));
+                }
+            })();
+
+            const restored = targetDb.prepare('SELECT ambulatory_id FROM patients_to_ambulatories WHERE patient_id = ? ORDER BY ambulatory_id').all('roundtrip-patient') as Array<{ ambulatory_id: string }>;
+            assert.deepEqual(restored.map((row) => row.ambulatory_id), [primaryAmbulatoryId, 'roundtrip-amb-secondary'].sort());
+        } finally {
+            targetDb.close();
+        }
+    } finally {
+        fs.rmSync(workDir, { recursive: true, force: true });
+    }
+});

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test:document-input-normalization": "node scripts/run-strip-types.mjs --test lib/domain/documents/document-input-normalization.test.ts",
     "test:ocr-service:date": "node scripts/run-strip-types.mjs --test lib/domain/documents/ocr-service-date.test.ts",
     "test:ollama-pull-stream": "node scripts/run-strip-types.mjs --test lib/ollama-pull-stream.test.ts",
-    "test:backup-restore:preflight": "node scripts/run-strip-types.mjs --test lib/backup-artifact.test.ts lib/backup-restore-preflight.test.ts",
+    "test:backup-restore:preflight": "node scripts/run-strip-types.mjs --test lib/backup-artifact.test.ts lib/backup-restore-preflight.test.ts lib/scheduled-backup-membership-roundtrip.test.ts",
     "test:backup-restore:date-fields": "node --test scripts/backup-restore-date-fields.test.mjs",
     "test:backup-restore:drill": "node scripts/run-strip-types.mjs scripts/backup-restore-drill.mjs",
     "test:backup-scheduler": "bash scripts/backup-scheduler-test.sh",

--- a/scripts/backup-restore-drill.mjs
+++ b/scripts/backup-restore-drill.mjs
@@ -178,6 +178,8 @@ async function main() {
     const unrelatedFile = path.join(backupDir, 'operator-note.txt');
     fs.writeFileSync(staleArtifact, 'stale artifact');
     fs.writeFileSync(staleTemp, 'stale temp');
+    const staleTempAt = new Date(Date.now() - (16 * 60 * 1000));
+    fs.utimesSync(staleTemp, staleTempAt, staleTempAt);
     fs.writeFileSync(unrelatedFile, 'do not delete');
 
     const schedulerResult = timed('scheduledExportAndRetentionMs', timings, () => JSON.parse(command(

--- a/scripts/backup-scheduler-test.sh
+++ b/scripts/backup-scheduler-test.sh
@@ -36,6 +36,10 @@ NODE
 
 printf 'old artifact' > "$OUT_DIR/mediflow-backup-v1-2026-03-17T00-00-00.000Z.mediflow"
 printf 'orphan temp' > "$OUT_DIR/mediflow-backup-v1-2026-03-17T00-00-00.000Z.mediflow.tmp"
+touch -t 202001010000 "$OUT_DIR/mediflow-backup-v1-2026-03-17T00-00-00.000Z.mediflow.tmp"
+printf 'recent temp' > "$OUT_DIR/mediflow-backup-v1-current.mediflow.tmp"
+printf 'stale lock' > "$OUT_DIR/.mediflow-backup.lock"
+touch -t 202001010000 "$OUT_DIR/.mediflow-backup.lock"
 printf 'keep me' > "$OUT_DIR/notes.txt"
 
 MEDIFLOW_DATA_DIR="$DATA_DIR" \
@@ -60,6 +64,12 @@ if (fs.existsSync(path.join(path.dirname(result.artifactPath), 'mediflow-backup-
 }
 if (fs.existsSync(path.join(path.dirname(result.artifactPath), 'mediflow-backup-v1-2026-03-17T00-00-00.000Z.mediflow.tmp'))) {
   throw new Error('Retention did not remove the orphan temp file.');
+}
+if (!fs.existsSync(path.join(path.dirname(result.artifactPath), 'mediflow-backup-v1-current.mediflow.tmp'))) {
+  throw new Error('Retention removed a recent temp file.');
+}
+if (fs.existsSync(path.join(path.dirname(result.artifactPath), '.mediflow-backup.lock'))) {
+  throw new Error('Runner did not recover and release a stale backup lock.');
 }
 if (!fs.existsSync(path.join(path.dirname(result.artifactPath), 'notes.txt'))) {
   throw new Error('Retention removed an unrelated file.');

--- a/scripts/backup-scheduler-test.sh
+++ b/scripts/backup-scheduler-test.sh
@@ -87,19 +87,41 @@ NODE
 
 TMP_DIR="$TMP_DIR" node "$TMP_DIR/verify-backup-artifact.mjs"
 
-printf '{"pid":%s,"startedAt":"2020-01-01T00:00:00.000Z"}' "$$" > "$OUT_DIR/.mediflow-backup.lock"
-touch -t 202001010000 "$OUT_DIR/.mediflow-backup.lock"
+# @Codex: a recent lock owned by a live PID must remain exclusive.
+printf '{"pid":%s,"startedAt":"%s"}' "$$" "$(date -u +%Y-%m-%dT%H:%M:%S.000Z)" > "$OUT_DIR/.mediflow-backup.lock"
 if MEDIFLOW_DATA_DIR="$DATA_DIR" \
   MEDIFLOW_BACKUP_DEST_DIR="$OUT_DIR" \
   MEDIFLOW_BACKUP_FORCE=1 \
   node "$ROOT_DIR/scripts/run-scheduled-backup.mjs" > "$TMP_DIR/live-lock-result.json"; then
-  echo 'Runner acquired an old lock held by a live PID.' >&2
+  echo 'Runner acquired a recent lock held by a live PID.' >&2
   exit 1
 fi
 if [[ ! -f "$OUT_DIR/.mediflow-backup.lock" ]]; then
-  echo 'Runner removed an old lock held by a live PID.' >&2
+  echo 'Runner removed a recent lock held by a live PID.' >&2
   exit 1
 fi
+
+# @Codex: the same live PID must not keep a stale lock active after PID reuse.
+printf '{"pid":%s,"startedAt":"2020-01-01T00:00:00.000Z"}' "$$" > "$OUT_DIR/.mediflow-backup.lock"
+touch -t 202001010000 "$OUT_DIR/.mediflow-backup.lock"
+MEDIFLOW_DATA_DIR="$DATA_DIR" \
+MEDIFLOW_BACKUP_DEST_DIR="$OUT_DIR" \
+MEDIFLOW_BACKUP_FORCE=1 \
+node "$ROOT_DIR/scripts/run-scheduled-backup.mjs" > "$TMP_DIR/reused-pid-lock-result.json"
+
+TMP_DIR="$TMP_DIR" OUT_DIR="$OUT_DIR" node --input-type=module <<'NODE'
+import fs from 'fs';
+import path from 'path';
+
+const { TMP_DIR, OUT_DIR } = process.env;
+const result = JSON.parse(fs.readFileSync(path.join(TMP_DIR, 'reused-pid-lock-result.json'), 'utf8'));
+if (!result.ok || !result.artifactPath || !fs.existsSync(result.artifactPath)) {
+  throw new Error('Runner did not recover a stale lock whose PID was reused.');
+}
+if (fs.existsSync(path.join(OUT_DIR, '.mediflow-backup.lock'))) {
+  throw new Error('Runner did not release the recovered reused-PID lock.');
+}
+NODE
 
 printf '{not valid json' > "$OUT_DIR/.mediflow-backup.lock"
 MEDIFLOW_DATA_DIR="$DATA_DIR" \

--- a/scripts/backup-scheduler-test.sh
+++ b/scripts/backup-scheduler-test.sh
@@ -38,7 +38,7 @@ printf 'old artifact' > "$OUT_DIR/mediflow-backup-v1-2026-03-17T00-00-00.000Z.me
 printf 'orphan temp' > "$OUT_DIR/mediflow-backup-v1-2026-03-17T00-00-00.000Z.mediflow.tmp"
 touch -t 202001010000 "$OUT_DIR/mediflow-backup-v1-2026-03-17T00-00-00.000Z.mediflow.tmp"
 printf 'recent temp' > "$OUT_DIR/mediflow-backup-v1-current.mediflow.tmp"
-printf 'stale lock' > "$OUT_DIR/.mediflow-backup.lock"
+printf '{"pid":999999999,"startedAt":"2020-01-01T00:00:00.000Z"}' > "$OUT_DIR/.mediflow-backup.lock"
 touch -t 202001010000 "$OUT_DIR/.mediflow-backup.lock"
 printf 'keep me' > "$OUT_DIR/notes.txt"
 
@@ -86,5 +86,39 @@ if (!artifact.manifest || !artifact.payload) {
 NODE
 
 TMP_DIR="$TMP_DIR" node "$TMP_DIR/verify-backup-artifact.mjs"
+
+printf '{"pid":%s,"startedAt":"2020-01-01T00:00:00.000Z"}' "$$" > "$OUT_DIR/.mediflow-backup.lock"
+touch -t 202001010000 "$OUT_DIR/.mediflow-backup.lock"
+if MEDIFLOW_DATA_DIR="$DATA_DIR" \
+  MEDIFLOW_BACKUP_DEST_DIR="$OUT_DIR" \
+  MEDIFLOW_BACKUP_FORCE=1 \
+  node "$ROOT_DIR/scripts/run-scheduled-backup.mjs" > "$TMP_DIR/live-lock-result.json"; then
+  echo 'Runner acquired an old lock held by a live PID.' >&2
+  exit 1
+fi
+if [[ ! -f "$OUT_DIR/.mediflow-backup.lock" ]]; then
+  echo 'Runner removed an old lock held by a live PID.' >&2
+  exit 1
+fi
+
+printf '{not valid json' > "$OUT_DIR/.mediflow-backup.lock"
+MEDIFLOW_DATA_DIR="$DATA_DIR" \
+MEDIFLOW_BACKUP_DEST_DIR="$OUT_DIR" \
+MEDIFLOW_BACKUP_FORCE=1 \
+node "$ROOT_DIR/scripts/run-scheduled-backup.mjs" > "$TMP_DIR/corrupt-lock-result.json"
+
+TMP_DIR="$TMP_DIR" OUT_DIR="$OUT_DIR" node --input-type=module <<'NODE'
+import fs from 'fs';
+import path from 'path';
+
+const { TMP_DIR, OUT_DIR } = process.env;
+const result = JSON.parse(fs.readFileSync(path.join(TMP_DIR, 'corrupt-lock-result.json'), 'utf8'));
+if (!result.ok || !result.artifactPath || !fs.existsSync(result.artifactPath)) {
+  throw new Error('Runner did not recover a corrupted backup lock.');
+}
+if (fs.existsSync(path.join(OUT_DIR, '.mediflow-backup.lock'))) {
+  throw new Error('Runner did not release the recovered corrupted backup lock.');
+}
+NODE
 
 node "$ROOT_DIR/scripts/run-strip-types.mjs" --test "$ROOT_DIR/lib/backup-scheduler.test.ts"

--- a/scripts/run-scheduled-backup.mjs
+++ b/scripts/run-scheduled-backup.mjs
@@ -180,10 +180,34 @@ function isRecentTemp(file, nowMs = Date.now()) {
   return file.kind === 'temp' && nowMs - file.modifiedAtMs < BACKUP_TEMP_MIN_AGE_MS;
 }
 
+function readBackupLockPid(lockPath) {
+  try {
+    const lock = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
+    return Number.isSafeInteger(lock?.pid) && lock.pid > 0 ? lock.pid : null;
+  } catch {
+    return undefined;
+  }
+}
+
+function isProcessAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error?.code === 'ESRCH') return false;
+    if (error?.code === 'EPERM') return true;
+    return true;
+  }
+}
+
 function isBackupLockActive(destinationDir, nowMs = Date.now()) {
   const lockPath = path.join(destinationDir, BACKUP_LOCK_FILE_NAME);
   try {
-    return nowMs - fs.statSync(lockPath).mtimeMs < BACKUP_LOCK_STALE_MS;
+    const lockAgeMs = nowMs - fs.statSync(lockPath).mtimeMs;
+    const lockPid = readBackupLockPid(lockPath);
+    if (lockPid === undefined) return false;
+    if (lockPid !== null) return isProcessAlive(lockPid);
+    return lockAgeMs < BACKUP_LOCK_STALE_MS;
   } catch {
     return false;
   }

--- a/scripts/run-scheduled-backup.mjs
+++ b/scripts/run-scheduled-backup.mjs
@@ -15,6 +15,10 @@ const DEFAULT_BACKUP_RETENTION_KEEP_ARTIFACTS = 14;
 const BACKUP_ARTIFACT_FILE_PREFIX = 'mediflow-backup-v1-';
 const BACKUP_ARTIFACT_FILE_SUFFIX = '.mediflow';
 const BACKUP_ARTIFACT_TEMP_SUFFIX = '.mediflow.tmp';
+const BACKUP_LOCK_FILE_NAME = '.mediflow-backup.lock';
+const BACKUP_LOCK_STALE_MS = 6 * 60 * 60 * 1000;
+const BACKUP_TEMP_MIN_AGE_MS = 15 * 60 * 1000;
+const PATIENT_AMBULATORY_TABLE = 'patients_to_ambulatories';
 
 /* @Codex */
 const BACKUP_TABLES = {
@@ -35,7 +39,6 @@ const BACKUP_TABLES = {
   checkups: 'checkups',
   therapies: 'therapies',
 };
-const BACKUP_COLLECTIONS = Object.keys(BACKUP_TABLES);
 
 function getDefaultDataDir() {
   return process.env.MEDIFLOW_DATA_DIR
@@ -120,7 +123,7 @@ async function serializeBackupArtifact(payload, createdAt = new Date()) {
   const payloadSnapshot = normalizeJson(payload);
   const checksum = await sha256Hex(stableStringify(payloadSnapshot));
   const recordCounts = Object.fromEntries(
-    BACKUP_COLLECTIONS.map((collection) => [collection, payload[collection]?.length ?? 0]),
+    Object.keys(BACKUP_TABLES).map((collection) => [collection, payload[collection]?.length ?? 0]),
   );
   const artifact = {
     format: BACKUP_ARTIFACT_FORMAT,
@@ -130,7 +133,7 @@ async function serializeBackupArtifact(payload, createdAt = new Date()) {
       createdAt: createdAt.toISOString(),
       checksumAlgorithm: 'sha256',
       checksum,
-      collections: BACKUP_COLLECTIONS,
+      collections: Object.keys(BACKUP_TABLES),
       recordCounts,
     },
     payload,
@@ -173,8 +176,48 @@ function listManagedBackupFiles(destinationDir) {
   });
 }
 
+function isRecentTemp(file, nowMs = Date.now()) {
+  return file.kind === 'temp' && nowMs - file.modifiedAtMs < BACKUP_TEMP_MIN_AGE_MS;
+}
+
+function isBackupLockActive(destinationDir, nowMs = Date.now()) {
+  const lockPath = path.join(destinationDir, BACKUP_LOCK_FILE_NAME);
+  try {
+    return nowMs - fs.statSync(lockPath).mtimeMs < BACKUP_LOCK_STALE_MS;
+  } catch {
+    return false;
+  }
+}
+
+function acquireBackupLock(destinationDir) {
+  const lockPath = path.join(destinationDir, BACKUP_LOCK_FILE_NAME);
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      const descriptor = fs.openSync(lockPath, 'wx');
+      try {
+        fs.writeFileSync(descriptor, JSON.stringify({ pid: process.pid, startedAt: new Date().toISOString() }));
+      } finally {
+        fs.closeSync(descriptor);
+      }
+      return lockPath;
+    } catch (error) {
+      if (error?.code !== 'EEXIST' || isBackupLockActive(destinationDir)) {
+        throw new Error('Backup automatico gia in esecuzione.');
+      }
+      fs.rmSync(lockPath, { force: true });
+    }
+  }
+  throw new Error('Impossibile acquisire il lock del backup automatico.');
+}
+
+function releaseBackupLock(lockPath) {
+  if (lockPath) fs.rmSync(lockPath, { force: true });
+}
+
 function applyBackupRetention(config, options = {}) {
   const preservePaths = new Set((options.preservePaths ?? []).map((value) => path.resolve(value)));
+  const nowMs = options.nowMs ?? Date.now();
+  const activeBackupLock = !options.ignoreBackupLock && isBackupLockActive(config.destinationDir, nowMs);
   const managedFiles = listManagedBackupFiles(config.destinationDir).sort((left, right) => {
     if (left.modifiedAtMs !== right.modifiedAtMs) return right.modifiedAtMs - left.modifiedAtMs;
     return right.name.localeCompare(left.name);
@@ -182,7 +225,9 @@ function applyBackupRetention(config, options = {}) {
   const artifacts = managedFiles.filter((file) => file.kind === 'artifact');
   const orphanTemps = managedFiles
     .filter((file) => file.kind === 'temp')
-    .filter((file) => !preservePaths.has(path.resolve(file.path)));
+    .filter((file) => !preservePaths.has(path.resolve(file.path)))
+    .filter((file) => !isRecentTemp(file, nowMs))
+    .filter(() => !activeBackupLock);
   const staleArtifacts = artifacts
     .slice(clampRetentionKeepArtifacts(config.retentionKeepArtifacts))
     .filter((file) => !preservePaths.has(path.resolve(file.path)));
@@ -271,35 +316,58 @@ function filterRowsByReference(rows, foreignKey, validRefs) {
   return rows.filter((row) => typeof row?.[foreignKey] === 'string' && validRefs.has(row[foreignKey]));
 }
 
+function buildAssignedAmbulatoryIds(patient, rows) {
+  const ids = new Set();
+  if (typeof patient.ambulatoryId === 'string' && patient.ambulatoryId.trim().length > 0) {
+    ids.add(patient.ambulatoryId);
+  }
+  for (const row of rows) {
+    if (row.patientId === patient.id && typeof row.ambulatoryId === 'string' && row.ambulatoryId.trim().length > 0) {
+      ids.add(row.ambulatoryId);
+    }
+  }
+  return Array.from(ids).sort((left, right) => left.localeCompare(right));
+}
+
 function buildDataset(db, backupCollections) {
-  const dataset = Object.fromEntries(
-    backupCollections.map((collection) => [
-      collection,
-      hasTable(db, BACKUP_TABLES[collection])
-        ? db.prepare(`SELECT * FROM ${BACKUP_TABLES[collection]}`).all().map((row) => normalizeRowDates(normalizeRowKeys(row)))
-        : [],
-    ]),
-  );
+  return db.transaction(() => {
+    const dataset = Object.fromEntries(
+      backupCollections.map((collection) => [
+        collection,
+        hasTable(db, BACKUP_TABLES[collection])
+          ? db.prepare(`SELECT * FROM ${BACKUP_TABLES[collection]}`).all().map((row) => normalizeRowDates(normalizeRowKeys(row)))
+          : [],
+      ]),
+    );
+    const patientAmbulatoryRows = hasTable(db, PATIENT_AMBULATORY_TABLE)
+      ? db.prepare(`SELECT * FROM ${PATIENT_AMBULATORY_TABLE}`).all().map((row) => normalizeRowKeys(row))
+      : [];
+    dataset.patients = dataset.patients.map((patient) => {
+      const assignedAmbulatoryIds = buildAssignedAmbulatoryIds(patient, patientAmbulatoryRows);
+      return assignedAmbulatoryIds.length > 0 ? { ...patient, assignedAmbulatoryIds } : patient;
+    });
 
-  const patientIds = new Set(dataset.patients.map((row) => row.id).filter((value) => typeof value === 'string' && value.length > 0));
-  const conversationIds = new Set(dataset.conversations.map((row) => row.id).filter((value) => typeof value === 'string' && value.length > 0));
+    const patientIds = new Set(dataset.patients.map((row) => row.id).filter((value) => typeof value === 'string' && value.length > 0));
+    const conversationIds = new Set(dataset.conversations.map((row) => row.id).filter((value) => typeof value === 'string' && value.length > 0));
 
-  dataset.attachments = filterRowsByReference(dataset.attachments, 'patientId', patientIds);
-  dataset.entries = filterRowsByReference(dataset.entries, 'patientId', patientIds);
-  dataset.observations = filterRowsByReference(dataset.observations, 'patientId', patientIds);
-  dataset.checkups = filterRowsByReference(dataset.checkups, 'patientId', patientIds);
-  dataset.therapies = filterRowsByReference(dataset.therapies, 'patientId', patientIds);
-  dataset.prostheticPrescriptions = filterRowsByReference(dataset.prostheticPrescriptions, 'patientId', patientIds);
-  dataset.sissHandoffs = filterRowsByReference(dataset.sissHandoffs, 'patientId', patientIds);
-  dataset.messages = filterRowsByReference(dataset.messages, 'conversationId', conversationIds);
+    dataset.attachments = filterRowsByReference(dataset.attachments, 'patientId', patientIds);
+    dataset.entries = filterRowsByReference(dataset.entries, 'patientId', patientIds);
+    dataset.observations = filterRowsByReference(dataset.observations, 'patientId', patientIds);
+    dataset.checkups = filterRowsByReference(dataset.checkups, 'patientId', patientIds);
+    dataset.therapies = filterRowsByReference(dataset.therapies, 'patientId', patientIds);
+    dataset.prostheticPrescriptions = filterRowsByReference(dataset.prostheticPrescriptions, 'patientId', patientIds);
+    dataset.sissHandoffs = filterRowsByReference(dataset.sissHandoffs, 'patientId', patientIds);
+    dataset.messages = filterRowsByReference(dataset.messages, 'conversationId', conversationIds);
 
-  return dataset;
+    return dataset;
+  })();
 }
 
 async function main() {
   const dataDir = getDefaultDataDir();
   const dbPath = path.join(dataDir, 'medical.db');
   const forced = process.env.MEDIFLOW_BACKUP_FORCE === '1';
+  let backupLockPath = null;
 
   try {
     if (!fs.existsSync(dbPath)) {
@@ -315,9 +383,10 @@ async function main() {
     }
 
     fs.mkdirSync(destinationDir, { recursive: true });
+    backupLockPath = acquireBackupLock(destinationDir);
 
     const createdAt = new Date();
-    const payload = buildDataset(db, BACKUP_COLLECTIONS);
+    const payload = buildDataset(db, Object.keys(BACKUP_TABLES));
     const artifact = await serializeBackupArtifact(payload, createdAt);
     const fileName = `mediflow-backup-v1-${formatTimestamp(createdAt)}.mediflow`;
     const finalPath = path.join(destinationDir, fileName);
@@ -344,7 +413,7 @@ async function main() {
         destinationDir,
         retentionKeepArtifacts: currentState.config.retentionKeepArtifacts,
       },
-      { preservePaths: [finalPath] },
+      { preservePaths: [finalPath], ignoreBackupLock: true },
     );
     const nextState = applyRetentionResultToState(backedUpState, retentionResult, 'auto', createdAt);
     nextState.run.lastRunMessage = retentionResult.deletedCount > 0
@@ -391,6 +460,8 @@ async function main() {
       message,
     }));
     process.exitCode = 1;
+  } finally {
+    releaseBackupLock(backupLockPath);
   }
 }
 

--- a/scripts/run-scheduled-backup.mjs
+++ b/scripts/run-scheduled-backup.mjs
@@ -180,12 +180,17 @@ function isRecentTemp(file, nowMs = Date.now()) {
   return file.kind === 'temp' && nowMs - file.modifiedAtMs < BACKUP_TEMP_MIN_AGE_MS;
 }
 
-function readBackupLockPid(lockPath) {
+/* @Codex */
+function readBackupLock(lockPath) {
   try {
     const lock = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
-    return Number.isSafeInteger(lock?.pid) && lock.pid > 0 ? lock.pid : null;
+    const startedAtMs = typeof lock?.startedAt === 'string' ? Date.parse(lock.startedAt) : Number.NaN;
+    return {
+      pid: Number.isSafeInteger(lock?.pid) && lock.pid > 0 ? lock.pid : null,
+      startedAtMs: Number.isFinite(startedAtMs) ? startedAtMs : null,
+    };
   } catch {
-    return undefined;
+    return null;
   }
 }
 
@@ -203,11 +208,15 @@ function isProcessAlive(pid) {
 function isBackupLockActive(destinationDir, nowMs = Date.now()) {
   const lockPath = path.join(destinationDir, BACKUP_LOCK_FILE_NAME);
   try {
-    const lockAgeMs = nowMs - fs.statSync(lockPath).mtimeMs;
-    const lockPid = readBackupLockPid(lockPath);
-    if (lockPid === undefined) return false;
-    if (lockPid !== null) return isProcessAlive(lockPid);
-    return lockAgeMs < BACKUP_LOCK_STALE_MS;
+    const lock = readBackupLock(lockPath);
+    if (!lock) return false;
+
+    const modifiedAtMs = fs.statSync(lockPath).mtimeMs;
+    const startedAtMs = lock.startedAtMs !== null && lock.startedAtMs <= nowMs
+      ? lock.startedAtMs
+      : modifiedAtMs;
+    if (nowMs - startedAtMs >= BACKUP_LOCK_STALE_MS) return false;
+    return lock.pid === null || isProcessAlive(lock.pid);
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary

- Include nel backup schedulato le membership ambulatoriali necessarie al restore.
- Costruisce il dataset dentro una transazione di lettura per evitare snapshot incoerenti.
- Protegge i file temporanei durante retention e recupera lock morti o corrotti.
- Usa `startedAt` come stale cap: un PID vivo mantiene il lock solo entro 6 ore, evitando blocchi permanenti dopo PID reuse.

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm run test:backup-scheduler` con Node 24.18.0: 11/11
- `npm run test:backup-scheduler:collections` con Node 24.18.0: 2/2
- `bash -n scripts/backup-scheduler-test.sh`
- `node --check scripts/run-scheduled-backup.mjs`
- `git diff --check origin/main..HEAD`
- Verifica indipendente read-only: APPROVA, nessun finding

## Risk / Notes

- Il cap di staleness e 6 ore: un backup realmente piu lungo potrebbe vedere il lock recuperato; il limite evita lock indefiniti quando il PID viene riutilizzato.
- Artefatti senza membership restano compatibili tramite il fallback esistente.
- Nessun database reale, PHI/PII o destinazione backup dell'utente e stata letta.

## Ticket

Refs WUL-486