### PR TITLE
fix(crypto): sigilla il boundary paired e irrobustisce cifratura e re-wrap

### DIFF
--- a/app/api/auth/rewrap-master-key/route.ts
+++ b/app/api/auth/rewrap-master-key/route.ts
@@ -31,8 +31,18 @@ export async function POST(request: Request) {
     const session = await requireSession();
     if (!session) return unauthorizedResponse();
 
+    let body: unknown;
     try {
-        const payload = validateKdfRewrapPayload(await request.json());
+        body = await request.json();
+    } catch (error) {
+        if (error instanceof SyntaxError) {
+            return failureResponse(400, 'KDF_REWRAP_INVALID', 'Payload di re-wrap non valido.');
+        }
+        throw error;
+    }
+
+    try {
+        const payload = validateKdfRewrapPayload(body);
         if (!payload) {
             return failureResponse(400, 'KDF_REWRAP_INVALID', 'Payload di re-wrap non valido.');
         }

--- a/app/api/auth/rewrap-master-key/route.ts
+++ b/app/api/auth/rewrap-master-key/route.ts
@@ -14,6 +14,8 @@ import { dbServer } from '@/lib/db-server';
 import { users } from '@/lib/schema';
 /* @Codex */
 import { requireSession, unauthorizedResponse } from '@/lib/security/server-auth';
+/* @Codex */
+import { validateKdfRewrapPayload } from '@/lib/security/kdf-rewrap-validation';
 
 // Lazy KDF upgrade: persists a re-wrapped master-key blob (and its salt) without
 // touching the PIN. The client calls this after a successful login when the
@@ -30,13 +32,11 @@ export async function POST(request: Request) {
     if (!session) return unauthorizedResponse();
 
     try {
-        const body = await request.json();
-        const encryptedMasterKey = typeof body?.encryptedMasterKey === 'string' ? body.encryptedMasterKey : '';
-        const salt = typeof body?.salt === 'string' ? body.salt : '';
-
-        if (!encryptedMasterKey || !salt) {
-            return failureResponse(400, 'KDF_REWRAP_INVALID', 'Payload di re-wrap incompleto.');
+        const payload = validateKdfRewrapPayload(await request.json());
+        if (!payload) {
+            return failureResponse(400, 'KDF_REWRAP_INVALID', 'Payload di re-wrap non valido.');
         }
+        const { encryptedMasterKey, salt } = payload;
 
         const user = await dbServer.select().from(users).where(eq(users.id, session.userId)).get();
         if (!user) {

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -448,9 +448,11 @@ class ApiTable<T> {
         }
 
         const init: RequestInit = { method: 'DELETE' };
-        if (typeof options?.version === 'number' || typeof options?.deletionReason === 'string') {
-            const deletionReason = typeof options?.deletionReason === 'string'
-                ? await this.encryptDeleteField('deletionReason', options.deletionReason)
+        const encryptsDeletionReason = ENCRYPTED_FIELDS[this.tableName]?.includes('deletionReason') ?? false;
+        const rawDeletionReason = options?.deletionReason ?? (encryptsDeletionReason ? 'web-delete' : undefined);
+        if (typeof options?.version === 'number' || typeof rawDeletionReason === 'string') {
+            const deletionReason = typeof rawDeletionReason === 'string'
+                ? await this.encryptDeleteField('deletionReason', rawDeletionReason)
                 : undefined;
             init.headers = { 'Content-Type': 'application/json' };
             init.body = JSON.stringify({

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -198,9 +198,9 @@ const ENCRYPTED_FIELDS: Record<string, string[]> = {
     patients: ['address', 'phone', 'caregiver', 'exemptions', 'diagnoses', 'statusReason', 'notes', 'aiSummary', 'documentInsights', 'archiveReason', 'archiveNote', 'deletionReason'],
     entries: ['title', 'content', 'metadata', 'attachments', 'deletionReason'],
     therapies: ['motivation', 'deletionReason'],
-    checkups: ['notes'],
+    checkups: ['notes', 'deletionReason'],
     /* @Codex */
-    observations: ['notes'],
+    observations: ['notes', 'deletionReason'],
     /* @Codex */
     prosthetic_prescriptions: ['description', 'measures', 'clinicalReason', 'regionalPrescriptionId', 'supplier', 'collaudoOutcome', 'documentRefs', 'notes'],
     /* @Codex */
@@ -650,7 +650,10 @@ class ApiTable<T> {
     private async encryptDeleteField(field: string, value: string): Promise<string> {
         const fields = ENCRYPTED_FIELDS[this.tableName];
         const key = this.getMasterKey();
-        if (!fields?.includes(field) || !key || !value) return value;
+        if (!fields?.includes(field) || !value) return value;
+        if (!key) {
+            throw new Error(`Encryption key unavailable for ${this.tableName}.${field}`);
+        }
 
         const { iv, data } = await encryptData(value, key);
         return `ENC:${iv}:${data}`;
@@ -683,13 +686,15 @@ class ApiTable<T> {
                 }
                 continue;
             }
-            if (!key) continue;
-            if (copy[field]) {
+            if (copy[field] !== undefined && copy[field] !== null) {
+                if (!key) {
+                    throw new Error(`Encryption key unavailable for ${this.tableName}.${field}`);
+                }
                 try {
                     const { iv, data } = await encryptData(copy[field], key);
                     copy[field] = `ENC:${iv}:${data}`;
-                } catch (e) {
-                    console.error(`Failed to encrypt ${this.tableName}.${field}`, e);
+                } catch (error) {
+                    throw new Error(`Encryption failed for ${this.tableName}.${field}`, { cause: error });
                 }
             }
         }

--- a/lib/locked-field-guard.test.ts
+++ b/lib/locked-field-guard.test.ts
@@ -153,4 +153,65 @@ describe('db locked-data round trip (WUL-323)', () => {
         assert.equal(postBody.phone, ciphertext);
         assert.equal(LOCKED_CIPHERTEXT_KEY in postBody, false);
     });
+
+    it('refuses plaintext encrypted-field writes when the master key is unavailable', async () => {
+        db.setKey(null);
+        const calls = installFetchMock(() => ({ id: 'p5' }));
+
+        await assert.rejects(
+            db.patients.put({ id: 'p5', notes: 'dato clinico' } as never, { suppressNotify: true }),
+            /Encryption key unavailable for patients\.notes/,
+        );
+        assert.equal(calls.length, 0, 'the plaintext payload must not reach fetch');
+    });
+
+    it('refuses the write when encryption fails', async () => {
+        const incompatibleKey = await globalThis.crypto.subtle.generateKey(
+            { name: 'HMAC', hash: 'SHA-256' },
+            false,
+            ['sign', 'verify'],
+        );
+        db.setKey(incompatibleKey);
+        const calls = installFetchMock(() => ({ id: 'p6' }));
+
+        await assert.rejects(
+            db.patients.put({ id: 'p6', notes: 'dato clinico' } as never, { suppressNotify: true }),
+            /Encryption failed for patients\.notes/,
+        );
+        assert.equal(calls.length, 0, 'a failed encryption must abort before fetch');
+    });
+
+    it('encrypts normally when the master key is available', async () => {
+        db.setKey(await generateMasterKey());
+        const calls = installFetchMock(() => ({ id: 'p7' }));
+
+        await db.patients.put({ id: 'p7', notes: 'dato clinico' } as never, { suppressNotify: true });
+
+        const postBody = calls.find((call) => call.method === 'POST')?.body;
+        assert.ok(postBody);
+        assert.match(String(postBody.notes), /^ENC:/);
+    });
+
+    it('keeps legacy plaintext deletion reasons readable and encrypts new writes', async () => {
+        db.setKey(await generateMasterKey());
+        const calls = installFetchMock((call) => {
+            if (call.method === 'GET') {
+                return { id: 'legacy', version: 1, deletionReason: 'motivo legacy' };
+            }
+            return { id: 'legacy' };
+        });
+
+        const checkup = await db.checkups.get('legacy');
+        const observation = await db.observations.get('legacy');
+        assert.equal(checkup?.deletionReason, 'motivo legacy');
+        assert.equal(observation?.deletionReason, 'motivo legacy');
+
+        await db.checkups.update('legacy', { version: 1, deletionReason: 'nuovo motivo' });
+        await db.observations.update('legacy', { deletionReason: 'nuovo motivo' });
+        const putBodies = calls.filter((call) => call.method === 'PUT').map((call) => call.body);
+        assert.equal(putBodies.length, 2);
+        for (const body of putBodies) {
+            assert.match(String(body?.deletionReason), /^ENC:/);
+        }
+    });
 });

--- a/lib/locked-field-guard.test.ts
+++ b/lib/locked-field-guard.test.ts
@@ -193,7 +193,8 @@ describe('db locked-data round trip (WUL-323)', () => {
     });
 
     it('keeps legacy plaintext deletion reasons readable and encrypts new writes', async () => {
-        db.setKey(await generateMasterKey());
+        const key = await generateMasterKey();
+        db.setKey(key);
         const calls = installFetchMock((call) => {
             if (call.method === 'GET') {
                 return { id: 'legacy', version: 1, deletionReason: 'motivo legacy' };
@@ -207,11 +208,21 @@ describe('db locked-data round trip (WUL-323)', () => {
         assert.equal(observation?.deletionReason, 'motivo legacy');
 
         await db.checkups.update('legacy', { version: 1, deletionReason: 'nuovo motivo' });
-        await db.observations.update('legacy', { deletionReason: 'nuovo motivo' });
+        await db.observations.update('legacy', { version: 1, deletionReason: 'nuovo motivo' });
         const putBodies = calls.filter((call) => call.method === 'PUT').map((call) => call.body);
         assert.equal(putBodies.length, 2);
         for (const body of putBodies) {
             assert.match(String(body?.deletionReason), /^ENC:/);
+        }
+
+        await db.checkups.delete('legacy', { version: 1, suppressNotify: true });
+        await db.observations.delete('legacy', { version: 1, suppressNotify: true });
+        const deleteBodies = calls.filter((call) => call.method === 'DELETE').map((call) => call.body);
+        assert.equal(deleteBodies.length, 2);
+        for (const body of deleteBodies) {
+            assert.match(String(body?.deletionReason), /^ENC:/);
+            const [, iv, ciphertext] = String(body?.deletionReason).split(':');
+            assert.equal(await decryptData(ciphertext, iv, key), 'web-delete');
         }
     });
 });

--- a/lib/network-checkup-write.ts
+++ b/lib/network-checkup-write.ts
@@ -20,6 +20,8 @@ import type { NetworkWriteContext } from './network-write-context';
 import { patientsToAmbulatories, checkups } from './schema';
 /* @Codex */
 import { buildCheckupVersionConflictPayload, parseCheckupExpectedVersion } from './checkup-concurrency';
+/* @Codex */
+import { isSealedValue } from './network-patient-lifecycle';
 
 /* @Codex */
 export const NETWORK_CHECKUP_WRITE_CAPABILITY = 'network.replica.write-checkups';
@@ -74,6 +76,16 @@ function validateNetworkCheckupMutationBoundary(
                 },
             };
         }
+    }
+
+    const notes = body.notes;
+    if (notes !== undefined && notes !== null && !isSealedValue(notes)) {
+        return {
+            status: 400,
+            value: {
+                error: 'Network checkup notes must be sealed with ENC:',
+            },
+        };
     }
 
     return null;

--- a/lib/network-checkup-write.ts
+++ b/lib/network-checkup-write.ts
@@ -21,7 +21,7 @@ import { patientsToAmbulatories, checkups } from './schema';
 /* @Codex */
 import { buildCheckupVersionConflictPayload, parseCheckupExpectedVersion } from './checkup-concurrency';
 /* @Codex */
-import { isSealedValue } from './network-patient-lifecycle';
+import { isSealedValue, validateNetworkDeletionReason } from './network-patient-lifecycle';
 
 /* @Codex */
 export const NETWORK_CHECKUP_WRITE_CAPABILITY = 'network.replica.write-checkups';
@@ -87,6 +87,9 @@ function validateNetworkCheckupMutationBoundary(
             },
         };
     }
+
+    const deletionReason = validateNetworkDeletionReason(body.deletionReason);
+    if (!deletionReason.ok) return deletionReason;
 
     return null;
 }

--- a/lib/network-entry-write.ts
+++ b/lib/network-entry-write.ts
@@ -57,6 +57,7 @@ const NETWORK_FORBIDDEN_ENTRY_WRITE_FIELDS = new Set([
 ]);
 const NETWORK_FORBIDDEN_ENTRY_CREATE_FIELDS = new Set(['patientId', 'createdAt', 'updatedAt', 'version']);
 const NETWORK_FORBIDDEN_ENTRY_UPDATE_FIELDS = new Set(['patientId', 'createdAt', 'updatedAt']);
+const NETWORK_ENTRY_SEALED_FIELDS = ['title', 'content', 'metadata', 'attachments', 'deletionReason'] as const;
 
 function hasOwn(input: Record<string, unknown>, key: string): boolean {
     return Object.prototype.hasOwnProperty.call(input, key);
@@ -92,15 +93,21 @@ function validateNetworkEntryMutationBoundary(
         }
     }
 
-    if (hasOwn(body, 'attachments')
-        && !isEmptyAttachmentValue(body.attachments)
-        && !isSealedValue(body.attachments)) {
-        return {
-            status: 400,
-            value: {
-                error: 'Network diary attachment references must be sealed with ENC:',
-            },
-        };
+    for (const field of NETWORK_ENTRY_SEALED_FIELDS) {
+        const value = body[field];
+        const isEmptyValue = field === 'attachments'
+            ? isEmptyAttachmentValue(value)
+            : value === undefined || value === null;
+        if (!isEmptyValue && !isSealedValue(value)) {
+            return {
+                status: 400,
+                value: {
+                    error: field === 'attachments'
+                        ? 'Network diary attachment references must be sealed with ENC:'
+                        : `Network diary ${field} must be sealed with ENC:`,
+                },
+            };
+        }
     }
 
     return null;

--- a/lib/network-observation-write.ts
+++ b/lib/network-observation-write.ts
@@ -20,6 +20,8 @@ import type { NetworkWriteContext } from './network-write-context';
 import { observations, patientsToAmbulatories } from './schema';
 /* @Codex */
 import { buildObservationVersionConflictPayload, parseObservationExpectedVersion } from './observation-concurrency';
+/* @Codex */
+import { isSealedValue } from './network-patient-lifecycle';
 
 /* @Codex */
 export const NETWORK_OBSERVATION_WRITE_CAPABILITY = 'network.replica.write-observations';
@@ -74,6 +76,16 @@ function validateNetworkObservationMutationBoundary(
                 },
             };
         }
+    }
+
+    const notes = body.notes;
+    if (notes !== undefined && notes !== null && !isSealedValue(notes)) {
+        return {
+            status: 400,
+            value: {
+                error: 'Network observation notes must be sealed with ENC:',
+            },
+        };
     }
 
     return null;

--- a/lib/network-observation-write.ts
+++ b/lib/network-observation-write.ts
@@ -21,7 +21,7 @@ import { observations, patientsToAmbulatories } from './schema';
 /* @Codex */
 import { buildObservationVersionConflictPayload, parseObservationExpectedVersion } from './observation-concurrency';
 /* @Codex */
-import { isSealedValue } from './network-patient-lifecycle';
+import { isSealedValue, validateNetworkDeletionReason } from './network-patient-lifecycle';
 
 /* @Codex */
 export const NETWORK_OBSERVATION_WRITE_CAPABILITY = 'network.replica.write-observations';
@@ -87,6 +87,9 @@ function validateNetworkObservationMutationBoundary(
             },
         };
     }
+
+    const deletionReason = validateNetworkDeletionReason(body.deletionReason);
+    if (!deletionReason.ok) return deletionReason;
 
     return null;
 }

--- a/lib/network-therapy-write.ts
+++ b/lib/network-therapy-write.ts
@@ -20,6 +20,8 @@ import type { NetworkWriteContext } from './network-write-context';
 import { patientsToAmbulatories, therapies } from './schema';
 /* @Codex */
 import { buildTherapyVersionConflictPayload, parseTherapyExpectedVersion } from './therapy-concurrency';
+/* @Codex */
+import { isSealedValue } from './network-patient-lifecycle';
 
 /* @Codex */
 export const NETWORK_THERAPY_WRITE_CAPABILITY = 'network.replica.write-therapies';
@@ -45,6 +47,7 @@ const NETWORK_FORBIDDEN_THERAPY_WRITE_FIELDS = new Set([
 ]);
 const NETWORK_FORBIDDEN_THERAPY_CREATE_FIELDS = new Set(['patientId', 'createdAt', 'updatedAt', 'version', 'deletedAt', 'deletionReason']);
 const NETWORK_FORBIDDEN_THERAPY_UPDATE_FIELDS = new Set(['patientId', 'createdAt', 'updatedAt']);
+const NETWORK_THERAPY_SEALED_FIELDS = ['motivation', 'deletionReason'] as const;
 
 function hasOwn(input: Record<string, unknown>, key: string): boolean {
     return Object.prototype.hasOwnProperty.call(input, key);
@@ -71,6 +74,18 @@ function validateNetworkTherapyMutationBoundary(
                 status: 400,
                 value: {
                     error: `Network therapy write boundary rejects client-controlled ${field}`,
+                },
+            };
+        }
+    }
+
+    for (const field of NETWORK_THERAPY_SEALED_FIELDS) {
+        const value = body[field];
+        if (value !== undefined && value !== null && !isSealedValue(value)) {
+            return {
+                status: 400,
+                value: {
+                    error: `Network therapy ${field} must be sealed with ENC:`,
                 },
             };
         }

--- a/lib/security/kdf-rewrap-validation.test.ts
+++ b/lib/security/kdf-rewrap-validation.test.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { validateKdfRewrapPayload } from './kdf-rewrap-validation';
+
+const validPayload = {
+    encryptedMasterKey: `v2:${Buffer.alloc(60, 1).toString('base64')}`,
+    salt: Buffer.alloc(16, 2).toString('base64'),
+};
+
+test('accepts a current-version wrapped key and a 16-byte salt', () => {
+    assert.deepEqual(validateKdfRewrapPayload(validPayload), validPayload);
+});
+
+test('rejects malformed, legacy, oversized, and wrong-length wrapped keys', () => {
+    for (const encryptedMasterKey of [
+        'AAAA',
+        `v1:${Buffer.alloc(60, 1).toString('base64')}`,
+        'v2:not base64',
+        `v2:${Buffer.alloc(59, 1).toString('base64')}`,
+        `v2:${'A'.repeat(600)}`,
+    ]) {
+        assert.equal(validateKdfRewrapPayload({ ...validPayload, encryptedMasterKey }), null);
+    }
+});
+
+test('rejects malformed, oversized, and wrong-length salts', () => {
+    for (const salt of [
+        'not base64',
+        Buffer.alloc(15, 2).toString('base64'),
+        Buffer.alloc(17, 2).toString('base64'),
+        'A'.repeat(200),
+    ]) {
+        assert.equal(validateKdfRewrapPayload({ ...validPayload, salt }), null);
+    }
+});
+
+test('rejects missing and non-string fields', () => {
+    assert.equal(validateKdfRewrapPayload(null), null);
+    assert.equal(validateKdfRewrapPayload({ salt: validPayload.salt }), null);
+    assert.equal(validateKdfRewrapPayload({ ...validPayload, salt: 42 }), null);
+});

--- a/lib/security/kdf-rewrap-validation.ts
+++ b/lib/security/kdf-rewrap-validation.ts
@@ -1,0 +1,42 @@
+import { CURRENT_KDF_VERSION } from './security';
+
+const WRAPPED_MASTER_KEY_BYTES = 12 + 32 + 16;
+const SALT_BYTES = 16;
+const MAX_WRAPPED_MASTER_KEY_LENGTH = 512;
+const MAX_SALT_LENGTH = 128;
+const BASE64_PATTERN = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+
+export type KdfRewrapPayload = {
+    encryptedMasterKey: string;
+    salt: string;
+};
+
+function hasCanonicalBase64ByteLength(value: string, expectedBytes: number): boolean {
+    if (!BASE64_PATTERN.test(value)) return false;
+    try {
+        const decoded = Uint8Array.from(atob(value), (character) => character.charCodeAt(0));
+        return decoded.byteLength === expectedBytes;
+    } catch {
+        return false;
+    }
+}
+
+export function validateKdfRewrapPayload(value: unknown): KdfRewrapPayload | null {
+    if (!value || typeof value !== 'object') return null;
+    const body = value as Record<string, unknown>;
+    if (typeof body.encryptedMasterKey !== 'string' || typeof body.salt !== 'string') return null;
+    if (body.encryptedMasterKey.length > MAX_WRAPPED_MASTER_KEY_LENGTH || body.salt.length > MAX_SALT_LENGTH) {
+        return null;
+    }
+
+    const prefix = `v${CURRENT_KDF_VERSION}:`;
+    if (!body.encryptedMasterKey.startsWith(prefix)) return null;
+    const wrappedBase64 = body.encryptedMasterKey.slice(prefix.length);
+    if (!hasCanonicalBase64ByteLength(wrappedBase64, WRAPPED_MASTER_KEY_BYTES)) return null;
+    if (!hasCanonicalBase64ByteLength(body.salt, SALT_BYTES)) return null;
+
+    return {
+        encryptedMasterKey: body.encryptedMasterKey,
+        salt: body.salt,
+    };
+}

--- a/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/PairedPatientsWorkspaceModel.swift
+++ b/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/PairedPatientsWorkspaceModel.swift
@@ -2192,8 +2192,9 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
                 payload: HomeBaseCheckupUpdatePayload(
                     version: checkup.version,
                     deletedAt: Date(),
-                    // checkups encrypt only `notes` (lib/db.ts), so deletionReason
-                    // stays plaintext to match what the web decrypts.
+                    // The web now encrypts deletionReason in lib/db.ts. The paired client
+                    // does not seal it yet; this documented drift remains because the server
+                    // does not enforce sealing for this field.
                     deletionReason: "mobile-paired-operator-cancelled"
                 ),
                 credentials: credentials,
@@ -2362,8 +2363,9 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
                 payload: HomeBaseObservationUpdatePayload(
                     version: observation.version,
                     deletedAt: Date(),
-                    // observations encrypt only `notes` (lib/db.ts), so deletionReason
-                    // stays plaintext to match what the web decrypts.
+                    // The web now encrypts deletionReason in lib/db.ts. The paired client
+                    // does not seal it yet; this documented drift remains because the server
+                    // does not enforce sealing for this field.
                     deletionReason: "mobile-paired-operator-cancelled"
                 ),
                 credentials: credentials,

--- a/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/PairedPatientsWorkspaceModel.swift
+++ b/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/PairedPatientsWorkspaceModel.swift
@@ -2192,10 +2192,7 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
                 payload: HomeBaseCheckupUpdatePayload(
                     version: checkup.version,
                     deletedAt: Date(),
-                    // The web now encrypts deletionReason in lib/db.ts. The paired client
-                    // does not seal it yet; this documented drift remains because the server
-                    // does not enforce sealing for this field.
-                    deletionReason: "mobile-paired-operator-cancelled"
+                    deletionReason: try self.sealField("mobile-paired-operator-cancelled")
                 ),
                 credentials: credentials,
                 sessionCookie: sessionCookie,
@@ -2363,10 +2360,7 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
                 payload: HomeBaseObservationUpdatePayload(
                     version: observation.version,
                     deletedAt: Date(),
-                    // The web now encrypts deletionReason in lib/db.ts. The paired client
-                    // does not seal it yet; this documented drift remains because the server
-                    // does not enforce sealing for this field.
-                    deletionReason: "mobile-paired-operator-cancelled"
+                    deletionReason: try self.sealField("mobile-paired-operator-cancelled")
                 ),
                 credentials: credentials,
                 sessionCookie: sessionCookie,

--- a/scripts/network-home-base-account-pin.test.mjs
+++ b/scripts/network-home-base-account-pin.test.mjs
@@ -35,6 +35,22 @@ test('paired account PIN rotation preserves the master key and sealed patient fi
     const sealedNotes = await sealField('account-pin ciphertext survives rewrap', originalMasterKey);
 
     try {
+        const invalidRewrapPayloads = [
+            { encryptedMasterKey: 'v2:not base64', salt: firstLogin.json.salt },
+            { encryptedMasterKey: `v1:${Buffer.alloc(60, 1).toString('base64')}`, salt: firstLogin.json.salt },
+            { encryptedMasterKey: `v2:${Buffer.alloc(60, 1).toString('base64')}`, salt: Buffer.alloc(15, 2).toString('base64') },
+            { encryptedMasterKey: `v2:${'A'.repeat(600)}`, salt: firstLogin.json.salt },
+        ];
+        for (const payload of invalidRewrapPayloads) {
+            const rejected = await rewrapMasterKey(firstLogin.cookie, payload);
+            assert.equal(rejected.response.status, 400);
+            assert.equal(rejected.json?.code, 'KDF_REWRAP_INVALID');
+        }
+        const loginAfterRejectedRewrap = await login(PIN);
+        assert.equal(loginAfterRejectedRewrap.response.status, 200);
+        assert.equal(loginAfterRejectedRewrap.json.encryptedMasterKey, firstLogin.json.encryptedMasterKey);
+        assert.equal(loginAfterRejectedRewrap.json.salt, firstLogin.json.salt);
+
         const created = await request('POST', '/api/v1/network/patients', {
             headers: { ...pairedHeaders(client), Cookie: firstLogin.cookie },
             body: patientPayload(patientId, sealedNotes),
@@ -105,6 +121,7 @@ async function assertServerReady() { const result = await request('GET', '/api/v
 async function enableHomeBaseMode() { const result = await request('PUT', '/api/settings/network.mode', { headers: localApiHeaders(), body: { value: 'network-home-base' } }); assert.equal(result.response.status, 200); }
 async function login(pin) { const result = await request('POST', '/api/auth/login', { body: { username: USERNAME, password: pin } }); return { ...result, cookie: result.response.status === 200 ? extractSessionCookie(result.response) : null }; }
 async function changePin(cookie, currentPin, newPin, blob, salt) { return request('POST', '/api/auth/change-pin', { headers: { Cookie: cookie }, body: { currentPin, newPin, encryptedMasterKey: blob, salt: salt.toString('base64') } }); }
+async function rewrapMasterKey(cookie, body) { return request('POST', '/api/auth/rewrap-master-key', { headers: { Cookie: cookie }, body }); }
 async function pairClient(requestedCapabilities, deviceName) { const intent = await request('POST', '/api/v1/network/pairing-intents', { body: { deviceName, clientPlatform: 'ipados', appVersion: '0.7.1-smoke', requestedCapabilities } }); assert.equal(intent.response.status, 201); const confirmed = await request('POST', `/api/v1/network/pairing-intents/${intent.json.intentId}/confirm`, { headers: localApiHeaders() }); assert.equal(confirmed.response.status, 201); return { pairedClientId: confirmed.json.pairedClient.clientId, pairedClientToken: confirmed.json.pairedClientToken }; }
 function patientPayload(id, notes) { const suffix = id.replace(/-/g, '').slice(0, 13).toUpperCase(); return { id, firstName: 'Account', lastName: 'Pin', taxCode: `ACP${suffix}`, notes, isAdi: false }; }
 async function cleanupPatient(patientId) { const detail = await request('GET', `/api/v1/patients/${patientId}`, { headers: localApiHeaders() }); if (detail.response.status === 200) { const deleted = await request('DELETE', `/api/v1/patients/${patientId}`, { headers: localApiHeaders(), body: { version: detail.json.version } }); assert.equal(deleted.response.status, 200); } }

--- a/scripts/network-home-base-account-pin.test.mjs
+++ b/scripts/network-home-base-account-pin.test.mjs
@@ -24,6 +24,21 @@ after(() => {
     console.log(`[network-home-base-account-pin] Report written to ${REPORT_PATH}`);
 });
 
+test('re-wrap master key rejects malformed JSON bodies', async () => {
+    await assertServerReady();
+    const firstLogin = await login(PIN);
+    assert.equal(firstLogin.response.status, 200);
+
+    const rejected = await rewrapMasterKeyWithRawBody(firstLogin.cookie, '{"encryptedMasterKey":');
+    assert.equal(rejected.response.status, 400);
+    assert.equal(rejected.json?.code, 'KDF_REWRAP_INVALID');
+
+    const loginAfterRejectedRewrap = await login(PIN);
+    assert.equal(loginAfterRejectedRewrap.response.status, 200);
+    assert.equal(loginAfterRejectedRewrap.json.encryptedMasterKey, firstLogin.json.encryptedMasterKey);
+    assert.equal(loginAfterRejectedRewrap.json.salt, firstLogin.json.salt);
+});
+
 test('paired account PIN rotation preserves the master key and sealed patient field', async () => {
     await assertServerReady();
     await enableHomeBaseMode();
@@ -122,6 +137,7 @@ async function enableHomeBaseMode() { const result = await request('PUT', '/api/
 async function login(pin) { const result = await request('POST', '/api/auth/login', { body: { username: USERNAME, password: pin } }); return { ...result, cookie: result.response.status === 200 ? extractSessionCookie(result.response) : null }; }
 async function changePin(cookie, currentPin, newPin, blob, salt) { return request('POST', '/api/auth/change-pin', { headers: { Cookie: cookie }, body: { currentPin, newPin, encryptedMasterKey: blob, salt: salt.toString('base64') } }); }
 async function rewrapMasterKey(cookie, body) { return request('POST', '/api/auth/rewrap-master-key', { headers: { Cookie: cookie }, body }); }
+async function rewrapMasterKeyWithRawBody(cookie, body) { const response = await fetch(new URL('/api/auth/rewrap-master-key', BASE_URL), { method: 'POST', headers: { Cookie: cookie, 'Content-Type': 'application/json' }, body }); const text = await response.text(); let json = null; try { json = text ? JSON.parse(text) : null; } catch { json = text; } return { response, json, text }; }
 async function pairClient(requestedCapabilities, deviceName) { const intent = await request('POST', '/api/v1/network/pairing-intents', { body: { deviceName, clientPlatform: 'ipados', appVersion: '0.7.1-smoke', requestedCapabilities } }); assert.equal(intent.response.status, 201); const confirmed = await request('POST', `/api/v1/network/pairing-intents/${intent.json.intentId}/confirm`, { headers: localApiHeaders() }); assert.equal(confirmed.response.status, 201); return { pairedClientId: confirmed.json.pairedClient.clientId, pairedClientToken: confirmed.json.pairedClientToken }; }
 function patientPayload(id, notes) { const suffix = id.replace(/-/g, '').slice(0, 13).toUpperCase(); return { id, firstName: 'Account', lastName: 'Pin', taxCode: `ACP${suffix}`, notes, isAdi: false }; }
 async function cleanupPatient(patientId) { const detail = await request('GET', `/api/v1/patients/${patientId}`, { headers: localApiHeaders() }); if (detail.response.status === 200) { const deleted = await request('DELETE', `/api/v1/patients/${patientId}`, { headers: localApiHeaders(), body: { version: detail.json.version } }); assert.equal(deleted.response.status, 200); } }

--- a/scripts/network-home-base-checkup-write.test.mjs
+++ b/scripts/network-home-base-checkup-write.test.mjs
@@ -185,7 +185,7 @@ test('paired checkup write requires capability, session, scope, version, and PHI
         assert.equal(aiField.response.status, 403);
         assert.equal(aiField.json?.error, 'Network checkup write boundary excludes AI/document-derived fields');
 
-        const softDelete = await request('PUT', `/api/v1/network/patients/${patientId}/checkups/${checkupId}`, {
+        const plaintextDeletionReason = await request('PUT', `/api/v1/network/patients/${patientId}/checkups/${checkupId}`, {
             headers: {
                 ...pairedHeaders(checkupWriter),
                 Cookie: sessionCookie,
@@ -194,6 +194,21 @@ test('paired checkup write requires capability, session, scope, version, and PHI
                 version: 2,
                 deletedAt: '2026-05-02T10:00:00.000Z',
                 deletionReason: 'network-smoke-soft-delete',
+            },
+        });
+        assert.equal(plaintextDeletionReason.response.status, 400);
+        assert.equal(plaintextDeletionReason.json?.error, 'Network delete requires a sealed deletion reason');
+
+        const sealedDeletionReason = 'ENC:aXY=:cmVhc29u';
+        const softDelete = await request('PUT', `/api/v1/network/patients/${patientId}/checkups/${checkupId}`, {
+            headers: {
+                ...pairedHeaders(checkupWriter),
+                Cookie: sessionCookie,
+            },
+            body: {
+                version: 2,
+                deletedAt: '2026-05-02T10:00:00.000Z',
+                deletionReason: sealedDeletionReason,
             },
         });
         assert.equal(softDelete.response.status, 200);
@@ -207,6 +222,7 @@ test('paired checkup write requires capability, session, scope, version, and PHI
         assert.equal(deletedDetail.response.status, 200);
         assert.equal(deletedDetail.json?.version, 3);
         assert.equal(deletedDetail.json?.deletedAt, '2026-05-02T10:00:00.000Z');
+        assert.equal(deletedDetail.json?.deletionReason, sealedDeletionReason);
 
         const remoteHardDelete = await request('DELETE', `/api/v1/network/patients/${patientId}/checkups/${checkupId}`, {
             headers: {
@@ -246,6 +262,7 @@ test('paired checkup write requires capability, session, scope, version, and PHI
             updateStatus: update.response.status,
             conflictStatus: conflict.response.status,
             aiFieldStatus: aiField.response.status,
+            plaintextDeletionReasonStatus: plaintextDeletionReason.response.status,
             softDeleteStatus: softDelete.response.status,
             remoteHardDeleteStatus: remoteHardDelete.response.status,
             pairedClientId: checkupWriter.pairedClientId,

--- a/scripts/network-home-base-checkup-write.test.mjs
+++ b/scripts/network-home-base-checkup-write.test.mjs
@@ -15,6 +15,7 @@ const REPORT_PATH = resolveReportPath();
 const READ_PATIENTS_CAPABILITY = 'network.replica.readonly-patients';
 const READ_CHECKUPS_CAPABILITY = 'network.replica.readonly-checkups';
 const WRITE_CHECKUPS_CAPABILITY = 'network.replica.write-checkups';
+const SEALED_NOTES = 'ENC:bm90ZXNpdg==:bm90ZXNjaXBoZXI=';
 
 const scenarioResults = [];
 
@@ -83,7 +84,7 @@ test('paired checkup write requires capability, session, scope, version, and PHI
         });
         assert.equal(missingSession.response.status, 401);
 
-        const create = await request('POST', `/api/v1/network/patients/${patientId}/checkups`, {
+        const plaintextNotes = await request('POST', `/api/v1/network/patients/${patientId}/checkups`, {
             headers: {
                 ...pairedHeaders(checkupWriter),
                 Cookie: sessionCookie,
@@ -93,6 +94,22 @@ test('paired checkup write requires capability, session, scope, version, and PHI
                 title: 'Controllo rete',
                 status: 'pending',
                 notes: 'smoke-test',
+                source: 'manual',
+            },
+        });
+        assert.equal(plaintextNotes.response.status, 400);
+        assert.equal(plaintextNotes.json?.error, 'Network checkup notes must be sealed with ENC:');
+
+        const create = await request('POST', `/api/v1/network/patients/${patientId}/checkups`, {
+            headers: {
+                ...pairedHeaders(checkupWriter),
+                Cookie: sessionCookie,
+            },
+            body: {
+                date: '2026-05-02T09:00:00.000Z',
+                title: 'Controllo rete',
+                status: 'pending',
+                notes: SEALED_NOTES,
                 source: 'manual',
             },
         });

--- a/scripts/network-home-base-diary-write.test.mjs
+++ b/scripts/network-home-base-diary-write.test.mjs
@@ -17,6 +17,11 @@ const READ_PATIENTS_CAPABILITY = 'network.replica.readonly-patients';
 const READ_DIARY_CAPABILITY = 'network.replica.readonly-clinical-diary';
 const WRITE_DIARY_CAPABILITY = 'network.replica.write-clinical-diary';
 const VISIT_DRAFT_CAPABILITY = 'network.compute.visit-draft';
+const SEALED_TITLE = 'ENC:dGl0bGVpdg==:dGl0bGVjaXBoZXI=';
+const SEALED_CONTENT = 'ENC:Y29udGVudGl2:Y29udGVudGNpcGhlcg==';
+const SEALED_UPDATED_CONTENT = 'ENC:dXBkYXRlaXY=:dXBkYXRlY2lwaGVy';
+const SEALED_METADATA = 'ENC:bWV0YWRhdGFpdg==:bWV0YWRhdGFjaXBoZXI=';
+const SEALED_DELETION_REASON = 'ENC:ZGVsZXRlaXY=:ZGVsZXRlY2lwaGVy';
 
 const scenarioResults = [];
 
@@ -147,14 +152,29 @@ test('paired diary write requires capability, session, scope, version, and PHI-s
         });
         assert.equal(missingSession.response.status, 401);
 
+        const plaintextClinicalField = await request('POST', `/api/v1/network/patients/${patientId}/entries`, {
+            headers: {
+                ...pairedHeaders(diaryWriter),
+                Cookie: sessionCookie,
+            },
+            body: {
+                type: 'note',
+                title: 'Diario rete',
+                date: '2026-05-02T09:00:00.000Z',
+                content: SEALED_CONTENT,
+            },
+        });
+        assert.equal(plaintextClinicalField.response.status, 400);
+        assert.equal(plaintextClinicalField.json?.error, 'Network diary title must be sealed with ENC:');
+
         const createBody = {
             id: `network-diary-${crypto.randomUUID()}`,
             type: 'note',
-            title: 'Diario rete',
+            title: SEALED_TITLE,
             date: '2026-05-02T09:00:00.000Z',
-            content: 'prima nota',
+            content: SEALED_CONTENT,
             setting: 'ambulatory',
-            metadata: { lane: 'network-diary-write-smoke' },
+            metadata: SEALED_METADATA,
             attachments: 'ENC:aXY=:c2VhbGVkcmVmcw==',
         };
         const create = await request('POST', `/api/v1/network/patients/${patientId}/entries`, {
@@ -189,7 +209,7 @@ test('paired diary write requires capability, session, scope, version, and PHI-s
             },
             body: {
                 ...createBody,
-                content: 'payload diverso',
+                content: SEALED_UPDATED_CONTENT,
             },
         });
         assert.equal(conflictingCreate.response.status, 409);
@@ -203,7 +223,7 @@ test('paired diary write requires capability, session, scope, version, and PHI-s
         assert.equal(detail.response.status, 200);
         assert.equal(detail.json?.id, entryId);
         assert.equal(detail.json?.version, 1);
-        assert.equal(detail.json?.title, 'Diario rete');
+        assert.equal(detail.json?.title, SEALED_TITLE);
         assert.equal(detail.json?.setting, 'ambulatory');
         assert.equal(detail.json?.attachments, createBody.attachments);
 
@@ -286,7 +306,7 @@ test('paired diary write requires capability, session, scope, version, and PHI-s
             },
             body: {
                 version: 2,
-                content: 'nota aggiornata',
+                content: SEALED_UPDATED_CONTENT,
             },
         });
         assert.equal(update.response.status, 200);
@@ -299,7 +319,7 @@ test('paired diary write requires capability, session, scope, version, and PHI-s
             },
         });
         assert.equal(updatedDetail.response.status, 200);
-        assert.equal(updatedDetail.json?.content, 'nota aggiornata');
+        assert.equal(updatedDetail.json?.content, SEALED_UPDATED_CONTENT);
         assert.equal(updatedDetail.json?.version, 3);
 
         const conflict = await request('PUT', `/api/v1/network/patients/${patientId}/entries/${entryId}`, {
@@ -309,7 +329,7 @@ test('paired diary write requires capability, session, scope, version, and PHI-s
             },
             body: {
                 version: 2,
-                content: 'stale update',
+                content: SEALED_CONTENT,
             },
         });
         assert.equal(conflict.response.status, 409);
@@ -339,7 +359,7 @@ test('paired diary write requires capability, session, scope, version, and PHI-s
             body: {
                 version: 3,
                 deletedAt: '2026-05-02T10:00:00.000Z',
-                deletionReason: 'network-smoke-soft-delete',
+                deletionReason: SEALED_DELETION_REASON,
             },
         });
         assert.equal(softDelete.response.status, 200);

--- a/scripts/network-home-base-observation-write.test.mjs
+++ b/scripts/network-home-base-observation-write.test.mjs
@@ -15,6 +15,7 @@ const REPORT_PATH = resolveReportPath();
 const READ_PATIENTS_CAPABILITY = 'network.replica.readonly-patients';
 const READ_OBSERVATIONS_CAPABILITY = 'network.replica.readonly-observations';
 const WRITE_OBSERVATIONS_CAPABILITY = 'network.replica.write-observations';
+const SEALED_NOTES = 'ENC:bm90ZXNpdg==:bm90ZXNjaXBoZXI=';
 
 const scenarioResults = [];
 
@@ -91,7 +92,7 @@ test('paired observation write requires capability, session, scope, version, and
         });
         assert.equal(missingSession.response.status, 401);
 
-        const create = await request('POST', `/api/v1/network/patients/${patientId}/observations`, {
+        const plaintextNotes = await request('POST', `/api/v1/network/patients/${patientId}/observations`, {
             headers: {
                 ...pairedHeaders(observationWriter),
                 Cookie: sessionCookie,
@@ -105,6 +106,26 @@ test('paired observation write requires capability, session, scope, version, and
                 value: 128,
                 observedAt: '2026-05-02T09:00:00.000Z',
                 notes: 'smoke-test',
+                source: 'manual',
+            },
+        });
+        assert.equal(plaintextNotes.response.status, 400);
+        assert.equal(plaintextNotes.json?.error, 'Network observation notes must be sealed with ENC:');
+
+        const create = await request('POST', `/api/v1/network/patients/${patientId}/observations`, {
+            headers: {
+                ...pairedHeaders(observationWriter),
+                Cookie: sessionCookie,
+            },
+            body: {
+                codeSystem: 'LOINC',
+                code: '8480-6',
+                display: 'Systolic blood pressure',
+                unitSystem: 'UCUM',
+                unitCode: 'mm[Hg]',
+                value: 128,
+                observedAt: '2026-05-02T09:00:00.000Z',
+                notes: SEALED_NOTES,
                 source: 'manual',
             },
         });

--- a/scripts/network-home-base-observation-write.test.mjs
+++ b/scripts/network-home-base-observation-write.test.mjs
@@ -204,7 +204,7 @@ test('paired observation write requires capability, session, scope, version, and
         assert.equal(aiField.response.status, 403);
         assert.equal(aiField.json?.error, 'Network observation write boundary excludes AI/document-derived fields');
 
-        const softDelete = await request('PUT', `/api/v1/network/patients/${patientId}/observations/${observationId}`, {
+        const plaintextDeletionReason = await request('PUT', `/api/v1/network/patients/${patientId}/observations/${observationId}`, {
             headers: {
                 ...pairedHeaders(observationWriter),
                 Cookie: sessionCookie,
@@ -213,6 +213,21 @@ test('paired observation write requires capability, session, scope, version, and
                 version: 2,
                 deletedAt: '2026-05-02T10:00:00.000Z',
                 deletionReason: 'network-smoke-soft-delete',
+            },
+        });
+        assert.equal(plaintextDeletionReason.response.status, 400);
+        assert.equal(plaintextDeletionReason.json?.error, 'Network delete requires a sealed deletion reason');
+
+        const sealedDeletionReason = 'ENC:aXY=:cmVhc29u';
+        const softDelete = await request('PUT', `/api/v1/network/patients/${patientId}/observations/${observationId}`, {
+            headers: {
+                ...pairedHeaders(observationWriter),
+                Cookie: sessionCookie,
+            },
+            body: {
+                version: 2,
+                deletedAt: '2026-05-02T10:00:00.000Z',
+                deletionReason: sealedDeletionReason,
             },
         });
         assert.equal(softDelete.response.status, 200);
@@ -226,6 +241,7 @@ test('paired observation write requires capability, session, scope, version, and
         assert.equal(deletedDetail.response.status, 200);
         assert.equal(deletedDetail.json?.version, 3);
         assert.equal(deletedDetail.json?.deletedAt, '2026-05-02T10:00:00.000Z');
+        assert.equal(deletedDetail.json?.deletionReason, sealedDeletionReason);
 
         const remoteHardDelete = await request('DELETE', `/api/v1/network/patients/${patientId}/observations/${observationId}`, {
             headers: {
@@ -265,6 +281,7 @@ test('paired observation write requires capability, session, scope, version, and
             updateStatus: update.response.status,
             conflictStatus: conflict.response.status,
             aiFieldStatus: aiField.response.status,
+            plaintextDeletionReasonStatus: plaintextDeletionReason.response.status,
             softDeleteStatus: softDelete.response.status,
             remoteHardDeleteStatus: remoteHardDelete.response.status,
             pairedClientId: observationWriter.pairedClientId,

--- a/scripts/network-home-base-therapy-write.test.mjs
+++ b/scripts/network-home-base-therapy-write.test.mjs
@@ -15,6 +15,8 @@ const REPORT_PATH = resolveReportPath();
 const READ_PATIENTS_CAPABILITY = 'network.replica.readonly-patients';
 const READ_THERAPIES_CAPABILITY = 'network.replica.readonly-therapies';
 const WRITE_THERAPIES_CAPABILITY = 'network.replica.write-therapies';
+const SEALED_MOTIVATION = 'ENC:bW90aXZhdGlvbml2:bW90aXZhdGlvbmNpcGhlcg==';
+const SEALED_DELETION_REASON = 'ENC:ZGVsZXRlaXY=:ZGVsZXRlY2lwaGVy';
 
 const scenarioResults = [];
 
@@ -81,7 +83,7 @@ test('paired therapy write requires capability, session, scope, version, and PHI
         });
         assert.equal(missingSession.response.status, 401);
 
-        const create = await request('POST', `/api/v1/network/patients/${patientId}/therapies`, {
+        const plaintextMotivation = await request('POST', `/api/v1/network/patients/${patientId}/therapies`, {
             headers: {
                 ...pairedHeaders(therapyWriter),
                 Cookie: sessionCookie,
@@ -92,6 +94,22 @@ test('paired therapy write requires capability, session, scope, version, and PHI
                 status: 'active',
                 startDate: '2026-05-02T09:00:00.000Z',
                 motivation: 'smoke-test',
+            },
+        });
+        assert.equal(plaintextMotivation.response.status, 400);
+        assert.equal(plaintextMotivation.json?.error, 'Network therapy motivation must be sealed with ENC:');
+
+        const create = await request('POST', `/api/v1/network/patients/${patientId}/therapies`, {
+            headers: {
+                ...pairedHeaders(therapyWriter),
+                Cookie: sessionCookie,
+            },
+            body: {
+                drugName: 'Metformina',
+                dosage: '500 mg x 2',
+                status: 'active',
+                startDate: '2026-05-02T09:00:00.000Z',
+                motivation: SEALED_MOTIVATION,
             },
         });
         assert.equal(create.response.status, 201);
@@ -164,7 +182,7 @@ test('paired therapy write requires capability, session, scope, version, and PHI
         assert.equal(aiField.response.status, 403);
         assert.equal(aiField.json?.error, 'Network therapy write boundary excludes AI/document-derived fields');
 
-        const softDelete = await request('PUT', `/api/v1/network/patients/${patientId}/therapies/${therapyId}`, {
+        const plaintextDeletionReason = await request('PUT', `/api/v1/network/patients/${patientId}/therapies/${therapyId}`, {
             headers: {
                 ...pairedHeaders(therapyWriter),
                 Cookie: sessionCookie,
@@ -173,6 +191,20 @@ test('paired therapy write requires capability, session, scope, version, and PHI
                 version: 2,
                 deletedAt: '2026-05-02T10:00:00.000Z',
                 deletionReason: 'network-smoke-soft-delete',
+            },
+        });
+        assert.equal(plaintextDeletionReason.response.status, 400);
+        assert.equal(plaintextDeletionReason.json?.error, 'Network therapy deletionReason must be sealed with ENC:');
+
+        const softDelete = await request('PUT', `/api/v1/network/patients/${patientId}/therapies/${therapyId}`, {
+            headers: {
+                ...pairedHeaders(therapyWriter),
+                Cookie: sessionCookie,
+            },
+            body: {
+                version: 2,
+                deletedAt: '2026-05-02T10:00:00.000Z',
+                deletionReason: SEALED_DELETION_REASON,
             },
         });
         assert.equal(softDelete.response.status, 200);


### PR DESCRIPTION
## Summary

- Richiede envelope `ENC:<iv>:<ciphertext>` per i campi clinici supportati dal boundary paired.
- Cifra `deletionReason` per checkup e osservazioni anche nei percorsi web e bulk-delete, con default `web-delete` fail-closed.
- Sigilla le motivazioni di cancellazione nel producer Swift e rifiuta il plaintext nei writer network.
- Valida il payload di re-wrap della master key e restituisce 400 per JSON malformato.

## Verification

- `npm run typecheck`
- `npm run lint`
- test mirati locked-field + patient lifecycle: 16/16
- `npm run test:unit`: 616/616
- `npm run test:network:home-base-checkup-write`: 1/1
- `npm run test:network:home-base-observation-write`: 2/2
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcrun swift test --filter PairedPatientsWorkspaceModel`: 46/46
- range-diff post-rebase: cinque commit invariati; commit tipi Observation eliminato perché già assorbito da PR #22
- verifica indipendente finale: APPROVA, nessun P1/P2 residuo

## Risk / Notes

- I valori legacy di `deletionReason` in chiaro restano leggibili; tutte le nuove scritture coperte richiedono la chiave e falliscono senza cifratura.
- I client paired devono inviare la motivazione sigillata; il producer Swift incluso nella PR è allineato.
- Nessun claim zero-knowledge è stato modificato.
- Nessuna PHI/PII o dato paziente reale è stato usato.

## Ticket

Refs WUL-484