### PR TITLE
feat(ui): applica Lume alla lock screen

### DIFF
--- a/components/kree8/kree8-lock-screen.module.css
+++ b/components/kree8/kree8-lock-screen.module.css
@@ -1,45 +1,34 @@
 /* @Codex */
-/* WUL-274: scoped Kree8 lock screen tokens. No globals, no auth semantics. */
+/* WUL-55 F2d-A: scoped Lume lock-screen styling on the canonical --lume-* active
+   aliases (giorno/grafite auto-flip via html.dark). No globals, no auth semantics.
+   Historical filename kept only for import-path compatibility. */
 
 .lockShell {
-  --surface: #ffffff;
-  --surface-soft: #f5f6f7;
-  --surface-inset: #f3f4f6;
-  --canvas: #eef0f2;
-  --ink: #0f172a;
-  --ink-strong: #1e293b;
-  --ink-muted: #475569;
-  --ink-subtle: #52606d;
-  --line: rgba(15, 23, 42, 0.05);
-  --line-strong: rgba(15, 23, 42, 0.08);
-  --pill-blue-bg: #dbeafe;
-  --pill-blue-fg: #1d4ed8;
-  --pill-coral-bg: #ffe2dd;
-  --pill-coral-fg: #9a3412;
-  --pill-muted-bg: #eef0f2;
-  --pill-muted-fg: #475569;
-  --solid-action-bg: #0f172a;
-  --solid-action-fg: #ffffff;
-  --brand-dot-bg: #2563eb;
-  --brand-dot-fg: #ffffff;
-  --surface-glow: rgba(255, 255, 255, 0.4);
-  --focus-ring: rgba(15, 23, 42, 0.32);
-  --shadow-card: 0 0 0 1px rgba(15, 23, 42, 0.05), 0 4px 12px rgba(15, 23, 42, 0.04);
-  --shadow-panel: 0 1px 0 rgba(15, 23, 42, 0.04), 0 0 0 1px rgba(15, 23, 42, 0.05), 0 8px 24px rgba(15, 23, 42, 0.04);
+  /* Local layer maps 1:1 to the canonical Lume active aliases (app/lume-tokens.css);
+     giorno/grafite flip automatically under html.dark, so no scoped dark block is
+     needed. Opaque surfaces; borders via color-mix. No glass/gradient/glow/shadow. */
+  --surface-focal: var(--lume-surface-focal);
+  --surface-field: var(--lume-surface-field);
+  --canvas: var(--lume-surface-canvas);
+  --chrome: var(--lume-surface-chrome);
+  --ink: var(--lume-ink);
+  --ink-muted: var(--lume-ink-muted);
+  --accent: var(--lume-accent);
+  --accent-ink: var(--lume-surface-focal);
+  --line: color-mix(in srgb, var(--lume-ink) 20%, var(--lume-surface-focal));
+  --critical: var(--lume-signal-critical);
+  --critical-bg: color-mix(in srgb, var(--lume-signal-critical) 14%, var(--lume-surface-focal));
   --motion-ease: cubic-bezier(0.4, 0, 0.2, 1);
-  --motion-spring: cubic-bezier(0.34, 1.36, 0.64, 1);
 
   position: fixed;
   inset: 0;
   z-index: 1100;
-  display: grid;
-  place-items: center;
+  display: flex;
+  flex-direction: column;
   min-height: 100vh;
   padding: 24px;
-  overflow: hidden;
-  background:
-    linear-gradient(180deg, var(--surface-glow), rgba(255, 255, 255, 0)),
-    var(--canvas);
+  overflow-y: auto;
+  background: var(--canvas);
   color: var(--ink);
   font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display",
     "Inter", "Segoe UI", system-ui, sans-serif;
@@ -47,41 +36,16 @@
   -webkit-font-smoothing: antialiased;
 }
 
