### PR TITLE
refactor(ai): estrai il prompt document synthesis

### DIFF
--- a/lib/ai-task-contract-prompts.ts
+++ b/lib/ai-task-contract-prompts.ts
@@ -178,3 +178,104 @@ export function buildSmartImportExtractionPrompt(payload: unknown): string {
         JSON.stringify(payload, null, 2),
     );
 }
+
+export function buildDocumentSynthesisExtractionPrompt(rawText: string): string {
+    return buildExtractionPrompt(
+        'document_synthesis',
+        [
+            'Sei un assistente clinico locale.',
+            'Ricevi testo OCR grezzo di un documento medico italiano e devi estrarre solo dati supportati dal testo.',
+        ].join('\n'),
+        `{
+    "qualityLevel": "green|yellow|red",
+    "qualityReason": "motivo sintetico della valutazione",
+    "medications": [
+      "farmaco o principio attivo esplicitamente presente nel documento, con posologia se esplicita"
+    ],
+    "diagnoses": [
+      {
+        "code": "codice ICD esplicito nel documento",
+        "description": "descrizione clinica associata",
+        "system": "ICD-9|ICD-10|ICD-11",
+        "evidence": "breve citazione/parafrasi locale del passaggio rilevante",
+        "confidence": "high|medium|low"
+      }
+    ],
+    "problemStatements": [
+      {
+        "label": "problema clinico in italiano",
+        "icdQuery": "query breve in inglese per ICD-11",
+        "confidence": "high|medium|low",
+        "evidence": "breve evidenza testuale locale"
+      }
+    ],
+    "therapyCandidates": [
+      {
+        "drugMention": "farmaco o principio attivo menzionato",
+        "drugQuery": "chiave breve per catalogo AIFA",
+        "activePrinciple": "principio attivo se disponibile",
+        "dosage": "posologia se disponibile",
+        "motivation": "indicazione o contesto clinico se disponibile",
+        "therapyState": "active|transition|uncertain|inactive",
+        "reviewNote": "motivo breve se non immediatamente applicabile",
+        "confidence": "high|medium|low",
+        "evidence": "breve evidenza testuale locale"
+      }
+    ],
+    "servicePrescriptions": [
+      {
+        "serviceName": "visita, esame, imaging, riabilitazione, screening o procedura prescritta",
+        "category": "lab|imaging|visit|rehab|screening|procedure|other",
+        "priority": "priorita se esplicita",
+        "codeSystem": "sistema di codifica se esplicito",
+        "serviceCode": "codice prestazione se esplicito",
+        "clinicalQuestion": "quesito o motivazione se esplicita",
+        "provider": "struttura o specialita se esplicita",
+        "prescribedAt": "data prescrizione se esplicita",
+        "requestReference": "riferimento impegnativa se esplicito",
+        "confidence": "high|medium|low",
+        "evidence": "breve evidenza testuale locale",
+        "items": [
+          {
+            "serviceName": "singolo atto richiesto, es. EMOCROMO o AST",
+            "category": "lab|imaging|visit|rehab|screening|procedure|other",
+            "codeSystem": "sistema di codifica se esplicito",
+            "serviceCode": "codice del singolo atto se esplicito",
+            "confidence": "high|medium|low",
+            "evidence": "evidenza atomica del singolo atto"
+          }
+        ]
+      }
+    ]
+  }`,
+        [
+            'qualityLevel usa green se il contenuto OCR e chiaro, yellow se ambiguo o parziale, red se insufficiente o rumoroso',
+            'summary deve essere un riassunto clinico conciso in plain text, senza markdown',
+            'summary massimo 2 frasi brevi e non oltre 220 caratteri circa',
+            'in medications includi solo terapie esplicite e correnti nel testo OCR, senza duplicati e senza presidi, detergenti o indicazioni non farmacologiche',
+            'non inserire in medications o therapyCandidates visite specialistiche, prestazioni, esami, controlli, consulenze, impegnative o referral: sono prescrizioni di prestazione, non farmaci',
+            'se il documento e una ricetta/impegnativa per prestazione specialistica, usa servicePrescriptions e lascia medications e therapyCandidates vuoti salvo farmaci espliciti separati',
+            'in servicePrescriptions includi visite specialistiche, laboratorio, imaging, riabilitazione, screening o procedure prescritte; non copiarle in medications o therapyCandidates',
+            'se una richiesta contiene un pannello o piu prestazioni, mantieni il contenitore in serviceName e spacchetta i singoli atti in items, uno per riga clinicamente distinta',
+            'per esami ematochimici esplicita items separati come EMOCROMO, D-DIMERO, LDH, AST, ALT, VITAMINA D quando presenti nel testo; non inventare atti non citati',
+            'in diagnoses includi solo patologie con codice ICD esplicito nel testo OCR; se il documento non riporta codici espliciti restituisci diagnoses come array vuoto e non inventare placeholder o code vuoti',
+            'in problemStatements includi solo patologie attuali, attive o clinicamente rilevanti per la gestione corrente anche se prive di codice esplicito',
+            'problemStatements deve usare label in italiano clinico sintetico e icdQuery breve in inglese',
+            'escludi negazioni, familiarita, anamnesi remota risolta, counselling generico e fattori di rischio non trattati come problema clinico attivo',
+            'in therapyCandidates includi preferibilmente farmaci attivi con posologia esplicita; se la posologia manca non inventarla',
+            'drugQuery deve essere una chiave breve per il catalogo AIFA, preferendo brand o principio attivo con strength se esplicita',
+            'se il documento contiene sezioni come terapia alla dimissione o terapia domiciliare, privilegia quelle rispetto ai farmaci descritti solo durante il ricovero',
+            'non marcare active antibiotici, profilassi, nutrizione enterale o terapie di degenza se non ricompaiono nella terapia alla dimissione o domiciliare',
+            'se una terapia domiciliare pre-ricovero sembra sostituita da una nuova terapia alla dimissione nello stesso ambito terapeutico, usa transition o uncertain per la terapia precedente',
+            'se una terapia ha durata breve, data di stop, oppure testo come fino al, poi stop, sospendere, usa transition o inactive invece di active',
+            'massimo 6 medications, massimo 4 problemStatements, massimo 6 therapyCandidates e massimo 10 servicePrescriptions; se il documento contiene piu elementi tieni solo quelli piu correnti e clinicamente utili',
+            'se una terapia e solo proposta, in switch o da confermare, usa therapyState transition o uncertain invece di active',
+            'evidence deve restare atomica e riferita al singolo problema o farmaco',
+            'non inventare posologie, farmaci o codici mancanti',
+            'mantieni le stringhe molto compatte per restare entro il budget di output',
+            'massimo 4 diagnosi con codice esplicito, massimo 4 problemStatements e massimo 6 therapyCandidates',
+        ],
+        'DOCUMENTO OCR',
+        rawText,
+    );
+}

