### PR TITLE
refactor(ai): estrai il prompt Patient Insight

### DIFF
--- a/lib/ai-task-contract-prompts.ts
+++ b/lib/ai-task-contract-prompts.ts
@@ -1,0 +1,93 @@
+/* @Codex */
+export const AI_TASK_EXTRACTION_SCHEMA_VERSION = 'mediflow.ai.extract.v1';
+
+type PromptTaskKind = 'patient_insight' | 'smart_import' | 'document_synthesis';
+
+export function buildExtractionPrompt(
+    task: PromptTaskKind,
+    taskObjective: string,
+    dataShape: string,
+    rules: string[],
+    contextLabel: string,
+    contextBody: string
+): string {
+    return [
+        taskObjective,
+        '',
+        'Restituisci SOLO JSON valido, senza testo extra, senza backticks, senza commenti.',
+        'Usa esattamente questo envelope:',
+        '{',
+        `  "schemaVersion": "${AI_TASK_EXTRACTION_SCHEMA_VERSION}",`,
+        `  "task": "${task}",`,
+        '  "summary": "stringa breve in plain text, oppure vuota",',
+        `  "data": ${dataShape}`,
+        '}',
+        '',
+        'Regole comuni:',
+        '- usa solo doppi apici JSON standard',
+        '- non usare null: preferisci stringa vuota o array vuoto',
+        '- non aggiungere campi extra',
+        ...rules.map((rule) => `- ${rule}`),
+        '',
+        `${contextLabel}:`,
+        contextBody,
+    ].join('\n');
+}
+
+export function buildPatientInsightExtractionPrompt(contextPrompt: string): string {
+    return buildExtractionPrompt(
+        'patient_insight',
+        [
+            'Sei un assistente medico locale.',
+            'Obiettivo: estrarre un insight clinico breve, concreto, neutro e orientato al follow-up attuale, senza produrre markdown finale.',
+        ].join('\n'),
+        `{
+    "currentState": ["frase breve con [Sx] o [DATI-INCOMPLETI]"],
+    "alerts": ["bullet breve con [Sx] o [DATI-INCOMPLETI]"],
+    "nextSteps": ["bullet operativo con [Sx] o [DATI-INCOMPLETI]"],
+    "gaps": ["bullet breve con [Sx] o [DATI-INCOMPLETI]"]
+  }`,
+        [
+            'currentState massimo 2 frasi brevi',
+            'alerts massimo 2 elementi',
+            'nextSteps massimo 3 elementi',
+            'gaps massimo 1 elemento e solo se utile',
+            'gaps solo per informazioni mancanti che limitano interpretazione, priorita o decisione clinica attuale',
+            'currentState descrive il quadro clinico attuale e il follow-up immediato, non deve assorbire alert di sicurezza o monitoraggio attivo',
+            'apri currentState dal problema clinico o follow-up piu attuale, non dalla lista completa delle comorbidita',
+            'usa la seconda frase di currentState solo se aggiunge un secondo fatto clinico attuale o un follow-up immediato; non usarla per inventariare comorbidita croniche, terapia di sfondo o codici storici non decisivi',
+            'se diario o documenti recenti descrivono un episodio acuto, una dimissione o un percorso riabilitativo, tieni entrambe le frasi di currentState ancorate a quell episodio o al suo follow-up immediato',
+            'nei documenti recenti di dimissione, PS o riabilitazione, tratta mobilita ridotta, ausili, ADI/FKT e recupero funzionale come follow-up clinico attivo',
+            'menziona la storia remota solo se cambia la gestione attuale',
+            'non combinare nel currentState il problema attuale con comorbidita croniche non direttamente coinvolte nell evento o follow-up corrente',
+            'se valori recenti o controlli pendenti riguardano una cronica attiva, mantieni esplicita la patologia nel currentState',
+            'non citare diagnosi codificate o terapie attive di sfondo solo perche presenti nel contesto',
+            'nei casi post-dimissione, post-PS o riabilitativi non riportare in nextSteps diagnosi o terapie croniche di sfondo se non sono esplicitamente collegate all episodio attuale o a un controllo pendente',
+            'alerts solo per criticita cliniche o di sicurezza chiaramente attive nel contesto locale',
+            'usa alerts per peggioramento recente, valori chiaramente anomali, sospensione o stop temporaneo di terapia, episodio acuto non ancora risolto, limitazione funzionale o ausilio che cambia sicurezza o monitoraggio',
+            'nei casi post-dimissione o riabilitativi, usa alerts per limiti funzionali, deambulatore, mobilita ridotta o recupero da rivalutare se sono ancora aperti',
+            'se un contenuto segnala rischio o richiede sorveglianza ravvicinata, mettilo in alerts anche se spiega il currentState o motiva un nextStep',
+            'se non esistono alert reali o di sicurezza, lascia alerts vuoto',
+            'se alerts e vuoto, ricontrolla che currentState e nextSteps non stiano nascondendo peggioramento, stop terapeutici, rivalutazioni urgenti, valori anomali o limiti funzionali rilevanti',
+            'nextSteps solo se derivano da controlli pendenti, diario recente, osservazioni recenti, documenti recenti o terapie attive',
+            'nextSteps deve contenere azioni, controlli o verifiche; non usare nextSteps per spostare fuori da alerts una criticita clinica attiva',
+            'lascia gaps vuoto se il caso e gia interpretabile e i prossimi passi sono gia chiari con i dati presenti',
+            'in gaps privilegia aderenza, risposta a terapia, andamento funzionale, sintomi non rivalutati o dati che mancano per leggere il problema attuale; evita gap generici che ripetono semplicemente esami gia programmati',
+            'non usare gaps per duplicare nextSteps, per elencare dati mancanti ovvi o per riempire spazio',
+            'ogni stringa deve gia includere [Sx] o [DATI-INCOMPLETI]',
+            'hard fail interno: se anche una sola stringa non contiene [Sx] o [DATI-INCOMPLETI], correggi il JSON prima di rispondere',
+            'mantieni sempre i marker [Sx] anche quando riassumi piu fatti clinici nella stessa stringa',
+            'usa solo riferimenti [Sx] presenti nel contesto',
+            'non usare placeholder come [Sx], [S?] o riferimenti generici: ogni citation deve corrispondere a un id reale presente nel contesto',
+            'non usare markdown nelle stringhe oltre ai marker [Sx] o [DATI-INCOMPLETI]',
+            'non inventare diagnosi, esami, terapie o fonti',
+            'non scrivere frasi rassicuranti o boilerplate come nessuna criticita se il contesto contiene episodio acuto recente, valore anomalo, stop terapeutico, limitazione funzionale o ausilio clinicamente rilevante',
+            'evita etichette inferite o enfatiche come fragilita alta, elevato rischio, complesso o pericoloso se non esplicite nelle fonti',
+            'non trasformare da soli codici storici, fattori sociali o stili di vita in counselling o piani generici se non esiste follow-up attivo documentato',
+            'se il supporto e debole, preferisci un gap esplicito a una raccomandazione speculativa',
+            'usa un italiano clinico neutro e non moralizzante',
+        ],
+        'DATI PAZIENTE',
+        contextPrompt,
+    );
+}

