### PR TITLE
fix(ai): harden PM2 and production dependencies

### DIFF
--- a/app/api/system/mlx/route.ts
+++ b/app/api/system/mlx/route.ts
@@ -35,14 +35,10 @@ export async function GET(request: Request) {
     if (!MLX_SUPPORTED) return mlxUnsupportedResponse();
 
     try {
-        await PM2Manager.connect();
-        const status = await PM2Manager.getStatus();
+        const status = await PM2Manager.withConnection(() => PM2Manager.getStatus());
         return NextResponse.json(status);
     } catch (e: any) {
         return NextResponse.json({ error: e.message }, { status: 500 });
-    } finally {
-        /* @Codex */
-        PM2Manager.disconnect();
     }
 }
 
@@ -59,12 +55,9 @@ export async function POST() {
     if (!MLX_SUPPORTED) return mlxUnsupportedResponse();
 
     try {
-        await PM2Manager.connect();
-        await PM2Manager.start();
-        PM2Manager.disconnect();
-        return NextResponse.json({ success: true, message: "Started" });
+        await PM2Manager.withConnection(() => PM2Manager.start());
+        return NextResponse.json({ success: true, message: "Avvio PM2 richiesto; verifica lo stato locale." });
     } catch (e: any) {
-        PM2Manager.disconnect();
         return NextResponse.json({ error: e.message }, { status: 500 });
     }
 }
@@ -78,12 +71,9 @@ export async function DELETE() {
     if (!MLX_SUPPORTED) return mlxUnsupportedResponse();
 
     try {
-        await PM2Manager.connect();
-        await PM2Manager.stop();
-        PM2Manager.disconnect();
+        await PM2Manager.withConnection(() => PM2Manager.stop());
         return NextResponse.json({ success: true, message: "Stopped" });
     } catch (e: any) {
-        PM2Manager.disconnect();
         return NextResponse.json({ error: e.message }, { status: 500 });
     }
 }

