### PR TITLE
fix(native): preserva i campi paziente bloccati

### DIFF
--- a/native/MediFlowAppleApp/Tests/MediFlowMobileAppUITests/MediFlowMobileAppUITests.swift
+++ b/native/MediFlowAppleApp/Tests/MediFlowMobileAppUITests/MediFlowMobileAppUITests.swift
@@ -11,8 +11,9 @@ final class MediFlowMobileAppUITests: XCTestCase {
         app = XCUIApplication()
     }
 
-    private func launch(seedPatients: Bool = false, section: String? = nil) {
+    private func launch(seedPatients: Bool = false, lockedPatientFields: Bool = false, section: String? = nil) {
         if seedPatients { app.launchEnvironment["MEDIFLOW_APPLE_UITEST_PATIENTS"] = "1" }
+        if lockedPatientFields { app.launchEnvironment["MEDIFLOW_APPLE_UITEST_LOCKED_PATIENT_FIELDS"] = "1" }
         if let section { app.launchEnvironment["MEDIFLOW_APPLE_INITIAL_SECTION"] = section }
         app.launch()
     }
@@ -244,6 +245,20 @@ final class MediFlowMobileAppUITests: XCTestCase {
         // The detail re-renders with the new address; the form is dismissed.
         XCTAssertTrue(app.staticTexts["Via Nuova 5"].waitForExistence(timeout: 5))
         XCTAssertTrue(app.staticTexts["Via Roma 1, Milano"].waitForNonExistence(timeout: 3))
+    }
+
+    func testEditPatientFormDisablesLockedFieldWithoutShowingCiphertext() {
+        launch(seedPatients: true, lockedPatientFields: true, section: "modules")
+        XCTAssertTrue(sectionView("clinical-workspace-patients-view").waitForExistence(timeout: 20))
+        app.buttons["patient-cell-uitest-1"].tap()
+        XCTAssertTrue(sectionView("patient-detail-name").waitForExistence(timeout: 10))
+
+        app.buttons["edit-patient-button"].tap()
+        let address = app.textFields["edit-patient-address"]
+        XCTAssertTrue(address.waitForExistence(timeout: 5))
+        XCTAssertFalse(address.isEnabled)
+        XCTAssertTrue(sectionView("edit-patient-locked-fields-message").exists)
+        XCTAssertFalse(app.staticTexts["ENC:locked:uitest"].exists)
     }
 
     func testEditPatientFormArchivesPatient() {

--- a/native/MediFlowAppleApp/Tests/MediFlowMobileAppUITests/MediFlowMobileAppUITests.swift
+++ b/native/MediFlowAppleApp/Tests/MediFlowMobileAppUITests/MediFlowMobileAppUITests.swift
@@ -11,6 +11,7 @@ final class MediFlowMobileAppUITests: XCTestCase {
         app = XCUIApplication()
     }
 
+    /* @Codex */
     private func launch(seedPatients: Bool = false, lockedPatientFields: Bool = false, section: String? = nil) {
         if seedPatients { app.launchEnvironment["MEDIFLOW_APPLE_UITEST_PATIENTS"] = "1" }
         if lockedPatientFields { app.launchEnvironment["MEDIFLOW_APPLE_UITEST_LOCKED_PATIENT_FIELDS"] = "1" }
@@ -247,6 +248,7 @@ final class MediFlowMobileAppUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["Via Roma 1, Milano"].waitForNonExistence(timeout: 3))
     }
 
+    /* @Codex */
     func testEditPatientFormDisablesLockedFieldWithoutShowingCiphertext() {
         launch(seedPatients: true, lockedPatientFields: true, section: "modules")
         XCTAssertTrue(sectionView("clinical-workspace-patients-view").waitForExistence(timeout: 20))

--- a/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/PairedPatientsWorkspaceModel.swift
+++ b/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/PairedPatientsWorkspaceModel.swift
@@ -34,6 +34,7 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
     @Published private(set) var selectedPatient: HomeBasePatientDetail? {
         didSet {
             guard oldValue?.id != selectedPatient?.id else { return }
+            /* @Codex */
             editablePatientFields = [:]
             lockedPatientFields = []
             invalidateAttachmentPatientState()
@@ -408,6 +409,7 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
         guard ProcessInfo.processInfo.environment["MEDIFLOW_APPLE_UITEST_PATIENTS"] == "1" else {
             return nil
         }
+        /* @Codex */
         let lockedAddress = ProcessInfo.processInfo.environment["MEDIFLOW_APPLE_UITEST_LOCKED_PATIENT_FIELDS"] == "1"
             ? "ENC:locked:uitest" : "Via Roma 1, Milano"
         return HomeBasePatientDetail(
@@ -765,7 +767,7 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
         }
         #if DEBUG
         if let detail = Self.uiTestSeededDetail(for: patient) {
-            setSelectedPatient(detail)
+            setSelectedPatient(detail) // @Codex
             entries = Self.uiTestSeededEntries(patientId: patient.id)
             therapies = Self.uiTestSeededTherapies(patientId: patient.id)
             checkups = Self.uiTestSeededCheckups(patientId: patient.id)
@@ -795,7 +797,7 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
                 sessionCookie: sessionCookie,
                 ambulatoryId: self.ambulatoryId.trimmedOrNil
             )
-            self.setSelectedPatient(fetchedDetail)
+            self.setSelectedPatient(fetchedDetail) // @Codex
             self.entries = try await self.fetchDecryptedEntries(
                 patientId: patient.id,
                 credentials: credentials,
@@ -866,7 +868,7 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
             let fetchedDetail = try await self.makeClient().fetchPatient(
                 id: id, credentials: credentials, sessionCookie: sessionCookie,
                 ambulatoryId: self.ambulatoryId.trimmedOrNil)
-            self.setSelectedPatient(fetchedDetail)
+            self.setSelectedPatient(fetchedDetail) // @Codex
             self.patientReportURL = nil
             self.patientFHIRExportURL = nil
             self.pendingFHIRWarningValidation = nil
@@ -1390,6 +1392,7 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
             errorMessage = "Cifratura non disponibile: riaccedi con il PIN operatore prima di salvare."
             return
         }
+        /* @Codex */
         let payload = HomeBasePatientUpdatePayload(
             version: current.version,
             firstName: editPatientFirstName.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -1425,7 +1428,7 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
                 sessionCookie: sessionCookie,
                 ambulatoryId: self.ambulatoryId.trimmedOrNil
             )
-            self.setSelectedPatient(fetchedDetail)
+            self.setSelectedPatient(fetchedDetail) // @Codex
             self.statusMessage = "Anagrafica aggiornata sull'home-base."
         }
     }
@@ -1500,7 +1503,7 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
                 sessionCookie: sessionCookie,
                 ambulatoryId: self.ambulatoryId.trimmedOrNil
             )
-            self.setSelectedPatient(fetchedDetail)
+            self.setSelectedPatient(fetchedDetail) // @Codex
             self.patients = try await self.makeClient().fetchPatients(
                 credentials: credentials,
                 sessionCookie: sessionCookie,
@@ -1582,6 +1585,7 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
     /// JSON-encode (matching JSON.stringify) and encrypt to ENC:. The caller holds
     /// the key, so this never emits plaintext for an encrypted field (.omit on a
     /// crypto failure leaves the stored value untouched rather than clobbering it).
+    /* @Codex */
     private func encryptedPatientPatchValue(
         _ text: String?, field: EncryptedPatientField, masterKey: SymmetricKey, structured: Bool = false
     ) -> PatchValue<String> {
@@ -3728,7 +3732,7 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
                 sessionCookie: sessionCookie,
                 ambulatoryId: ambulatoryId.trimmedOrNil
             )
-            setSelectedPatient(fetchedDetail)
+            setSelectedPatient(fetchedDetail) // @Codex
             entries = try await fetchDecryptedEntries(patientId: patientId, credentials: credentials, sessionCookie: sessionCookie, ambulatoryId: ambulatoryId.trimmedOrNil)
             therapies = try await fetchDecryptedTherapies(patientId: patientId, credentials: credentials, sessionCookie: sessionCookie, ambulatoryId: ambulatoryId.trimmedOrNil)
             checkups = try await fetchDecryptedCheckups(patientId: patientId, credentials: credentials, sessionCookie: sessionCookie, ambulatoryId: ambulatoryId.trimmedOrNil)

--- a/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/PairedPatientsWorkspaceModel.swift
+++ b/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/PairedPatientsWorkspaceModel.swift
@@ -34,6 +34,8 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
     @Published private(set) var selectedPatient: HomeBasePatientDetail? {
         didSet {
             guard oldValue?.id != selectedPatient?.id else { return }
+            editablePatientFields = [:]
+            lockedPatientFields = []
             invalidateAttachmentPatientState()
             invalidatePatientBoundNewEntryState()
         }
@@ -95,6 +97,13 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
     @Published private(set) var editPatientDiagnoses: [ClinicalDiagnosis] = []
     @Published var editPatientIsAdi = false
     @Published private(set) var editPatientExemptions: [String] = []
+    /* @Codex */
+    enum EncryptedPatientField: Hashable {
+        case address, phone, caregiver, notes, diagnoses, exemptions
+    }
+    /* @Codex */
+    @Published private(set) var lockedPatientFields: Set<EncryptedPatientField> = []
+    private var editablePatientFields: [EncryptedPatientField: PatientFieldCrypto.EditableField] = [:]
     @Published var newExemptionCode = ""
     /* @Codex */
     @Published private(set) var exemptionCatalogResults: [HomeBaseExemptionSummary] = []
@@ -399,11 +408,13 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
         guard ProcessInfo.processInfo.environment["MEDIFLOW_APPLE_UITEST_PATIENTS"] == "1" else {
             return nil
         }
+        let lockedAddress = ProcessInfo.processInfo.environment["MEDIFLOW_APPLE_UITEST_LOCKED_PATIENT_FIELDS"] == "1"
+            ? "ENC:locked:uitest" : "Via Roma 1, Milano"
         return HomeBasePatientDetail(
             id: patient.id, firstName: patient.firstName, lastName: patient.lastName,
             birthDate: Date(timeIntervalSince1970: 315_532_800),
             taxCode: patient.taxCode,
-            address: "Via Roma 1, Milano", phone: "+39 02 1234567", caregiver: "Caregiver Test",
+            address: lockedAddress, phone: "+39 02 1234567", caregiver: "Caregiver Test",
             exemptions: "[\"048\",\"C01\"]",
             diagnoses: "[{\"code\":\"E11.9\",\"description\":\"Diabete tipo 2\",\"system\":\"ICD-10\",\"date\":\"2026-01-01T00:00:00.000Z\"}]",
             monitoringProfile: "Profilo di monitoraggio test", statusReason: nil,
@@ -754,7 +765,7 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
         }
         #if DEBUG
         if let detail = Self.uiTestSeededDetail(for: patient) {
-            selectedPatient = detail
+            setSelectedPatient(detail)
             entries = Self.uiTestSeededEntries(patientId: patient.id)
             therapies = Self.uiTestSeededTherapies(patientId: patient.id)
             checkups = Self.uiTestSeededCheckups(patientId: patient.id)
@@ -784,7 +795,7 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
                 sessionCookie: sessionCookie,
                 ambulatoryId: self.ambulatoryId.trimmedOrNil
             )
-            self.selectedPatient = PatientFieldCrypto.decryptDetail(fetchedDetail, masterKey: self.masterKey)
+            self.setSelectedPatient(fetchedDetail)
             self.entries = try await self.fetchDecryptedEntries(
                 patientId: patient.id,
                 credentials: credentials,
@@ -855,7 +866,7 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
             let fetchedDetail = try await self.makeClient().fetchPatient(
                 id: id, credentials: credentials, sessionCookie: sessionCookie,
                 ambulatoryId: self.ambulatoryId.trimmedOrNil)
-            self.selectedPatient = PatientFieldCrypto.decryptDetail(fetchedDetail, masterKey: self.masterKey)
+            self.setSelectedPatient(fetchedDetail)
             self.patientReportURL = nil
             self.patientFHIRExportURL = nil
             self.pendingFHIRWarningValidation = nil
@@ -1286,6 +1297,11 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
         statusMessage = "Modifica anagrafica pronta."
     }
 
+    /* @Codex */
+    func isPatientFieldLocked(_ field: EncryptedPatientField) -> Bool {
+        lockedPatientFields.contains(field)
+    }
+
     func addDiagnosis() {
         addDiagnosis(code: newDiagnosisCode, description: newDiagnosisDescription, system: nil)
         newDiagnosisCode = ""
@@ -1381,12 +1397,16 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
             taxCode: editPatientTaxCode.trimmingCharacters(in: .whitespacesAndNewlines),
             isAdi: editPatientIsAdi,
             isArchived: editPatientIsArchived,
-            address: encryptedStringPatchValue(editPatientAddress, masterKey: masterKey),
-            phone: encryptedStringPatchValue(editPatientPhone, masterKey: masterKey),
-            caregiver: encryptedStringPatchValue(editPatientCaregiver, masterKey: masterKey),
-            notes: encryptedStringPatchValue(editPatientNotes, masterKey: masterKey),
-            diagnoses: encryptedDiagnosesPatchValue(masterKey: masterKey),
-            exemptions: encryptedExemptionsPatchValue(masterKey: masterKey)
+            address: encryptedPatientPatchValue(editPatientAddress.trimmedOrNil, field: .address, masterKey: masterKey),
+            phone: encryptedPatientPatchValue(editPatientPhone.trimmedOrNil, field: .phone, masterKey: masterKey),
+            caregiver: encryptedPatientPatchValue(editPatientCaregiver.trimmedOrNil, field: .caregiver, masterKey: masterKey),
+            notes: encryptedPatientPatchValue(editPatientNotes.trimmedOrNil, field: .notes, masterKey: masterKey),
+            diagnoses: encryptedPatientPatchValue(
+                DiagnosesCodec.encode(editPatientDiagnoses, defaultDate: Self.nowISODate()),
+                field: .diagnoses, masterKey: masterKey, structured: true),
+            exemptions: encryptedPatientPatchValue(
+                ExemptionCodesCodec.encode(editPatientExemptions),
+                field: .exemptions, masterKey: masterKey, structured: true)
         )
         let patientId = current.id
         await runTask {
@@ -1405,7 +1425,7 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
                 sessionCookie: sessionCookie,
                 ambulatoryId: self.ambulatoryId.trimmedOrNil
             )
-            self.selectedPatient = PatientFieldCrypto.decryptDetail(fetchedDetail, masterKey: self.masterKey)
+            self.setSelectedPatient(fetchedDetail)
             self.statusMessage = "Anagrafica aggiornata sull'home-base."
         }
     }
@@ -1480,7 +1500,7 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
                 sessionCookie: sessionCookie,
                 ambulatoryId: self.ambulatoryId.trimmedOrNil
             )
