### PR TITLE
ci: limit static checks to Ubuntu

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, windows-latest, macos-latest]
+        os: [ubuntu-22.04]
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- Limit the `static-checks` matrix in `.github/workflows/cross-platform.yml` to `ubuntu-22.04`.
- Preserve the three-OS `build-start` matrix, Node 20, workflow/job naming, and the Ubuntu static-check name.

## Verification
- Parsed the workflow with Ruby Psych and asserted the exact expanded job set.
- `git diff --check`
- `npm run lint`
- `npm run typecheck`
- Independent read-only autoreview: no accepted/actionable findings.

## Risk / Notes
- Cross-platform install/build/start coverage remains on Ubuntu, Windows, and macOS.
- Windows/macOS lint and typecheck jobs are intentionally removed; live protection/ruleset audit found no required checks at PR creation.
- This PR is prepared for review only; it does not merge or close the issue.

## Ticket
Refs WUL-496