### PR TITLE
feat(native): modella stati dei campi cifrati

### DIFF
--- a/native/MediFlowMac/Sources/MediFlowCore/PatientFieldCrypto.swift
+++ b/native/MediFlowMac/Sources/MediFlowCore/PatientFieldCrypto.swift
@@ -8,6 +8,28 @@ import Foundation
 import Crypto  // swift-crypto: re-exports CryptoKit on Apple, BoringSSL on Linux/Windows (ADR 0071)
 
 public enum PatientFieldCrypto {
+    /* @Codex */
+    public enum EditableField: Equatable, Sendable {
+        case absent
+        case plaintext(String)
+        case locked(ciphertext: String)
+
+        public var isLocked: Bool {
+            if case .locked = self { return true }
+            return false
+        }
+    }
+
+    /* @Codex */
+    public static func resolveStringField(_ value: String?, masterKey: SymmetricKey?) -> EditableField {
+        resolveField(value, masterKey: masterKey) { CryptoService.jsonDecodeString($0) ?? $0 }
+    }
+
+    /* @Codex */
+    public static func resolveStructuredField(_ value: String?, masterKey: SymmetricKey?) -> EditableField {
+        resolveField(value, masterKey: masterKey) { $0 }
+    }
+
     /// A plain string field: ENC -> decrypt -> JSON-unwrap; plaintext -> as-is;
     /// undecryptable ENC (no/wrong key) -> nil so ciphertext is never shown.
     public static func decryptStringField(_ value: String?, masterKey: SymmetricKey?) -> String? {
@@ -75,5 +97,29 @@ public enum PatientFieldCrypto {
             deletedAt: detail.deletedAt,
             deletionReason: decryptStringField(detail.deletionReason, masterKey: masterKey)
         )
+    }
+
+    /* @Codex */
+    public static func encryptedPatchValue(
+        _ plaintext: String?, original: EditableField, masterKey: SymmetricKey, structured: Bool = false
+    ) -> PatchValue<String> {
+        guard !original.isLocked else { return .omit }
+        guard let plaintext, !plaintext.isEmpty else { return .null }
+        let value = structured ? plaintext : (CryptoService.jsonEncode(plaintext) ?? "")
+        guard !value.isEmpty, let encrypted = CryptoService.encryptField(value, masterKey: masterKey) else {
+            return .omit
+        }
+        return .value(encrypted)
+    }
+
+    private static func resolveField(
+        _ value: String?, masterKey: SymmetricKey?, transform: (String) -> String
+    ) -> EditableField {
+        guard let value else { return .absent }
+        guard value.hasPrefix(CryptoService.encPrefix) else { return .plaintext(value) }
+        guard let masterKey, let decrypted = CryptoService.decryptField(value, masterKey: masterKey) else {
+            return .locked(ciphertext: value)
+        }
+        return .plaintext(transform(decrypted))
     }
 }

--- a/native/MediFlowMac/Tests/MediFlowAppleSharedTests/PatientFieldCryptoTests.swift
+++ b/native/MediFlowMac/Tests/MediFlowAppleSharedTests/PatientFieldCryptoTests.swift
@@ -32,6 +32,31 @@ final class PatientFieldCryptoTests: XCTestCase {
                      "ciphertext must never be shown when the key is unavailable")
     }
 
+    /* @Codex */
+    func testEditableFieldResolvesAbsentPlaintextAndLockedByteExactly() {
+        XCTAssertEqual(PatientFieldCrypto.resolveStringField(nil, masterKey: key), .absent)
+        XCTAssertEqual(
+            PatientFieldCrypto.resolveStringField("Via Roma 1", masterKey: key),
+            .plaintext("Via Roma 1"))
+
+        let wrongKey = SymmetricKey(size: .bits256)
+        let locked = PatientFieldCrypto.resolveStringField(encString, masterKey: wrongKey)
+        XCTAssertEqual(locked, .locked(ciphertext: encString))
+        XCTAssertEqual(
+            PatientFieldCrypto.resolveStringField("ENC:corrupt:value", masterKey: key),
+            .locked(ciphertext: "ENC:corrupt:value"))
+    }
+
+    /* @Codex */
+    func testLockedEditableFieldEncodesAsOmit() {
+        let wrongKey = SymmetricKey(size: .bits256)
+        let locked = PatientFieldCrypto.resolveStringField(encString, masterKey: wrongKey)
+        guard case .omit = PatientFieldCrypto.encryptedPatchValue(
+            "", original: locked, masterKey: wrongKey) else {
+            return XCTFail("locked fields must be omitted")
+        }
+    }
+
     func testStructuredFieldRoundTripsArrayJson() {
         let arrayJSON = "[{\"code\":\"E11.9\",\"description\":\"Diabete\",\"system\":\"ICD-10\",\"date\":\"2026-01-01T00:00:00.000Z\"}]"
         let enc = CryptoService.encryptField(arrayJSON, masterKey: key)!


### PR DESCRIPTION
## Summary
- introduce lo stato additivo `absent | plaintext | locked(ciphertext)` per i campi paziente cifrati
- preserva byte-identico il valore `ENC:` quando la decifratura fallisce
- converte uno stato locked in `PatchValue.omit` senza collegarlo ancora ai call site live
- aggiunge test sintetici per assenza, plaintext, wrong key, ciphertext corrotto e omit

## Verification
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --filter PatientFieldCryptoTests`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --filter "CryptoGoldenVectorsTests|CryptoGoldenVectorsV2Tests|HomeBaseDateCodingTests"`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test` (337 test, 0 failure)
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift build`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcodebuild -project native/MediFlowAppleApp/MediFlowAppleApp.xcodeproj -scheme MediFlowMacApp -configuration Debug -destination "platform=macOS" CODE_SIGNING_ALLOWED=NO build`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcodebuild -project native/MediFlowAppleApp/MediFlowAppleApp.xcodeproj -scheme MediFlowMobileApp -configuration Debug -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO build`
- review indipendente read-only: PASS, nessun P1/P2

## Risk / Notes
- diff limitato a 71 LOC gross nei due file autorizzati
- nessun call site live, datasource, store, model, view, CryptoService, formato ENC, API o schema modificato
- l integrazione atomica datasource-model-UI resta separata in WUL-495
- no contract impact
- PR preparata per review; nessun merge eseguito

## Ticket
Refs WUL-489