-:global(html.dark) .lockShell {
-  --surface: #0f172a;
-  --surface-soft: #111827;
-  --surface-inset: #1e293b;
-  --canvas: #020617;
-  --ink: #f8fafc;
-  --ink-strong: #e2e8f0;
-  --ink-muted: #cbd5e1;
-  --ink-subtle: #b6c2d0;
-  --line: rgba(226, 232, 240, 0.10);
-  --line-strong: rgba(226, 232, 240, 0.16);
-  --pill-blue-bg: rgba(148, 163, 184, 0.18);
-  --pill-blue-fg: #dbeafe;
-  --pill-coral-bg: rgba(248, 113, 113, 0.16);
-  --pill-coral-fg: #fecaca;
-  --pill-muted-bg: rgba(148, 163, 184, 0.14);
-  --pill-muted-fg: #cbd5e1;
-  --solid-action-bg: #e2e8f0;
-  --solid-action-fg: #020617;
-  --brand-dot-bg: #93c5fd;
-  --brand-dot-fg: #0f172a;
-  --surface-glow: rgba(255, 255, 255, 0.06);
-  --focus-ring: rgba(226, 232, 240, 0.42);
-  --shadow-card: 0 0 0 1px rgba(226, 232, 240, 0.10), 0 10px 24px rgba(0, 0, 0, 0.28);
-  --shadow-panel: 0 1px 0 rgba(255, 255, 255, 0.04), 0 0 0 1px rgba(226, 232, 240, 0.10), 0 14px 34px rgba(0, 0, 0, 0.32);
-}
-
 .lockCard {
   width: min(100%, 428px);
-  border: 1px solid var(--line-strong);
-  border-radius: 28px;
+  /* margin:auto centers the focal surface in the flex column and collapses to 0
+     when the card is taller than the viewport, so short heights scroll instead
+     of clipping (paired with overflow-y:auto on .lockShell). */
+  margin: auto;
+  border: 1px solid var(--line);
+  border-radius: 20px;
   padding: 24px;
-  background: var(--surface);
-  box-shadow: var(--shadow-panel);
-  animation: lockEnter 280ms var(--motion-ease) both;
+  background: var(--surface-focal);
 }
 
 .brandRow {
@@ -95,15 +59,13 @@
   width: 22px;
   height: 22px;
   border-radius: 7px;
-  background: var(--brand-dot-bg);
-  color: var(--brand-dot-fg);
+  background: var(--accent);
+  color: var(--accent-ink);
   display: inline-flex;
   align-items: center;
   justify-content: center;
   font-size: 11px;
   font-weight: 700;
-  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.22),
-    inset 0 1px 0 rgba(255, 255, 255, 0.25);
 }
 
 .brandWord {
@@ -117,36 +79,11 @@
   font-weight: 700;
 }
 
-.statusPill {
-  margin-left: auto;
-  display: inline-flex;
-  align-items: center;
-  min-height: 24px;
-  padding: 4px 10px;
-  border-radius: 999px;
-  background: var(--pill-muted-bg);
-  color: var(--pill-muted-fg);
-  font-size: 11px;
-  font-weight: 600;
-}
-
 .headerBlock {
   display: flex;
   flex-direction: column;
   gap: 8px;
   margin-bottom: 22px;
-}
-
-.kicker {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  width: fit-content;
-  color: var(--ink-subtle);
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
 }
 
 .title {
@@ -158,13 +95,6 @@
   letter-spacing: 0;
 }
 
-.subtitle {
-  margin: 0;
-  color: var(--ink-muted);
-  font-size: 13px;
-  line-height: 1.5;
-}
-
 .form {
   display: flex;
   flex-direction: column;
@@ -172,7 +102,7 @@
 }
 
 .fieldLabel {
-  color: var(--ink-subtle);
+  color: var(--ink-muted);
   font-size: 10px;
   font-weight: 700;
   letter-spacing: 0.14em;
@@ -186,9 +116,9 @@
 .pinInput {
   width: 100%;
   min-height: 50px;
-  border: 1px solid var(--line-strong);
-  border-radius: 14px;
-  background: var(--surface-soft);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--surface-field);
   color: var(--ink);
   padding: 12px 14px;
   text-align: center;
@@ -202,15 +132,15 @@
 }
 
 .pinInput::placeholder {
-  color: var(--ink-subtle);
+  color: var(--ink-muted);
   font-size: 13px;
   letter-spacing: 0.02em;
 }
 
 .pinInput:focus {
-  border-color: var(--focus-ring);
-  background: var(--surface);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--focus-ring) 24%, transparent);
+  border-color: var(--accent);
+  background: var(--surface-focal);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 35%, transparent);
 }
 
 .pinInput:disabled {
@@ -224,14 +154,14 @@
   gap: 6px;
   max-width: 100%;
   padding: 7px 10px;
-  border-radius: 999px;
-  background: var(--pill-coral-bg);
-  color: var(--pill-coral-fg);
+  border: 1px solid var(--critical);
+  border-radius: 12px;
+  background: var(--critical-bg);
+  color: var(--ink);
   font-size: 12px;
   font-weight: 600;
   line-height: 1.35;
   text-align: center;
-  animation: commitPulse 320ms var(--motion-spring) both;
 }
 
 .errorChip span {
@@ -246,71 +176,30 @@
   width: 100%;
   min-height: 50px;
   border: 0;
-  border-radius: 14px;
-  background: var(--solid-action-bg);
-  color: var(--solid-action-fg);
+  border-radius: 10px;
+  background: var(--accent);
+  color: var(--accent-ink);
   padding: 12px 18px;
   font-size: 14px;
   font-weight: 650;
   cursor: pointer;
-  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.18),
-    inset 0 1px 0 rgba(255, 255, 255, 0.18);
-  transition: transform 120ms var(--motion-ease),
-    opacity 160ms var(--motion-ease),
-    box-shadow 160ms var(--motion-ease);
+  transition: background-color 160ms var(--motion-ease);
 }
 
