### PR TITLE
feat(native): rendi opache le card cliniche

### DIFF
--- a/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/AppleFoundationStyle.swift
+++ b/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/AppleFoundationStyle.swift
@@ -1,65 +1,9 @@
 import SwiftUI
-#if os(macOS)
-import AppKit
-#else
-import UIKit
-#endif
-
-private struct CardStyleModifier: ViewModifier {
-    private let cornerRadius: CGFloat = 14
-
-    func body(content: Content) -> some View {
-        if #available(iOS 26.0, macOS 26.0, *) {
-            // Vetro Clinico: real Liquid Glass.
-            content
-                .padding(16)
-                .glassEffect(.regular, in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
-        } else {
-            // Older OS: opaque card with a subtle border. The translucent material
-            // alone washes out on grouped backgrounds, so keep the fill + stroke.
-            content
-                .padding(16)
-                .background(
-                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                        .fill(PlatformColors.cardBackground)
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                        .stroke(Color.primary.opacity(0.06), lineWidth: 1)
-                )
-        }
-    }
-}
 
 extension View {
+    // @Codex: compatibility alias; clinical surfaces now share one opaque primitive.
     func cardStyle() -> some View {
-        modifier(CardStyleModifier())
-    }
-}
-
-enum PlatformColors {
-    static var groupedBackground: Color {
-        #if os(macOS)
-        return Color(nsColor: .windowBackgroundColor)
-        #else
-        return Color(uiColor: .systemGroupedBackground)
-        #endif
-    }
-
-    static var cardBackground: Color {
-        #if os(macOS)
-        return Color(nsColor: .controlBackgroundColor)
-        #else
-        return Color(uiColor: .secondarySystemBackground)
-        #endif
-    }
-
-    static var separator: Color {
-        #if os(macOS)
-        return Color(nsColor: .separatorColor)
-        #else
-        return Color(uiColor: .separator)
-        #endif
+        clinicalCardStyle()
     }
 }
 

--- a/native/MediFlowMac/Sources/MediFlowAppleShared/VetroClinico.swift
+++ b/native/MediFlowMac/Sources/MediFlowAppleShared/VetroClinico.swift
@@ -1,8 +1,12 @@
-// Vetro Clinico: the shared Liquid Glass design kit for the universal app.
-// Adopts Apple Liquid Glass (WWDC25/26) on iOS 26 / macOS 26 and degrades to a
-// system material on the iOS 17 / macOS 14 deployment floor, so one set of
-// primitives renders correctly on every supported OS.
+// Vetro Clinico: the shared design kit for the universal app.
+// Liquid Glass belongs to controls and service chrome; clinical content stays
+// opaque on every supported OS.
 import SwiftUI
+#if os(macOS)
+import AppKit
+#else
+import UIKit
+#endif
 
 /// Clinical tone for status surfaces. Maps to a single source-of-truth color.
 public enum VetroTone: Equatable {
@@ -24,6 +28,32 @@ public enum VetroPalette {
         case .attention: return .orange
         case .critical: return .red
         }
+    }
+}
+
+enum PlatformColors {
+    static var groupedBackground: Color {
+        #if os(macOS)
+        return Color(nsColor: .windowBackgroundColor)
+        #else
+        return Color(uiColor: .systemGroupedBackground)
+        #endif
+    }
+
+    static var cardBackground: Color {
+        #if os(macOS)
+        return Color(nsColor: .controlBackgroundColor)
+        #else
+        return Color(uiColor: .secondarySystemBackground)
+        #endif
+    }
+
+    static var separator: Color {
+        #if os(macOS)
+        return Color(nsColor: .separatorColor)
+        #else
+        return Color(uiColor: .separator)
+        #endif
     }
 }
 
@@ -56,7 +86,31 @@ public extension View {
     }
 }
 
