### PR TITLE
feat(ai): aggiungi control-flow documentale shadow-first

### DIFF
--- a/app/api/ai/document-router-audit/route.ts
+++ b/app/api/ai/document-router-audit/route.ts
@@ -1,0 +1,43 @@
+/* @Codex */
+import { NextResponse } from 'next/server';
+
+import { appendDocumentRouterControlFlowAudit } from '@/lib/document-router-control-flow-audit';
+import { requireSession, unauthorizedResponse } from '@/lib/security/server-auth';
+import type { DocumentDecisionClassification, DocumentDecisionConfidence } from '@/lib/domain/documents/document-decision';
+import type { DocumentRouterControlFlowMode } from '@/lib/domain/documents/document-router-control-flow';
+
+const DOCUMENT_CLASSES: ReadonlySet<string> = new Set([
+    'identity_document', 'medication_prescription', 'specialist_service_prescription',
+    'lab_prescription', 'imaging_prescription', 'screening_prescription_or_invitation',
+    'specialist_report', 'lab_report', 'imaging_report', 'exemption_document',
+    'prosthetic_prescription', 'administrative', 'mute_or_scanned', 'unknown',
+]);
+const CONFIDENCES: ReadonlySet<string> = new Set(['low', 'medium', 'high']);
+const MODES: ReadonlySet<string> = new Set(['shadow']);
+
+export async function POST(request: Request) {
+    const session = await requireSession();
+    if (!session) return unauthorizedResponse();
+
+    try {
+        const body = await request.json() as Record<string, unknown>;
+        if (
+            typeof body.classification !== 'string' || !DOCUMENT_CLASSES.has(body.classification)
+            || typeof body.confidence !== 'string' || !CONFIDENCES.has(body.confidence)
+            || typeof body.wouldSkip !== 'boolean'
+            || typeof body.mode !== 'string' || !MODES.has(body.mode)
+        ) {
+            return NextResponse.json({ error: 'Payload audit document router non valido' }, { status: 400 });
+        }
+
+        appendDocumentRouterControlFlowAudit({
+            classification: body.classification as DocumentDecisionClassification,
+            confidence: body.confidence as DocumentDecisionConfidence,
+            wouldSkip: body.wouldSkip,
+            mode: body.mode as DocumentRouterControlFlowMode,
+        });
+        return NextResponse.json({ success: true });
+    } catch {
+        return NextResponse.json({ error: 'Impossibile registrare l\'audit del router documentale' }, { status: 500 });
+    }
+}