--- a/lib/ai-task-contracts.test.ts
+++ b/lib/ai-task-contracts.test.ts
@@ -483,6 +483,7 @@ test('smart import prompt stays byte-identical through the compatible barrel', (
     assert.equal(createHash('sha256').update(prompt).digest('hex'), 'e0a67ae602f10e8d5e68b4dacfca678bdca72993a0597ebfe77b9bb038c6e430');
 });
 
+/* @Codex */
 test('document synthesis prompt stays byte-identical through the compatible barrel', () => {
     const rawText = 'REFERTO SINTETICO\nNessun dato reale';
     const prompt = buildDocumentSynthesisExtractionPrompt(rawText);

--- a/lib/ai-task-contracts.test.ts
+++ b/lib/ai-task-contracts.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
 import {
     AI_TASK_EXTRACTION_SCHEMA_VERSION,
+    buildDocumentSynthesisExtractionPrompt,
     buildPatientInsightExtractionPrompt,
     buildSmartImportExtractionPrompt,
     parseDocumentSynthesisExtractionResponse,
@@ -11,7 +12,10 @@ import {
     renderPatientInsightMarkdown,
     toPatientInsightRenderContract,
 } from './ai-task-contracts';
-import { buildSmartImportExtractionPrompt as buildSmartImportPromptDirect } from './ai-task-contract-prompts';
+import {
+    buildDocumentSynthesisExtractionPrompt as buildDocumentSynthesisPromptDirect,
+    buildSmartImportExtractionPrompt as buildSmartImportPromptDirect,
+} from './ai-task-contract-prompts';
 
 test('patient insight extraction renders local markdown sections from shared JSON contract', () => {
     const parsed = parsePatientInsightExtractionResponse(JSON.stringify({
@@ -477,6 +481,15 @@ test('smart import prompt stays byte-identical through the compatible barrel', (
     assert.equal(prompt, buildSmartImportPromptDirect(payload));
     assert.equal(Buffer.byteLength(prompt, 'utf8'), 5382);
     assert.equal(createHash('sha256').update(prompt).digest('hex'), 'e0a67ae602f10e8d5e68b4dacfca678bdca72993a0597ebfe77b9bb038c6e430');
+});
+
+test('document synthesis prompt stays byte-identical through the compatible barrel', () => {
+    const rawText = 'REFERTO SINTETICO\nNessun dato reale';
+    const prompt = buildDocumentSynthesisExtractionPrompt(rawText);
+
+    assert.equal(prompt, buildDocumentSynthesisPromptDirect(rawText));
+    assert.equal(Buffer.byteLength(prompt, 'utf8'), 6519);
+    assert.equal(createHash('sha256').update(prompt).digest('hex'), '6f03db526863f776ac3efecaaab4730963eb3be982189a29c3b30292057a2624');
 });
 
 test('document synthesis extraction keeps service prescriptions out of medication lanes', () => {

--- a/lib/ai-task-contracts.ts
+++ b/lib/ai-task-contracts.ts
@@ -1,14 +1,12 @@
 /* @Codex */
 import { filterServicePrescriptionTherapyCandidates, isServicePrescriptionLikeTherapy } from './prescription-boundary';
 import { stripModelArtifacts } from './model-artifacts';
-import {
-    AI_TASK_EXTRACTION_SCHEMA_VERSION,
-    buildExtractionPrompt,
-} from './ai-task-contract-prompts';
+import { AI_TASK_EXTRACTION_SCHEMA_VERSION } from './ai-task-contract-prompts';
 
 /* @Codex */
 export {
     AI_TASK_EXTRACTION_SCHEMA_VERSION,
+    buildDocumentSynthesisExtractionPrompt,
     buildPatientInsightExtractionPrompt,
     buildSmartImportExtractionPrompt,
 } from './ai-task-contract-prompts';
@@ -836,106 +834,4 @@ export function parseDocumentSynthesisExtractionResponse(
             },
         },
     };
-}
-
-
-export function buildDocumentSynthesisExtractionPrompt(rawText: string): string {
-    return buildExtractionPrompt(
-        'document_synthesis',
-        [
-            'Sei un assistente clinico locale.',
-            'Ricevi testo OCR grezzo di un documento medico italiano e devi estrarre solo dati supportati dal testo.',
-        ].join('\n'),
-        `{
-    "qualityLevel": "green|yellow|red",
-    "qualityReason": "motivo sintetico della valutazione",
-    "medications": [
-      "farmaco o principio attivo esplicitamente presente nel documento, con posologia se esplicita"
-    ],
-    "diagnoses": [
-      {
-        "code": "codice ICD esplicito nel documento",
-        "description": "descrizione clinica associata",
-        "system": "ICD-9|ICD-10|ICD-11",
-        "evidence": "breve citazione/parafrasi locale del passaggio rilevante",
-        "confidence": "high|medium|low"
-      }
-    ],
-    "problemStatements": [
-      {
-        "label": "problema clinico in italiano",
-        "icdQuery": "query breve in inglese per ICD-11",
-        "confidence": "high|medium|low",
-        "evidence": "breve evidenza testuale locale"
-      }
-    ],
-    "therapyCandidates": [
-      {
-        "drugMention": "farmaco o principio attivo menzionato",
-        "drugQuery": "chiave breve per catalogo AIFA",
-        "activePrinciple": "principio attivo se disponibile",
-        "dosage": "posologia se disponibile",
-        "motivation": "indicazione o contesto clinico se disponibile",
-        "therapyState": "active|transition|uncertain|inactive",
-        "reviewNote": "motivo breve se non immediatamente applicabile",
-        "confidence": "high|medium|low",
-        "evidence": "breve evidenza testuale locale"
-      }
-    ],
-    "servicePrescriptions": [
-      {
-        "serviceName": "visita, esame, imaging, riabilitazione, screening o procedura prescritta",
-        "category": "lab|imaging|visit|rehab|screening|procedure|other",
-        "priority": "priorita se esplicita",
-        "codeSystem": "sistema di codifica se esplicito",
-        "serviceCode": "codice prestazione se esplicito",
-        "clinicalQuestion": "quesito o motivazione se esplicita",
-        "provider": "struttura o specialita se esplicita",
-        "prescribedAt": "data prescrizione se esplicita",
-        "requestReference": "riferimento impegnativa se esplicito",
-        "confidence": "high|medium|low",
-        "evidence": "breve evidenza testuale locale",
-        "items": [
-          {
-            "serviceName": "singolo atto richiesto, es. EMOCROMO o AST",
-            "category": "lab|imaging|visit|rehab|screening|procedure|other",
-            "codeSystem": "sistema di codifica se esplicito",
-            "serviceCode": "codice del singolo atto se esplicito",
-            "confidence": "high|medium|low",
-            "evidence": "evidenza atomica del singolo atto"
-          }
-        ]
-      }
-    ]
-  }`,
-        [
-            'qualityLevel usa green se il contenuto OCR e chiaro, yellow se ambiguo o parziale, red se insufficiente o rumoroso',
-            'summary deve essere un riassunto clinico conciso in plain text, senza markdown',
-            'summary massimo 2 frasi brevi e non oltre 220 caratteri circa',
-            'in medications includi solo terapie esplicite e correnti nel testo OCR, senza duplicati e senza presidi, detergenti o indicazioni non farmacologiche',
-            'non inserire in medications o therapyCandidates visite specialistiche, prestazioni, esami, controlli, consulenze, impegnative o referral: sono prescrizioni di prestazione, non farmaci',
-            'se il documento e una ricetta/impegnativa per prestazione specialistica, usa servicePrescriptions e lascia medications e therapyCandidates vuoti salvo farmaci espliciti separati',
-            'in servicePrescriptions includi visite specialistiche, laboratorio, imaging, riabilitazione, screening o procedure prescritte; non copiarle in medications o therapyCandidates',
-            'se una richiesta contiene un pannello o piu prestazioni, mantieni il contenitore in serviceName e spacchetta i singoli atti in items, uno per riga clinicamente distinta',
-            'per esami ematochimici esplicita items separati come EMOCROMO, D-DIMERO, LDH, AST, ALT, VITAMINA D quando presenti nel testo; non inventare atti non citati',
-            'in diagnoses includi solo patologie con codice ICD esplicito nel testo OCR; se il documento non riporta codici espliciti restituisci diagnoses come array vuoto e non inventare placeholder o code vuoti',
-            'in problemStatements includi solo patologie attuali, attive o clinicamente rilevanti per la gestione corrente anche se prive di codice esplicito',
-            'problemStatements deve usare label in italiano clinico sintetico e icdQuery breve in inglese',
-            'escludi negazioni, familiarita, anamnesi remota risolta, counselling generico e fattori di rischio non trattati come problema clinico attivo',
-            'in therapyCandidates includi preferibilmente farmaci attivi con posologia esplicita; se la posologia manca non inventarla',
-            'drugQuery deve essere una chiave breve per il catalogo AIFA, preferendo brand o principio attivo con strength se esplicita',
-            'se il documento contiene sezioni come terapia alla dimissione o terapia domiciliare, privilegia quelle rispetto ai farmaci descritti solo durante il ricovero',
-            'non marcare active antibiotici, profilassi, nutrizione enterale o terapie di degenza se non ricompaiono nella terapia alla dimissione o domiciliare',
-            'se una terapia domiciliare pre-ricovero sembra sostituita da una nuova terapia alla dimissione nello stesso ambito terapeutico, usa transition o uncertain per la terapia precedente',
-            'se una terapia ha durata breve, data di stop, oppure testo come fino al, poi stop, sospendere, usa transition o inactive invece di active',
-            'massimo 6 medications, massimo 4 problemStatements, massimo 6 therapyCandidates e massimo 10 servicePrescriptions; se il documento contiene piu elementi tieni solo quelli piu correnti e clinicamente utili',
-            'se una terapia e solo proposta, in switch o da confermare, usa therapyState transition o uncertain invece di active',
-            'evidence deve restare atomica e riferita al singolo problema o farmaco',
-            'non inventare posologie, farmaci o codici mancanti',
-            'mantieni le stringhe molto compatte per restare entro il budget di output',
-            'massimo 4 diagnosi con codice esplicito, massimo 4 problemStatements e massimo 6 therapyCandidates',
-        ],
-        'DOCUMENTO OCR',
-        rawText,
-    );
 }


### PR DESCRIPTION
## Summary
- Estrae builder, schema fragment e regole del prompt document synthesis in `lib/ai-task-contract-prompts.ts`.
- Mantiene `lib/ai-task-contracts.ts` come barrel pubblico compatibile.
- Aggiunge una prova diretta di uguaglianza tra modulo e barrel, con byte e SHA-256 canonici.
- Marca il nuovo test con `/* @Codex */` secondo la policy repository.
- Non modifica consumer, parser, normalizer, envelope o comportamento runtime/modello AI.

## Verification
- `npm run test:ai-task-contracts` — 23/23, rieseguito sul nuovo head `0f3526ad5`
- `npm run test:document-synthesis` — 28/28
- `npm run test:unit` — 621/621
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `git diff --check`
- Patient Insight: 5286 byte, SHA-256 `e4150b764f8581ba6478cd89c0b33fd22d66f47798cf916a3e31478971f8547b`
- Smart Import: 5382 byte, SHA-256 `e0a67ae602f10e8d5e68b4dacfca678bdca72993a0597ebfe77b9bb038c6e430`
- Document synthesis: 6519 byte, SHA-256 `6f03db526863f776ac3efecaaab4730963eb3be982189a29c3b30292057a2624`
- Review indipendente read-only: CLEAN, nessun P1/P2

## Risk / Notes
- Diff lordo: 225 LOC (118 aggiunte, 107 rimozioni), sotto il cap 240.
- Nessun impatto su API, dipendenze, schema, migrazioni o dati.
- Nessuna PHI/PII, dato paziente reale o artefatto privato.
- PR preparata per review; merge e chiusura issue non eseguiti.

## Ticket
Refs WUL-493