--- a/lib/pm2-manager.test.ts
+++ b/lib/pm2-manager.test.ts
@@ -1,0 +1,256 @@
+/* @Codex */
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import Module from 'node:module';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+interface CommonJSModuleLoader {
+    _load(request: string, parent: unknown, isMain: boolean): unknown;
+}
+
+test('PM2 is isolated and the port guard leaves an occupied service untouched', async () => {
+    const moduleLoader = Module as unknown as CommonJSModuleLoader;
+    const originalLoad = moduleLoader._load;
+    const originalPM2Home = process.env.PM2_HOME;
+    const originalDataDir = process.env.MEDIFLOW_DATA_DIR;
+    const originalMediFlowPM2Home = process.env.MEDIFLOW_PM2_HOME;
+    const originalEnvironmentValue = process.env.PM2_NO_INTERACTION;
+    const originalOverHome = process.env.OVER_HOME;
+    const originalRPCOverride = process.env.PM2_DAEMON_RPC_PORT;
+    const originalPUBOverride = process.env.PM2_DAEMON_PUB_PORT;
+    const managerPath = require.resolve('./pm2-manager');
+    const dataDirPath = require.resolve('./data-dir');
+    const isolatedDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mediflow-pm2-manager-'));
+    const isolatedPM2Home = path.join(isolatedDataDir, 'pm2');
+    const unrelatedPM2Home = path.join(os.tmpdir(), 'unrelated-global-pm2');
+    let environmentAtPM2Load: {
+        home?: string;
+        noInteraction?: string;
+        overHome?: string;
+        rpcOverride?: string;
+        pubOverride?: string;
+    } | undefined;
+    let online = false;
+    let startCalls = 0;
+    let stopCalls = 0;
+    let connectCalls = 0;
+    let disconnectCalls = 0;
+    let activeConnections = 0;
+    let maxActiveConnections = 0;
+    const pm2Stub = {
+        pm2_home: isolatedPM2Home,
+        Client: {
+            pm2_home: isolatedPM2Home,
+            rpc_socket_file: path.join(isolatedPM2Home, 'rpc.sock'),
+            pub_socket_file: path.join(isolatedPM2Home, 'pub.sock'),
+        },
+        connect(callback: (error: Error | null) => void) {
+            connectCalls += 1;
+            setTimeout(() => {
+                activeConnections += 1;
+                maxActiveConnections = Math.max(maxActiveConnections, activeConnections);
+                callback(null);
+            }, 5);
+        },
+        disconnect(callback?: (error?: Error | null) => void) {
+            disconnectCalls += 1;
+            setTimeout(() => {
+                activeConnections -= 1;
+                callback?.(null);
+            }, 5);
+        },
+        describe(_name: string, callback: (error: Error | null, description: unknown[]) => void) {
+            callback(null, online
+                ? [{ name: 'mlx-inference-server', pm2_env: { status: 'online' }, monit: {} }]
+                : []);
+        },
+        start(_path: string, callback: (error: Error | null) => void) {
+            startCalls += 1;
+            setTimeout(() => {
+                online = true;
+                callback(null);
+            }, 10);
+        },
+        stop(_name: string, callback: (error: Error | null) => void) {
+            stopCalls += 1;
+            callback(new Error('process or namespace not found'));
+        },
+    };
+
+    process.env.PM2_HOME = unrelatedPM2Home;
+    process.env.MEDIFLOW_PM2_HOME = unrelatedPM2Home;
+    process.env.MEDIFLOW_DATA_DIR = isolatedDataDir;
+    process.env.OVER_HOME = unrelatedPM2Home;
+    process.env.PM2_DAEMON_RPC_PORT = path.join(unrelatedPM2Home, 'rpc.sock');
+    process.env.PM2_DAEMON_PUB_PORT = path.join(unrelatedPM2Home, 'pub.sock');
+    delete process.env.PM2_NO_INTERACTION;
+    delete require.cache[managerPath];
+    delete require.cache[dataDirPath];
+
+    moduleLoader._load = function loadWithPM2Probe(request, parent, isMain) {
+        if (request === 'pm2') {
+            environmentAtPM2Load = {
+                home: process.env.PM2_HOME,
+                noInteraction: process.env.PM2_NO_INTERACTION,
+                overHome: process.env.OVER_HOME,
+                rpcOverride: process.env.PM2_DAEMON_RPC_PORT,
+                pubOverride: process.env.PM2_DAEMON_PUB_PORT,
+            };
+            return pm2Stub;
+        }
+
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    try {
+        // The probe must exercise the same CommonJS initialization boundary as PM2.
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const managerModule = require(managerPath) as typeof import('./pm2-manager');
+        assert.deepEqual(environmentAtPM2Load, {
+            home: isolatedPM2Home,
+            noInteraction: 'true',
+            overHome: undefined,
+            rpcOverride: undefined,
+            pubOverride: undefined,
+        });
+
+        const sentinel = net.createServer();
+        await new Promise<void>((resolve, reject) => {
+            sentinel.once('error', reject);
+            sentinel.listen({ host: '127.0.0.1', port: 0, exclusive: true }, resolve);
+        });
+        const address = sentinel.address();
+        assert.ok(address && typeof address === 'object');
+
+        try {
+            await assert.rejects(
+                managerModule.assertLoopbackPortAvailable(address.port),
+                /porta locale .* già in uso/,
+            );
+            assert.equal(sentinel.listening, true);
+        } finally {
+            await new Promise<void>((resolve, reject) => {
+                sentinel.close((error) => {
+                    if (error) reject(error);
+                    else resolve();
+                });
+            });
+        }
+
+        await managerModule.assertLoopbackPortAvailable(address.port);
+
+        const originalPlatform = process.platform;
+        Object.defineProperty(process, 'platform', { configurable: true, value: 'darwin' });
+        try {
+            await Promise.all([
+                managerModule.PM2Manager.start(),
+                managerModule.PM2Manager.start(),
+            ]);
+            assert.equal(startCalls, 1);
+
+            await managerModule.PM2Manager.start();
+            assert.equal(startCalls, 1);
+
+            online = false;
+            await managerModule.PM2Manager.stop();
+            assert.equal(stopCalls, 1);
+
+            const connectionOrder: string[] = [];
+            const results = await Promise.all([
+                managerModule.PM2Manager.withConnection(async () => {
+                    connectionOrder.push('first:start');
+                    await new Promise((resolve) => setTimeout(resolve, 15));
+                    connectionOrder.push('first:end');
+                    return 'first';
+                }),
+                managerModule.PM2Manager.withConnection(async () => {
+                    connectionOrder.push('second:start');
+                    connectionOrder.push('second:end');
+                    return 'second';
+                }),
+            ]);
+            assert.deepEqual(results, ['first', 'second']);
+            assert.deepEqual(connectionOrder, ['first:start', 'first:end', 'second:start', 'second:end']);
+            assert.equal(connectCalls, 2);
+            assert.equal(disconnectCalls, 2);
+            assert.equal(maxActiveConnections, 1);
+            assert.equal(activeConnections, 0);
+        } finally {
+            Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform });
+        }
+    } finally {
+        moduleLoader._load = originalLoad;
+        delete require.cache[managerPath];
+        delete require.cache[dataDirPath];
+
+        if (originalPM2Home === undefined) delete process.env.PM2_HOME;
+        else process.env.PM2_HOME = originalPM2Home;
+
+        if (originalDataDir === undefined) delete process.env.MEDIFLOW_DATA_DIR;
+        else process.env.MEDIFLOW_DATA_DIR = originalDataDir;
+
+        if (originalMediFlowPM2Home === undefined) delete process.env.MEDIFLOW_PM2_HOME;
+        else process.env.MEDIFLOW_PM2_HOME = originalMediFlowPM2Home;
+
+        if (originalOverHome === undefined) delete process.env.OVER_HOME;
+        else process.env.OVER_HOME = originalOverHome;
+
+        if (originalRPCOverride === undefined) delete process.env.PM2_DAEMON_RPC_PORT;
+        else process.env.PM2_DAEMON_RPC_PORT = originalRPCOverride;
+
+        if (originalPUBOverride === undefined) delete process.env.PM2_DAEMON_PUB_PORT;
+        else process.env.PM2_DAEMON_PUB_PORT = originalPUBOverride;
+
+        if (originalEnvironmentValue === undefined) {
+            delete process.env.PM2_NO_INTERACTION;
+        } else {
+            process.env.PM2_NO_INTERACTION = originalEnvironmentValue;
+        }
+
+        fs.rmSync(isolatedDataDir, { recursive: true, force: true });
+    }
+});
+
+test('an oversized PM2 socket path fails before PM2 is loaded', {
+    skip: process.platform === 'win32',
+}, () => {
+    const moduleLoader = Module as unknown as CommonJSModuleLoader;
+    const originalLoad = moduleLoader._load;
+    const originalDataDir = process.env.MEDIFLOW_DATA_DIR;
+    const originalNoInteraction = process.env.PM2_NO_INTERACTION;
+    const managerPath = require.resolve('./pm2-manager');
+    const dataDirPath = require.resolve('./data-dir');
+    const oversizedDataDir = path.join(os.tmpdir(), 'm'.repeat(180));
+    let pm2LoadCalls = 0;
+
+    process.env.MEDIFLOW_DATA_DIR = oversizedDataDir;
+    delete require.cache[managerPath];
+    delete require.cache[dataDirPath];
+    moduleLoader._load = function rejectPM2Load(request, parent, isMain) {
+        if (request === 'pm2') {
+            pm2LoadCalls += 1;
+            return {};
+        }
+        return originalLoad.call(this, request, parent, isMain);
+    };
+
+    try {
+        assert.throws(() => {
+            // eslint-disable-next-line @typescript-eslint/no-require-imports
+            require(managerPath);
+        }, /percorso socket MediFlow supera/);
+        assert.equal(pm2LoadCalls, 0);
+    } finally {
+        moduleLoader._load = originalLoad;
+        delete require.cache[managerPath];
+        delete require.cache[dataDirPath];
+        if (originalDataDir === undefined) delete process.env.MEDIFLOW_DATA_DIR;
+        else process.env.MEDIFLOW_DATA_DIR = originalDataDir;
+        if (originalNoInteraction === undefined) delete process.env.PM2_NO_INTERACTION;
+        else process.env.PM2_NO_INTERACTION = originalNoInteraction;
+        fs.rmSync(oversizedDataDir, { recursive: true, force: true });
+    }
+});