-/// A Liquid Glass clinical card container.
+/* @Codex */
+private struct ClinicalCardStyleModifier: ViewModifier {
+    let cornerRadius: CGFloat
+
+    func body(content: Content) -> some View {
+        let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+
+        content
+            .padding(16)
+            .background(shape.fill(PlatformColors.cardBackground))
+            .overlay(shape.stroke(PlatformColors.separator, lineWidth: 1))
+    }
+}
+
+public extension View {
+    /// Applies the shared opaque surface for clinical content. Liquid Glass is
+    /// intentionally excluded so legibility does not depend on OS appearance.
+    func clinicalCardStyle(cornerRadius: CGFloat = 14) -> some View {
+        modifier(ClinicalCardStyleModifier(cornerRadius: cornerRadius))
+    }
+}
+
+/// Legacy card name retained while call sites migrate to Lume terminology.
+/// The rendered surface is opaque on every supported OS.
+@available(*, deprecated, message: "Use clinicalCardStyle(cornerRadius:) for clinical content.")
 public struct GlassCard<Content: View>: View {
     private let cornerRadius: CGFloat
     private let content: Content
@@ -68,8 +122,7 @@ public struct GlassCard<Content: View>: View {
 
     public var body: some View {
         content
-            .padding(16)
-            .vetroGlass(in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+            .clinicalCardStyle(cornerRadius: cornerRadius)
     }
 }
 

--- a/native/MediFlowMac/Tests/MediFlowAppleSharedTests/ClinicalCardStyleTests.swift
+++ b/native/MediFlowMac/Tests/MediFlowAppleSharedTests/ClinicalCardStyleTests.swift
@@ -1,0 +1,76 @@
+// @Codex
+#if os(macOS)
+import AppKit
+import SwiftUI
+import XCTest
+@testable import MediFlowAppleShared
+
+/* @Codex */
+@MainActor
+final class ClinicalCardStyleTests: XCTestCase {
+    func testClinicalCardSurfacesRenderOpaqueInLightAndDark() throws {
+        let clinicalCard = Color.clear
+            .frame(width: 48, height: 24)
+            .clinicalCardStyle()
+
+        let clinicalLight = try centerPixel(clinicalCard, colorScheme: .light)
+        let clinicalDark = try centerPixel(clinicalCard, colorScheme: .dark)
+
+        XCTAssertEqual(clinicalLight.alpha, 255)
+        XCTAssertEqual(clinicalDark.alpha, 255)
+        XCTAssertNotEqual(clinicalLight.rgb, clinicalDark.rgb)
+    }
+
+    func testOpacityAssertionRejectsAKnownTranslucentSurface() throws {
+        let translucentSurface = Color.clear
+            .frame(width: 48, height: 24)
+            .background(Color.red.opacity(0.5))
+
+        let center = try centerPixel(translucentSurface, colorScheme: .light)
+        XCTAssertLessThan(center.alpha, 255)
+    }
+
+    private func centerPixel<Content: View>(
+        _ content: Content,
+        colorScheme: ColorScheme,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> (rgb: [UInt8], alpha: UInt8) {
+        let renderer = ImageRenderer(
+            content: content.environment(\.colorScheme, colorScheme)
+        )
+        renderer.scale = 1
+
+        let image = try XCTUnwrap(renderer.nsImage, file: file, line: line)
+        var rect = CGRect(origin: .zero, size: image.size)
+        let cgImage = try XCTUnwrap(
+            image.cgImage(forProposedRect: &rect, context: nil, hints: nil),
+            file: file,
+            line: line
+        )
+        let width = cgImage.width
+        let height = cgImage.height
+        var pixels = [UInt8](repeating: 0, count: width * height * 4)
+        let context = try XCTUnwrap(
+            CGContext(
+                data: &pixels,
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bytesPerRow: width * 4,
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+            ),
+            file: file,
+            line: line
+        )
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+        let center = ((height / 2) * width + (width / 2)) * 4
+        return (
+            rgb: Array(pixels[center..<(center + 3)]),
+            alpha: pixels[center + 3]
+        )
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- introduce clinicalCardStyle() come superficie clinica opaca condivisa;
- mantiene cardStyle() come alias compatibile per gli otto call-site correnti;
- depreca GlassCard senza rimuoverne la compatibilità sorgente;
- aggiunge regressioni alpha light/dark e un controllo negativo traslucido.

## Verification
- git diff --check origin/main...HEAD
- npm run check:claims
- npm run check:never-regress
- npm run check:apple-wide-qa
- npm run test:native — 340/340
- npm run test:native:xcode — 340/340, TEST SUCCEEDED
- npm run typecheck
- npm run lint
- Node 24 scripts/build-apple-macos-app.sh — BUILD SUCCEEDED, WebRuntime embedded
- autoreview Codex gpt-5.6-sol high — no actionable findings

## Risk / Notes
- tranche runtime strettamente limitata a tre file Swift;
- non rinomina VetroClinico.swift, non introduce LumeKit e non modifica call-site, navigazione, API o dominio;
- la resa opaca è provata a livello di primitiva; la verifica visuale sintetica nel bundle resta parte del programma Lume complessivo;
- nessuna PHI/PII o dato paziente reale.

## Ticket
Refs WUL-55

Questa PR sostituisce soltanto la parte native opaque-card della vecchia PR #40.