--- a/app/settings/ai/funzioni/page.tsx
+++ b/app/settings/ai/funzioni/page.tsx
@@ -36,6 +36,8 @@ export default function SettingsAiFunctionsPage() {
         setTreatmentReasoningEnabled,
         ocrEnabled,
         setOcrEnabled,
+        documentRouterControlFlowMode,
+        setDocumentRouterControlFlowMode,
         selectedInsightMode,
         insightRuntimePreview,
         updateManualInsightConfig,
@@ -217,6 +219,41 @@ export default function SettingsAiFunctionsPage() {
                                     </button>
                                 </div>
                             </div>
+                        </div>
+
+                        <div
+                            className="rounded-[18px] border p-4"
+                            style={{ borderColor: 'rgba(15, 23, 42, 0.18)', background: 'rgba(248, 250, 252, 0.85)' }}
+                            data-testid="document-router-control-flow-card"
+                        >
+                            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                                <div className="min-w-0">
+                                    <p className="text-sm font-semibold" style={{ color: 'var(--mf-ink)' }}>Instradamento documentale deterministico</p>
+                                    <p className="mt-1 text-[11px] leading-5" style={{ color: 'var(--mf-muted)' }}>
+                                        Decide quando le classi a estrazione certa possono usare la sintesi deterministica invece del modello.
+                                    </p>
+                                </div>
+                                <label className="text-xs font-medium" style={{ color: 'var(--mf-muted)' }}>
+                                    Modalita
+                                    <select
+                                        aria-label="Modalita instradamento documentale deterministico"
+                                        value={documentRouterControlFlowMode}
+                                        onChange={(event) => setDocumentRouterControlFlowMode(event.target.value as typeof documentRouterControlFlowMode)}
+                                        className={`mt-1 min-w-40 ${SETTINGS_INPUT_CLASS}`}
+                                    >
+                                        <option value="off">Spento</option>
+                                        <option value="shadow">Osservazione</option>
+                                        <option value="active">Attivo</option>
+                                    </select>
+                                </label>
+                            </div>
+                            <p className="mt-3 rounded-[14px] border px-3 py-2 text-[11px] leading-5" style={{ borderColor: 'rgba(15, 23, 42, 0.12)', background: 'rgba(255,255,255,0.72)', color: 'var(--mf-muted)' }}>
+                                {documentRouterControlFlowMode === 'off'
+                                    ? 'Spento: il modello analizza tutti i documenti.'
+                                    : documentRouterControlFlowMode === 'shadow'
+                                        ? 'Osservazione: il router registra cosa salterebbe senza cambiare la sintesi.'
+                                        : 'Attivo: le classi a estrazione certa saltano il modello e usano la sintesi deterministica.'}
+                            </p>
                         </div>
 
                         <div

--- a/components/document-insights-panel.tsx
+++ b/components/document-insights-panel.tsx
@@ -203,6 +203,14 @@ export default function DocumentInsightsPanel({ patient }: DocumentInsightsPanel
                                                     {documentClassLabel(insight.routedClass.classification)}
                                                 </span>
                                             )}
+                                            {insight.routedClass?.synthesis?.kind === 'deterministic' && (
+                                                <span
+                                                    className="ml-1 inline-flex items-center rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-[10px] font-medium text-emerald-700 dark:border-emerald-400/30 dark:bg-emerald-500/10 dark:text-emerald-200"
+                                                    title={insight.routedClass.synthesis.rationale}
+                                                >
+                                                    Sintesi senza modello: {documentClassLabel(insight.routedClass.classification)}
+                                                </span>
+                                            )}
                                         </div>
                                     </div>
                                 </div>

--- a/lib/ai-task-contracts.ts
+++ b/lib/ai-task-contracts.ts
@@ -353,7 +353,7 @@ function renderListSection(title: string, items: string[]): string {
     return `**${title}:**\n${items.map((item) => `- ${item}`).join('\n')}`;
 }
 
-function buildDocumentFallbackSummary(rawText: string): string {
+export function buildDocumentFallbackSummary(rawText: string): string {
     const normalized = rawText
         .split(/\n+/)
         .map((line) => line.trim())

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -92,6 +92,10 @@ export interface DocumentInsight {
     routedClass?: {
         classification: string;
         confidence: string;
+        synthesis?: {
+            kind: 'deterministic';
+            rationale: string;
+        };
     };
     documentDate?: string;
 }

--- a/lib/document-router-control-flow-audit.test.ts
+++ b/lib/document-router-control-flow-audit.test.ts
@@ -1,0 +1,37 @@
+/* @Codex */
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+    appendDocumentRouterControlFlowAudit,
+    getDocumentRouterControlFlowAuditPath,
+} from './document-router-control-flow-audit';
+
+test('appends only PHI-safe document router shadow fields', () => {
+    const previousDataDir = process.env.MEDIFLOW_DATA_DIR;
+    const dataDir = mkdtempSync(path.join(os.tmpdir(), 'mediflow-document-router-audit-'));
+    process.env.MEDIFLOW_DATA_DIR = dataDir;
+
+    try {
+        const record = appendDocumentRouterControlFlowAudit({
+            classification: 'lab_report',
+            confidence: 'high',
+            wouldSkip: true,
+            mode: 'shadow',
+        });
+        const audit = readFileSync(getDocumentRouterControlFlowAuditPath(), 'utf8');
+
+        assert.equal(record.mode, 'shadow');
+        assert.match(audit, /"classification":"lab_report"/);
+        assert.match(audit, /"confidence":"high"/);
+        assert.match(audit, /"wouldSkip":true/);
+        assert.doesNotMatch(audit, /rawMarkdown|fileName|summary|Mario Rossi/i);
+    } finally {
+        if (previousDataDir === undefined) delete process.env.MEDIFLOW_DATA_DIR;
+        else process.env.MEDIFLOW_DATA_DIR = previousDataDir;
+        rmSync(dataDir, { recursive: true, force: true });
+    }
+});

--- a/lib/document-router-control-flow-audit.ts
+++ b/lib/document-router-control-flow-audit.ts
@@ -1,0 +1,39 @@
+/* @Codex */
+import { appendFileSync, mkdirSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import type { DocumentRouterControlFlowMode } from './domain/documents/document-router-control-flow';
+import type { DocumentDecisionClassification, DocumentDecisionConfidence } from './domain/documents/document-decision';
+
+export interface DocumentRouterControlFlowAuditRecord {
+    timestamp: string;
+    classification: DocumentDecisionClassification;
+    confidence: DocumentDecisionConfidence;
+    wouldSkip: boolean;
+    mode: DocumentRouterControlFlowMode;
+}
+
+export function getDocumentRouterControlFlowAuditPath(): string {
+    const dataDir = process.env.MEDIFLOW_DATA_DIR
+        || (process.platform === 'darwin'
+            ? path.join(os.homedir(), 'Library', 'Application Support', 'MediFlow')
+            : path.join(os.homedir(), '.mediflow'));
+    return path.join(dataDir, 'ai', 'document-router', 'audit.ndjson');
+}
+
+export function appendDocumentRouterControlFlowAudit(input: Omit<DocumentRouterControlFlowAuditRecord, 'timestamp'> & {
+    timestamp?: Date;
+}): DocumentRouterControlFlowAuditRecord {
+    const record: DocumentRouterControlFlowAuditRecord = {
+        timestamp: (input.timestamp ?? new Date()).toISOString(),
+        classification: input.classification,
+        confidence: input.confidence,
+        wouldSkip: input.wouldSkip,
+        mode: input.mode,
+    };
+    const auditPath = getDocumentRouterControlFlowAuditPath();
+    mkdirSync(path.dirname(auditPath), { recursive: true });
+    appendFileSync(auditPath, `${JSON.stringify(record)}\n`, { encoding: 'utf8', mode: 0o600 });
+    return record;
+}

--- a/lib/domain/documents/document-class-router.ts
+++ b/lib/domain/documents/document-class-router.ts
@@ -40,6 +40,29 @@ export interface DocumentClassRouterResult {
     rationale: string;
 }
 
+/**
+ * Classi con struttura abbastanza certa da usare la sintesi di fallback senza
+ * invocare il modello, ma solo quando il router ha confidence `high`.
+ */
+export const DETERMINISTIC_SYNTHESIS_CLASSES: ReadonlySet<DocumentDecisionClassification> = new Set([
+    // Referti di laboratorio: il layout di valori e intervalli e gia strutturato.
+    'lab_report',
+    // Ricette farmacologiche: nome file esplicito, senza narrativa clinica da interpretare.
+    'medication_prescription',
+    // Prescrizioni protesiche: documento prescrittivo con codici e ausili espliciti.
+    'prosthetic_prescription',
+    // Certificati e moduli amministrativi: non richiedono interpretazione clinica narrativa.
+    'administrative',
+    // Documento identificativo: contenuto amministrativo, non una relazione clinica.
+    'identity_document',
+]);
+
+export function isDeterministicSynthesisRoute(
+    routed: Pick<DocumentClassRouterResult, 'classification' | 'confidence'>,
+): boolean {
+    return routed.confidence === 'high' && DETERMINISTIC_SYNTHESIS_CLASSES.has(routed.classification);
+}
+
 // Vocabolario controllato del campo classe nel nome file -> classificazione.
 // Alcuni token (ricetta, promemoria) sono intrinsecamente ambigui tra farmaco e
 // prestazione: mappati alla classe piu probabile ma con confidence contenuta.

--- a/lib/domain/documents/document-class-router.ts
+++ b/lib/domain/documents/document-class-router.ts
@@ -45,22 +45,20 @@ export interface DocumentClassRouterResult {
  * invocare il modello, ma solo quando il router ha confidence `high`.
  */
 export const DETERMINISTIC_SYNTHESIS_CLASSES: ReadonlySet<DocumentDecisionClassification> = new Set([
-    // Referti di laboratorio: il layout di valori e intervalli e gia strutturato.
+    // Referti di laboratorio: ammessi solo con testata riconosciuta e testo utile.
     'lab_report',
-    // Ricette farmacologiche: nome file esplicito, senza narrativa clinica da interpretare.
-    'medication_prescription',
-    // Prescrizioni protesiche: documento prescrittivo con codici e ausili espliciti.
-    'prosthetic_prescription',
-    // Certificati e moduli amministrativi: non richiedono interpretazione clinica narrativa.
-    'administrative',
-    // Documento identificativo: contenuto amministrativo, non una relazione clinica.
-    'identity_document',
 ]);
 
 export function isDeterministicSynthesisRoute(
-    routed: Pick<DocumentClassRouterResult, 'classification' | 'confidence'>,
+    routed: Pick<DocumentClassRouterResult, 'classification' | 'confidence' | 'signals'>,
+    normalizedText: string,
 ): boolean {
-    return routed.confidence === 'high' && DETERMINISTIC_SYNTHESIS_CLASSES.has(routed.classification);
+    const hasUsableText = normalizedText.trim().length >= 80;
+    const hasContentSignal = routed.signals.some((signal) => signal.startsWith('content:'));
+    return routed.confidence === 'high'
+        && hasUsableText
+        && hasContentSignal
+        && DETERMINISTIC_SYNTHESIS_CLASSES.has(routed.classification);
 }
 
 // Vocabolario controllato del campo classe nel nome file -> classificazione.
@@ -180,6 +178,10 @@ export function routeDocumentClass(input: DocumentClassRouterInput): DocumentCla
         signals.push(`filename:${fileHints.classToken}`);
         // Un token forte del filename vince anche sui producer di scansione.
         if (mapped.confident) {
+            const contentMatch = matchContent(input.textSample);
+            if (contentMatch && contentMatch.classification === mapped.classification) {
+                signals.push(`content:${contentMatch.pattern}`);
+            }
             return finalize(mapped.classification, 'high', fileHints, postProcessed, signals,
                 `Token di classe "${fileHints.classToken}" nel nome file.`);
         }

--- a/lib/domain/documents/document-router-control-flow.test.ts
+++ b/lib/domain/documents/document-router-control-flow.test.ts
@@ -10,16 +10,23 @@ import {
 } from './document-router-control-flow';
 import type { DocumentClassRouterResult } from './document-class-router';
 
-const deterministicRoute = { classification: 'lab_report' as const, confidence: 'high' as const };
+const deterministicRoute = {
+    classification: 'lab_report' as const,
+    confidence: 'high' as const,
+    signals: ['filename:laboratorio', 'content:referto'] as string[],
+};
+const usableText = 'Referto di laboratorio con determinazione risultato e intervalli di riferimento. '.repeat(2);
 
 function decide(
     mode: 'off' | 'shadow' | 'active',
-    routed: Pick<DocumentClassRouterResult, 'classification' | 'confidence'> = deterministicRoute,
+    routed: Pick<DocumentClassRouterResult, 'classification' | 'confidence' | 'signals'> = deterministicRoute,
+    normalizedText = usableText,
 ) {
     return decideDocumentRouterControlFlow({
         documentSynthesisKillSwitchValue: 'enabled',
         mode,
         routed,
+        normalizedText,
     });
 }
 
@@ -50,13 +57,43 @@ test('active uses deterministic synthesis only for an eligible high-confidence r
 });
 
 test('active retains the model path for low confidence and narrative classes', () => {
-    const lowConfidence = decide('active', { classification: 'lab_report', confidence: 'medium' });
-    const narrative = decide('active', { classification: 'specialist_report', confidence: 'high' });
+    const lowConfidence = decide('active', { ...deterministicRoute, confidence: 'medium' });
+    const narrative = decide('active', { ...deterministicRoute, classification: 'specialist_report' });
 
     assert.equal(lowConfidence.wouldSkip, false);
     assert.equal(lowConfidence.useDeterministicSynthesis, false);
     assert.equal(narrative.wouldSkip, false);
     assert.equal(narrative.useDeterministicSynthesis, false);
+});
+
+test('active retains the model path for filename-only, empty, and narrative administrative routes', () => {
+    const filenameOnly = decide('active', {
+        classification: 'lab_report',
+        confidence: 'high',
+        signals: ['filename:laboratorio'],
+    });
+    const empty = decide('active', deterministicRoute, '');
+    const administrative = decide('active', {
+        classification: 'administrative',
+        confidence: 'high',
+        signals: ['filename:certificato_medico_introduttivo', 'content:certificato'],
+    });
+    const medicationPrescription = decide('active', {
+        classification: 'medication_prescription',
+        confidence: 'high',
+        signals: ['filename:prescrizione_medica', 'content:ricetta'],
+    });
+    const prostheticPrescription = decide('active', {
+        classification: 'prosthetic_prescription',
+        confidence: 'high',
+        signals: ['filename:protesica', 'content:prescrizione_protesica'],
+    });
+
+    assert.equal(filenameOnly.useDeterministicSynthesis, false);
+    assert.equal(empty.useDeterministicSynthesis, false);
+    assert.equal(administrative.useDeterministicSynthesis, false);
+    assert.equal(medicationPrescription.useDeterministicSynthesis, false);
+    assert.equal(prostheticPrescription.useDeterministicSynthesis, false);
 });
 
 test('the document synthesis kill switch stops control-flow before an active skip', () => {
@@ -65,6 +102,7 @@ test('the document synthesis kill switch stops control-flow before an active ski
             documentSynthesisKillSwitchValue: 'disabled',
             mode: 'active',
             routed: deterministicRoute,
+            normalizedText: usableText,
         }),
         (error: unknown) => error instanceof AiDocumentSynthesisDisabledError,
     );

--- a/lib/domain/documents/document-router-control-flow.test.ts
+++ b/lib/domain/documents/document-router-control-flow.test.ts
@@ -1,0 +1,71 @@
+/* @Codex */
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { AiDocumentSynthesisDisabledError } from '../../ai-document-synthesis-kill-switch';
+import {
+    DEFAULT_DOCUMENT_ROUTER_CONTROL_FLOW_MODE,
+    decideDocumentRouterControlFlow,
+    parseDocumentRouterControlFlowMode,
+} from './document-router-control-flow';
+import type { DocumentClassRouterResult } from './document-class-router';
+
+const deterministicRoute = { classification: 'lab_report' as const, confidence: 'high' as const };
+
+function decide(
+    mode: 'off' | 'shadow' | 'active',
+    routed: Pick<DocumentClassRouterResult, 'classification' | 'confidence'> = deterministicRoute,
+) {
+    return decideDocumentRouterControlFlow({
+        documentSynthesisKillSwitchValue: 'enabled',
+        mode,
+        routed,
+    });
+}
+
+test('control-flow defaults missing or invalid settings to shadow', () => {
+    assert.equal(parseDocumentRouterControlFlowMode(undefined), DEFAULT_DOCUMENT_ROUTER_CONTROL_FLOW_MODE);
+    assert.equal(parseDocumentRouterControlFlowMode('unexpected'), 'shadow');
+});
+
+test('off retains the model path without a shadow decision', () => {
+    const decision = decide('off');
+
+    assert.equal(decision.wouldSkip, true);
+    assert.equal(decision.useDeterministicSynthesis, false);
+});
+
+test('shadow records an eligible skip without changing the model path', () => {
+    const decision = decide('shadow');
+
+    assert.equal(decision.wouldSkip, true);
+    assert.equal(decision.useDeterministicSynthesis, false);
+});
+
+test('active uses deterministic synthesis only for an eligible high-confidence route', () => {
+    const decision = decide('active');
+
+    assert.equal(decision.wouldSkip, true);
+    assert.equal(decision.useDeterministicSynthesis, true);
+});
+
+test('active retains the model path for low confidence and narrative classes', () => {
+    const lowConfidence = decide('active', { classification: 'lab_report', confidence: 'medium' });
+    const narrative = decide('active', { classification: 'specialist_report', confidence: 'high' });
+
+    assert.equal(lowConfidence.wouldSkip, false);
+    assert.equal(lowConfidence.useDeterministicSynthesis, false);
+    assert.equal(narrative.wouldSkip, false);
+    assert.equal(narrative.useDeterministicSynthesis, false);
+});
+
+test('the document synthesis kill switch stops control-flow before an active skip', () => {
+    assert.throws(
+        () => decideDocumentRouterControlFlow({
+            documentSynthesisKillSwitchValue: 'disabled',
+            mode: 'active',
+            routed: deterministicRoute,
+        }),
+        (error: unknown) => error instanceof AiDocumentSynthesisDisabledError,
+    );
+});

--- a/lib/domain/documents/document-router-control-flow.ts
+++ b/lib/domain/documents/document-router-control-flow.ts
@@ -1,0 +1,62 @@
+/* @Codex */
+import { buildDocumentFallbackSummary } from '../../ai-task-contracts';
+/* @Codex */
+import { assertAiDocumentSynthesisEnabledValue } from '../../ai-document-synthesis-kill-switch';
+/* @Codex */
+import type { DocumentStructuredAnalysis } from './document-synthesis-parser';
+/* @Codex */
+import {
+    isDeterministicSynthesisRoute,
+    type DocumentClassRouterResult,
+} from './document-class-router';
+
+export const DOCUMENT_ROUTER_CONTROL_FLOW_SETTING_KEY = 'documentRouterControlFlow';
+
+export type DocumentRouterControlFlowMode = 'off' | 'shadow' | 'active';
+
+export const DEFAULT_DOCUMENT_ROUTER_CONTROL_FLOW_MODE: DocumentRouterControlFlowMode = 'shadow';
+
+export function parseDocumentRouterControlFlowMode(value: unknown): DocumentRouterControlFlowMode {
+    return value === 'off' || value === 'shadow' || value === 'active'
+        ? value
+        : DEFAULT_DOCUMENT_ROUTER_CONTROL_FLOW_MODE;
+}
+
+export interface DocumentRouterControlFlowDecision {
+    mode: DocumentRouterControlFlowMode;
+    wouldSkip: boolean;
+    useDeterministicSynthesis: boolean;
+}
+
+export function decideDocumentRouterControlFlow(input: {
+    documentSynthesisKillSwitchValue: unknown;
+    mode: DocumentRouterControlFlowMode;
+    routed: Pick<DocumentClassRouterResult, 'classification' | 'confidence'>;
+}): DocumentRouterControlFlowDecision {
+    assertAiDocumentSynthesisEnabledValue(input.documentSynthesisKillSwitchValue);
+    const wouldSkip = isDeterministicSynthesisRoute(input.routed);
+
+    return {
+        mode: input.mode,
+        wouldSkip,
+        useDeterministicSynthesis: input.mode === 'active' && wouldSkip,
+    };
+}
+
+export function buildDeterministicDocumentSynthesisAnalysis(
+    rawMarkdown: string,
+    routed: Pick<DocumentClassRouterResult, 'classification' | 'rationale'>,
+): DocumentStructuredAnalysis {
+    return {
+        summary: buildDocumentFallbackSummary(rawMarkdown),
+        quality: {
+            level: 'yellow',
+            reason: `Sintesi deterministica per ${routed.classification}: ${routed.rationale}`,
+        },
+        medications: [],
+        diagnoses: [],
+        problemStatements: [],
+        therapyCandidates: [],
+        servicePrescriptions: [],
+    };
+}

--- a/lib/domain/documents/document-router-control-flow.ts
+++ b/lib/domain/documents/document-router-control-flow.ts
@@ -31,10 +31,11 @@ export interface DocumentRouterControlFlowDecision {
 export function decideDocumentRouterControlFlow(input: {
     documentSynthesisKillSwitchValue: unknown;
     mode: DocumentRouterControlFlowMode;
-    routed: Pick<DocumentClassRouterResult, 'classification' | 'confidence'>;
+    routed: Pick<DocumentClassRouterResult, 'classification' | 'confidence' | 'signals'>;
+    normalizedText: string;
 }): DocumentRouterControlFlowDecision {
     assertAiDocumentSynthesisEnabledValue(input.documentSynthesisKillSwitchValue);
-    const wouldSkip = isDeterministicSynthesisRoute(input.routed);
+    const wouldSkip = isDeterministicSynthesisRoute(input.routed, input.normalizedText);
 
     return {
         mode: input.mode,

--- a/lib/domain/documents/document-synthesis-service.test.ts
+++ b/lib/domain/documents/document-synthesis-service.test.ts
@@ -8,6 +8,10 @@ import { routeDocumentClassForSynthesis } from './document-synthesis-routing';
 import { rememberPdfDocumentMetadata } from '../../pdf-document-metadata';
 import { parseStructuredAnalysisResponse } from './document-synthesis-parser';
 import { parseDocumentIntelligenceCasePack } from './document-intelligence-case-pack';
+/* @Codex */
+import { decideDocumentRouterControlFlow } from './document-router-control-flow';
+/* @Codex */
+import { selectDocumentSynthesisAnalysis } from './document-synthesis-service';
 import {
     buildDocumentParseEvidenceArtifact,
     evaluateDocumentParseEvidenceArtifact,
@@ -15,6 +19,118 @@ import {
     projectDocumentEvidencePack,
     serializeDocumentParseEvidenceArtifact,
 } from './document-parse-evidence-artifact';
+
+test('shadow synthesis calls the model without waiting for a pending audit write', async () => {
+    const rawMarkdown = 'Referto di laboratorio con determinazione risultato e intervalli di riferimento. '.repeat(2);
+    const routed = routeDocumentClassForSynthesis(rawMarkdown, '2026-07-12__laboratorio__synthetic.pdf');
+    const routerDecision = decideDocumentRouterControlFlow({
+        documentSynthesisKillSwitchValue: 'enabled',
+        mode: 'shadow',
+        routed,
+        normalizedText: rawMarkdown,
+    });
+    let modelCalls = 0;
+    let auditCalls = 0;
+    const pendingAudit = () => {
+        auditCalls += 1;
+        return new Promise<void>(() => undefined);
+    };
+
+    const analysis = await Promise.race([
+        selectDocumentSynthesisAnalysis({
+            rawMarkdown,
+            normalizedText: rawMarkdown,
+            routed,
+            routerMode: 'shadow',
+            routerDecision,
+            recordShadow: pendingAudit,
+            analyze: async () => {
+                modelCalls += 1;
+                return {
+                    summary: 'Sintesi modello sintetica',
+                    quality: { level: 'green', reason: 'Test sintetico' },
+                    medications: [],
+                    diagnoses: [],
+                    problemStatements: [],
+                    therapyCandidates: [],
+                    servicePrescriptions: [],
+                };
+            },
+        }),
+        new Promise<never>((_, reject) => setTimeout(() => reject(new Error('audit blocked synthesis')), 75)),
+    ]);
+
+    assert.equal(modelCalls, 1);
+    assert.equal(auditCalls, 1);
+    assert.equal(analysis.summary, 'Sintesi modello sintetica');
+});
+
+test('off synthesis preserves model output and never dispatches the shadow audit', async () => {
+    const rawMarkdown = 'Referto di laboratorio con determinazione risultato e intervalli di riferimento. '.repeat(2);
+    const routed = routeDocumentClassForSynthesis(rawMarkdown, '2026-07-12__laboratorio__synthetic.pdf');
+    const routerDecision = decideDocumentRouterControlFlow({
+        documentSynthesisKillSwitchValue: 'enabled',
+        mode: 'off',
+        routed,
+        normalizedText: rawMarkdown,
+    });
+    let auditCalls = 0;
+    const expected = {
+        summary: 'Output modello invariato',
+        quality: { level: 'green' as const, reason: 'Test sintetico' },
+        medications: [],
+        diagnoses: [],
+        problemStatements: [],
+        therapyCandidates: [],
+        servicePrescriptions: [],
+    };
+
+    const analysis = await selectDocumentSynthesisAnalysis({
+        rawMarkdown,
+        normalizedText: rawMarkdown,
+        routed,
+        routerMode: 'off',
+        routerDecision,
+        recordShadow: async () => { auditCalls += 1; },
+        analyze: async () => expected,
+    });
+
+    assert.equal(auditCalls, 0);
+    assert.deepEqual(analysis, expected);
+});
+
+test('shadow synthesis absorbs a rejected audit write and preserves model output', async (context) => {
+    const rawMarkdown = 'Referto di laboratorio con determinazione risultato e intervalli di riferimento. '.repeat(2);
+    const routed = routeDocumentClassForSynthesis(rawMarkdown, '2026-07-12__laboratorio__synthetic.pdf');
+    const routerDecision = decideDocumentRouterControlFlow({
+        documentSynthesisKillSwitchValue: 'enabled',
+        mode: 'shadow',
+        routed,
+        normalizedText: rawMarkdown,
+    });
+    const warn = context.mock.method(console, 'warn', () => undefined);
+    const analysis = await selectDocumentSynthesisAnalysis({
+        rawMarkdown,
+        normalizedText: rawMarkdown,
+        routed,
+        routerMode: 'shadow',
+        routerDecision,
+        recordShadow: async () => { throw new Error('synthetic audit failure'); },
+        analyze: async () => ({
+            summary: 'Output modello invariato',
+            quality: { level: 'green', reason: 'Test sintetico' },
+            medications: [],
+            diagnoses: [],
+            problemStatements: [],
+            therapyCandidates: [],
+            servicePrescriptions: [],
+        }),
+    });
+    await Promise.resolve();
+
+    assert.equal(analysis.summary, 'Output modello invariato');
+    assert.equal(warn.mock.callCount(), 1);
+});
 
 test('parses explicit medications from the model JSON payload', () => {
     const analysis = parseStructuredAnalysisResponse(

--- a/lib/domain/documents/document-synthesis-service.ts
+++ b/lib/domain/documents/document-synthesis-service.ts
@@ -37,6 +37,13 @@ import {
     buildDocumentSynthesisAutofillPlan,
     parseExistingDocumentSynthesisDiagnoses,
 } from './document-synthesis-autofill';
+/* @Codex */
+import {
+    buildDeterministicDocumentSynthesisAnalysis,
+    decideDocumentRouterControlFlow,
+    DOCUMENT_ROUTER_CONTROL_FLOW_SETTING_KEY,
+    parseDocumentRouterControlFlowMode,
+} from './document-router-control-flow';
 
 /* @Codex */
 const MAX_SYNTHESIS_CHARS = 12000;
@@ -63,6 +70,25 @@ function parseExistingInsights(raw: unknown): DocumentInsight[] {
         return Array.isArray(parsed) ? parsed as DocumentInsight[] : [];
     } catch {
         return [];
+    }
+}
+
+/* @Codex */
+async function recordDocumentRouterShadowDecision(input: {
+    classification: string;
+    confidence: string;
+    wouldSkip: boolean;
+}): Promise<void> {
+    try {
+        const response = await fetch('/api/ai/document-router-audit', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ ...input, mode: 'shadow' }),
+        });
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    } catch (error) {
+        // L'audit shadow non deve modificare la pipeline clinica gia esistente.
+        console.warn('[DocumentSynthesis] document router shadow audit unavailable', error);
     }
 }
 
@@ -97,11 +123,26 @@ export async function synthesizeDocument(
     assertAiDocumentSynthesisEnabledValue(documentSynthesisKillSwitch?.value);
 
     const normalized = normalizeDocumentInput(rawMarkdown);
-    const analysis = await analyzeDocumentContent(rawMarkdown);
-
-    // Classificazione deterministica (nome file + metadata PDF + testata):
-    // segnale additivo per la review, non altera il flusso di sintesi.
     const routed = routeDocumentClassForSynthesis(rawMarkdown, fileName, options);
+    const routerControlFlow = await db.settings.get(DOCUMENT_ROUTER_CONTROL_FLOW_SETTING_KEY);
+    const routerMode = parseDocumentRouterControlFlowMode(routerControlFlow?.value);
+    const routerDecision = decideDocumentRouterControlFlow({
+        documentSynthesisKillSwitchValue: documentSynthesisKillSwitch?.value,
+        mode: routerMode,
+        routed,
+    });
+
+    if (routerMode === 'shadow') {
+        await recordDocumentRouterShadowDecision({
+            classification: routed.classification,
+            confidence: routed.confidence,
+            wouldSkip: routerDecision.wouldSkip,
+        });
+    }
+
+    const analysis = routerDecision.useDeterministicSynthesis
+        ? buildDeterministicDocumentSynthesisAnalysis(normalized.normalizedText, routed)
+        : await analyzeDocumentContent(rawMarkdown);
 
     const patient = await db.patients.get(patientId);
     if (!patient) {
@@ -142,7 +183,13 @@ export async function synthesizeDocument(
         autofill: appliedCodes.length > 0
             ? { appliedDiagnoses: appliedCodes }
             : undefined,
-        routedClass: { classification: routed.classification, confidence: routed.confidence },
+        routedClass: {
+            classification: routed.classification,
+            confidence: routed.confidence,
+            ...(routerDecision.useDeterministicSynthesis
+                ? { synthesis: { kind: 'deterministic' as const, rationale: routed.rationale } }
+                : {}),
+        },
         ...(routed.documentDate ? { documentDate: routed.documentDate } : {}),
     };
 

--- a/lib/domain/documents/document-synthesis-service.ts
+++ b/lib/domain/documents/document-synthesis-service.ts
@@ -93,6 +93,44 @@ async function recordDocumentRouterShadowDecision(input: {
 }
 
 /* @Codex */
+type DocumentRouterShadowRecorder = typeof recordDocumentRouterShadowDecision;
+
+/* @Codex */
+export function dispatchDocumentRouterShadowDecision(
+    input: Parameters<DocumentRouterShadowRecorder>[0],
+    recorder: DocumentRouterShadowRecorder = recordDocumentRouterShadowDecision,
+): void {
+    // Telemetria best-effort: una richiesta lenta o pendente non entra mai nel
+    // percorso critico della sintesi.
+    void recorder(input).catch((error) => {
+        console.warn('[DocumentSynthesis] document router shadow audit unavailable', error);
+    });
+}
+
+/* @Codex */
+export async function selectDocumentSynthesisAnalysis(input: {
+    rawMarkdown: string;
+    normalizedText: string;
+    routed: ReturnType<typeof routeDocumentClassForSynthesis>;
+    routerMode: ReturnType<typeof parseDocumentRouterControlFlowMode>;
+    routerDecision: ReturnType<typeof decideDocumentRouterControlFlow>;
+    analyze?: typeof analyzeDocumentContent;
+    recordShadow?: DocumentRouterShadowRecorder;
+}): Promise<DocumentStructuredAnalysis> {
+    if (input.routerMode === 'shadow') {
+        dispatchDocumentRouterShadowDecision({
+            classification: input.routed.classification,
+            confidence: input.routed.confidence,
+            wouldSkip: input.routerDecision.wouldSkip,
+        }, input.recordShadow);
+    }
+
+    return input.routerDecision.useDeterministicSynthesis
+        ? buildDeterministicDocumentSynthesisAnalysis(input.normalizedText, input.routed)
+        : (input.analyze ?? analyzeDocumentContent)(input.rawMarkdown);
+}
+
+/* @Codex */
 /**
  * Analyze OCR text without persisting anything.
  */
@@ -130,19 +168,16 @@ export async function synthesizeDocument(
         documentSynthesisKillSwitchValue: documentSynthesisKillSwitch?.value,
         mode: routerMode,
         routed,
+        normalizedText: normalized.normalizedText,
     });
 
-    if (routerMode === 'shadow') {
-        await recordDocumentRouterShadowDecision({
-            classification: routed.classification,
-            confidence: routed.confidence,
-            wouldSkip: routerDecision.wouldSkip,
-        });
-    }
-
-    const analysis = routerDecision.useDeterministicSynthesis
-        ? buildDeterministicDocumentSynthesisAnalysis(normalized.normalizedText, routed)
-        : await analyzeDocumentContent(rawMarkdown);
+    const analysis = await selectDocumentSynthesisAnalysis({
+        rawMarkdown,
+        normalizedText: normalized.normalizedText,
+        routed,
+        routerMode,
+        routerDecision,
+    });
 
     const patient = await db.patients.get(patientId);
     if (!patient) {

--- a/lib/hooks/use-ai-settings-controller.ts
+++ b/lib/hooks/use-ai-settings-controller.ts
@@ -42,6 +42,12 @@ import {
     isAiOcrEnabledValue,
     serializeAiOcrKillSwitchState,
 } from '@/lib/ai-ocr-kill-switch';
+import {
+    DEFAULT_DOCUMENT_ROUTER_CONTROL_FLOW_MODE,
+    DOCUMENT_ROUTER_CONTROL_FLOW_SETTING_KEY,
+    parseDocumentRouterControlFlowMode,
+    type DocumentRouterControlFlowMode,
+} from '@/lib/domain/documents/document-router-control-flow';
 
 type HardwareProfile = 'low' | 'medium' | 'high' | 'custom';
 
@@ -85,6 +91,9 @@ export function useAiSettingsController() {
     const [smartImportEnabled, setSmartImportEnabled] = useState(true);
     const [treatmentReasoningEnabled, setTreatmentReasoningEnabled] = useState(false);
     const [ocrEnabled, setOcrEnabled] = useState(true);
+    const [documentRouterControlFlowMode, setDocumentRouterControlFlowMode] = useState<DocumentRouterControlFlowMode>(
+        DEFAULT_DOCUMENT_ROUTER_CONTROL_FLOW_MODE,
+    );
 
     useEffect(() => {
         void loadAiConfig();
@@ -122,6 +131,7 @@ export function useAiSettingsController() {
             const smartImportKillSwitch = await safeGet(AI_SMART_IMPORT_KILL_SWITCH_KEY);
             const treatmentReasoningKillSwitch = await safeGet(AI_TREATMENT_REASONING_KILL_SWITCH_KEY);
             const ocrKillSwitch = await safeGet(AI_OCR_KILL_SWITCH_KEY);
+            const documentRouterControlFlow = await safeGet(DOCUMENT_ROUTER_CONTROL_FLOW_SETTING_KEY);
 
             let currentUrl = genericUrl?.value;
             if (!currentUrl) currentUrl = legacyUrl?.value;
@@ -145,6 +155,7 @@ export function useAiSettingsController() {
             setSmartImportEnabled(isAiSmartImportEnabledValue(smartImportKillSwitch?.value));
             setTreatmentReasoningEnabled(isAiTreatmentReasoningEnabledValue(treatmentReasoningKillSwitch?.value));
             setOcrEnabled(isAiOcrEnabledValue(ocrKillSwitch?.value));
+            setDocumentRouterControlFlowMode(parseDocumentRouterControlFlowMode(documentRouterControlFlow?.value));
         } catch (e) {
             console.error('Failed to load AI config:', e);
         }
@@ -193,6 +204,10 @@ export function useAiSettingsController() {
             await db.settings.put({ key: 'aiModel', value: aiConfig.model_clinical });
             await db.settings.put({ key: 'aiUrl', value: aiConfig.url });
             await db.settings.put({ key: 'ollamaUrl', value: aiConfig.url });
+            await db.settings.put({
+                key: DOCUMENT_ROUTER_CONTROL_FLOW_SETTING_KEY,
+                value: documentRouterControlFlowMode,
+            });
             await db.settings.put({
                 key: AI_PATIENT_INSIGHT_KILL_SWITCH_KEY,
                 value: serializeAiPatientInsightKillSwitchState(patientInsightEnabled),
@@ -310,6 +325,8 @@ export function useAiSettingsController() {
         setTreatmentReasoningEnabled,
         ocrEnabled,
         setOcrEnabled,
+        documentRouterControlFlowMode,
+        setDocumentRouterControlFlowMode,
         selectedInsightMode,
         insightRuntimePreview,
         applyHardwareProfile,

--- a/lib/security/settings-write-policy.test.ts
+++ b/lib/security/settings-write-policy.test.ts
@@ -90,6 +90,7 @@ test('current key/writer pairs still resolve to allowed', () => {
         'aiProvider', 'aiUrl', 'ollamaUrl', 'aiModel', 'aiModel_clinical',
         'aiModel_reasoning', 'aiModel_ocr', 'aiModelDefaultVersion', 'hardwareProfile',
         'aiInsightMode', 'aiInsightManualConfig', 'aiPatientInsightKillSwitch',
+        'documentRouterControlFlow',
         'aiDocumentSynthesisKillSwitch', 'aiSmartImportKillSwitch', 'aiTreatmentReasoningKillSwitch',
         'aiOcrKillSwitch', 'uiReduceMotion',
         'uiReduceTransparency', 'uiStyleMode', 'terminologyRegistry', 'clinicName', 'network.mode',

--- a/lib/security/settings-write-policy.ts
+++ b/lib/security/settings-write-policy.ts
@@ -41,6 +41,7 @@ export const SETTINGS_WRITE_REGISTRY: Record<string, SettingsKeyPolicy> = {
     hardwareProfile: { write: ['web-session'], note: 'AI hardware profile (use-ai-settings-controller, ai-insight-settings)' },
     aiInsightMode: { write: ['web-session'], note: 'AI insight mode (lib/ai-insight-settings.ts)' },
     aiInsightManualConfig: { write: ['web-session'], note: 'AI insight manual config (lib/ai-insight-settings.ts)' },
+    documentRouterControlFlow: { write: ['web-session'], note: 'document router control-flow mode (use-ai-settings-controller)' },
 
     // --- AI kill switches (safety toggles; web session only). ---
     aiPatientInsightKillSwitch: { write: ['web-session'], note: 'kill switch (lib/ai-patient-insight-kill-switch.ts)' },

--- a/scripts/benchmark-document-router.test.ts
+++ b/scripts/benchmark-document-router.test.ts
@@ -15,6 +15,15 @@ test('document router benchmark self-test fixtures classify cleanly', () => {
     assert.equal(report.total, 4);
     assert.equal(report.accuracy, 1);
     assert.deepEqual(report.confusions, []);
+    assert.deepEqual(
+        report.skipDecisions.map((metric) => [metric.classification, metric.wouldSkip]),
+        [
+            ['administrative', 1],
+            ['lab_report', 1],
+            ['prosthetic_prescription', 1],
+            ['specialist_report', 0],
+        ],
+    );
 });
 
 test('document router benchmark reports class-level metrics and confusions', () => {
@@ -43,6 +52,7 @@ test('document router benchmark reports class-level metrics and confusions', () 
     assert.equal(report.confusions[0]?.predictedClass, 'unknown');
     assert.match(formatted, /By class/);
     assert.match(formatted, /Confusions/);
+    assert.match(formatted, /Deterministic skip decisions/);
 });
 
 test('document router manifest parser validates required fields', () => {

--- a/scripts/benchmark-document-router.test.ts
+++ b/scripts/benchmark-document-router.test.ts
@@ -18,9 +18,9 @@ test('document router benchmark self-test fixtures classify cleanly', () => {
     assert.deepEqual(
         report.skipDecisions.map((metric) => [metric.classification, metric.wouldSkip]),
         [
-            ['administrative', 1],
+            ['administrative', 0],
             ['lab_report', 1],
-            ['prosthetic_prescription', 1],
+            ['prosthetic_prescription', 0],
             ['specialist_report', 0],
         ],
     );

--- a/scripts/benchmark-document-router.ts
+++ b/scripts/benchmark-document-router.ts
@@ -70,7 +70,7 @@ export const DOCUMENT_ROUTER_SELF_TEST_FIXTURES: DocumentRouterBenchmarkEntry[] 
         file: '2026-01-12__laboratorio__emocromo_sintetico.pdf',
         expectedClass: 'lab_report',
         labelSource: 'synthetic_filename',
-        text: 'Ematologia. Determinazione Risultato Unita Limiti di riferimento.',
+        text: 'Ematologia. Referto di laboratorio con determinazione risultato, unita e limiti di riferimento per campione sintetico.',
         producer: 'JasperReports Library',
     },
     {
@@ -191,7 +191,7 @@ export function runDocumentRouterBenchmark(entries: DocumentRouterBenchmarkEntry
             labelSource: entry.labelSource,
             confidence: routed.confidence,
             signals: routed.signals,
-            wouldSkip: isDeterministicSynthesisRoute(routed),
+            wouldSkip: isDeterministicSynthesisRoute(routed, entry.text ?? ''),
         };
     });
 

--- a/scripts/benchmark-document-router.ts
+++ b/scripts/benchmark-document-router.ts
@@ -1,7 +1,11 @@
 /* @Codex */
 import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
-import { routeDocumentClass, type DocumentClassRouterInput } from '../lib/domain/documents/document-class-router';
+import {
+    isDeterministicSynthesisRoute,
+    routeDocumentClass,
+    type DocumentClassRouterInput,
+} from '../lib/domain/documents/document-class-router';
 import type { DocumentDecisionClassification } from '../lib/domain/documents/document-decision';
 
 /* @Codex */
@@ -23,6 +27,7 @@ export interface DocumentRouterBenchmarkRow {
     labelSource: string;
     confidence: string;
     signals: string[];
+    wouldSkip: boolean;
 }
 
 /* @Codex */
@@ -41,6 +46,13 @@ export interface DocumentRouterConfusion {
 }
 
 /* @Codex */
+export interface DocumentRouterSkipDecisionMetric {
+    classification: DocumentDecisionClassification;
+    total: number;
+    wouldSkip: number;
+}
+
+/* @Codex */
 export interface DocumentRouterBenchmarkReport {
     schemaVersion: 'mediflow.document_router_benchmark.v1';
     total: number;
@@ -48,6 +60,7 @@ export interface DocumentRouterBenchmarkReport {
     accuracy: number;
     byClass: DocumentRouterClassMetric[];
     confusions: DocumentRouterConfusion[];
+    skipDecisions: DocumentRouterSkipDecisionMetric[];
     rows: DocumentRouterBenchmarkRow[];
 }
 
@@ -178,16 +191,23 @@ export function runDocumentRouterBenchmark(entries: DocumentRouterBenchmarkEntry
             labelSource: entry.labelSource,
             confidence: routed.confidence,
             signals: routed.signals,
+            wouldSkip: isDeterministicSynthesisRoute(routed),
         };
     });
 
     const byClassMap = new Map<DocumentDecisionClassification, { total: number; correct: number }>();
     const confusionMap = new Map<string, DocumentRouterConfusion>();
+    const skipDecisionMap = new Map<DocumentDecisionClassification, { total: number; wouldSkip: number }>();
     for (const row of rows) {
         const current = byClassMap.get(row.expectedClass) ?? { total: 0, correct: 0 };
         current.total += 1;
         if (row.correct) current.correct += 1;
         byClassMap.set(row.expectedClass, current);
+
+        const skipMetric = skipDecisionMap.get(row.predictedClass) ?? { total: 0, wouldSkip: 0 };
+        skipMetric.total += 1;
+        if (row.wouldSkip) skipMetric.wouldSkip += 1;
+        skipDecisionMap.set(row.predictedClass, skipMetric);
 
         if (!row.correct) {
             const key = `${row.expectedClass}->${row.predictedClass}`;
@@ -221,6 +241,9 @@ export function runDocumentRouterBenchmark(entries: DocumentRouterBenchmarkEntry
             a.expectedClass.localeCompare(b.expectedClass)
             || a.predictedClass.localeCompare(b.predictedClass)
         )),
+        skipDecisions: Array.from(skipDecisionMap.entries())
+            .map(([classification, metric]) => ({ classification, ...metric }))
+            .sort((a, b) => a.classification.localeCompare(b.classification)),
         rows,
     };
 }
@@ -260,7 +283,15 @@ export function formatDocumentRouterBenchmarkReport(report: DocumentRouterBenchm
                 String(item.count),
             ]),
         );
-    return `${summary}\n\nBy class\n${byClass}\n\nConfusions\n${confusions}`;
+    const skipDecisions = table(
+        ['class', 'documents', 'wouldSkip'],
+        report.skipDecisions.map((metric) => [
+            metric.classification,
+            String(metric.total),
+            String(metric.wouldSkip),
+        ]),
+    );
+    return `${summary}\n\nBy class\n${byClass}\n\nConfusions\n${confusions}\n\nDeterministic skip decisions\n${skipDecisions}`;
 }
 
 async function main(argv: string[]): Promise<void> {


### PR DESCRIPTION
## Summary
- introduce il controllo `off | shadow | active` per il router documentale deterministico, con default `shadow`;
- registra decisioni PHI-safe senza mettere l’audit sul percorso critico della sintesi;
- limita lo skip attivo ai soli referti di laboratorio con confidence alta, testo sufficiente e segnale di contenuto;
- espone stato e provenienza nella UI e rende il benchmark degli skip verificabile.

## Verification
- `npm run typecheck`
- `npm run lint`
- `npm run check:claims`
- `npm run test:unit`: 655/655 pass
- test mirati control-flow, synthesis e benchmark: 20/20 pass
- benchmark router self-test: accuracy 1; skip positivo solo per `lab_report`
- revisione indipendente Claude Opus 4.8 max: blocker V3 risolti; finding di copertura successivamente chiusi localmente

## Risk / Notes
- La modalità predefinita resta `shadow`: la sintesi continua a usare il modello.
- `active` è intenzionalmente conservativa e non salta documenti amministrativi, prescrizioni farmacologiche o protesiche.
- Il fallback deterministico resta a qualità `yellow` e senza scritture cliniche automatiche.
- Nessuna PHI/PII o fixture clinica reale inclusa.
- PR preparata come draft; nessun merge o ticket chiuso.

## Ticket
Refs WUL-443