--- a/lib/pm2-manager.ts
+++ b/lib/pm2-manager.ts
@@ -1,7 +1,131 @@
-import pm2 from 'pm2';
+import net from 'node:net';
 import path from 'path';
 
+import { resolveDataPath } from '@/lib/data-dir';
+
+/* @Codex */
+const PM2_PATH_OVERRIDE_KEYS = [
+    'OVER_HOME',
+    'PM2_ROOT_PATH',
+    'PM2_CONF_FILE',
+    'PM2_MODULE_CONF_FILE',
+    'PM2_LOG_FILE_PATH',
+    'PM2_PID_FILE_PATH',
+    'PM2_RELOAD_LOCKFILE',
+    'PM2_DEFAULT_PID_PATH',
+    'PM2_DEFAULT_LOG_PATH',
+    'PM2_DEFAULT_MODULE_PATH',
+    'PM2_IO_ACCESS_TOKEN',
+    'PM2_DUMP_FILE_PATH',
+    'PM2_DUMP_BACKUP_FILE_PATH',
+    'PM2_DAEMON_RPC_PORT',
+    'PM2_DAEMON_PUB_PORT',
+    'PM2_INTERACTOR_RPC_PORT',
+    'PM2_INTERACTOR_LOG_FILE_PATH',
+    'PM2_INTERACTOR_PID_PATH',
+    'PM2_INTERACTION_CONF',
+    'PM2_HAS_NODE_EMBEDDED',
+    'PM2_BUILTIN_NODE_PATH',
+    'PM2_BUILTIN_NPM_PATH',
+] as const;
+
+for (const key of PM2_PATH_OVERRIDE_KEYS) delete process.env[key];
+
+process.env.PM2_NO_INTERACTION = 'true';
+// Keep MediFlow out of a pre-existing global PM2 daemon: it may be linked to an
+// external PM2 service or manage unrelated applications. Both values must be
+// fixed before CommonJS initialization because PM2 snapshots them at load time.
+const mediflowPM2Home = path.resolve(resolveDataPath('pm2'));
+const longestSocketPath = path.join(mediflowPM2Home, 'interactor.sock');
+const unixSocketLimit = process.platform === 'darwin' ? 103 : 107;
+
+if (process.platform !== 'win32' && Buffer.byteLength(longestSocketPath) > unixSocketLimit) {
+    throw new Error(
+        `PM2 non avviato: il percorso socket MediFlow supera ${unixSocketLimit} byte. `
+        + 'Configura MEDIFLOW_DATA_DIR con un percorso locale più corto.',
+    );
+}
+
+process.env.PM2_HOME = mediflowPM2Home;
+
+type IsolatedPM2 = Omit<typeof import('pm2'), 'disconnect'> & {
+    pm2_home?: string;
+    Client?: {
+        pm2_home?: string;
+        rpc_socket_file?: string;
+        pub_socket_file?: string;
+    };
+    disconnect(callback?: (error?: Error | null) => void): void;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const pm2 = require('pm2') as IsolatedPM2;
+
+const effectivePaths = [pm2.pm2_home, pm2.Client?.pm2_home];
+if (process.platform !== 'win32') {
+    effectivePaths.push(pm2.Client?.rpc_socket_file, pm2.Client?.pub_socket_file);
+}
+
+for (const effectivePath of effectivePaths) {
+    if (!effectivePath) throw new Error('PM2 non avviato: configurazione di isolamento incompleta.');
+    const relativePath = path.relative(mediflowPM2Home, effectivePath);
+    if (relativePath === '..' || relativePath.startsWith(`..${path.sep}`) || path.isAbsolute(relativePath)) {
+        throw new Error('PM2 non avviato: un percorso runtime esce dalla home MediFlow isolata.');
+    }
+}
+
 const PROCESS_NAME = 'mlx-inference-server';
+const MLX_LOOPBACK_PORT = 8080;
+let startInFlight: Promise<void> | null = null;
+let connectionTail: Promise<void> = Promise.resolve();
+
+function withConnectionLock<T>(operation: () => Promise<T>): Promise<T> {
+    const previous = connectionTail;
+    let release: () => void = () => undefined;
+    connectionTail = new Promise<void>((resolve) => {
+        release = resolve;
+    });
+
+    return previous.then(operation).finally(release);
+}
+
+function disconnectPM2(): Promise<void> {
+    return new Promise((resolve, reject) => {
+        pm2.disconnect((error) => {
+            if (error) reject(error);
+            else resolve();
+        });
+    });
+}
+
+/* @Codex */
+export function assertLoopbackPortAvailable(port: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const probe = net.createServer();
+
+        probe.once('error', (error: NodeJS.ErrnoException) => {
+            if (error.code === 'EADDRINUSE') {
+                reject(new Error(
+                    `MLX non avviato: la porta locale ${port} è già in uso. `
+                    + 'Arresta soltanto l’eventuale istanza legacy di mlx-inference-server e riprova; '
+                    + 'MediFlow non modificherà altri processi PM2.',
+                ));
+                return;
+            }
+
+            reject(error);
+        });
+
+        probe.once('listening', () => {
+            probe.close((error) => {
+                if (error) reject(error);
+                else resolve();
+            });
+        });
+
+        probe.listen({ host: '127.0.0.1', port, exclusive: true });
+    });
+}
 
 export interface ProcessStatus {
     name: string;
@@ -12,17 +136,33 @@ export interface ProcessStatus {
 }
 
 export class PM2Manager {
-    static connect(): Promise<void> {
-        return new Promise((resolve, reject) => {
-            pm2.connect((err) => {
-                if (err) reject(err);
-                else resolve();
-            });
-        });
-    }
+    static withConnection<T>(operation: () => Promise<T>): Promise<T> {
+        return withConnectionLock(async () => {
+            try {
+                await new Promise<void>((resolve, reject) => {
+                    pm2.connect((err) => {
+                        if (err) reject(err);
+                        else resolve();
+                    });
+                });
+            } catch (error) {
+                // PM2 may leave a partially initialized RPC client after a
+                // failed connect. Best-effort closure keeps the next queued
+                // request from inheriting that client; preserve the root error.
+                await disconnectPM2().catch(() => undefined);
+                throw error;
+            }
 
-    static disconnect(): void {
-        pm2.disconnect();
+            try {
+                return await operation();
+            } finally {
+                // PM2's disconnect callback fires only after RPC/PUB sockets
+                // have closed. Await it before releasing the queue: calling
+                // connect again while Client.close is in flight can null the
+                // socket underneath PM2's next connect handler.
+                await disconnectPM2();
+            }
+        });
     }
 
     static async getStatus(): Promise<ProcessStatus> {
@@ -53,7 +193,16 @@ export class PM2Manager {
         });
     }
 
-    static async start(): Promise<void> {
+    static start(): Promise<void> {
+        if (startInFlight) return startInFlight;
+
+        startInFlight = this.startOnce().finally(() => {
+            startInFlight = null;
+        });
+        return startInFlight;
+    }
+
+    private static async startOnce(): Promise<void> {
         // @Codex
         // The MLX inference server (ecosystem.config.js -> bash start-mlx.sh) only
         // runs on macOS Apple Silicon. Fail fast with a clear message elsewhere
@@ -63,6 +212,11 @@ export class PM2Manager {
                 `MLX inference server non supportato su ${process.platform}/${process.arch}: disponibile solo su macOS Apple Silicon. Usa Ollama come runtime AI cross-platform.`,
             );
         }
+
+        const currentStatus = await this.getStatus();
+        if (currentStatus.status === 'online') return;
+        await assertLoopbackPortAvailable(MLX_LOOPBACK_PORT);
+
         return new Promise((resolve, reject) => {
             // We start using the ecosystem file to ensure config is loaded
             const cwd = process.cwd();
@@ -79,7 +233,8 @@ export class PM2Manager {
         return new Promise((resolve, reject) => {
             pm2.stop(PROCESS_NAME, (err) => {
                 // Ignore error if process not found to stop
-                if (err && (err as any).message?.includes('process not found')) {
+                const message = err instanceof Error ? err.message : String(err || '');
+                if (err && /process(?: or namespace)? not found/i.test(message)) {
                     resolve();
                 } else if (err) {
                     reject(err);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "medical-record-app",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "medical-record-app",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@tailwindcss/typography": "^0.5.19",
@@ -28,7 +28,7 @@
         "next": "16.2.6",
         "openai": "^6.16.0",
         "pdfjs-dist": "4.10.38",
-        "pm2": "^6.0.14",
+        "pm2": "^7.0.3",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-dropzone": "^14.3.8",
@@ -49,7 +49,7 @@
         "drizzle-kit": "^0.31.8",
         "eslint": "^9",
         "eslint-config-next": "16.1.1",
-        "js-yaml": "^4.1.1",
+        "js-yaml": "^4.3.0",
         "tailwindcss": "^4",
         "typescript": "5.9.3"
       }
@@ -2429,116 +2429,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@pm2/agent": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@pm2/agent/-/agent-2.1.1.tgz",
-      "integrity": "sha512-0V9ckHWd/HSC8BgAbZSoq8KXUG81X97nSkAxmhKDhmF8vanyaoc1YXwc2KVkbWz82Rg4gjd2n9qiT3i7bdvGrQ==",
-      "license": "AGPL-3.0",
-      "dependencies": {
-        "async": "~3.2.0",
-        "chalk": "~3.0.0",
-        "dayjs": "~1.8.24",
-        "debug": "~4.3.1",
-        "eventemitter2": "~5.0.1",
-        "fast-json-patch": "^3.1.0",
-        "fclone": "~1.0.11",
-        "pm2-axon": "~4.0.1",
-        "pm2-axon-rpc": "~0.7.0",
-        "proxy-agent": "~6.4.0",
-        "semver": "~7.5.0",
-        "ws": "~7.5.10"
-      }
-    },
-    "node_modules/@pm2/agent/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@pm2/agent/node_modules/dayjs": {
-      "version": "1.8.36",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.36.tgz",
-      "integrity": "sha512-3VmRXEtw7RZKAf+4Tv1Ym9AGeo8r8+CjDi26x+7SYQil1UqtqdaokhzoEJohqlzt0m5kacJSDhJQkG/LWhpRBw==",
-      "license": "MIT"
-    },
-    "node_modules/@pm2/agent/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@pm2/agent/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@pm2/agent/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@pm2/agent/node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@pm2/agent/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
-    },
     "node_modules/@pm2/blessed": {
       "version": "0.1.81",
       "resolved": "https://registry.npmjs.org/@pm2/blessed/-/blessed-0.1.81.tgz",
@@ -2551,107 +2441,17 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/@pm2/io": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@pm2/io/-/io-6.1.0.tgz",
-      "integrity": "sha512-IxHuYURa3+FQ6BKePlgChZkqABUKFYH6Bwbw7V/pWU1pP6iR1sCI26l7P9ThUEB385ruZn/tZS3CXDUF5IA1NQ==",
-      "license": "Apache-2",
-      "dependencies": {
-        "async": "~2.6.1",
-        "debug": "~4.3.1",
-        "eventemitter2": "^6.3.1",
-        "require-in-the-middle": "^5.0.0",
-        "semver": "~7.5.4",
-        "shimmer": "^1.2.0",
-        "signal-exit": "^3.0.3",
-        "tslib": "1.9.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      }
-    },
-    "node_modules/@pm2/io/node_modules/async": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.14"
-      }
-    },
-    "node_modules/@pm2/io/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@pm2/io/node_modules/eventemitter2": {
-      "version": "6.4.9",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
-      "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==",
-      "license": "MIT"
-    },
-    "node_modules/@pm2/io/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@pm2/io/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@pm2/io/node_modules/tslib": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@pm2/io/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
-    },
     "node_modules/@pm2/js-api": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@pm2/js-api/-/js-api-0.8.0.tgz",
-      "integrity": "sha512-nmWzrA/BQZik3VBz+npRcNIu01kdBhWL0mxKmP1ciF/gTcujPTQqt027N9fc1pK9ERM8RipFhymw7RcmCyOEYA==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@pm2/js-api/-/js-api-0.8.1.tgz",
+      "integrity": "sha512-n9tDOz1ojyDOs05XthEXrLFVQYbbh2oAN19UakLPyEZDrUyEq05h8wIZU8+dNXBQY/KeFlWMLVA76nnX52ofRg==",
       "license": "Apache-2",
       "dependencies": {
         "async": "^2.6.3",
         "debug": "~4.3.1",
         "eventemitter2": "^6.3.1",
         "extrareqp2": "^1.0.0",
-        "ws": "^7.0.0"
+        "ws": "^8.21.0"
       },
       "engines": {
         "node": ">=4.0"
@@ -2679,33 +2479,6 @@
       },
       "peerDependenciesMeta": {
         "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@pm2/js-api/node_modules/eventemitter2": {
-      "version": "6.4.9",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
-      "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==",
-      "license": "MIT"
-    },
-    "node_modules/@pm2/js-api/node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
           "optional": true
         }
       }
@@ -3841,6 +3614,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -3871,15 +3653,6 @@
       "license": "MIT",
       "dependencies": {
         "amp": "0.3.1"
-      }
-    },
-    "node_modules/ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/ansi-styles": {
@@ -4298,12 +4071,6 @@
         "readable-stream": "^3.4.0"
       }
     },
-    "node_modules/bodec": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/bodec/-/bodec-0.1.0.tgz",
-      "integrity": "sha512-Ylo+MAo5BDUq1KA3f3R/MFhh+g8cnHmo8bz3YPGhI1znrMaf77ol1sfvYJzsw3nTE+Y2GryfDxBaR+AqpAkEHQ==",
-      "license": "MIT"
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
@@ -4389,6 +4156,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/call-bind": {
@@ -4557,12 +4325,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/charm": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz",
-      "integrity": "sha512-syedaZ9cPe7r3hoQA9twWYKu5AIyCswN5+szkmPBe9ccdLrj4bYaCnLVPTLd2kgVRc7+zoX4tyPgRnFKCj5YjQ==",
-      "license": "MIT/X11"
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
@@ -4746,12 +4508,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT"
-    },
-    "node_modules/culvert": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/culvert/-/culvert-0.1.2.tgz",
-      "integrity": "sha512-yi1x3EAWKjQTreYWeSd98431AV+IEE0qoDyOoaHJ7KJ21gv6HtBXHVLX74opVSGqcR8/AbjJBHAHpcOy2bj5Gg==",
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -4998,9 +4754,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.7.tgz",
-      "integrity": "sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optional": true,
       "optionalDependencies": {
@@ -5210,18 +4966,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/enquirer": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
-      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-colors": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=8.6"
       }
     },
     "node_modules/es-abstract": {
@@ -5470,6 +5214,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -5945,9 +5690,9 @@
       }
     },
     "node_modules/eventemitter2": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-5.0.1.tgz",
-      "integrity": "sha512-5EM1GHXycJBS6mauYAbVKT1cVs7POKWb2NXD4Vyt8dDqeZa7LaDK1/sjtL+Zb0lzTpSNil4596Dyu97hz37QLg==",
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
+      "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==",
       "license": "MIT"
     },
     "node_modules/expand-template": {
@@ -6051,12 +5796,6 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
-    },
-    "node_modules/fclone": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/fclone/-/fclone-1.0.11.tgz",
-      "integrity": "sha512-GDqVQezKzRABdeqflsgMr7ktzgF9CyS+p2oe0jJqUY6izSSbhPIQJDpoU4PtGcD7VPM9xh/dVrTu6z1nwgmEGw==",
-      "license": "MIT"
     },
     "node_modules/fflate": {
       "version": "0.8.2",
@@ -6232,6 +5971,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6371,18 +6111,6 @@
       "engines": {
         "node": ">= 14"
       }
-    },
-    "node_modules/git-node-fs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/git-node-fs/-/git-node-fs-1.0.0.tgz",
-      "integrity": "sha512-bLQypt14llVXBg0S0u8q8HmU7g9p3ysH+NvVlae5vILuUvs759665HvmR5+wb04KjHyjFcDRxdYb4kyNnluMUQ==",
-      "license": "MIT"
-    },
-    "node_modules/git-sha1": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/git-sha1/-/git-sha1-0.1.2.tgz",
-      "integrity": "sha512-2e/nZezdVlyCopOCYHeW0onkbZg7xP1Ad6pndPy1rCygeRykefUS6r7oA5cJRGEFvseiaz5a/qUHFVX1dd6Isg==",
-      "license": "MIT"
     },
     "node_modules/github-from-package": {
       "version": "0.0.0",
@@ -6537,6 +6265,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -6639,25 +6368,17 @@
         "node": ">= 14"
       }
     },