-            self.selectedPatient = PatientFieldCrypto.decryptDetail(fetchedDetail, masterKey: self.masterKey)
+            self.setSelectedPatient(fetchedDetail)
             self.patients = try await self.makeClient().fetchPatients(
                 credentials: credentials,
                 sessionCookie: sessionCookie,
@@ -1562,14 +1582,12 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
     /// JSON-encode (matching JSON.stringify) and encrypt to ENC:. The caller holds
     /// the key, so this never emits plaintext for an encrypted field (.omit on a
     /// crypto failure leaves the stored value untouched rather than clobbering it).
-    private func encryptedStringPatchValue(_ text: String, masterKey: SymmetricKey) -> PatchValue<String> {
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return .null }
-        guard let json = CryptoService.jsonEncode(trimmed),
-              let enc = CryptoService.encryptField(json, masterKey: masterKey) else {
-            return .omit
-        }
-        return .value(enc)
+    private func encryptedPatientPatchValue(
+        _ text: String?, field: EncryptedPatientField, masterKey: SymmetricKey, structured: Bool = false
+    ) -> PatchValue<String> {
+        PatientFieldCrypto.encryptedPatchValue(
+            text, original: editablePatientFields[field] ?? .absent,
+            masterKey: masterKey, structured: structured)
     }
 
     /// Seal one encrypted clinical sub-resource field for write. Throws if the
@@ -1595,28 +1613,19 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
         return enc
     }
 
