### PR TITLE
feat(ui): attiva i token runtime Lume

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from 'next';
 import Script from 'next/script';
 import './globals.css';
+// WUL-55: Lume runtime token mirror loads after globals so its --lume-* custom
+// properties are the first design-token input available to the live cockpit.
+import './lume-tokens.css';
 import { getAppFingerprint } from '@/lib/app-revision';
 import { RootRuntimeShell } from '@/components/root-runtime-shell';
 import {
@@ -17,6 +20,7 @@ const uiStyleBootstrapScript = `
   const root = document.documentElement;
   const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
   try {
+    root.dataset.lume = 'true';
     root.dataset.uiStyle = 'redesign';
     root.dataset.uiReduceMotion = localStorage.getItem('${UI_REDUCE_MOTION_STORAGE_KEY}') === 'true' ? 'true' : 'false';
     root.dataset.uiReduceTransparency = 'false';
@@ -27,6 +31,7 @@ const uiStyleBootstrapScript = `
     root.classList.add(resolved);
     root.style.colorScheme = resolved;
   } catch (error) {
+    root.dataset.lume = 'true';
     root.dataset.uiStyle = 'redesign';
     root.dataset.uiReduceMotion = 'false';
     root.dataset.uiReduceTransparency = 'false';
@@ -47,7 +52,7 @@ export default function RootLayout({
   const appFingerprint = getAppFingerprint();
 
   return (
-    <html lang="it" data-ui-style="redesign" suppressHydrationWarning>
+    <html lang="it" data-ui-style="redesign" data-lume="true" suppressHydrationWarning>
       {/* @Codex: keep layout fully local/offline by avoiding remote Google Font fetches */}
       <head>
         <meta name="mediflow-app-fingerprint" content={appFingerprint} />

--- a/app/lume-tokens.css
+++ b/app/lume-tokens.css
@@ -1,0 +1,58 @@
+/* Lume runtime token mirror (WUL-55, F2a). Hand-kept mirror of
+   docs/design/lume/tokens/lume.tokens.json, which stays the single source of
+   truth; scripts/check-lume-tokens.mjs fails closed on any drift. The namespaced
+   --lume-<register>-* properties declare giorno/grafite/guardia plus the
+   register-independent signals; the active aliases resolve to giorno under light
+   and grafite under html.dark. guardia is declared only, never a user control. */
+
+:root {
+  /* register: giorno */
+  --lume-giorno-surface-canvas: #eef0f2;
+  --lume-giorno-surface-field: #f5f5f4;
+  --lume-giorno-surface-focal: #fbfaf7;
+  --lume-giorno-surface-chrome: #e6e8eb;
+  --lume-giorno-ink-primary: #1a1c1e;
+  --lume-giorno-ink-muted: #5c6772;
+  --lume-giorno-accent-minerale: #33506b;
+  /* register: grafite */
+  --lume-grafite-surface-canvas: #121417;
+  --lume-grafite-surface-field: #191c21;
+  --lume-grafite-surface-focal: #22252b;
+  --lume-grafite-surface-chrome: #0e1013;
+  --lume-grafite-ink-primary: #e9ecef;
+  --lume-grafite-ink-muted: #8f9aa6;
+  --lume-grafite-accent-minerale: #8fb0cc;
+  /* register: guardia (declared only; not user-selectable) */
+  --lume-guardia-surface-canvas: #0c0e12;
+  --lume-guardia-surface-field: #14171d;
+  --lume-guardia-surface-focal: #1a1e26;
+  --lume-guardia-surface-chrome: #090b0e;
+  --lume-guardia-ink-primary: #e3e8ee;
+  --lume-guardia-ink-muted: #8792a3;
+  --lume-guardia-accent-minerale: #7fa0bc;
+  /* register-independent clinical signals */
+  --lume-signal-warning: #9a6a2f;
+  --lume-signal-critical: #a33a2f;
+  --lume-signal-success: #4b6354;
+  --lume-signal-plum: #555161;
+  /* active aliases: giorno is the light default */
+  --lume-surface-canvas: var(--lume-giorno-surface-canvas);
+  --lume-surface-field: var(--lume-giorno-surface-field);
+  --lume-surface-focal: var(--lume-giorno-surface-focal);
+  --lume-surface-chrome: var(--lume-giorno-surface-chrome);
+  --lume-ink: var(--lume-giorno-ink-primary);
+  --lume-ink-muted: var(--lume-giorno-ink-muted);
+  --lume-accent: var(--lume-giorno-accent-minerale);
+}
+
+/* active aliases: grafite is the dark default (html.dark is set by the layout
+   bootstrap; it coexists with mediflow-theme and data-ui-style=redesign). */
+.dark {
+  --lume-surface-canvas: var(--lume-grafite-surface-canvas);
+  --lume-surface-field: var(--lume-grafite-surface-field);
+  --lume-surface-focal: var(--lume-grafite-surface-focal);
+  --lume-surface-chrome: var(--lume-grafite-surface-chrome);
+  --lume-ink: var(--lume-grafite-ink-primary);
+  --lume-ink-muted: var(--lume-grafite-ink-muted);
+  --lume-accent: var(--lume-grafite-accent-minerale);
+}

--- a/components/kree8/kree8-clinical-cockpit.module.css
+++ b/components/kree8/kree8-clinical-cockpit.module.css
@@ -3,20 +3,20 @@
 
 .shell {
   /* ── local tokens (scoped; no globals touched) ── */
-  --surface: #ffffff;
-  --surface-soft: #f5f6f7;
+  --surface: var(--lume-surface-focal);
+  --surface-soft: var(--lume-surface-field);
   --surface-inset: #f3f4f6;
-  --canvas: #eef0f2;
-  --ink: #0f172a;
+  --canvas: var(--lume-surface-canvas);
+  --ink: var(--lume-ink);
   --ink-strong: #1e293b;
-  --ink-muted: #475569;
+  --ink-muted: var(--lume-ink-muted);
   --ink-subtle: #52606d;
   --ink-faint: #64748b;
   --line: rgba(15, 23, 42, 0.05);
   --line-strong: rgba(15, 23, 42, 0.08);
   --rail-green: #2f7d4f;
   /* @Codex WUL-UIUX: ex #1d4ed8, portato su slate per coerenza col focus globale */
-  --rail-blue: #334155;
+  --rail-blue: var(--lume-accent);
   --rail-yellow: #b45309;
   --rail-coral: #dc2626;
   --rail-violet: #6d28d9;
@@ -81,19 +81,19 @@
 }
 
 :global(html.dark) .shell {
-  --surface: #0f172a;
-  --surface-soft: #111827;
+  --surface: var(--lume-surface-focal);
+  --surface-soft: var(--lume-surface-field);
   --surface-inset: #1e293b;
-  --canvas: #020617;
-  --ink: #f8fafc;
+  --canvas: var(--lume-surface-canvas);
+  --ink: var(--lume-ink);
   --ink-strong: #e2e8f0;
-  --ink-muted: #cbd5e1;
+  --ink-muted: var(--lume-ink-muted);
   --ink-subtle: #b6c2d0;
   --ink-faint: #94a3b8;
   --line: rgba(226, 232, 240, 0.10);
   --line-strong: rgba(226, 232, 240, 0.16);
   --rail-green: #4ade80;
-  --rail-blue: #cbd5e1;
+  --rail-blue: var(--lume-accent);
   --rail-yellow: #fbbf24;
   --rail-coral: #f87171;
   --rail-violet: #a78bfa;

--- a/e2e/lume-runtime.spec.ts
+++ b/e2e/lume-runtime.spec.ts
@@ -1,0 +1,71 @@
+/* @Codex */
+import { expect, test, type Page } from '@playwright/test';
+import { bootstrapUnlockedSession } from './utils';
+
+const GIORNO_CANVAS_RGB = 'rgb(238, 240, 242)'; // #eef0f2
+const GRAFITE_CANVAS_RGB = 'rgb(18, 20, 23)'; // #121417
+
+// Custom properties compute to raw var() text, so resolve an alias by consuming
+// it on a throwaway probe element.
+async function resolveActiveVar(page: Page, varName: string): Promise<string> {
+  return page.evaluate((name) => {
+    const probe = document.createElement('div');
+    probe.style.color = `var(${name})`;
+    document.body.appendChild(probe);
+    const resolved = getComputedStyle(probe).color;
+    probe.remove();
+    return resolved;
+  }, varName);
+}
+
+async function readNamespacedVar(page: Page, varName: string): Promise<string> {
+  return page.evaluate(
+    (name) => getComputedStyle(document.documentElement).getPropertyValue(name).trim().toLowerCase(),
+    varName,
+  );
+}
+
+// Flip the theme class the way the bootstrap does — F2a adds no Lume selector.
+async function setThemeClass(page: Page, theme: 'light' | 'dark'): Promise<void> {
+  await page.evaluate((next) => {
+    const root = document.documentElement;
+    root.classList.remove('light', 'dark');
+    root.classList.add(next);
+  }, theme);
+}
+
+test('lume runtime tokens are the live default across theme changes, reload and cockpit routes', async ({ page }) => {
+  await bootstrapUnlockedSession(page, process.env.E2E_PIN || '1234');
+  const html = page.locator('html');
+  await expect(html).toHaveAttribute('data-lume', 'true');
+  // The redesign identity (ADR 0078) still coexists; F2a does not replace it.
+  await expect(html).toHaveAttribute('data-ui-style', 'redesign');
+  // Both register-scoped mirrors are present regardless of the active theme.
+  expect(await readNamespacedVar(page, '--lume-giorno-surface-canvas')).toBe('#eef0f2');
+  expect(await readNamespacedVar(page, '--lume-grafite-surface-canvas')).toBe('#121417');
+  // The active alias selects giorno under light and grafite under .dark.
+  await setThemeClass(page, 'light');
+  expect(await resolveActiveVar(page, '--lume-surface-canvas')).toBe(GIORNO_CANVAS_RGB);
+  await setThemeClass(page, 'dark');
+  expect(await resolveActiveVar(page, '--lume-surface-canvas')).toBe(GRAFITE_CANVAS_RGB);
+  await setThemeClass(page, 'light');
+  // The live cockpit is visible on the app root and paints the Lume giorno canvas.
+  const liveCockpit = page.getByLabel('MediFlow · spazio clinico Kree8');
+  await expect(liveCockpit).toBeVisible({ timeout: 20_000 });
+  expect(await liveCockpit.evaluate((el) => getComputedStyle(el).backgroundColor)).toBe(GIORNO_CANVAS_RGB);
+  // A patient-facing cockpit route reachable with only synthetic review data.
+  await page.goto('/mockups/kree8');
+  await page.waitForLoadState('domcontentloaded');
+  await expect(html).toHaveAttribute('data-lume', 'true');
+  await setThemeClass(page, 'light');
+  const reviewCockpit = page.getByLabel('MediFlow · Kree8 review surface');
+  await expect(reviewCockpit).toBeVisible({ timeout: 20_000 });
+  expect(await reviewCockpit.evaluate((el) => getComputedStyle(el).backgroundColor)).toBe(GIORNO_CANVAS_RGB);
+  // The bootstrap restores the persisted theme and matching alias on reload.
+  await page.evaluate(() => localStorage.setItem('mediflow-theme', 'dark'));
+  await page.reload();
+  await page.waitForLoadState('domcontentloaded');
+  await expect(html).toHaveAttribute('data-lume', 'true');
+  await expect(html).toHaveClass(/dark/);
+  expect(await resolveActiveVar(page, '--lume-surface-canvas')).toBe(GRAFITE_CANVAS_RGB);
+});

--- a/scripts/check-lume-tokens.mjs
+++ b/scripts/check-lume-tokens.mjs
@@ -11,6 +11,7 @@ import { fileURLToPath } from 'node:url';
 
 const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 export const DEFAULT_TOKENS_PATH = path.join(ROOT_DIR, 'docs/design/lume/tokens/lume.tokens.json');
+export const DEFAULT_CSS_MIRROR_PATH = path.join(ROOT_DIR, 'app/lume-tokens.css');
 
 export const REGISTERS = ['giorno', 'grafite', 'guardia'];
 export const SURFACES = ['canvas', 'field', 'focal', 'chrome'];
@@ -125,16 +126,123 @@ export function loadTokens(tokensPath = DEFAULT_TOKENS_PATH) {
   return JSON.parse(readFileSync(tokensPath, 'utf8'));
 }
 
+export function loadCssMirror(cssPath = DEFAULT_CSS_MIRROR_PATH) {
+  return readFileSync(cssPath, 'utf8');
+}
+
+// Active aliases resolve at runtime to a register-scoped variable.
+export const ACTIVE_ALIASES = [
+  { alias: '--lume-surface-canvas', suffix: 'surface-canvas' },
+  { alias: '--lume-surface-field', suffix: 'surface-field' },
+  { alias: '--lume-surface-focal', suffix: 'surface-focal' },
+  { alias: '--lume-surface-chrome', suffix: 'surface-chrome' },
+  { alias: '--lume-ink', suffix: 'ink-primary' },
+  { alias: '--lume-ink-muted', suffix: 'ink-muted' },
+  { alias: '--lume-accent', suffix: 'accent-minerale' },
+];
+
+export function expectedMirror(tokens) {
+  const map = new Map();
+  for (const register of REGISTERS) {
+    for (const surface of SURFACES) {
+      map.set(`--lume-${register}-surface-${surface}`, resolveColor(tokens, `register.${register}.surface.${surface}`));
+    }
+    map.set(`--lume-${register}-ink-primary`, resolveColor(tokens, `register.${register}.ink.primary`));
+    map.set(`--lume-${register}-ink-muted`, resolveColor(tokens, `register.${register}.ink.muted`));
+    map.set(`--lume-${register}-accent-minerale`, resolveColor(tokens, `register.${register}.accent.minerale`));
+  }
+  for (const signal of SIGNALS) {
+    map.set(`--lume-signal-${signal}`, resolveColor(tokens, `signal.${signal}`));
+  }
+  return map;
+}
+
+const NAMESPACED_TOKEN = /^--lume-(?:giorno|grafite|guardia)-|^--lume-signal-/;
+
+export function parseCssBlocks(css) {
+  const clean = css.replace(/\/\*[\s\S]*?\*\//g, '');
+  const blocks = [];
+  const ruleRe = /([^{}]+)\{([^{}]*)\}/g;
+  let rule;
+  while ((rule = ruleRe.exec(clean)) !== null) {
+    const decls = new Map();
+    const declRe = /(--[\w-]+)\s*:\s*([^;]+?)(?:;|$)/g;
+    let decl;
+    while ((decl = declRe.exec(rule[2])) !== null) {
+      const name = decl[1].trim();
+      if (decls.has(name)) throw new Error(`mirror duplicate declaration: ${name}`);
+      decls.set(name, decl[2].trim());
+    }
+    blocks.push({ selector: rule[1].trim(), decls });
+  }
+  return blocks;
+}
+
+function normalizeHex(value) {
+  const trimmed = value.trim();
+  parseHexColor(trimmed); // fail closed on a malformed mirror value
+  return trimmed.toLowerCase();
+}
+
+export function verifyCssMirror(tokens, css) {
+  const blocks = parseCssBlocks(css);
+  const flat = new Map();
+  for (const block of blocks) {
+    for (const [name, value] of block.decls) {
+      if (NAMESPACED_TOKEN.test(name) && flat.has(name)) throw new Error(`mirror duplicate token: ${name}`);
+      if (!flat.has(name)) flat.set(name, value);
+    }
+  }
+  const expected = expectedMirror(tokens);
+  for (const [name, hex] of expected) {
+    const got = flat.get(name);
+    if (got === undefined) throw new Error(`mirror missing token: ${name}`);
+    if (normalizeHex(got) !== normalizeHex(hex)) throw new Error(`mirror drift: ${name} is ${got}, expected ${hex}`);
+  }
+  for (const name of flat.keys()) {
+    if (NAMESPACED_TOKEN.test(name) && !expected.has(name)) throw new Error(`mirror unknown token: ${name}`);
+  }
+  const roots = blocks.filter((block) => block.selector.split(',').some((s) => s.trim() === ':root'));
+  const darks = blocks.filter((block) => block.selector.split(',').some((s) => s.trim() === '.dark'));
+  if (roots.length !== 1) throw new Error('mirror requires exactly one :root block');
+  if (darks.length !== 1) throw new Error('mirror requires exactly one .dark block');
+  const [root] = roots;
+  const [dark] = darks;
+  const aliasNames = new Set(ACTIVE_ALIASES.map(({ alias }) => alias));
+  for (const block of blocks) {
+    if (block !== root && block !== dark && [...block.decls.keys()].some((name) => aliasNames.has(name))) {
+      throw new Error(`mirror active alias outside theme block: ${block.selector}`);
+    }
+  }
+  for (const { alias, suffix } of ACTIVE_ALIASES) {
+    assertAlias(root.decls, alias, `var(--lume-giorno-${suffix})`, ':root/giorno');
+    assertAlias(dark.decls, alias, `var(--lume-grafite-${suffix})`, '.dark/grafite');
+  }
+  return { tokens: expected.size, aliases: ACTIVE_ALIASES.length };
+}
+
+function assertAlias(decls, alias, expectedValue, where) {
+  const got = decls.get(alias);
+  if (got === undefined) throw new Error(`mirror missing active alias ${alias} in ${where}`);
+  if (got.replace(/\s+/g, '') !== expectedValue.replace(/\s+/g, '')) {
+    throw new Error(`mirror alias ${alias} in ${where} is ${got}, expected ${expectedValue}`);
+  }
+}
+
 function main() {
   let result;
+  let mirror;
   try {
-    result = evaluateContract(loadTokens());
+    const tokens = loadTokens();
+    result = evaluateContract(tokens);
+    mirror = verifyCssMirror(tokens, loadCssMirror());
   } catch (error) {
     console.error(`lume token check failed: ${error.message}`);
     process.exitCode = 1;
     return;
   }
   console.log(formatReport(result));
+  console.log(`CSS mirror app/lume-tokens.css: ${mirror.tokens} namespaced tokens matched, ${mirror.aliases} active aliases per theme OK`);
   process.exitCode = result.pass ? 0 : 1;
 }
 

--- a/scripts/check-lume-tokens.test.mjs
+++ b/scripts/check-lume-tokens.test.mjs
@@ -8,6 +8,11 @@ import {
   evaluateContract,
   formatReport,
   loadTokens,
+  loadCssMirror,
+  parseCssBlocks,
+  expectedMirror,
+  verifyCssMirror,
+  ACTIVE_ALIASES,
 } from './check-lume-tokens.mjs';
 
 // Minimal well-formed tokens covering every path the contract references.
@@ -89,4 +94,42 @@ test('a deliberately low-contrast pair is reported as a violation', () => {
   assert.equal(bad.pass, false);
   assert.ok(bad.ratio < 4.5);
   assert.match(formatReport(result), /CONTRACT VIOLATED/);
+});
+
+// CSS mirror (app/lume-tokens.css)
+test('parseCssBlocks strips comments and reads namespaced + alias declarations', () => {
+  const blocks = parseCssBlocks('/* x */\n:root { --lume-a: #fff; --lume-b: var(--lume-a); }');
+  assert.equal(blocks.length, 1);
+  assert.equal(blocks[0].selector, ':root');
+  assert.equal(blocks[0].decls.get('--lume-a'), '#fff');
+  assert.equal(blocks[0].decls.get('--lume-b'), 'var(--lume-a)');
+});
+
+test('committed CSS mirror matches the committed token source', () => {
+  const summary = verifyCssMirror(loadTokens(), loadCssMirror());
+  // 3 registers x (4 surface + 2 ink + 1 accent) + 4 signals.
+  assert.equal(summary.tokens, expectedMirror(loadTokens()).size);
+  assert.equal(summary.tokens, 25);
+  assert.equal(summary.aliases, ACTIVE_ALIASES.length);
+});
+
+test('a drifted mirror value fails closed', () => {
+  const css = loadCssMirror().replace('--lume-giorno-surface-canvas: #eef0f2;', '--lume-giorno-surface-canvas: #ffffff;');
+  assert.throws(() => verifyCssMirror(loadTokens(), css), /mirror drift: --lume-giorno-surface-canvas/);
+  assert.throws(() => verifyCssMirror(loadTokens(), `${css}\n:root { --lume-giorno-surface-canvas: #eef0f2 }`), /duplicate token/);
+});
+
+test('a mirror missing a namespaced token fails closed', () => {
+  const css = loadCssMirror().replace('--lume-grafite-ink-muted: #8f9aa6;', '');
+  assert.throws(() => verifyCssMirror(loadTokens(), css), /mirror missing token: --lume-grafite-ink-muted/);
+});
+
+test('a mirror missing the :root (giorno) active alias fails closed', () => {
+  const css = loadCssMirror().replace('--lume-surface-canvas: var(--lume-giorno-surface-canvas);', '');
+  assert.throws(() => verifyCssMirror(loadTokens(), css), /missing active alias --lume-surface-canvas in :root\/giorno/);
+});
+
+test('a mirror whose .dark alias points at the wrong register fails closed', () => {
+  const css = loadCssMirror().replace('--lume-ink: var(--lume-grafite-ink-primary);', '--lume-ink: var(--lume-giorno-ink-primary);');
+  assert.throws(() => verifyCssMirror(loadTokens(), css), /alias --lume-ink in \.dark\/grafite/);
 });


### PR DESCRIPTION
## Summary
- importa il mirror CSS dei token Lume e attiva Giorno/Grafite alla radice
- migra il cockpit ai soli alias neutrali misurati, senza cambiare struttura o navigazione
- rende il controllo di drift fail-closed per token, alias, duplicati e dichiarazioni semicolon-less
- aggiunge una prova Playwright sintetica per tema, reload e route cockpit

## Verification
- `git diff --check`
- Node 24.18.0: `npm run check:lume-tokens` — 30/30 contrasti, 25 token e 7 alias per tema
- Node 24.18.0: `npm run test:lume-tokens` — 12/12
- Node 24.18.0: `npm run typecheck`
- Node 24.18.0: `npm run lint`
- `E2E_SPECS=e2e/lume-runtime.spec.ts scripts/e2e-smoke.sh` — 1/1
- autoreview Codex gpt-5.6-sol high — nessun finding azionabile, confidence 0.97
- copertura CI verificata: il workflow PR esegue la nuova spec nel set completo Playwright

## Risk / Notes
- il registro Guardia è dichiarato ma non attivato
- il pacchetto migra solo il consumo cromatico del cockpit; shell, auth, scheda, settings e rimozione della terminologia legacy restano filoni separati
- nessuna nuova dipendenza, migrazione database o modifica a dati clinici; nessuna PHI/PII

## Ticket
Refs WUL-55