-    "node_modules/http-proxy-agent/node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "license": "MIT",
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "agent-base": "^7.1.2",
+        "debug": "4"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">= 14"
       }
     },
     "node_modules/ieee754": {
@@ -6912,6 +6633,7 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -7286,24 +7008,6 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
-    "node_modules/js-git": {
-      "version": "0.7.8",
-      "resolved": "https://registry.npmjs.org/js-git/-/js-git-0.7.8.tgz",
-      "integrity": "sha512-+E5ZH/HeRnoc/LW0AmAyhU+mNcWBzAKE+30+IDMLSLbbK+Tdt02AdkOKq9u15rlJsDEGFqtgckc8ZM59LhhiUA==",
-      "license": "MIT",
-      "dependencies": {
-        "bodec": "^0.1.0",
-        "culvert": "^0.1.2",
-        "git-sha1": "^0.1.2",
-        "pako": "^0.2.5"
-      }
-    },
-    "node_modules/js-git/node_modules/pako": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
-      "license": "MIT"
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -7311,9 +7015,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -7360,8 +7074,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -8454,28 +8167,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT"
-    },
-    "node_modules/module-details-from-path": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
-      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
       "license": "MIT"
     },
     "node_modules/motion-dom": {
@@ -8498,12 +8193,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
-    },
-    "node_modules/mute-stream": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-      "license": "ISC"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -8552,36 +8241,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/needle": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
-      "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^3.2.6",
-        "iconv-lite": "^0.4.4",
-        "sax": "^1.2.4"
-      },
-      "bin": {
-        "needle": "bin/needle"
-      },
-      "engines": {
-        "node": ">= 4.4.x"
-      }
-    },
-    "node_modules/needle/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
     "node_modules/netmask": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
