### PR TITLE
feat(ui): definisci il contratto token Lume

### DIFF
--- a/.github/workflows/web-core.yml
+++ b/.github/workflows/web-core.yml
@@ -22,4 +22,6 @@ jobs:
       - run: npm run lint
       - run: npm run typecheck
       - run: npm run build
+      - run: npm run check:lume-tokens
+      - run: npm run test:lume-tokens
       - run: npm run test:unit

--- a/docs/adr/0078-lume-lingua-di-design-di-destinazione.md
+++ b/docs/adr/0078-lume-lingua-di-design-di-destinazione.md
@@ -65,7 +65,9 @@ Si adotta l'opzione 2:
    consolidamento DS-1..DS-3 sono prerequisito tecnico della migrazione.
 3. La migrazione segue `docs/design/lume/03-migrazione.md` (fasi L0-L6 con
    gate); il flag di convivenza `data-lume` e strumento di sviluppo, non un
-   selettore utente: ADR 0047 resta pienamente in vigore.
+   selettore utente: ADR 0047 resta pienamente in vigore. La condizione di
+   uscita da quella convivenza e formalizzata qui sotto prima che L1b la
+   introduca.
 4. I segnali clinici e le leggi cliniche (colore = semantica, stati onesti,
    tastiera, AA) sono invarianti tra le due lingue.
 
@@ -82,8 +84,34 @@ Si adotta l'opzione 2:
   (lane GPT-5.6, 2026-07-12) alimenta il raffinamento della grammatica
   dell'attenzione prima della fase L2.
 
+## Condizione di uscita dalla convivenza `data-lume`
+
+Il flag `data-lume` e la convivenza dei due vocabolari di token sono temporanei.
+Questa condizione di uscita e definita prima che L1b introduca il flag, cosi la
+convivenza nasce gia con la sua fine scritta. Non e legata a una data di
+calendario ma al raggiungimento congiunto di questi cancelli:
+
+1. Tutti i consumatori previsti delle fasi L2-L5 (cockpit, Scheda, filo, voci,
+   overlay e motion) sono migrati a Lume: non resta superficie in produzione
+   che dipenda dal vocabolario di token legacy.
+2. Il guard runtime a vocabolario-zero passa, cioe nessun riferimento residuo ai
+   token o alle classi legacy compare nel runtime.
+3. I cancelli visivi e di accessibilita richiesti passano: smoke sui tre
+   registri e le coppie di contrasto misurate restano sopra soglia dopo la
+   migrazione.
+
+Quando i tre cancelli sono verdi insieme, si rimuovono il flag di sviluppo
+`data-lume` e gli alias dei vecchi token: la convivenza finisce e Lume resta
+l'unico vocabolario. Finche anche uno solo e rosso, la convivenza prosegue e il
+flag resta strumento di sviluppo (ADR 0047).
+
 ## First Thin Slice
 
-Fase L1 di `docs/design/lume/03-migrazione.md`: i tre registri di luce nel
-sorgente token DTCG con misura strumentale dei contrasti AA, dietro flag di
-sviluppo, senza toccare alcuna superficie utente.
+Fase L1a di `docs/design/lume/03-migrazione.md`: i tre registri di luce nel
+sorgente token DTCG (`docs/design/lume/tokens/lume.tokens.json`) con misura
+strumentale del contrasto (`scripts/check-lume-tokens.mjs`), senza toccare
+alcuna superficie utente e senza introdurre ancora il flag `data-lume`. Questo
+branch (WUL-55) e un candidato L1a, non adozione runtime: non esiste ancora
+nessun consumatore. L1 si considera consegnata quando il contratto token e
+mergiato e misurato; la convivenza runtime (L1b) arriva in un pacchetto
+successivo, dietro la condizione di uscita qui sopra.

