### PR TITLE
ci: delegate macOS core gate to Apple Native

### DIFF
--- a/.github/workflows/core-tri-os.yml
+++ b/.github/workflows/core-tri-os.yml
@@ -1,12 +1,13 @@
 name: Core tri-OS gate
 
 # ADR 0071 "Punto di non ritorno": the platform-free MediFlowCore must build and
-# pass the byte-exact zero-knowledge crypto golden-vector gate on macOS, Linux AND
-# Windows. This is the kill-switch that confirms the Swift-core direction: if the
-# Swift toolchain on Windows/Linux ever diverges on AES-GCM/PBKDF2 (swift-crypto),
-# this fails and we reconsider a Rust core (the golden vectors are language-neutral
-# and already in hand). On non-Apple OSes the package manifest excludes the SwiftUI
-# targets, so only MediFlowCore + MediFlowCoreTests compile here.
+# pass the byte-exact zero-knowledge crypto golden-vector gate on Linux and
+# Windows. Apple Native owns the macOS coverage through its full SwiftPM suite.
+# This cross-OS gate confirms the Swift-core direction: if the Swift toolchain on
+# Windows/Linux ever diverges on AES-GCM/PBKDF2 (swift-crypto), this fails and we
+# reconsider a Rust core (the golden vectors are language-neutral and already in
+# hand). On non-Apple OSes the package manifest excludes the SwiftUI targets, so
+# only MediFlowCore + MediFlowCoreTests compile here.
 
 on:
   pull_request:
@@ -67,14 +68,3 @@ jobs:
       - name: Golden-vector gate (MediFlowCoreTests)
         run: swift test --package-path native/MediFlowMac --filter CryptoGoldenVectorsTests
         shell: pwsh
-
-  macos:
-    runs-on: macos-15
-    steps:
-      - uses: actions/checkout@v5
-      - name: Select latest stable Xcode
-        run: sudo xcode-select -s "$(ls -d /Applications/Xcode_*.app | sort -V | tail -1)"
-      - name: Build + golden-vector gate
-        run: |
-          swift build --package-path native/MediFlowMac --target MediFlowCore
-          swift test --package-path native/MediFlowMac --filter CryptoGoldenVectorsTests


### PR DESCRIPTION
## Summary
- remove the duplicated macOS job from Core tri-OS gate
- retain Linux and Windows as the cross-OS Swift crypto golden-vector gate
- document Apple Native as the owner of macOS coverage through its full SwiftPM suite
- leave `.github/workflows/apple-native.yml` unchanged

## Verification
- `git diff --check`
- Ruby YAML parse for `core-tri-os.yml` and `apple-native.yml`
- Xcode beta 27.0: `swift test --package-path native/MediFlowMac --filter CryptoGoldenVectorsTests` (3/3)
- Xcode beta 27.0: `scripts/native-test.sh` (335/335)
- independent read-only autoreview: clean, no accepted/actionable findings
- fresh Apple Native `native-build-test`: success ([job](https://github.com/Wulfgardr/mediflow/actions/runs/29170158574/job/86589897156))
- normal PR CI: 13/13 success ([checks](https://github.com/Wulfgardr/mediflow/pull/27/checks))
- Core Linux and Windows golden-vector gates: success ([run](https://github.com/Wulfgardr/mediflow/actions/runs/29170167732))

## Risk / Notes
- Live GitHub evidence before editing: `main` has no branch protection and no applicable repository or parent rulesets, so the removed macOS check is not required.
- Apple Native remains manually dispatchable and its `native-build-test` job runs the full SwiftPM suite.
- `actionlint` was not available locally; workflow YAML was parse-validated.
- No PHI/PII, patient data, runtime code, package surface, or TypeScript configuration is touched.
- This PR is prepared for review and is not merged or closed.

## Ticket
Refs WUL-490