-      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
@@ -8947,28 +8610,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/pac-proxy-agent/node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/pac-proxy-agent/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/pac-resolver": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
@@ -9050,6 +8691,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pdfjs-dist": {
@@ -9090,15 +8732,15 @@
       }
     },
     "node_modules/pidusage": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/pidusage/-/pidusage-3.0.2.tgz",
-      "integrity": "sha512-g0VU+y08pKw5M8EZ2rIGiEBaB8wrQMjYGFfW2QVIfyT8V+fq8YFLkvlz4bz5ljvFDJYNFCWT3PWqcRr2FKO81w==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pidusage/-/pidusage-4.0.1.tgz",
+      "integrity": "sha512-yCH2dtLHfEBnzlHUJymR/Z1nN2ePG3m392Mv8TFlTP1B0xkpMQNHAnfkY0n2tAi6ceKO6YWhxYfZ96V4vVkh/g==",
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.2.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/playwright": {
@@ -9148,16 +8790,16 @@
       }
     },
     "node_modules/pm2": {
-      "version": "6.0.14",
-      "resolved": "https://registry.npmjs.org/pm2/-/pm2-6.0.14.tgz",
-      "integrity": "sha512-wX1FiFkzuT2H/UUEA8QNXDAA9MMHDsK/3UHj6Dkd5U7kxyigKDA5gyDw78ycTQZAuGCLWyUX5FiXEuVQWafukA==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/pm2/-/pm2-7.0.3.tgz",
+      "integrity": "sha512-zRJOdburpb9OEPB0uqoNT8C1Gp7hPJPVy4Kr67XJNuT9UlMQcOt1WXrYQUmwqKPHk8FyauvP1CPhqoCrCaPw0Q==",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@pm2/agent": "~2.1.1",
         "@pm2/blessed": "0.1.81",
-        "@pm2/io": "~6.1.0",
-        "@pm2/js-api": "~0.8.0",
-        "@pm2/pm2-version-check": "^1.0.4",
+        "@pm2/js-api": "0.8.1",
+        "@pm2/pm2-version-check": "1.0.4",
+        "amp": "0.3.1",
+        "amp-message": "0.1.2",
         "ansis": "4.0.0-node10",
         "async": "3.2.6",
         "chokidar": "3.6.0",
@@ -9166,22 +8808,15 @@
         "croner": "4.1.97",
         "dayjs": "1.11.15",
         "debug": "4.4.3",
-        "enquirer": "2.3.6",
-        "eventemitter2": "5.0.1",
-        "fclone": "1.0.11",
-        "js-yaml": "4.1.1",
-        "mkdirp": "1.0.4",
-        "needle": "2.4.0",
-        "pidusage": "3.0.2",
-        "pm2-axon": "~4.0.1",
-        "pm2-axon-rpc": "~0.7.1",
-        "pm2-deploy": "~1.0.2",
-        "pm2-multimeter": "^0.1.2",
-        "promptly": "2.2.0",
+        "eventemitter2": "6.4.9",
+        "fast-json-patch": "3.1.1",
+        "js-yaml": "4.3.0",
+        "pidusage": "4.0.1",
+        "pm2-deploy": "1.0.2",
+        "proxy-agent": "6.5.0",
         "semver": "7.7.2",
-        "source-map-support": "0.5.21",
-        "sprintf-js": "1.1.2",
-        "vizion": "~2.2.1"
+        "tx2": "1.0.5",
+        "ws": "8.21.0"
       },
       "bin": {
         "pm2": "bin/pm2",
@@ -9190,37 +8825,7 @@
         "pm2-runtime": "bin/pm2-runtime"
       },
       "engines": {
-        "node": ">=16.0.0"
-      },
-      "optionalDependencies": {
-        "pm2-sysmonit": "^1.2.8"
-      }
-    },
-    "node_modules/pm2-axon": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pm2-axon/-/pm2-axon-4.0.1.tgz",
-      "integrity": "sha512-kES/PeSLS8orT8dR5jMlNl+Yu4Ty3nbvZRmaAtROuVm9nYYGiaoXqqKQqQYzWQzMYWUKHMQTvBlirjE5GIIxqg==",
-      "license": "MIT",
-      "dependencies": {
-        "amp": "~0.3.1",
-        "amp-message": "~0.1.1",
-        "debug": "^4.3.1",
-        "escape-string-regexp": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=5"
-      }
-    },
-    "node_modules/pm2-axon-rpc": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/pm2-axon-rpc/-/pm2-axon-rpc-0.7.1.tgz",
-      "integrity": "sha512-FbLvW60w+vEyvMjP/xom2UPhUN/2bVpdtLfKJeYM3gwzYhoTEEChCOICfFzxkxuoEleOlnpjie+n1nue91bDQw==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.1"
-      },
-      "engines": {
-        "node": ">=5"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/pm2-deploy": {
@@ -9234,42 +8839,6 @@
       },
       "engines": {
         "node": ">=4.0.0"
-      }
-    },
-    "node_modules/pm2-multimeter": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/pm2-multimeter/-/pm2-multimeter-0.1.2.tgz",
-      "integrity": "sha512-S+wT6XfyKfd7SJIBqRgOctGxaBzUOmVQzTAS+cg04TsEUObJVreha7lvCfX8zzGVr871XwCSnHUU7DQQ5xEsfA==",
-      "license": "MIT/X11",
-      "dependencies": {
-        "charm": "~0.1.1"
-      }
-    },
-    "node_modules/pm2-sysmonit": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/pm2-sysmonit/-/pm2-sysmonit-1.2.8.tgz",
-      "integrity": "sha512-ACOhlONEXdCTVwKieBIQLSi2tQZ8eKinhcr9JpZSUAL8Qy0ajIgRtsLxG/lwPOW3JEKqPyw/UaHmTWhUzpP4kA==",
-      "license": "Apache",
-      "optional": true,
-      "dependencies": {
-        "async": "^3.2.0",
-        "debug": "^4.3.1",
-        "pidusage": "^2.0.21",
-        "systeminformation": "^5.7",
-        "tx2": "~1.0.4"
-      }
-    },
-    "node_modules/pm2-sysmonit/node_modules/pidusage": {
-      "version": "2.0.21",
-      "resolved": "https://registry.npmjs.org/pidusage/-/pidusage-2.0.21.tgz",
-      "integrity": "sha512-cv3xAQos+pugVX+BfXpHsbyz/dLzX+lr44zNMsYiGxUw+kV5sgQCIcLd1z+0vq+KyC7dJ+/ts2PsfgWfSC3WXA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "safe-buffer": "^5.2.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/pm2/node_modules/semver": {
@@ -9424,15 +8993,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/promptly": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/promptly/-/promptly-2.2.0.tgz",
-      "integrity": "sha512-aC9j+BZsRSSzEsXBNBwDnAxujdx19HycZoKgRgzWnS8eOHg1asuf9heuLprfbe739zY3IdUQx+Egv6Jn135WHA==",
-      "license": "MIT",
-      "dependencies": {
-        "read": "^1.0.4"
-      }
-    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -9455,41 +9015,19 @@
       }
     },
     "node_modules/proxy-agent": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