--- a/docs/design/lume/01-lingua.md
+++ b/docs/design/lume/01-lingua.md
@@ -39,10 +39,12 @@ Tre registri di luce, non tre temi (giorno/grafite seguono il chiaro/scuro di si
 | `surface.focal` (fuoco) | `#fbfaf7` | `#22252b` | `#1a1e26` |
 | `surface.chrome` (buio operativo) | `#e6e8eb` | `#0e1013` | `#090b0e` |
 | `ink.primary` | `#1a1c1e` | `#e9ecef` | `#e3e8ee` |
-| `ink.muted` | `#5f6b76` | `#8f9aa6` | `#8792a3` |
+| `ink.muted` | `#5c6772` | `#8f9aa6` | `#8792a3` |
 | `accent.minerale` (interattivo) | `#33506b` | `#8fb0cc` | `#7fa0bc` |
 
 Il gradiente di temperatura è la novità: il fuoco è appena più caldo (avorio), la periferia appena più fredda (minerale). Sotto la soglia del dichiarabile a parole, sopra la soglia del percepibile: è la lampada, non un tema.
+
+I valori sono formalizzati nel sorgente token DTCG `tokens/lume.tokens.json` e misurati da `scripts/check-lume-tokens.mjs` (WUL-55, candidato L1a: sorgente e misura, nessun consumatore runtime). In `giorno` `ink.muted` è stato scurito da `#5f6b76` a `#5c6772`: il valore originale misurava 4,44:1 su `surface.chrome` (la superficie chiara più scura, quindi la coppia vincolante), sotto la soglia 4,5:1; ora misura 4,70:1. Le altre coppie erano già sopra soglia.
 
 I segnali clinici NON cambiano: `signal.warning #9a6a2f`, `signal.critical #a33a2f`, `signal.success #4b6354`, `signal.plum #555161` (e le loro derivazioni scure/notturne dai token). La semantica clinica è patrimonio, non stile.
 
@@ -122,4 +124,4 @@ Il layout di Lume non presenta dati: presenta decisioni.
 
 ## 9. Contratti invariati
 
-Accessibilità ([../vetro-clinico/06-accessibilita.md](../vetro-clinico/06-accessibilita.md)), interazione e stati onesti ([../vetro-clinico/04-interazione.md](../vetro-clinico/04-interazione.md)), responsività e densità ([../vetro-clinico/05-responsivita.md](../vetro-clinico/05-responsivita.md)) valgono in Lume parola per parola. I contrasti dei registri vanno misurati come da matrice (i valori di palette qui sopra sono progettati per passare 4.5:1 ma la misura fa fede).
+Accessibilità ([../vetro-clinico/06-accessibilita.md](../vetro-clinico/06-accessibilita.md)), interazione e stati onesti ([../vetro-clinico/04-interazione.md](../vetro-clinico/04-interazione.md)), responsività e densità ([../vetro-clinico/05-responsivita.md](../vetro-clinico/05-responsivita.md)) valgono in Lume parola per parola. I contrasti dei registri sono misurati da `scripts/check-lume-tokens.mjs` sul sorgente token: testo primario e attenuato su tutte e quattro le superfici, e l'accento minerale interattivo sulle superfici di lavoro (penombra, fuoco), soglia 4,5:1 perché portano testo di dimensione normale. Le trenta coppie dichiarate passano tutte; la misura fa fede. Questa è la coppia testo/superficie misurata, non una dichiarazione di accessibilità piena: i segnali clinici, gli stati di focus, i componenti e le superfici native restano da verificare nelle fasi successive.

--- a/docs/design/lume/03-migrazione.md
+++ b/docs/design/lume/03-migrazione.md
@@ -40,7 +40,8 @@ Principio: Lume non butta niente di ciò che vale. Il consolidamento di Vetro Cl
 | Fase | Contenuto | Gate |
 | --- | --- | --- |
 | L0 | Decisione di prodotto e canone: Lume lingua di destinazione, ADR 0078 e contratti di piattaforma | Completata per la direzione; font non-Apple e slice restano decisioni di delivery |
-| L1 | Token: registri giorno/grafite/guardia nel sorgente DTCG, misura dei contrasti, `data-lume` accanto ai token attuali (convivenza temporanea, non selettore utente: flag di sviluppo) | Tutte le coppie AA misurate |
+| L1a | Contratto token: registri giorno/grafite/guardia nel sorgente DTCG (`tokens/lume.tokens.json`) con misura strumentale dei contrasti (`scripts/check-lume-tokens.mjs`). Solo sorgente e misura: nessun consumatore runtime, nessun flag `data-lume` ancora | Tutte le coppie testo/superficie dichiarate misurate >= 4,5:1 |
+| L1b | Convivenza: `data-lume` accanto ai token attuali (convivenza temporanea, non selettore utente: flag di sviluppo), introdotto in un pacchetto successivo quando arriva il primo consumatore | Flag di sviluppo isolato, ADR 0047 rispettato |
 | L2 | Fuoco e chrome: modello focale nel cockpit (worklist/Quadro), rail e barre a chrome opaco, ritiro del vetro strutturale | Smoke visivo 3 registri + 3 segnali di accessibilità |
 | L3 | Il filo: selezione focale, timeline diario, storia valori con banda personale | Leggibilità misurata; il tratteggio bozza copre i contenuti proposti |
 | L4 | Le due voci: bundling font, regola del Registro su dosi/valori/codici/date (web e nativo) | Nessun fetch remoto; parity visiva print |
@@ -48,6 +49,8 @@ Principio: Lume non butta niente di ciò che vale. Il consolidamento di Vetro Cl
 | L6 | Piattaforme native: Apple viene implementata per prima; Windows/Linux restano documentazione prospettica finché le lane non vengono riaperte | Contratto macOS verificato nel bundle; nessuna claim di client tri-OS |
 
 Le fasi L2-L5 atterrano in fette piccole per superficie (prima il cockpit, poi la Scheda, poi settings), con la disciplina già in uso.
+
+Stato di questo branch (WUL-55): è un candidato **L1a**, non adozione runtime. Consegna il contratto token (sorgente DTCG più misura del contrasto) e nient'altro: non esiste ancora nessun consumatore `data-lume`, nessun CSS, componente o file nativo cambia. L1 si considera consegnata solo quando il contratto token è mergiato e misurato; la convivenza runtime (L1b, flag `data-lume`) inizia in un pacchetto successivo, dietro la condizione di uscita formalizzata in ADR 0078.
 
 ## 4. Rischi
 

--- a/docs/design/lume/tokens/lume.tokens.json
+++ b/docs/design/lume/tokens/lume.tokens.json
@@ -1,0 +1,57 @@
+{
+  "$description": "Lume design tokens (WUL-55, L1a candidate). DTCG-style source for the three light registers giorno/grafite/guardia plus register-independent clinical signals. Not yet wired to any runtime consumer; no data-lume flag exists yet. Text/background contrast is measured by scripts/check-lume-tokens.mjs.",
+  "$type": "color",
+  "register": {
+    "giorno": {
+      "surface": {
+        "canvas": { "$value": "#eef0f2" },
+        "field": { "$value": "#f5f5f4" },
+        "focal": { "$value": "#fbfaf7" },
+        "chrome": { "$value": "#e6e8eb" }
+      },
+      "ink": {
+        "primary": { "$value": "#1a1c1e" },
+        "muted": { "$value": "#5c6772" }
+      },
+      "accent": {
+        "minerale": { "$value": "#33506b" }
+      }
+    },
+    "grafite": {
+      "surface": {
+        "canvas": { "$value": "#121417" },
+        "field": { "$value": "#191c21" },
+        "focal": { "$value": "#22252b" },
+        "chrome": { "$value": "#0e1013" }
+      },
+      "ink": {
+        "primary": { "$value": "#e9ecef" },
+        "muted": { "$value": "#8f9aa6" }
+      },
+      "accent": {
+        "minerale": { "$value": "#8fb0cc" }
+      }
+    },
+    "guardia": {
+      "surface": {
+        "canvas": { "$value": "#0c0e12" },
+        "field": { "$value": "#14171d" },
+        "focal": { "$value": "#1a1e26" },
+        "chrome": { "$value": "#090b0e" }
+      },
+      "ink": {
+        "primary": { "$value": "#e3e8ee" },
+        "muted": { "$value": "#8792a3" }
+      },
+      "accent": {
+        "minerale": { "$value": "#7fa0bc" }
+      }
+    }
+  },
+  "signal": {
+    "warning": { "$value": "#9a6a2f" },
+    "critical": { "$value": "#a33a2f" },
+    "success": { "$value": "#4b6354" },
+    "plum": { "$value": "#555161" }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "check:claims": "node scripts/check-claims-guard.mjs",
     "rehearse:api-v1-compatibility": "node scripts/api-v1-compatibility-rehearsal.mjs",
     "check:never-regress": "node scripts/check-never-regress.mjs",
+    "check:lume-tokens": "node scripts/check-lume-tokens.mjs",
+    "test:lume-tokens": "node --test scripts/check-lume-tokens.test.mjs",
     "test:run-strip-types": "node --test scripts/run-strip-types.test.mjs",
     "test:unit": "node scripts/run-strip-types.mjs --test --exclude lib/security/audit.test.ts --exclude lib/patient-ambulatory-membership.test.ts --exclude lib/patient-cascade.test.ts --exclude lib/patient-lifecycle.test.ts --exclude lib/sqlite-repair.test.ts --exclude lib/test-container-clear.test.ts --glob \"lib/**/*.test.ts\" --glob \"components/**/*.test.ts\" scripts/check-schema-drift.test.ts",
     "test:api-v1-contract-negative": "bash scripts/api-v1-contract-negative-test.sh",

--- a/scripts/check-lume-tokens.mjs
+++ b/scripts/check-lume-tokens.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+// Lume token contract checker (WUL-55, L1a). Dependency-free ESM.
+// Verifies WCAG 2.x relative-luminance contrast for the declared Lume
+// text/background pairs across the three registers giorno/grafite/guardia.
+// Pure functions are exported for tests; running the file measures the
+// committed docs/design/lume/tokens/lume.tokens.json and prints a report.
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+export const DEFAULT_TOKENS_PATH = path.join(ROOT_DIR, 'docs/design/lume/tokens/lume.tokens.json');
+
+export const REGISTERS = ['giorno', 'grafite', 'guardia'];
+export const SURFACES = ['canvas', 'field', 'focal', 'chrome'];
+export const SIGNALS = ['warning', 'critical', 'success', 'plum'];
+// Normal-size text must clear WCAG AA 4.5:1. accent.minerale is documented as
+// interactive text (links, minerale admin queue), so it uses the text threshold
+// on the work surfaces (field = penombra, focal = fuoco) where it carries text.
+export const TEXT_MIN_RATIO = 4.5;
+const ACCENT_TEXT_SURFACES = ['field', 'focal'];
+
+// Parse "#rrggbb" (case-insensitive). Fails closed: throws on anything else.
+export function parseHexColor(value) {
+  if (typeof value !== 'string' || !/^#[0-9a-fA-F]{6}$/.test(value)) {
+    throw new Error(`malformed color: ${JSON.stringify(value)}`);
+  }
+  const n = Number.parseInt(value.slice(1), 16);
+  return { r: (n >> 16) & 0xff, g: (n >> 8) & 0xff, b: n & 0xff };
+}
+
+function channelLuminance(c) {
+  const s = c / 255;
+  return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+}
+
+// WCAG relative luminance of a "#rrggbb" color.
+export function relativeLuminance(hex) {
+  const { r, g, b } = parseHexColor(hex);
+  return 0.2126 * channelLuminance(r) + 0.7152 * channelLuminance(g) + 0.0722 * channelLuminance(b);
+}
+
+// WCAG contrast ratio between two colors, in [1, 21].
+export function contrastRatio(hexA, hexB) {
+  const la = relativeLuminance(hexA);
+  const lb = relativeLuminance(hexB);
+  const [hi, lo] = la >= lb ? [la, lb] : [lb, la];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+// Resolve a dotted token path to its "#rrggbb" value. Fails closed: throws if
+// the path is missing or the leaf is not a DTCG color token.
+export function resolveColor(tokens, dottedPath) {
+  let node = tokens;
+  for (const key of dottedPath.split('.')) {
+    if (!node || typeof node !== 'object' || !(key in node)) {
+      throw new Error(`missing token: ${dottedPath}`);
+    }
+    node = node[key];
+  }
+  if (!node || typeof node !== 'object' || !('$value' in node)) {
+    throw new Error(`missing token value: ${dottedPath}`);
+  }
+  parseHexColor(node.$value); // throws on malformed
+  return node.$value;
+}
+
+// Deterministic ordered contract: primary + muted text on every surface, then
+// accent text on the work surfaces, for each register.
+export function buildContract() {
+  const checks = [];
+  for (const register of REGISTERS) {
+    for (const ink of ['primary', 'muted']) {
+      for (const surface of SURFACES) {
+        checks.push({
+          register,
+          label: `ink.${ink} on surface.${surface}`,
+          text: `register.${register}.ink.${ink}`,
+          background: `register.${register}.surface.${surface}`,
+          minRatio: TEXT_MIN_RATIO,
+        });
+      }
+    }
+    for (const surface of ACCENT_TEXT_SURFACES) {
+      checks.push({
+        register,
+        label: `accent.minerale on surface.${surface}`,
+        text: `register.${register}.accent.minerale`,
+        background: `register.${register}.surface.${surface}`,
+        minRatio: TEXT_MIN_RATIO,
+      });
+    }
+  }
+  return checks;
+}
+
+// Pure evaluation: given parsed tokens, measure every contract pair. Fails
+// closed by throwing (via resolveColor) on any missing/malformed required token.
+export function evaluateContract(tokens, contract = buildContract()) {
+  for (const signal of SIGNALS) resolveColor(tokens, `signal.${signal}`);
+  const checks = contract.map((c) => {
+    const ratio = contrastRatio(resolveColor(tokens, c.text), resolveColor(tokens, c.background));
+    return { ...c, ratio, pass: ratio >= c.minRatio };
+  });
+  return { checks, pass: checks.every((c) => c.pass) };
+}
+
+// Concise deterministic report grouped by register.
+export function formatReport(result) {
+  const lines = ['Lume token contract: WCAG contrast (measured)'];
+  for (const register of REGISTERS) {
+    lines.push(`register ${register}`);
+    for (const c of result.checks.filter((x) => x.register === register)) {
+      const ratio = `${c.ratio.toFixed(3)}:1`.padStart(9);
+      lines.push(`  ${c.pass ? 'PASS' : 'FAIL'}  ${ratio}  (min ${c.minRatio}:1)  ${c.label}`);
+    }
+  }
+  const failed = result.checks.filter((c) => !c.pass).length;
+  lines.push(`${result.checks.length} pairs measured, ${failed} below threshold: ${result.pass ? 'OK' : 'CONTRACT VIOLATED'}`);
+  return lines.join('\n');
+}
+
+export function loadTokens(tokensPath = DEFAULT_TOKENS_PATH) {
+  return JSON.parse(readFileSync(tokensPath, 'utf8'));
+}
+
+function main() {
+  let result;
+  try {
+    result = evaluateContract(loadTokens());
+  } catch (error) {
+    console.error(`lume token check failed: ${error.message}`);
+    process.exitCode = 1;
+    return;
+  }
+  console.log(formatReport(result));
+  process.exitCode = result.pass ? 0 : 1;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/check-lume-tokens.test.mjs
+++ b/scripts/check-lume-tokens.test.mjs
@@ -1,0 +1,92 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  parseHexColor,
+  contrastRatio,
+  resolveColor,
+  evaluateContract,
+  formatReport,
+  loadTokens,
+} from './check-lume-tokens.mjs';
+
+// Minimal well-formed tokens covering every path the contract references.
+function validTokens() {
+  const register = (surface, ink, accent) => ({
+    surface: {
+      canvas: { $value: surface[0] },
+      field: { $value: surface[1] },
+      focal: { $value: surface[2] },
+      chrome: { $value: surface[3] },
+    },
+    ink: { primary: { $value: ink[0] }, muted: { $value: ink[1] } },
+    accent: { minerale: { $value: accent } },
+  });
+  return {
+    register: {
+      giorno: register(['#eef0f2', '#f5f5f4', '#fbfaf7', '#e6e8eb'], ['#1a1c1e', '#5c6772'], '#33506b'),
+      grafite: register(['#121417', '#191c21', '#22252b', '#0e1013'], ['#e9ecef', '#8f9aa6'], '#8fb0cc'),
+      guardia: register(['#0c0e12', '#14171d', '#1a1e26', '#090b0e'], ['#e3e8ee', '#8792a3'], '#7fa0bc'),
+    },
+    signal: {
+      warning: { $value: '#9a6a2f' },
+      critical: { $value: '#a33a2f' },
+      success: { $value: '#4b6354' },
+      plum: { $value: '#555161' },
+    },
+  };
+}
+
+test('WCAG primitives match known reference values', () => {
+  // Black on white is the canonical 21:1 pair; equal colors are 1:1.
+  assert.equal(Math.round(contrastRatio('#000000', '#ffffff')), 21);
+  assert.equal(contrastRatio('#abcdef', '#abcdef'), 1);
+  assert.deepEqual(parseHexColor('#33506b'), { r: 0x33, g: 0x50, b: 0x6b });
+});
+
+test('committed token source passes the whole contract', () => {
+  const result = evaluateContract(loadTokens());
+  assert.equal(result.pass, true);
+  assert.equal(result.checks.length, 30); // 3 registers x (2 ink x 4 surface + 2 accent)
+  assert.ok(result.checks.every((c) => c.ratio >= c.minRatio));
+  // The adjusted binding pair: giorno muted on chrome clears 4.5 with margin.
+  const bind = result.checks.find(
+    (c) => c.register === 'giorno' && c.label === 'ink.muted on surface.chrome',
+  );
+  assert.equal(bind.ratio.toFixed(3), '4.702');
+  assert.match(formatReport(result), /CONTRACT VIOLATED|OK/);
+});
+
+test('inline valid tokens pass and report is deterministic', () => {
+  const result = evaluateContract(validTokens());
+  assert.equal(result.pass, true);
+  assert.equal(formatReport(result), formatReport(evaluateContract(validTokens())));
+});
+
+test('missing required token fails closed', () => {
+  const broken = validTokens();
+  delete broken.signal.warning;
+  assert.throws(() => evaluateContract(broken), /missing token: signal\.warning/);
+  assert.throws(() => resolveColor(broken, 'signal.warning'), /missing token/);
+});
+
+test('malformed color value fails closed', () => {
+  const broken = validTokens();
+  broken.register.grafite.surface.focal.$value = 'rgb(1,2,3)';
+  assert.throws(() => evaluateContract(broken), /malformed color/);
+  assert.throws(() => parseHexColor('#fff'), /malformed color/);
+});
+
+test('a deliberately low-contrast pair is reported as a violation', () => {
+  const failing = validTokens();
+  // Muted on chrome lifted to near-chrome luminance drops well below 4.5:1.
+  failing.register.giorno.ink.muted.$value = '#c8ccd0';
+  const result = evaluateContract(failing);
+  assert.equal(result.pass, false);
+  const bad = result.checks.find(
+    (c) => c.register === 'giorno' && c.label === 'ink.muted on surface.chrome',
+  );
+  assert.equal(bad.pass, false);
+  assert.ok(bad.ratio < 4.5);
+  assert.match(formatReport(result), /CONTRACT VIOLATED/);
+});


### PR DESCRIPTION
## Summary
- aggiunge il sorgente DTCG dei registri Lume giorno, grafite e guardia;
- misura 30 coppie testo/superficie con soglia WCAG 4,5:1;
- valida in modo fail-closed anche i quattro segnali clinici richiesti;
- formalizza la condizione di uscita dalla convivenza data-lume senza introdurre consumatori runtime.

## Verification
- npm run check:lume-tokens — 30/30 coppie
- npm run test:lume-tokens — 6/6
- npm run check:claims
- npm run check:never-regress
- npm run check:apple-wide-qa
- npm run typecheck
- npm run lint
- git diff --check origin/main...HEAD
- autoreview Codex gpt-5.6-sol high — secondo ciclo pulito, confidenza 0,96

## Risk / Notes
- L1a è soltanto contratto token e misura; non aggiunge CSS, data-lume, componenti o file nativi;
- ink.muted giorno passa da #5f6b76 a #5c6772 perché la coppia vincolante sale da 4,44:1 a 4,70:1;
- nessuna dipendenza o modifica a package-lock;
- nessuna PHI/PII.

## Ticket
Refs WUL-55