-    /// Seal the edited diagnoses (lossless round-trip verified) and encrypt. An
-    /// empty list clears the field.
-    private func encryptedDiagnosesPatchValue(masterKey: SymmetricKey) -> PatchValue<String> {
-        guard let plainJSON = DiagnosesCodec.encode(editPatientDiagnoses, defaultDate: Self.nowISODate()) else {
-            return .null
-        }
-        guard let enc = CryptoService.encryptField(plainJSON, masterKey: masterKey) else {
-            return .omit
-        }
-        return .value(enc)
-    }
-
-    /// Seal the edited exemption codes (structured JSON array) and encrypt. An empty
-    /// list clears the field (encode returns nil -> .null), matching the diagnoses flow.
-    private func encryptedExemptionsPatchValue(masterKey: SymmetricKey) -> PatchValue<String> {
-        guard let plainJSON = ExemptionCodesCodec.encode(editPatientExemptions) else {
-            return .null
-        }
-        guard let enc = CryptoService.encryptField(plainJSON, masterKey: masterKey) else {
-            return .omit
-        }
-        return .value(enc)
+    /* @Codex */
+    private func setSelectedPatient(_ raw: HomeBasePatientDetail) {
+        let fields: [EncryptedPatientField: PatientFieldCrypto.EditableField] = [
+            .address: PatientFieldCrypto.resolveStringField(raw.address, masterKey: masterKey),
+            .phone: PatientFieldCrypto.resolveStringField(raw.phone, masterKey: masterKey),
+            .caregiver: PatientFieldCrypto.resolveStringField(raw.caregiver, masterKey: masterKey),
+            .notes: PatientFieldCrypto.resolveStringField(raw.notes, masterKey: masterKey),
+            .diagnoses: PatientFieldCrypto.resolveStructuredField(raw.diagnoses, masterKey: masterKey),
+            .exemptions: PatientFieldCrypto.resolveStructuredField(raw.exemptions, masterKey: masterKey),
+        ]
+        selectedPatient = PatientFieldCrypto.decryptDetail(raw, masterKey: masterKey)
+        editablePatientFields = fields
+        lockedPatientFields = Set(fields.compactMap { $0.value.isLocked ? $0.key : nil })
     }
 
     static func nowISODate() -> String {
@@ -3719,7 +3728,7 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
                 sessionCookie: sessionCookie,
                 ambulatoryId: ambulatoryId.trimmedOrNil
             )
-            selectedPatient = PatientFieldCrypto.decryptDetail(fetchedDetail, masterKey: masterKey)
+            setSelectedPatient(fetchedDetail)
             entries = try await fetchDecryptedEntries(patientId: patientId, credentials: credentials, sessionCookie: sessionCookie, ambulatoryId: ambulatoryId.trimmedOrNil)
             therapies = try await fetchDecryptedTherapies(patientId: patientId, credentials: credentials, sessionCookie: sessionCookie, ambulatoryId: ambulatoryId.trimmedOrNil)
             checkups = try await fetchDecryptedCheckups(patientId: patientId, credentials: credentials, sessionCookie: sessionCookie, ambulatoryId: ambulatoryId.trimmedOrNil)

--- a/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/PairedPatientsWorkspaceView.swift
+++ b/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/PairedPatientsWorkspaceView.swift
@@ -809,12 +809,22 @@ struct PairedPatientsWorkspaceView: View {
                 .accessibilityIdentifier("edit-patient-taxCode")
             TextField("Indirizzo", text: $model.editPatientAddress)
                 .accessibilityIdentifier("edit-patient-address")
+                .disabled(model.isPatientFieldLocked(.address))
             TextField("Telefono", text: $model.editPatientPhone)
                 .accessibilityIdentifier("edit-patient-phone")
+                .disabled(model.isPatientFieldLocked(.phone))
             TextField("Caregiver", text: $model.editPatientCaregiver)
                 .accessibilityIdentifier("edit-patient-caregiver")
+                .disabled(model.isPatientFieldLocked(.caregiver))
             TextField("Note", text: $model.editPatientNotes, axis: .vertical)
                 .accessibilityIdentifier("edit-patient-notes")
+                .disabled(model.isPatientFieldLocked(.notes))
+            if !model.lockedPatientFields.isEmpty {
+                Label("Alcuni dati cifrati non sono disponibili e non verranno modificati.", systemImage: "lock.fill")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("edit-patient-locked-fields-message")
+            }
             Toggle("Archiviato", isOn: $model.editPatientIsArchived)
                 .accessibilityIdentifier("edit-patient-archived")
             Toggle("ADI (assistenza domiciliare)", isOn: $model.editPatientIsAdi)
@@ -872,6 +882,7 @@ struct PairedPatientsWorkspaceView: View {
                     .accessibilityIdentifier("add-diagnosis-button")
                 }
             }
+            .disabled(model.isPatientFieldLocked(.diagnoses))
 
             VStack(alignment: .leading, spacing: 4) {
                 Text("Esenzioni")
@@ -911,6 +922,7 @@ struct PairedPatientsWorkspaceView: View {
                 }
                 exemptionCatalogResultsList
             }
+            .disabled(model.isPatientFieldLocked(.exemptions))
 
             HStack(spacing: 10) {
                 Button("Salva") {

--- a/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/PairedPatientsWorkspaceView.swift
+++ b/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/PairedPatientsWorkspaceView.swift
@@ -807,6 +807,7 @@ struct PairedPatientsWorkspaceView: View {
                 .accessibilityIdentifier("edit-patient-lastName")
             TextField("Codice fiscale", text: $model.editPatientTaxCode)
                 .accessibilityIdentifier("edit-patient-taxCode")
+            /* @Codex */
             TextField("Indirizzo", text: $model.editPatientAddress)
                 .accessibilityIdentifier("edit-patient-address")
                 .disabled(model.isPatientFieldLocked(.address))
@@ -882,6 +883,7 @@ struct PairedPatientsWorkspaceView: View {
                     .accessibilityIdentifier("add-diagnosis-button")
                 }
             }
+            /* @Codex */
             .disabled(model.isPatientFieldLocked(.diagnoses))
 
             VStack(alignment: .leading, spacing: 4) {
@@ -922,6 +924,7 @@ struct PairedPatientsWorkspaceView: View {
                 }
                 exemptionCatalogResultsList
             }
+            /* @Codex */
             .disabled(model.isPatientFieldLocked(.exemptions))
 
             HStack(spacing: 10) {

--- a/native/MediFlowMac/Sources/MediFlowAppleShared/LocalPatientsDataSource.swift
+++ b/native/MediFlowMac/Sources/MediFlowAppleShared/LocalPatientsDataSource.swift
@@ -42,11 +42,10 @@ public actor LocalPatientsDataSource: HomeBasePatientsDataSource {
     public func fetchPatient(
         id: String, credentials: HomeBasePairedCredentials, sessionCookie: String, ambulatoryId: String?
     ) async throws -> HomeBasePatientDetail {
-        // loadPatientDetail decrypts the ENCRYPTED_FIELDS in-core; the model's later
-        // decryptDetail is a benign no-op (already-plaintext passes through). Scoped by
-        // the membership when present (1:1 with getNetworkScopedPatient's 404).
+        // Preserve raw ENC parity with the HTTP data source. The workspace model owns
+        // decrypt-or-lock resolution so failed decrypts cannot be collapsed to nil.
         let scope = ambulatoryId?.isEmpty == false ? ambulatoryId : nil
-        guard let detail = try patientStore.loadPatientDetail(id: id, scopeAmbulatoryId: scope, masterKey: masterKey) else {
+        guard let detail = try patientStore.loadRawPatientDetail(id: id, scopeAmbulatoryId: scope) else {
             throw HomeBaseClientError.httpStatus(404, "Not found")  // 1:1 with the HTTP 404
         }
         return detail

--- a/native/MediFlowMac/Sources/MediFlowAppleShared/LocalPatientsDataSource.swift
+++ b/native/MediFlowMac/Sources/MediFlowAppleShared/LocalPatientsDataSource.swift
@@ -39,6 +39,7 @@ public actor LocalPatientsDataSource: HomeBasePatientsDataSource {
             includeDeleted: includeDeleted)
     }
 
+    /* @Codex */
     public func fetchPatient(
         id: String, credentials: HomeBasePairedCredentials, sessionCookie: String, ambulatoryId: String?
     ) async throws -> HomeBasePatientDetail {

--- a/native/MediFlowMac/Sources/MediFlowCore/SQLitePatientStore.swift
+++ b/native/MediFlowMac/Sources/MediFlowCore/SQLitePatientStore.swift
@@ -111,6 +111,7 @@ public struct SQLitePatientStore {
     }
 
     /// Decrypted convenience retained for direct core consumers and tests.
+    /* @Codex */
     public func loadPatientDetail(
         id: String, scopeAmbulatoryId: String? = nil, masterKey: SymmetricKey
     ) throws -> HomeBasePatientDetail? {
@@ -118,6 +119,7 @@ public struct SQLitePatientStore {
         return PatientFieldCrypto.decryptDetail(raw, masterKey: masterKey)
     }
 
+    /* @Codex */
     private func loadPatientDetailRow(
         id: String, scopeAmbulatoryId: String?
     ) throws -> HomeBasePatientDetail? {

--- a/native/MediFlowMac/Sources/MediFlowCore/SQLitePatientStore.swift
+++ b/native/MediFlowMac/Sources/MediFlowCore/SQLitePatientStore.swift
@@ -102,12 +102,24 @@ public struct SQLitePatientStore {
         }
     }
 
-    /// One patient's full detail with the ENCRYPTED_FIELDS decrypted by the operator
-    /// master key. nil when the id is absent, soft-deleted, or (when a scope is given)
-    /// the patient is not a member of it - 1:1 with getNetworkScopedPatient's membership
-    /// scope. Reuses PatientFieldCrypto so decryption stays byte-identical with the web.
+    /// Raw patient detail with ENC fields untouched, matching the HomeBase HTTP wire.
+    /* @Codex */
+    public func loadRawPatientDetail(
+        id: String, scopeAmbulatoryId: String? = nil
+    ) throws -> HomeBasePatientDetail? {
+        try loadPatientDetailRow(id: id, scopeAmbulatoryId: scopeAmbulatoryId)
+    }
+
+    /// Decrypted convenience retained for direct core consumers and tests.
     public func loadPatientDetail(
         id: String, scopeAmbulatoryId: String? = nil, masterKey: SymmetricKey
+    ) throws -> HomeBasePatientDetail? {
+        guard let raw = try loadPatientDetailRow(id: id, scopeAmbulatoryId: scopeAmbulatoryId) else { return nil }
+        return PatientFieldCrypto.decryptDetail(raw, masterKey: masterKey)
+    }
+
+    private func loadPatientDetailRow(
+        id: String, scopeAmbulatoryId: String?
     ) throws -> HomeBasePatientDetail? {
         let db = try SQLiteConnection(readOnlyPath: path)
         try db.assertSchema(table: "patients", requiredColumns: Self.patientRequiredColumns)
@@ -135,8 +147,7 @@ public struct SQLitePatientStore {
                 createdAt: row.date(13), updatedAt: row.date(14),
                 deletedAt: row.date(21), deletionReason: row.text(22))
         }
-        guard let raw = rows.first else { return nil }
-        return PatientFieldCrypto.decryptDetail(raw, masterKey: masterKey)
+        return rows.first
     }
 
     // MARK: Write path (reversed flow: the core is the on-device write authority)

--- a/native/MediFlowMac/Tests/MediFlowAppleSharedTests/LocalPatientsDataSourceTests.swift
+++ b/native/MediFlowMac/Tests/MediFlowAppleSharedTests/LocalPatientsDataSourceTests.swift
@@ -38,11 +38,12 @@ final class LocalPatientsDataSourceTests: XCTestCase {
         XCTAssertTrue(outOfScope.isEmpty)
     }
 
-    func testFetchPatientDecryptsLocally() async throws {
+    func testFetchPatientPreservesRawEncryptedFieldsForModelParity() async throws {
         let detail = try await makeSource().fetchPatient(
             id: "fixture-1", credentials: credentials, sessionCookie: "", ambulatoryId: "AMB-1")
         XCTAssertEqual(detail.firstName, "Mario")
-        XCTAssertEqual(detail.address, "Via Roma 1, Milano")  // decrypted in-core, no HTTP
+        XCTAssertTrue(detail.address?.hasPrefix(CryptoService.encPrefix) == true)
+        XCTAssertEqual(PatientFieldCrypto.decryptStringField(detail.address, masterKey: masterKey), "Via Roma 1, Milano")
     }
 
     /* @Codex */
@@ -243,7 +244,8 @@ final class LocalPatientsDataSourceTests: XCTestCase {
         // Persisted locally + decrypts to the plaintext (no double-encryption).
         let detail = try await source.fetchPatient(
             id: "fixture-1", credentials: credentials, sessionCookie: "", ambulatoryId: "AMB-1")
-        XCTAssertEqual(detail.address, "Via Nuova 5")
+        XCTAssertTrue(detail.address?.hasPrefix(CryptoService.encPrefix) == true)
+        XCTAssertEqual(PatientFieldCrypto.decryptStringField(detail.address, masterKey: masterKey), "Via Nuova 5")
         XCTAssertEqual(detail.version, 2)
     }
 
@@ -283,7 +285,8 @@ final class LocalPatientsDataSourceTests: XCTestCase {
         XCTAssertTrue(list.contains { $0.id == created.id && $0.lastName == "Paziente" })
         let detail = try await source.fetchPatient(
             id: created.id, credentials: credentials, sessionCookie: "", ambulatoryId: "AMB-1")
-        XCTAssertEqual(detail.address, "Via Test 1")
+        XCTAssertTrue(detail.address?.hasPrefix(CryptoService.encPrefix) == true)
+        XCTAssertEqual(PatientFieldCrypto.decryptStringField(detail.address, masterKey: masterKey), "Via Test 1")
         XCTAssertEqual(detail.taxCode, "NVOPZT80A01H501Z")
     }
 

--- a/native/MediFlowMac/Tests/MediFlowAppleSharedTests/LocalPatientsDataSourceTests.swift
+++ b/native/MediFlowMac/Tests/MediFlowAppleSharedTests/LocalPatientsDataSourceTests.swift
@@ -38,10 +38,12 @@ final class LocalPatientsDataSourceTests: XCTestCase {
         XCTAssertTrue(outOfScope.isEmpty)
     }
 
+    /* @Codex */
     func testFetchPatientPreservesRawEncryptedFieldsForModelParity() async throws {
         let detail = try await makeSource().fetchPatient(
             id: "fixture-1", credentials: credentials, sessionCookie: "", ambulatoryId: "AMB-1")
         XCTAssertEqual(detail.firstName, "Mario")
+        /* @Codex */
         XCTAssertTrue(detail.address?.hasPrefix(CryptoService.encPrefix) == true)
         XCTAssertEqual(PatientFieldCrypto.decryptStringField(detail.address, masterKey: masterKey), "Via Roma 1, Milano")
     }
@@ -244,6 +246,7 @@ final class LocalPatientsDataSourceTests: XCTestCase {
         // Persisted locally + decrypts to the plaintext (no double-encryption).
         let detail = try await source.fetchPatient(
             id: "fixture-1", credentials: credentials, sessionCookie: "", ambulatoryId: "AMB-1")
+        /* @Codex */
         XCTAssertTrue(detail.address?.hasPrefix(CryptoService.encPrefix) == true)
         XCTAssertEqual(PatientFieldCrypto.decryptStringField(detail.address, masterKey: masterKey), "Via Nuova 5")
         XCTAssertEqual(detail.version, 2)
@@ -285,6 +288,7 @@ final class LocalPatientsDataSourceTests: XCTestCase {
         XCTAssertTrue(list.contains { $0.id == created.id && $0.lastName == "Paziente" })
         let detail = try await source.fetchPatient(
             id: created.id, credentials: credentials, sessionCookie: "", ambulatoryId: "AMB-1")
+        /* @Codex */
         XCTAssertTrue(detail.address?.hasPrefix(CryptoService.encPrefix) == true)
         XCTAssertEqual(PatientFieldCrypto.decryptStringField(detail.address, masterKey: masterKey), "Via Test 1")
         XCTAssertEqual(detail.taxCode, "NVOPZT80A01H501Z")

--- a/native/MediFlowMac/Tests/MediFlowAppleSharedTests/PairedPatientsWorkspaceModelLifecycleTests.swift
+++ b/native/MediFlowMac/Tests/MediFlowAppleSharedTests/PairedPatientsWorkspaceModelLifecycleTests.swift
@@ -129,6 +129,7 @@ final class PairedPatientsWorkspaceModelLifecycleTests: XCTestCase {
         }
     }
 
+    /* @Codex */
     func testLockedPatientFieldsStayEmptyAndAreOmittedFromUpdate() async throws {
         let locked = try XCTUnwrap(CryptoService.encryptField(
             CryptoService.jsonEncode("dato protetto")!, masterKey: SymmetricKey(size: .bits256)))
@@ -412,6 +413,7 @@ final class PairedPatientsWorkspaceModelLifecycleTests: XCTestCase {
         )
     }
 
+    /* @Codex */
     private func detail(
         id: String,
         archived: Bool,

--- a/native/MediFlowMac/Tests/MediFlowAppleSharedTests/PairedPatientsWorkspaceModelLifecycleTests.swift
+++ b/native/MediFlowMac/Tests/MediFlowAppleSharedTests/PairedPatientsWorkspaceModelLifecycleTests.swift
@@ -129,6 +129,33 @@ final class PairedPatientsWorkspaceModelLifecycleTests: XCTestCase {
         }
     }
 
+    func testLockedPatientFieldsStayEmptyAndAreOmittedFromUpdate() async throws {
+        let locked = try XCTUnwrap(CryptoService.encryptField(
+            CryptoService.jsonEncode("dato protetto")!, masterKey: SymmetricKey(size: .bits256)))
+        let remote = detail(id: "p1", archived: false, version: 1, encryptedValue: locked)
+        let source = LifecycleMockDataSource(details: ["p1": remote])
+        let model = await makeModel(source: source)
+        await model.configurePairedOnlineForTests(masterKey: masterKey)
+
+        await model.loadPatient(summary(id: "p1", archived: false, version: 1))
+        await model.startEditingPatient()
+
+        let expected: Set<PairedPatientsWorkspaceModel.EncryptedPatientField> = [
+            .address, .phone, .caregiver, .notes, .diagnoses, .exemptions,
+        ]
+        let lockedFields = await model.lockedPatientFields
+        XCTAssertEqual(lockedFields, expected)
+        let address = await model.editPatientAddress
+        XCTAssertTrue(address.isEmpty)
+
+        await model.savePatient()
+        let capturedUpdate = await source.lastUpdate
+        let payload = try XCTUnwrap(capturedUpdate?.payload)
+        for field in [payload.address, payload.phone, payload.caregiver, payload.notes, payload.diagnoses, payload.exemptions] {
+            guard case .omit = field else { return XCTFail("every locked encrypted field must be omitted") }
+        }
+    }
+
     func testRestoreUsesTombstoneVersionAndReloadsTrash() async throws {
         let deleted = summary(id: "p1", archived: false, version: 5, deleted: true, reason: "web-delete")
         let source = LifecycleMockDataSource(summaries: [deleted])
@@ -389,7 +416,8 @@ final class PairedPatientsWorkspaceModelLifecycleTests: XCTestCase {
         id: String,
         archived: Bool,
         version: Int,
-        deleted: Bool = false
+        deleted: Bool = false,
+        encryptedValue: String? = nil
     ) -> HomeBasePatientDetail {
         HomeBasePatientDetail(
             id: id,
@@ -397,14 +425,14 @@ final class PairedPatientsWorkspaceModelLifecycleTests: XCTestCase {
             lastName: "Rossi",
             birthDate: nil,
             taxCode: "RSSMRA80A01H501U",
-            address: nil,
-            phone: nil,
-            caregiver: nil,
-            exemptions: nil,
-            diagnoses: nil,
+            address: encryptedValue,
+            phone: encryptedValue,
+            caregiver: encryptedValue,
+            exemptions: encryptedValue,
+            diagnoses: encryptedValue,
             monitoringProfile: nil,
             statusReason: nil,
-            notes: nil,
+            notes: encryptedValue,
             aiSummary: nil,
             documentInsights: nil,
             isAdi: false,

--- a/native/MediFlowMac/Tests/MediFlowCoreTests/SQLitePatientStoreTests.swift
+++ b/native/MediFlowMac/Tests/MediFlowCoreTests/SQLitePatientStoreTests.swift
@@ -52,6 +52,13 @@ final class SQLitePatientStoreTests: XCTestCase {
         XCTAssertEqual(diagnoses.first?.system, "ICD-10")
     }
 
+    /* @Codex */
+    func testLoadRawPatientDetailPreservesCiphertext() throws {
+        let raw = try XCTUnwrap(try SQLitePatientStore(path: fixturePath()).loadRawPatientDetail(id: "fixture-1"))
+        XCTAssertTrue(raw.address?.hasPrefix(CryptoService.encPrefix) == true)
+        XCTAssertEqual(PatientFieldCrypto.decryptStringField(raw.address, masterKey: masterKey), "Via Roma 1, Milano")
+    }
+
     func testLoadPatientDetailMissingIdReturnsNil() throws {
         let store = SQLitePatientStore(path: fixturePath())
         XCTAssertNil(try store.loadPatientDetail(id: "does-not-exist", masterKey: masterKey))


### PR DESCRIPTION
## Summary
- Mantiene raw ENC parity tra SQLite locale e HomeBase HTTP.
- Conserva in RAM lo stato locked dei sei campi paziente cifrati editabili e usa PatchValue.omit nei salvataggi.
- Disabilita i controlli SwiftUI locked con copy PHI-safe, senza mostrare ciphertext.
- Aggiunge copertura store, datasource, lifecycle/model e XCUITest.
- Completa la attribuzione Codex obbligatoria sui blocchi introdotti. Diff: 232 LOC gross.

## Verification
- Focused SwiftPM: 76 test, 0 failure.
- Full SwiftPM: 338 test, 0 failure; inclusi HomeBaseDateCoding e crypto golden vectors.
- Swift build: PASS, incluso rerun dopo i marker di attribuzione.
- Xcode beta macOS build, scheme MediFlowMacApp, CODE_SIGNING_ALLOWED=NO: PASS.
- Xcode beta iOS Simulator build, scheme MediFlowMobileApp, CODE_SIGNING_ALLOWED=NO: PASS.
- XCUITest testEditPatientFormDisablesLockedFieldWithoutShowingCiphertext su iPhone 17 Pro: PASS.
- git diff --check: PASS.
- Independent read-only correctness review: nessun P1/P2.
- Final independent attribution audit: clean.

## Risk / Notes
- Nessuna modifica a PatientFieldCrypto foundation, CryptoService, HomeBaseDateCoding, formato ENC, API/OpenAPI, schema o dipendenze.
- Nessuna PHI/PII o dato paziente reale usato.
- Il ciphertext resta solo nel valore locked RAM-only e non viene mostrato, loggato o cacheato.
- PR pronta per review; nessun merge eseguito.

## Ticket
Refs WUL-495