-      "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "^4.3.4",
-        "http-proxy-agent": "^7.0.1",
-        "https-proxy-agent": "^7.0.3",
-        "lru-cache": "^7.14.1",
-        "pac-proxy-agent": "^7.0.1",
-        "proxy-from-env": "^1.1.0",
-        "socks-proxy-agent": "^8.0.2"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/proxy-agent/node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/proxy-agent/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
-        "debug": "4"
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
       },
       "engines": {
         "node": ">= 14"
@@ -9672,18 +9210,6 @@
         "react": ">=18"
       }
     },
-    "node_modules/read": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-      "integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
-      "license": "ISC",
-      "dependencies": {
-        "mute-stream": "~0.0.4"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -9794,24 +9320,11 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/require-in-the-middle": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-5.2.0.tgz",
-      "integrity": "sha512-efCx3b+0Z69/LGJmm9Yvi4cqEdxnoGnxYxGxBghkkTTFeXRtTCmmhO0AnAfHz59k957uTSuy8WaHqOs8wbYUWg==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "module-details-from-path": "^1.0.3",
-        "resolve": "^1.22.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
       "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.16.1",
@@ -9988,21 +9501,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT"
-    },
-    "node_modules/sax": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
-      "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=11.0.0"
-      }
-    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -10149,12 +9647,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/shimmer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
-      "license": "BSD-2-Clause"
-    },
     "node_modules/side-channel": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