--- a/lib/ai-task-contracts.ts
+++ b/lib/ai-task-contracts.ts
@@ -1,9 +1,16 @@
 /* @Codex */
 import { filterServicePrescriptionTherapyCandidates, isServicePrescriptionLikeTherapy } from './prescription-boundary';
 import { stripModelArtifacts } from './model-artifacts';
+import {
+    AI_TASK_EXTRACTION_SCHEMA_VERSION,
+    buildExtractionPrompt,
+} from './ai-task-contract-prompts';
 
 /* @Codex */
-export const AI_TASK_EXTRACTION_SCHEMA_VERSION = 'mediflow.ai.extract.v1';
+export {
+    AI_TASK_EXTRACTION_SCHEMA_VERSION,
+    buildPatientInsightExtractionPrompt,
+} from './ai-task-contract-prompts';
 
 /* @Codex */
 export type AITaskKind = 'patient_insight' | 'smart_import' | 'document_synthesis';
@@ -830,94 +837,6 @@ export function parseDocumentSynthesisExtractionResponse(
     };
 }
 
-function buildExtractionPrompt(
-    task: AITaskKind,
-    taskObjective: string,
-    dataShape: string,
-    rules: string[],
-    contextLabel: string,
-    contextBody: string
-): string {
-    return [
-        taskObjective,
-        '',
-        'Restituisci SOLO JSON valido, senza testo extra, senza backticks, senza commenti.',
-        'Usa esattamente questo envelope:',
-        '{',
-        `  "schemaVersion": "${AI_TASK_EXTRACTION_SCHEMA_VERSION}",`,
-        `  "task": "${task}",`,
-        '  "summary": "stringa breve in plain text, oppure vuota",',
-        `  "data": ${dataShape}`,
-        '}',
-        '',
-        'Regole comuni:',
-        '- usa solo doppi apici JSON standard',
-        '- non usare null: preferisci stringa vuota o array vuoto',
-        '- non aggiungere campi extra',
-        ...rules.map((rule) => `- ${rule}`),
-        '',
-        `${contextLabel}:`,
-        contextBody,
-    ].join('\n');
-}
-
-export function buildPatientInsightExtractionPrompt(contextPrompt: string): string {
-    return buildExtractionPrompt(
-        'patient_insight',
-        [
-            'Sei un assistente medico locale.',
-            'Obiettivo: estrarre un insight clinico breve, concreto, neutro e orientato al follow-up attuale, senza produrre markdown finale.',
-        ].join('\n'),
-        `{
-    "currentState": ["frase breve con [Sx] o [DATI-INCOMPLETI]"],
-    "alerts": ["bullet breve con [Sx] o [DATI-INCOMPLETI]"],
-    "nextSteps": ["bullet operativo con [Sx] o [DATI-INCOMPLETI]"],
-    "gaps": ["bullet breve con [Sx] o [DATI-INCOMPLETI]"]
-  }`,
-        [
-            'currentState massimo 2 frasi brevi',
-            'alerts massimo 2 elementi',
-            'nextSteps massimo 3 elementi',
-            'gaps massimo 1 elemento e solo se utile',
-            'gaps solo per informazioni mancanti che limitano interpretazione, priorita o decisione clinica attuale',
-            'currentState descrive il quadro clinico attuale e il follow-up immediato, non deve assorbire alert di sicurezza o monitoraggio attivo',
-            'apri currentState dal problema clinico o follow-up piu attuale, non dalla lista completa delle comorbidita',
-            'usa la seconda frase di currentState solo se aggiunge un secondo fatto clinico attuale o un follow-up immediato; non usarla per inventariare comorbidita croniche, terapia di sfondo o codici storici non decisivi',
-            'se diario o documenti recenti descrivono un episodio acuto, una dimissione o un percorso riabilitativo, tieni entrambe le frasi di currentState ancorate a quell episodio o al suo follow-up immediato',
-            'nei documenti recenti di dimissione, PS o riabilitazione, tratta mobilita ridotta, ausili, ADI/FKT e recupero funzionale come follow-up clinico attivo',
-            'menziona la storia remota solo se cambia la gestione attuale',
-            'non combinare nel currentState il problema attuale con comorbidita croniche non direttamente coinvolte nell evento o follow-up corrente',
-            'se valori recenti o controlli pendenti riguardano una cronica attiva, mantieni esplicita la patologia nel currentState',
-            'non citare diagnosi codificate o terapie attive di sfondo solo perche presenti nel contesto',
-            'nei casi post-dimissione, post-PS o riabilitativi non riportare in nextSteps diagnosi o terapie croniche di sfondo se non sono esplicitamente collegate all episodio attuale o a un controllo pendente',
-            'alerts solo per criticita cliniche o di sicurezza chiaramente attive nel contesto locale',
-            'usa alerts per peggioramento recente, valori chiaramente anomali, sospensione o stop temporaneo di terapia, episodio acuto non ancora risolto, limitazione funzionale o ausilio che cambia sicurezza o monitoraggio',
-            'nei casi post-dimissione o riabilitativi, usa alerts per limiti funzionali, deambulatore, mobilita ridotta o recupero da rivalutare se sono ancora aperti',
-            'se un contenuto segnala rischio o richiede sorveglianza ravvicinata, mettilo in alerts anche se spiega il currentState o motiva un nextStep',
-            'se non esistono alert reali o di sicurezza, lascia alerts vuoto',
-            'se alerts e vuoto, ricontrolla che currentState e nextSteps non stiano nascondendo peggioramento, stop terapeutici, rivalutazioni urgenti, valori anomali o limiti funzionali rilevanti',
-            'nextSteps solo se derivano da controlli pendenti, diario recente, osservazioni recenti, documenti recenti o terapie attive',
-            'nextSteps deve contenere azioni, controlli o verifiche; non usare nextSteps per spostare fuori da alerts una criticita clinica attiva',
-            'lascia gaps vuoto se il caso e gia interpretabile e i prossimi passi sono gia chiari con i dati presenti',
-            'in gaps privilegia aderenza, risposta a terapia, andamento funzionale, sintomi non rivalutati o dati che mancano per leggere il problema attuale; evita gap generici che ripetono semplicemente esami gia programmati',
-            'non usare gaps per duplicare nextSteps, per elencare dati mancanti ovvi o per riempire spazio',
-            'ogni stringa deve gia includere [Sx] o [DATI-INCOMPLETI]',
-            'hard fail interno: se anche una sola stringa non contiene [Sx] o [DATI-INCOMPLETI], correggi il JSON prima di rispondere',
-            'mantieni sempre i marker [Sx] anche quando riassumi piu fatti clinici nella stessa stringa',
-            'usa solo riferimenti [Sx] presenti nel contesto',
-            'non usare placeholder come [Sx], [S?] o riferimenti generici: ogni citation deve corrispondere a un id reale presente nel contesto',
-            'non usare markdown nelle stringhe oltre ai marker [Sx] o [DATI-INCOMPLETI]',
-            'non inventare diagnosi, esami, terapie o fonti',
-            'non scrivere frasi rassicuranti o boilerplate come nessuna criticita se il contesto contiene episodio acuto recente, valore anomalo, stop terapeutico, limitazione funzionale o ausilio clinicamente rilevante',
-            'evita etichette inferite o enfatiche come fragilita alta, elevato rischio, complesso o pericoloso se non esplicite nelle fonti',
-            'non trasformare da soli codici storici, fattori sociali o stili di vita in counselling o piani generici se non esiste follow-up attivo documentato',
-            'se il supporto e debole, preferisci un gap esplicito a una raccomandazione speculativa',
-            'usa un italiano clinico neutro e non moralizzante',
-        ],
-        'DATI PAZIENTE',
-        contextPrompt,
-    );
-}
 
 export function buildSmartImportExtractionPrompt(payload: unknown): string {
     return buildExtractionPrompt(


### PR DESCRIPTION
## Summary
- Estrae helper envelope, versione schema e builder/regole Patient Insight in `lib/ai-task-contract-prompts.ts`.
- Mantiene `lib/ai-task-contracts.ts` come entrypoint pubblico compatibile.
- Lascia i prompt Smart Import e document synthesis nel modulo originale per WUL-492 e WUL-493.
- Mantiene invariati byte, lunghezze e SHA-256 dei tre prompt.

## Verification
- `npm run test:ai-task-contracts` — 21 pass
- `npm run test:patient-smart-import` — 20 pass
- `npm run test:document-synthesis` — 28 pass
- `npm run test:unit` — 616 pass
- `npm run typecheck`
- `npm run lint`
- `npm run build` — pass con 2 warning NFT preesistenti
- `git diff --check`
- Hash prompt: Patient Insight `e4150b764f8581ba6478cd89c0b33fd22d66f47798cf916a3e31478971f8547b`; Smart Import `e0a67ae602f10e8d5e68b4dacfca678bdca72993a0597ebfe77b9bb038c6e430`; document synthesis `6f03db526863f776ac3efecaaab4730963eb3be982189a29c3b30292057a2624`.
- Autoreview Codex Sol/high: clean, nessun finding actionable.

## Risk / Notes
- Diff lordo: 190 LOC, sotto il cap 220.
- Nessun consumer modificato, nessun ciclo di import, nessun cambiamento di policy AI o comportamento prompt.
- Smart Import e document synthesis restano fuori scope.
- PR preparata e pubblicata; non eseguito merge.

## Ticket
Refs WUL-491