### PR TITLE
perf(ui): limita autocomplete farmaci alla ricerca server

### DIFF
--- a/components/drug-autocomplete.tsx
+++ b/components/drug-autocomplete.tsx
@@ -83,7 +83,7 @@ export default function DrugAutocomplete({ onSelect, placeholder = "Cerca per no
     }, [wrapperRef]);
 
     const handleSelect = (drug: AifaDrug) => {
-        commitDrugAutocompleteQueryChange(drugSearch, setQuery, drug.name); // @Codex WUL-488
+        commitDrugAutocompleteQueryChange(drugSearch, setQuery, drug.name, () => setIsLoading(false)); // @Codex WUL-488
         setIsOpen(false);
         setActiveIndex(-1);
         onSelect(drug);

--- a/components/drug-autocomplete.tsx
+++ b/components/drug-autocomplete.tsx
@@ -1,7 +1,11 @@
 'use client';
 
 import { useState, useRef, useEffect, useId } from 'react';
-import { db, AifaDrug } from '@/lib/db';
+import type { AifaDrug } from '@/lib/db';
+import {
+    commitDrugAutocompleteQueryChange,
+    createDrugAutocompleteSearch,
+} from '@/lib/drug-autocomplete-search';
 import { Search, X, Pill, Database, Activity } from 'lucide-react';
 
 interface DrugAutocompleteProps {
@@ -25,6 +29,7 @@ export default function DrugAutocomplete({ onSelect, placeholder = "Cerca per no
     const listboxId = useId();
     const optionId = (index: number) => `${listboxId}-opt-${index}`;
     const wrapperRef = useRef<HTMLDivElement>(null);
+    const [drugSearch] = useState(() => createDrugAutocompleteSearch()); // @Codex WUL-488
     /* @Codex WUL-UIUX: in modifica il campo parte con defaultValue (nome farmaco):
        non deve far partire una ricerca ne aprire il popover finche il medico non
        digita davvero. */
@@ -32,62 +37,39 @@ export default function DrugAutocomplete({ onSelect, placeholder = "Cerca per no
 
     // Debounce search
     useEffect(() => {
-        if (!hasUserTyped.current) return;
+        drugSearch.abort(); // @Codex WUL-488
+        if (!hasUserTyped.current) return () => drugSearch.abort();
         const timer = setTimeout(async () => {
             const tokens = query.trim().split(/\s+/).filter(t => t.length > 0);
 
             if (tokens.length > 0 && tokens[0].length > 2) {
                 setIsLoading(true);
                 try {
-                    // 1. Efficient DB Fetch using ONLY the first token
-                    const firstToken = tokens[0].toLowerCase();
-
-                    const allDrugs = await db.drugs.toArray();
-                    const candidateByAic = new Map<string, AifaDrug>();
-                    let nameMatchCount = 0;
-                    let principleMatchCount = 0;
-
-                    for (const drug of allDrugs) {
-                        if (nameMatchCount < 50 && drug.name.toLowerCase().startsWith(firstToken)) {
-                            candidateByAic.set(drug.aic, drug);
-                            nameMatchCount += 1;
-                        }
-                        if (
-                            principleMatchCount < 50 &&
-                            drug.activePrinciple?.toLowerCase().startsWith(firstToken)
-                        ) {
-                            candidateByAic.set(drug.aic, drug);
-                            principleMatchCount += 1;
-                        }
-                        if (nameMatchCount >= 50 && principleMatchCount >= 50) break;
-                    }
-
-                    const unique = Array.from(candidateByAic.values());
-
-                    // 3. Smart Filtering: Check if ALL tokens match anywhere in the drug data
-                    // This allows searching for "Depakin 500" where "500" might be in the packaging
-                    const filtered = unique.filter(drug => {
-                        const searchString = `${drug.name} ${drug.activePrinciple} ${drug.packaging || ''}`.toLowerCase();
-                        return tokens.every(token => searchString.includes(token.toLowerCase()));
-                    }).slice(0, 30); // Limit final display
-
-                    setResults(filtered);
+                    const matches = await drugSearch.run(query.trim()); // @Codex WUL-488
+                    if (matches === null) return;
+                    setResults(matches);
                     setActiveIndex(-1);
                     setIsOpen(true);
+                    setIsLoading(false);
                 } catch (e) {
                     console.error("Drug search error", e);
-                } finally {
                     setIsLoading(false);
                 }
             } else if (tokens.length === 0) {
                 setResults([]);
                 setActiveIndex(-1);
                 setIsOpen(false);
+                setIsLoading(false);
+            } else {
+                setIsLoading(false);
             }
         }, 300);
 
-        return () => clearTimeout(timer);
-    }, [query]);
+        return () => {
+            clearTimeout(timer);
+            drugSearch.abort();
+        };
+    }, [drugSearch, query]);
 
     // Handle outside click
     useEffect(() => {
@@ -101,7 +83,7 @@ export default function DrugAutocomplete({ onSelect, placeholder = "Cerca per no
     }, [wrapperRef]);
 
     const handleSelect = (drug: AifaDrug) => {
-        setQuery(drug.name);
+        commitDrugAutocompleteQueryChange(drugSearch, setQuery, drug.name); // @Codex WUL-488
         setIsOpen(false);
         setActiveIndex(-1);
         onSelect(drug);
@@ -147,7 +129,7 @@ export default function DrugAutocomplete({ onSelect, placeholder = "Cerca per no
                     value={query}
                     onChange={(e) => {
                         hasUserTyped.current = true;
-                        setQuery(e.target.value);
+                        commitDrugAutocompleteQueryChange(drugSearch, setQuery, e.target.value); // @Codex WUL-488
                     }}
                     onKeyDown={handleKeyDown}
                     placeholder={placeholder}
@@ -164,7 +146,7 @@ export default function DrugAutocomplete({ onSelect, placeholder = "Cerca per no
                 {!isLoading && query && (
                     <button
                         type="button"
-                        onClick={() => setQuery('')}
+                        onClick={() => commitDrugAutocompleteQueryChange(drugSearch, setQuery, '')} // @Codex WUL-488
                         className="absolute right-2 top-1/2 inline-flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-full text-[color:var(--mf-muted)] transition-colors hover:bg-[color:rgba(248,250,252,0.86)] hover:text-[color:var(--mf-ink)] dark:hover:bg-white/8"
                         style={{ color: 'var(--mf-muted)' }}
                         title="Cancella ricerca"

--- a/lib/drug-autocomplete-search.test.ts
+++ b/lib/drug-autocomplete-search.test.ts
@@ -1,0 +1,63 @@
+/* @Codex */
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { AifaDrug } from './db';
+import {
+    commitDrugAutocompleteQueryChange,
+    createDrugAutocompleteSearch,
+    fetchDrugAutocomplete,
+} from './drug-autocomplete-search';
+
+function jsonResponse(body: unknown): Response {
+    return new Response(JSON.stringify(body), { status: 200 });
+}
+
+test('production helper sends the full query, preserves payloads, and caps results at 30', async () => {
+    let requestedUrl = '';
+    const candidates = Array.from({ length: 35 }, (_, index): AifaDrug => ({
+        aic: String(index).padStart(9, '0'),
+        name: `Farmaco ${index}`,
+        activePrinciple: 'Principio sintetico',
+        packaging: '500 mg compresse',
+        company: 'Azienda sintetica',
+        price: 1234,
+    }));
+    const fetchImpl: typeof fetch = async (input) => {
+        requestedUrl = String(input);
+        return jsonResponse(candidates);
+    };
+
+    const results = await fetchDrugAutocomplete('  Farmaco principio 500  ', new AbortController().signal, fetchImpl);
+
+    assert.equal(requestedUrl, '/api/drugs?q=Farmaco%20principio%20500');
+    assert.equal(results.length, 30);
+    assert.deepEqual(results[0], candidates[0]);
+});
+
+test('coordinator aborts the prior request and suppresses its stale response', async () => {
+    const pending: Array<{ signal: AbortSignal; resolve: (response: Response) => void }> = [];
+    const fetchImpl: typeof fetch = async (_input, init) => new Promise<Response>((resolve) => {
+        pending.push({ signal: init?.signal as AbortSignal, resolve });
+    });
+    const search = createDrugAutocompleteSearch(fetchImpl);
+
+    const first = search.run('Primo farmaco');
+    let committedQuery = '';
+    commitDrugAutocompleteQueryChange(search, (value) => { committedQuery = value; }, 'Secondo farmaco');
+    assert.equal(committedQuery, 'Secondo farmaco');
+    assert.equal(pending[0].signal.aborted, true);
+
+    const second = search.run('Secondo farmaco');
+
+    pending[1].resolve(jsonResponse([{ aic: '2', name: 'Secondo farmaco' }]));
+    assert.deepEqual(await second, [{ aic: '2', name: 'Secondo farmaco' }]);
+
+    pending[0].resolve(jsonResponse([{ aic: '1', name: 'Primo farmaco' }]));
+    assert.equal(await first, null);
+
+    const unmounted = search.run('Terzo farmaco');
+    search.abort();
+    assert.equal(pending[2].signal.aborted, true);
+    pending[2].resolve(jsonResponse([{ aic: '3', name: 'Terzo farmaco' }]));
+    assert.equal(await unmounted, null);
+});

--- a/lib/drug-autocomplete-search.test.ts
+++ b/lib/drug-autocomplete-search.test.ts
@@ -12,6 +12,25 @@ function jsonResponse(body: unknown): Response {
     return new Response(JSON.stringify(body), { status: 200 });
 }
 
+test('production helper notifies auth failures without exposing the query or notifying on 5xx', async (t) => {
+    const notified: number[] = [];
+    const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+    Object.defineProperty(globalThis, 'window', { configurable: true, value: {
+        dispatchEvent: (event: CustomEvent<{ status: number }>) => notified.push(event.detail.status),
+    } });
+    t.after(() => originalWindow
+        ? Object.defineProperty(globalThis, 'window', originalWindow)
+        : Reflect.deleteProperty(globalThis, 'window'));
+
+    for (const status of [401, 403, 500]) {
+        await assert.rejects(
+            fetchDrugAutocomplete('query-riservata', new AbortController().signal, async () => new Response(null, { status })),
+            (error: unknown) => error instanceof Error && !error.message.includes('query-riservata'),
+        );
+    }
+    assert.deepEqual(notified, [401, 403]);
+});
+
 test('production helper sends the full query, preserves payloads, and caps results at 30', async () => {
     let requestedUrl = '';
     const candidates = Array.from({ length: 35 }, (_, index): AifaDrug => ({
@@ -53,11 +72,15 @@ test('coordinator aborts the prior request and suppresses its stale response', a
     assert.deepEqual(await second, [{ aic: '2', name: 'Secondo farmaco' }]);
 
     pending[0].resolve(jsonResponse([{ aic: '1', name: 'Primo farmaco' }]));
-    assert.equal(await first, null);
+    let newerLoading = true;
+    if (await first !== null) newerLoading = false;
+    assert.equal(newerLoading, true);
 
-    const unmounted = search.run('Terzo farmaco');
-    search.abort();
+    const selected = search.run('Secondo farmaco');
+    let isLoading = true;
+    commitDrugAutocompleteQueryChange(search, () => {}, 'Secondo farmaco', () => { isLoading = false; });
+    assert.equal(isLoading, false);
     assert.equal(pending[2].signal.aborted, true);
-    pending[2].resolve(jsonResponse([{ aic: '3', name: 'Terzo farmaco' }]));
-    assert.equal(await unmounted, null);
+    pending[2].resolve(jsonResponse([{ aic: '2', name: 'Secondo farmaco' }]));
+    assert.equal(await selected, null);
 });

--- a/lib/drug-autocomplete-search.ts
+++ b/lib/drug-autocomplete-search.ts
@@ -1,4 +1,5 @@
 import type { AifaDrug } from '@/lib/db';
+import { isApiTableAuthUnavailableStatus, notifyApiAuthUnavailable } from '@/lib/api-table-response';
 
 const RESULT_LIMIT = 30;
 type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
@@ -10,7 +11,10 @@ export async function fetchDrugAutocomplete(
     fetchImpl: FetchLike = fetch,
 ): Promise<AifaDrug[]> {
     const response = await fetchImpl(`/api/drugs?q=${encodeURIComponent(query.trim())}`, { signal });
-    if (!response.ok) throw new Error(`Drug search failed with status ${response.status}`);
+    if (!response.ok) {
+        if (isApiTableAuthUnavailableStatus(response.status)) notifyApiAuthUnavailable(response.status);
+        throw new Error(`Drug search failed with status ${response.status}`);
+    }
 
     const payload: unknown = await response.json();
     if (!Array.isArray(payload)) throw new Error('Drug search returned an invalid payload');
@@ -50,7 +54,9 @@ export function commitDrugAutocompleteQueryChange(
     search: Pick<ReturnType<typeof createDrugAutocompleteSearch>, 'abort'>,
     commit: (value: string) => void,
     value: string,
+    afterAbort?: () => void,
 ) {
     search.abort();
+    afterAbort?.();
     commit(value);
 }

--- a/lib/drug-autocomplete-search.ts
+++ b/lib/drug-autocomplete-search.ts
@@ -1,0 +1,56 @@
+import type { AifaDrug } from '@/lib/db';
+
+const RESULT_LIMIT = 30;
+type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+/* @Codex WUL-488 */
+export async function fetchDrugAutocomplete(
+    query: string,
+    signal: AbortSignal,
+    fetchImpl: FetchLike = fetch,
+): Promise<AifaDrug[]> {
+    const response = await fetchImpl(`/api/drugs?q=${encodeURIComponent(query.trim())}`, { signal });
+    if (!response.ok) throw new Error(`Drug search failed with status ${response.status}`);
+
+    const payload: unknown = await response.json();
+    if (!Array.isArray(payload)) throw new Error('Drug search returned an invalid payload');
+    return (payload as AifaDrug[]).slice(0, RESULT_LIMIT);
+}
+
+/* @Codex WUL-488 */
+export function createDrugAutocompleteSearch(fetchImpl: FetchLike = fetch) {
+    let revision = 0;
+    let activeController: AbortController | null = null;
+
+    return {
+        async run(query: string): Promise<AifaDrug[] | null> {
+            const currentRevision = ++revision;
+            activeController?.abort();
+            const controller = new AbortController();
+            activeController = controller;
+
+            try {
+                const results = await fetchDrugAutocomplete(query, controller.signal, fetchImpl);
+                return currentRevision === revision ? results : null;
+            } catch (error) {
+                if (controller.signal.aborted || currentRevision !== revision) return null;
+                throw error;
+            }
+        },
+        abort() {
+            revision += 1;
+            activeController?.abort();
+            activeController = null;
+        },
+    };
+}
+
+/* @Codex WUL-488 */
+export function commitDrugAutocompleteQueryChange(
+    search: Pick<ReturnType<typeof createDrugAutocompleteSearch>, 'abort'>,
+    commit: (value: string) => void,
+    value: string,
+) {
+    search.abort();
+    commit(value);
+}


### PR DESCRIPTION
## Summary
- Replace the full client-side drug catalog scan with one bounded authenticated `/api/drugs?q=` request using the full committed query.
- Preserve the existing auth-expiry boundary by notifying `SecurityProvider` on 401/403 before the helper throws; generic 5xx responses do not notify and errors do not expose the query.
- Abort and invalidate stale searches synchronously on typing, clear, selection, query changes, and unmount; selection also clears loading synchronously when `setQuery` is a no-op.
- Preserve the full `AifaDrug` selection payload and cap displayed results at 30 with permanent regression tests.

## Verification
- `node scripts/run-strip-types.mjs --test lib/drug-autocomplete-search.test.ts` — 3 passed
- `npm run test:unit` — 623 passed
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `git diff --check`
- Fresh independent read-only re-review of both P2 fixes — no P1/P2 findings

## Risk / Notes
- Depends on the token-aware server contract delivered by WUL-494; no route, database, schema, default limit, Dexie, or dependency changes are included.
- Gross diff is 212 LOC, below the 220 LOC cap.
- Build completes with the existing Turbopack NFT tracing warnings in the ATHENA MLX route.
- No PHI/PII or real clinical records are included.

## Ticket
Refs WUL-488