@@ -10231,12 +9723,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "license": "ISC"
-    },
     "node_modules/simple-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
@@ -10268,12 +9754,12 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
-      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "^10.0.1",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -10295,19 +9781,11 @@
         "node": ">= 14"
       }
     },
-    "node_modules/socks-proxy-agent/node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -10326,6 +9804,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -10341,12 +9820,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/stable-hash": {
       "version": "0.0.5",
@@ -10595,6 +10068,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10611,33 +10085,6 @@
       "optional": true,
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/systeminformation": {
-      "version": "5.31.7",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.7.tgz",
-      "integrity": "sha512-/8NC53e5nP9nmhn42/ncdOkyJnOoue/Vy+tJOyUGd1Yv66G069wK4rrziwhrqDETgk78CudTQupw5z19S5uoZw==",
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin",
-        "linux",
-        "win32",
-        "freebsd",
-        "openbsd",
-        "netbsd",
-        "sunos",
-        "android"
-      ],
-      "bin": {
-        "systeminformation": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "funding": {
-        "type": "Buy me a coffee",
-        "url": "https://www.buymeacoffee.com/systeminfo"
       }
     },
     "node_modules/tailwind-merge": {
@@ -10874,7 +10321,6 @@
       "resolved": "https://registry.npmjs.org/tx2/-/tx2-1.0.5.tgz",
       "integrity": "sha512-sJ24w0y03Md/bxzK4FU8J8JveYYUbSs2FViLJ2D/8bytSiyPRbuE3DyL/9UKYXTZlV3yXq0L8GLlhobTnekCVg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "json-stringify-safe": "^5.0.1"
       }