-.primaryButton:hover:not(:disabled) {
-  transform: translateY(-1px);
-}
-
-.primaryButton:active:not(:disabled) {
-  transform: scale(0.97);
+.primaryButton:focus-visible,
+.pinInput:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .primaryButton:disabled {
   cursor: not-allowed;
-  opacity: 0.52;
-  box-shadow: var(--shadow-card);
+  background: var(--chrome);
+  color: var(--ink-muted);
 }
 
 .spinner {
   animation: spin 900ms linear infinite;
-}
-
-.footer {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  margin-top: 22px;
-  color: var(--ink-subtle);
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.12em;
-  line-height: 1.6;
-  text-transform: uppercase;
-}
-
-.footer span:not(:last-child)::after {
-  content: "·";
-  margin-left: 6px;
-}
-
-@keyframes lockEnter {
-  from {
-    opacity: 0;
-    transform: translateY(6px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-@keyframes commitPulse {
-  0% { transform: scale(0.9); }
-  55% { transform: scale(1.04); }
-  100% { transform: scale(1); }
 }
 
 @keyframes spin {
@@ -323,7 +212,7 @@
   }
 
   .lockCard {
-    border-radius: 24px;
+    border-radius: 16px;
     padding: 20px;
   }
 
@@ -333,16 +222,6 @@
 
   .title {
     font-size: 24px;
-  }
-
-  .footer {
-    flex-direction: column;
-    gap: 2px;
-  }
-
-  .footer span:not(:last-child)::after {
-    content: "";
-    margin-left: 0;
   }
 }
 

--- a/components/lock-screen.tsx
+++ b/components/lock-screen.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useSecurity } from './security-provider';
-import { AlertCircle, KeyRound, Loader2, ShieldCheck, Unlock } from 'lucide-react';
+import { AlertCircle, Loader2, Unlock } from 'lucide-react';
 import styles from './kree8/kree8-lock-screen.module.css';
 
 export function LockScreen() {
@@ -11,6 +11,18 @@ export function LockScreen() {
     const [confirmPin, setConfirmPin] = useState('');
     const [error, setError] = useState('');
     const [loading, setLoading] = useState(false);
+    // WUL-55: ref + nonce to restore focus to the PIN operatore input after a failed login.
+    const pinInputRef = useRef<HTMLInputElement>(null);
+    const [failedAttempt, setFailedAttempt] = useState(0);
+
+    // A failed login re-enables and clears the input; deterministically restore focus so the
+    // operator can retry at once. Guards: !loading = input already enabled; optional chaining =
+    // safe across unmount, so a successful login (which unmounts this form) never focuses.
+    useEffect(() => {
+        if (failedAttempt > 0 && !loading) {
+            pinInputRef.current?.focus();
+        }
+    }, [failedAttempt, loading]);
 
     // If not locked and setup is done, don't render anything
     if (!isLocked && !requiresSetup) return null;
@@ -25,10 +37,12 @@ export function LockScreen() {
             if (!success) {
                 setError('');
                 setPin('');
+                setFailedAttempt((n) => n + 1);
             }
         } catch (err) {
             setError(err instanceof Error ? err.message : 'Errore durante il login');
             setPin('');
+            setFailedAttempt((n) => n + 1);
         } finally {
             setLoading(false);
         }
@@ -58,7 +72,7 @@ export function LockScreen() {
     const visibleError = error || authErrorMessage;
 
     return (
-        // @Codex WUL-274: lock chrome mirrors the Kree8 live root without changing auth semantics.
+        // @Codex WUL-55 F2d-A: lock chrome uses the landed Lume identity without changing auth semantics.
         <div className={styles.lockShell} aria-label="MediFlow lock screen">
             <section className={styles.lockCard} aria-labelledby="mediflow-lock-title">
                 <div className={styles.brandRow}>
@@ -66,42 +80,27 @@ export function LockScreen() {
                     <span className={styles.brandWord}>
                         MEDI<b>FLOW</b>
                     </span>
-                    <span className={styles.statusPill}>
-                        {requiresSetup ? 'primo avvio' : 'PIN richiesto'}
-                    </span>
                 </div>
 
                 <div className={styles.headerBlock}>
-                    <div className={styles.kicker}>
-                        {requiresSetup ? (
-                            <>
-                                <ShieldCheck size={13} /> Prima configurazione
-                            </>
-                        ) : (
-                            <>
-                                <KeyRound size={13} /> Sessione protetta
-                            </>
-                        )}
-                    </div>
                     <h1 id="mediflow-lock-title" className={styles.title}>
                         {requiresSetup ? 'Crea il tuo PIN' : 'Sblocca MediFlow'}
                     </h1>
-                    <p className={styles.subtitle}>
-                        {requiresSetup
-                            ? 'Crea un PIN per proteggere la sessione e cifrare i dati.'
-                            : 'Inserisci il PIN per riprendere il lavoro.'}
-                    </p>
                 </div>
 
                 <form onSubmit={requiresSetup ? handleSetup : handleLogin} className={styles.form}>
-                    <label className={styles.fieldLabel} htmlFor="mediflow-lock-pin">
-                        PIN operatore
-                    </label>
+                    {requiresSetup && (
+                        <label className={styles.fieldLabel} htmlFor="mediflow-lock-pin">
+                            PIN operatore
+                        </label>
+                    )}
                     <div className={styles.inputWrap}>
                         <input
                             id="mediflow-lock-pin"
+                            ref={pinInputRef}
                             type="password"
-                            placeholder="Inserisci PIN"
+                            aria-label="PIN operatore"
+                            placeholder={requiresSetup ? 'Inserisci PIN' : undefined}
                             value={pin}
                             onChange={(e) => setPin(e.target.value)}
                             className={styles.pinInput}
@@ -169,12 +168,6 @@ export function LockScreen() {
                         )}
                     </button>
                 </form>
-
-                <footer className={styles.footer}>
-                    <span>Sessione locale</span>
-                    <span>Nessun trasferimento di rete</span>
-                    <span>Zero-knowledge</span>
-                </footer>
             </section>
         </div>
     );

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -64,7 +64,7 @@ export async function unlockIfNeeded(page: Page, pin: string): Promise<void> {
   const lockHeading = page.getByRole('heading', { name: 'Sblocca MediFlow' });
   if (!(await isVisible(lockHeading))) return;
 
-  const pinInput = page.locator('input[placeholder="Inserisci PIN"]:not([disabled])').first();
+  const pinInput = page.getByLabel('PIN operatore').first();
   const unlockButton = page.getByRole('button', { name: /Sblocca/ }).first();
 
   await pinInput.fill(pin);


### PR DESCRIPTION
## Summary
- applica le superfici opache e i token Lume alla schermata di sblocco
- riduce il testo visibile a titolo, campo PIN e azione principale
- mantiene l'etichetta accessibile del campo e rifocalizza il controllo dopo errori 401/423
- aggiorna il locator E2E per usare il nome accessibile invece del placeholder rimosso

## Verification
- `npm run check:lume-tokens`
- `npm run test:lume-tokens`
- `npm run typecheck`
- `npm run lint`
- `npx next build --webpack`
- `npm run test:unit` — 672/672
- `npm run check:claims`
- `npm run check:never-regress`
- `npx playwright test e2e/web-smoke.spec.ts e2e/document-import.spec.ts --workers=1` — 2/2
- verifica sintetica responsive, giorno/grafite, tastiera, errori 401/423 e reduced motion
- review indipendente e autoreview: nessun finding P0-P2

## Risk / Notes
- nessuna nuova dipendenza, migrazione o modifica API
- test e fixture sintetici; nessuna PHI/PII o base dati reale
- la PR resta limitata alla lock screen e al relativo locator E2E

## Ticket
Refs WUL-55