@@ -11254,30 +10700,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/vizion": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/vizion/-/vizion-2.2.1.tgz",
-      "integrity": "sha512-sfAcO2yeSU0CSPFI/DmZp3FsFE9T+8913nv1xWBOyzODv13fwkn6Vl7HqxGpkr9F608M+8SuFId3s+BlZqfXww==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "async": "^2.6.3",
-        "git-node-fs": "^1.0.0",
-        "ini": "^1.3.5",
-        "js-git": "^0.7.8"
-      },
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/vizion/node_modules/async": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
-      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.14"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -11398,6 +10820,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
     "next": "16.2.6",
     "openai": "^6.16.0",
     "pdfjs-dist": "4.10.38",
-    "pm2": "^6.0.14",
+    "pm2": "^7.0.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-dropzone": "^14.3.8",
@@ -196,6 +196,9 @@
     "zod": "^4.2.1"
   },
   "overrides": {
+    "jspdf": {
+      "dompurify": "3.4.12"
+    },
     "next": {
       "postcss": "8.5.10"
     }
@@ -211,7 +214,7 @@
     "drizzle-kit": "^0.31.8",
     "eslint": "^9",
     "eslint-config-next": "16.1.1",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.3.0",
     "tailwindcss": "^4",
     "typescript": "5.9.3"
   }


### PR DESCRIPTION
## Summary
- Isola PM2 nella data directory MediFlow, rimuove gli override di percorso esterni e rifiuta socket Unix troppo lunghi prima del caricamento.
- Serializza l’intero ciclo connect → operazione → disconnect e attende la chiusura reale dei socket, mantenendo idempotenti start/stop e intatto qualunque servizio estraneo sulla porta MLX.
- Aggiorna PM2, js-yaml e il DOMPurify usato da jsPDF; il lockfile rimuove il vecchio ramo @pm2/agent.
- Mantiene le scritture MLX dietro sessione web admin e descrive il POST come richiesta di avvio, senza sovrastimare la readiness.

## Verification
- Node 24.18.0: `npm run test:unit` — 672/672.
- `node scripts/run-strip-types.mjs --test lib/pm2-manager.test.ts` — 2/2.
- `npm run typecheck`; `npm run lint`.
- `npm run test:admin-auth-boundary` — 4/4; `npm run test:server-auth-policy` — 1/1.
- `npm run check:mlx-operational-parity`; `npm run check:claims`; `npm run check:never-regress`.
- `npm ci`; `npm audit --omit=dev` — 0 vulnerabilità production.
- Smoke reale con due home PM2 temporanee: override ostili confinati, connessioni concorrenti serializzate, recovery dopo errore, sentinella esterna invariata, nessun daemon orfano.
- Due verificatori indipendenti: PASS senza P1/P2 sullo snapshot finale.

## Risk / Notes
- Il full audit conserva 11 advisory esclusivamente dev/tooling; non viene usato `npm audit fix --force`.
- Il probe della porta resta soggetto al normale intervallo TOCTOU e la coda è process-local; nessuna logica può terminare processi estranei.
- `package-lock.json` è churn meccanico da risoluzione dipendenze; partire dalla logica in `lib/pm2-manager.ts` e dal test dedicato.
- Nessuna PHI/PII, nessun dato paziente reale, nessun contenuto email.

## Ticket
Refs WUL-481