### PR TITLE
docs: qualifica i claim pubblici

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -17,7 +17,10 @@ Per il resto:
 
 - **Local-first / offline-first** di default.
 - **Privacy-by-design**: nessuna uscita verso cloud (telemetria, sync, chiamate AI) se non esplicitamente implementata e documentata.
-- **Zero-knowledge a riposo**: il database SQLite deve essere illeggibile senza il PIN utente.
+- **Cifratura clinica per campo a riposo**: i campi sensibili devono essere
+  cifrati lato client con AES-256-GCM. Il file SQLite, gli identificativi,
+  alcuni metadati e i backup non sono tutti coperti da un perimetro
+  whole-database verificato.
 - **Manutenibilità**: diff minimi, codice chiaro, contratti espliciti.
 
 ## ⚠️ Non-obiettivi (per ora)
@@ -78,6 +81,8 @@ create documentale manuale per client trusted su LAN.
 
 - Lo storage autorevole è un **singolo file SQLite** (`medical.db`).
 - I campi sensibili sono cifrati **lato client** (browser / client native) prima della scrittura su disco.
+- Il file SQLite non è cifrato integralmente: il PIN non viene persistito, ma
+  questo non equivale a zero-knowledge sull'intero database.
 - Anche gli artifact documentali (`attachments.summarySnapshot`,
   `attachments.parseEvidenceArtifactSnapshot`) sono trattati come dati clinici e
   persistiti cifrati.
@@ -100,7 +105,7 @@ MediFlow espone due superfici API:
   - protetta da **token locale** (trasporto su HTTPS locale via TLS proxy)
 - **Network API** (`/api/v1/network/*`):
   - si attiva solo in modalita `network-home-base`
-  - resta read-only-first, con write versionati su ciclo di vita paziente (creazione, cestino, ripristino), profilo/status, diario clinico, terapie, checkup, osservazioni, prestazioni e protesica, piu export FHIR generato lato client (nodo keyless), validazione FSE, guardia di revisione e discovery capabilities/identity/node in dual-auth
+  - resta read-only-first, con write versionati su ciclo di vita paziente (creazione, cestino, ripristino), profilo/status, diario clinico, terapie, checkup, osservazioni, prestazioni e protesica, piu mappatura export-only v0 in un Bundle FHIR R4 `collection` generato lato client (nodo keyless), pre-check FSE locale, guardia di revisione e discovery capabilities/identity/node in dual-auth; nessun claim di conformità completa a profili o ingestione di terze parti
   - i cataloghi (farmaci, esenzioni, terminologia, prestazioni) sono esposti in sola lettura
   - il dominio documentale consente lettura e create manuale cifrato, riferimenti allegato sigillati e compute deterministici senza persistenza; restano esclusi PUT/DELETE paired degli allegati, artifact document-derived, invocazione AI, hard delete remoto, sync e write offline (ADR 0076)
   - disattivare la modalita non revoca i pairing: i token dei client paired

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,7 @@ npm run check:never-regress
 
 Il guard fallisce se trova:
 - credenziali di default hardcoded nel runtime
-- endpoint runtime non locali o telemetry default-on
+- endpoint runtime non locali o attivazione implicita della telemetria
 - rotture delle invarianti zero-knowledge minime
 
 ### Claims guard

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,9 +110,10 @@ Il guard fallisce se trova:
 
 ### Claims guard
 
-Per bloccare claim di prodotto fuori scope (autonomia clinica AI, auto-apply senza
-review, integrazione regionale SISS/FSE certificata nativa, prescrizione regionale,
-cloud di default), ancorati all'ADR 0065:
+Per bloccare claim di prodotto fuori scope (autonomia clinica AI, auto-apply
+senza review, integrazione regionale SISS/FSE, cloud di default, cifratura
+whole-database, claim FHIR non qualificati, garanzie GDPR, topologia single-device e
+codifica ICD obbligatoria), ancorati all'ADR 0065:
 
 ```bash
 npm run check:claims

--- a/README.md
+++ b/README.md
@@ -128,10 +128,10 @@ Apple/native sul mainline con macOS come fronte più avanzato e iPhone e iPad co
 client paired sul modello `home-base`.
 
 - **ciclo di vita paziente sul boundary paired**: creazione, cestino con soft-delete e ripristino dal client Apple, con concorrenza ottimistica e senza accesso diretto al database;
-- **prestazioni, protesica ed export FHIR sul client paired**: nuove famiglie cliniche sul boundary con concorrenza ottimistica, e bundle FHIR generato on-device con pre-check di validazione FSE;
+- **prestazioni, protesica ed export FHIR sul client paired**: nuove famiglie cliniche sul boundary con concorrenza ottimistica, e mappatura export-only v0 in un Bundle FHIR R4 `collection` generato on-device con pre-check FSE locale, senza claim di conformità completa a profili o ingestione di terze parti;
 - **web app locale** come superficie primaria di lavoro sul Mac;
 - **Kree8 cockpit** come root web live, con una direzione visuale unica e senza selector persistiti: copy asciutto, palette semantica sobria, dark mode completa e flusso a un clic verso la Scheda paziente;
-- **database SQLite cifrato**, con approccio zero-knowledge;
+- **campi clinici sensibili cifrati lato client** con AES-256-GCM; il PIN non viene persistito, ma il file SQLite, gli identificativi, alcuni metadati e i backup non rientrano tutti in un perimetro whole-database cifrato verificato;
 - **backup, audit e contratto `/api/v1`** resi più chiari ed espliciti;
 - **AI locale** per insight e OCR, senza egress di default;
 - **import documentale reviewable**, con Smart Import prudente, artifact `parse/evidence`, ancore fonte e benchmark di assorbimento evidenza;

--- a/components/kree8/areas/live-governance-area.tsx
+++ b/components/kree8/areas/live-governance-area.tsx
@@ -94,7 +94,8 @@ function LiveGovernanceArea({
             Stato operativo <em>· controlli della postazione</em>
           </h1>
           <p className={styles.areaSubtitle}>
-            I dati clinici non lasciano il dispositivo.
+            Storage autorevole sul Mac home-base; accessi paired, cache ed export
+            restano percorsi espliciti.
           </p>
         </div>
       </header>

--- a/docs/ARCHITETTURA.md
+++ b/docs/ARCHITETTURA.md
@@ -16,7 +16,8 @@ MediFlow oggi va letto così:
 
 - **web app locale** come superficie primaria: la root `/` apre direttamente il
   cockpit Kree8, senza selector di shell;
-- **SQLite cifrato** come storage autorevole;
+- **SQLite locale** come storage autorevole, con campi clinici sensibili
+  cifrati lato client e senza claim di cifratura integrale del file;
 - **`/api/v1`** come contratto condiviso per i client Apple;
 - **`home-base` read-only-first** con write online limitati/versionati su
   profilo/status paziente, diario clinico, terapie, checkup e osservazioni;
@@ -80,7 +81,8 @@ Sul fronte cancellazione, il dato non viene orfanato: la rimozione di un
 paziente scrive un tombstone reversibile (`deletedAt` / `deletionReason`) con
 version guard, senza staccare i figli clinici. L'erasure GDPR esplicita
 (`purge-patient`) e il `restore-patient` restano azioni admin separate e
-audited. Il dato cifrato non viene mai sovrascritto dal placeholder
+audited; la purge non raggiunge backup gia esportati. Il dato cifrato non viene
+mai sovrascritto dal placeholder
 `[LOCKED DATA]`, che è solo presentazione.
 
 ---
@@ -93,7 +95,7 @@ Le superfici principali sono tre:
 | --- | --- | --- |
 | `/api/*` | sessione web | CRUD web e overview locale |
 | `/api/v1/*` | bearer token locale | contratto condiviso per client Apple |
-| `/api/v1/network/*` | paired client + sessione operatore | perimetro `home-base`, read-only-first con write versionati su ciclo di vita paziente, diario, terapie, checkup, osservazioni, prestazioni e protesica, piu export FHIR lato client, validazione FSE, revisione e discovery; cataloghi in sola lettura |
+| `/api/v1/network/*` | paired client + sessione operatore | perimetro `home-base`, read-only-first con write versionati su ciclo di vita paziente, diario, terapie, checkup, osservazioni, prestazioni e protesica, piu mappatura export-only v0 in un Bundle FHIR R4 `collection` lato client e pre-check FSE locale, senza claim di conformità completa; cataloghi in sola lettura |
 
 Le sotto-risorse cliniche (diario, terapie, checkup, osservazioni) condividono
 un ciclo di vita unificato: version guard con `409` sulle scritture, liste che

--- a/docs/COMPLIANCE.md
+++ b/docs/COMPLIANCE.md
@@ -13,50 +13,81 @@ Riferimenti correlati:
 
 ## ⚖️ 1. GDPR e privacy
 
-MediFlow segue il principio **Privacy by Design**.
-Nel contesto clinico, il medico resta il **Titolare del Trattamento**: il software è uno strumento, non un sostituto delle responsabilità.
+MediFlow applica misure tecniche coerenti con il principio **Privacy by
+Design**. Queste misure possono supportare la protezione dei dati, ma non
+certificano da sole la conformità GDPR.
+
+Ruoli e obblighi dipendono da finalità, mezzi e contesto effettivi del singolo
+deployment. Il software non assegna automaticamente il ruolo di titolare o
+responsabile del trattamento: la valutazione resta in capo all'organizzazione
+che usa MediFlow.
 
 ### Misure Tecniche di Sicurezza
 
-Per supportare gli obblighi GDPR (Art. 32), MediFlow implementa:
+MediFlow mette a disposizione misure tecniche che possono concorrere alla
+protezione richiesta dal contesto operativo:
 
-1. **Cifratura at-rest (AES-256)**: senza PIN i dati non sono leggibili.
-2. **Zero-knowledge**: il PIN non viene salvato e non esistono backdoor di recupero.
-3. **Minimizzazione**: niente telemetria e nessun egress di default verso terze parti.
-4. **Local-first**: i dati restano sul dispositivo del professionista.
+1. **Cifratura clinica per campo (AES-256-GCM)**: i campi elencati in
+   `ENCRYPTED_FIELDS` vengono cifrati lato client prima della persistenza. Il
+   file SQLite non è cifrato integralmente: identificativi, alcuni metadati e
+   gli artefatti di backup non rientrano tutti nello stesso perimetro
+   whole-database verificato.
+2. **Chiavi e PIN**: il PIN non viene persistito e la master key viene aperta
+   solo nella memoria del client durante la sessione. Questo non equivale a un
+   claim zero-knowledge sull'intero database.
+3. **Minimizzazione**: telemetria, cloud sync ed egress PHI non sono attivi per
+   default.
+4. **Local-first**: lo storage autorevole resta sul nodo `home-base`. Client
+   paired sulla LAN, cache locali ed export/backup avviati dall'operatore sono
+   percorsi espliciti, non eccezioni nascoste.
 
 ### Strumenti per i Diritti dell'Interessato
 
-Il GDPR garantisce diritti specifici ai pazienti. In MediFlow:
+MediFlow offre strumenti che possono aiutare l'operatore a gestire richieste
+degli interessati:
 
-* **Diritto all'oblio (Art. 17)**: la cancellazione del paziente scrive un tombstone reversibile (`deletedAt` / `deletionReason`) con version guard, senza orfanare i figli clinici. L'erasure GDPR esplicita è l'azione admin `purge-patient`, con dry-run e audit `patient.purged`; il ripristino è `restore-patient`, con audit `patient.restored`.
-* **Portabilità dei dati (Art. 20)**: puoi esportare la storia clinica in formato interoperabile (vedi sotto).
+* **Cancellazione ed erasure**: il DELETE operativo scrive un tombstone
+  reversibile (`deletedAt` / `deletionReason`) con version guard. L'azione admin
+  `purge-patient` rimuove il grafo paziente dal database live con dry-run e
+  audit `patient.purged`; non raggiunge backup già esportati, che devono essere
+  gestiti separatamente. `restore-patient` ripristina un tombstone e registra
+  `patient.restored`.
+* **Accesso e portabilità**: gli export possono supportare la risposta a una
+  richiesta. La loro disponibilità non prova da sola l'adempimento degli
+  articoli 17, 20 o 32 né sostituisce la valutazione del caso concreto.
 
 ---
 
-## 🔌 2. Interoperabilità (FHIR R4)
+## 🔌 2. Export FHIR R4 (v0)
 
-MediFlow adotta **HL7 FHIR R4** per evitare lock-in e facilitare integrazione/export.
+Lo storage interno di MediFlow non è FHIR-native. L'export locale genera una
+mappatura **export-only v0** in un `Bundle` FHIR R4 di tipo `collection`.
 
 ### Export FHIR
 
-Con l'export clinico viene generato un pacchetto JSON compatibile FHIR R4.
-
 | Risorsa FHIR | Contenuto |
 |---|---|
-| `Patient` | Anagrafica |
-| `Condition` | Diagnosi (codificate ICD-11/ICD-9) |
-| `Encounter` | Visite effettuate |
-| `MedicationStatement` | Terapie prescritte |
-| `Observation` | Note e parametri rilevati |
+| `Patient` | Campi anagrafici e identificativi selezionati |
+| `Condition` | Diagnosi strutturate presenti nel profilo |
+| `Encounter` | Una risorsa per ogni voce di diario clinico non eliminata |
+| `MedicationStatement` | Terapie, con farmaco rappresentato oggi come testo |
+| `Observation` | Scale con punteggio e osservazioni strutturate |
 
-Obiettivo: mantenere i dati riusabili anche fuori da MediFlow.
+I test correnti verificano il mapping su fixture sintetiche. Non attestano
+conformità completa alla base R4, a profili HL7 Italia/FSE, correttezza
+terminologica o ingestione da parte di sistemi terzi. L'export è una base di
+trasporto limitata ai record mappati, non una garanzia di interoperabilità o
+portabilità completa.
 
 ---
 
 ## 🩺 3. Standard diagnostici (ICD-11)
 
-Le diagnosi non restano solo testo libero: MediFlow integra ICD-11 via API OMS locale.
+Un resolver locale ICD-11 opzionale può supportare ricerca e codifica tramite
+API OMS locale.
 
-* **Precisione clinica**: ogni diagnosi ha codice univoco (es. `5A10`).
-* **Interoperabilità futura**: più dati strutturati, meno ambiguità nei flussi FSE.
+* **Codifica reviewable**: le diagnosi strutturate possono includere un codice;
+  i problemi free-text restano ammessi e non sono garantiti come codificati o
+  validati.
+* **Direzione futura**: più dati strutturati possono ridurre ambiguità nei
+  flussi FSE, dopo profili e verifiche dedicate.

--- a/docs/FSE2-terminology-roadmap.md
+++ b/docs/FSE2-terminology-roadmap.md
@@ -9,15 +9,16 @@ Questa roadmap non sostituisce la normativa nazionale/regionale: definisce il pi
 tecnico di MediFlow per supportare i requisiti documentali in modo incrementale.
 
 Chiave di lettura: percorso pragmatico ispirato a pratiche mature open source
-(incluso il lavoro su OpenHospital), adattato ai vincoli MediFlow
-local-first e zero-knowledge.
+(incluso il lavoro su OpenHospital), adattato ai vincoli MediFlow local-first e
+alla cifratura clinica per campo.
 
 ---
 
 ## Vincoli non negoziabili (già decisi)
 
 - Local-first: nessuna dipendenza cloud di default.
-- Zero-knowledge at rest: nessuna decifratura lato server.
+- Cifratura per campo a riposo: i campi clinici configurati arrivano al server
+  come ciphertext; identificativi e alcuni metadati restano fuori dal mapping.
 - Contratto stabile via API versionate (`/api/v1/*`).
 - Diff piccoli e reversibili, con migrazioni esplicite.
 
@@ -31,7 +32,8 @@ Riferimenti interni:
 
 ## Stato attuale (baseline)
 
-- Diagnosi: `ICD-11` (provider WHO via API locale).
+- Diagnosi: provider ICD-11 OMS opzionale via API locale; i record possono
+  includere ICD-9/10/11 o problemi free-text reviewable.
 - Farmaci: `AIC` (catalogo AIFA locale).
 - Farmaci (classificazione): `ATC` presente nel modello dati, da rendere first-class nei flussi.
 - Esenzioni: catalogo locale dedicato già operativo.

--- a/docs/MANUALE.md
+++ b/docs/MANUALE.md
@@ -39,9 +39,9 @@ Al primo avvio ti chiederò di creare un **Profilo Medico** e un **PIN**.
 Il PIN è la chiave che protegge i dati.
 
 > [!WARNING]
-> **Se perdi il PIN, perdi i dati.** Non c'è "recupero password" via email, e non c'è un server centrale che può aiutarti.
+> **Se perdi il PIN, MediFlow non può aprire i campi clinici cifrati con quella chiave.** Non c'è "recupero password" via email, né un servizio centrale di recupero.
 
-Questo è il prezzo di una privacy forte: controllo totale, ma nessuna backdoor.
+Questo è un confine della gestione locale delle chiavi, non un claim di cifratura integrale del database.
 
 ---
 
@@ -97,12 +97,16 @@ MediFlow può leggere documenti clinici e produrre sintesi direttamente in local
 
 Puoi aggiungere farmaci e mantenere una lista terapie aggiornata.
 
-### Diagnosi (ICD-11)
+### Diagnosi e resolver ICD-11
 
-Le diagnosi usano lo standard OMS ICD-11.
+Il resolver OMS ICD-11 è opzionale: può proporre un codice strutturato, che
+resta da rivedere prima del salvataggio. I problemi clinici possono anche
+restare free-text.
 
-* Inserisci una diagnosi e ottieni suggerimenti codificati (es. `5A10`).
-* Risultato: più precisione clinica e migliore interoperabilità.
+* Inserisci una diagnosi e, quando utile, richiedi un suggerimento codificato
+  (es. `5A10`).
+* Un codice strutturato può supportare riuso futuro; non garantisce da solo
+  validità clinica o interoperabilità.
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -17,10 +17,12 @@ read_when:
 
 Le fondamenta sono solide e usabili in produzione locale.
 
-* **Database solido**: migrazione completa a SQLite cifrato.
+* **Database solido**: migrazione a SQLite autorevole con cifratura lato client
+  dei campi clinici sensibili; il file non è cifrato integralmente.
 * **Privacy locale**: cifratura locale dei dati clinici sensibili e modello senza cloud di default; i claim zero-knowledge forti restano in riallineamento `WUL-342`/`WUL-354`.
 * **AI Locale**: Integrazione di Qwen text-only (sintesi/insight) e DeepSeek OCR via Ollama.
-* **ICD-11**: Diagnosi standardizzate OMS.
+* **ICD-11**: resolver OMS locale opzionale e diagnosi strutturate codificabili;
+  i problemi free-text restano reviewable.
 * **Multi-ambulatorio**: gestione sedi con identificazione visiva rapida.
 
 ---
@@ -32,7 +34,7 @@ Base tecnica più solida, con flussi documentali e contratti locali molto più e
 * **API locale più governata**: baseline OpenAPI `/api/v1`, guard anti-drift e concorrenza ottimistica sui pazienti.
 * **Import clinico più utile**: pipeline OCR-first strutturata e smart import reviewable verso diagnosi ICD-11 e terapie.
 * **Archivio intelligente più operabile**: pulizia per singolo documento o completa, persistenza farmaci estratti e riallineamento dell'insight AI.
-* **Sicurezza e continuita operative**: audit append-only, lockout auth, cambio PIN zero-knowledge, backup artifact/preflight, scheduler notturno e retention automatica.
+* **Sicurezza e continuita operative**: audit append-only, lockout auth, cambio PIN tramite re-wrap client-side della master key, backup artifact/preflight, scheduler notturno e retention automatica.
 * **Compliance locale piu esplicita**: terminology registry locale, baseline GTW/FSE, baseline SISS e pannello prescrizione con handoff controllato.
 * **Stabilizzazione web/core**: `typecheck` canonico, normalizzazione condivisa dei payload paziente e riduzione del carico nei file piu densi.
 

--- a/docs/STATE_OF_THE_SYSTEM.md
+++ b/docs/STATE_OF_THE_SYSTEM.md
@@ -103,7 +103,7 @@ Questo significa che non sono ammessi, senza ADR e documentazione esplicita:
 
 - sync cloud implicita;
 - telemetry o analytics in background;
-- non usare runtime AI remoto come default;
+- runtime AI remoto come default (vietato);
 - upload automatico di documenti clinici;
 - database remoto multi-tenant;
 - bypass del nodo Mac `home-base` per i client mobili.

--- a/docs/STATE_OF_THE_SYSTEM.md
+++ b/docs/STATE_OF_THE_SYSTEM.md
@@ -103,7 +103,7 @@ Questo significa che non sono ammessi, senza ADR e documentazione esplicita:
 
 - sync cloud implicita;
 - telemetry o analytics in background;
-- runtime AI remoto come default;
+- non usare runtime AI remoto come default;
 - upload automatico di documenti clinici;
 - database remoto multi-tenant;
 - bypass del nodo Mac `home-base` per i client mobili.

--- a/docs/adr/0006-terminology-plugin-and-fse-profiles.md
+++ b/docs/adr/0006-terminology-plugin-and-fse-profiles.md
@@ -14,7 +14,8 @@ e senza rompere la parita web/native.
 
 ## Contesto
 
-- Architettura local-first e zero-knowledge non negoziabile.
+- Architettura local-first e cifratura client-side dei campi clinici non
+  negoziabili; nessun claim di cifratura whole-database.
 - Contratto condiviso via `/api/v1/*` (ADR 0005).
 - Nessuna dipendenza cloud di default.
 - Evoluzione incrementale, diff piccoli.

--- a/docs/adr/0065-intended-purpose-and-claims-guard.md
+++ b/docs/adr/0065-intended-purpose-and-claims-guard.md
@@ -37,8 +37,10 @@ perimetro ADR esistente.
 
 Sono consentiti, quando veri nello stato corrente del repo:
 
-- `local-first`, `no cloud di default`, `dati locali`, `SQLite cifrato`,
-  `zero-knowledge a riposo`;
+- `local-first`, `no cloud di default`, storage autorevole sul nodo
+  `home-base`, campi clinici sensibili cifrati lato client con AES-256-GCM;
+- PIN non persistito e master key aperta solo nella memoria del client, senza
+  estendere questo fatto a un claim zero-knowledge sull'intero database;
 - `supporto`, `workbench`, `reviewable`, `draft`, `candidate`, `fonte`,
   `provenance`, `handoff`, `webapp-assisted`;
 - AI locale come supporto a sintesi, recupero fonti, Smart Import reviewable e
@@ -62,7 +64,17 @@ salvo citazione esplicita in un documento di policy o test negativo:
   verifica;
 - cloud AI, cloud sync, telemetry o upload di PHI/PII come default;
 - auto-import clinico, auto-apply strutturato o accettazione silenziosa di
-  output AI/documentali senza review, attore e audit trail.
+  output AI/documentali senza review, attore e audit trail;
+- cifratura integrale del file SQLite, database interamente illeggibile senza
+  PIN o zero-knowledge whole-database finche identificativi, metadati e backup
+  non rientrano nello stesso perimetro verificato;
+- compatibilita, conformita, interoperabilita o portabilita FHIR garantite
+  senza validator, profilo, terminologia e prova di ingestione espliciti;
+- conformita GDPR certificata dal prodotto, ruoli privacy assegnati in modo
+  categorico o diritti dichiarati garantiti dalle sole feature;
+- dati dichiarati confinati a un solo dispositivo senza esplicitare
+  `home-base`, client paired, cache locali ed export/backup;
+- ogni diagnosi dichiarata obbligatoriamente codificata o validata ICD-11.
 
 ## Frasi ambigue
 
@@ -82,6 +94,13 @@ Adottiamo un guard testuale repo-local, senza dipendenze nuove:
   modello remoto;
 - allowlist: esplicita, per file/rule/snippet, con rationale;
 - fallimento: stampa `CLAIM-*`, file, riga, categoria e snippet.
+
+La prima fase `WUL-354` applica le nuove regole alle superfici documentali
+tracciate. La root publication `whitepaper/` resta temporaneamente attivabile
+con `npm run check:claims -- --include-publication` finche la Phase B, posseduta
+dalla lane visuale, non riallinea il copy e abilita lo scan nel percorso di
+default. Il guard stampa questa dipendenza: l'esclusione non deve essere
+silenziosa ne diventare un'allowlist permanente.
 
 Il guard non sostituisce review umana o valutazione regolatoria. Serve come
 freno deterministico contro claim drift evidenti.

--- a/docs/product_roadmap.md
+++ b/docs/product_roadmap.md
@@ -17,11 +17,15 @@ Per la versione attiva consulta [docs/ROADMAP.md](./ROADMAP.md).
 Quello che c'è e funziona oggi:
 
 - **Database serio**: Addio IndexedDB, ora uso SQLite. I dati stanno in un file `.db` che posso backuppare.
-- **AI locale vera**: MedGemma gira su Ollama, niente cloud. I dati paziente non escono mai dal computer.
+- **AI locale (claim storico, oggi qualificato)**: il runtime ordinario usa
+  servizi locali senza cloud di default; client paired, cache ed export restano
+  percorsi espliciti del perimetro corrente.
 - **OCR con DeepSeek**: Carico un PDF o una foto di un referto → viene letto e estratto il testo.
 - **Archivio Intelligente**: Ogni documento caricato viene riassunto dall'AI. Vedo gli ultimi 3 nella scheda paziente.
-- **ICD-11**: Le diagnosi usano lo standard WHO ufficiale, non più il vecchio ICD-9.
-- **Cifratura**: Tutto cifrato con AES-256. Senza PIN non si legge nulla, nemmeno io.
+- **ICD-11 (claim storico, oggi qualificato)**: un resolver OMS locale opzionale
+  supporta la codifica; restano diagnosi ICD-9/10/11 e problemi free-text.
+- **Cifratura (claim storico superato)**: lo stato corrente cifra lato client i
+  campi clinici configurati; il file SQLite non è cifrato integralmente.
 - **Multi-ambulatorio**: Posso gestire più sedi/reparti con colori diversi.
 
 ---

--- a/docs/product_roadmap.md
+++ b/docs/product_roadmap.md
@@ -8,6 +8,8 @@
 > Snapshot storico pre-riordino roadmap.
 
 Questa versione è mantenuta solo come riferimento storico.
+Le formulazioni rischiose sono annotate come superate per non propagarle come
+stato corrente; il resto dello snapshot non viene riallineato retroattivamente.
 Per la versione attiva consulta [docs/ROADMAP.md](./ROADMAP.md).
 
 ---
@@ -37,7 +39,8 @@ Cose che mi servono per usarlo davvero ogni giorno:
 ### Sicurezza
 
 - **Log degli accessi**: Chi ha visto cosa e quando. Serve per GDPR.
-- **Cambio PIN**: Ora se perdi il PIN perdi tutto. Devo poterlo cambiare.
+- **Cambio PIN (claim storico superato)**: lo snapshot assumeva la perdita totale
+  senza PIN; la semantica corrente va verificata nelle fonti canoniche attive.
 - **Pulizia automatica**: Cancellare dati vecchi dopo X anni (configurabile).
 
 ### Usabilità

--- a/docs/system_architecture.md
+++ b/docs/system_architecture.md
@@ -21,10 +21,12 @@ Per la mappa documentale completa usa [docs/README.md](./README.md) e [docs/mark
 
 ## 🧭 Snapshot corrente
 
-1. **Local-first di default**: il dato resta sul computer locale e nessun cloud
-   entra nel runtime operativo per default.
-2. **Zero-knowledge a riposo**: i campi clinici e gli artifact documentali
-   persistono cifrati lato client.
+1. **Local-first di default**: lo storage autorevole resta sul nodo `home-base`;
+   client paired, cache locali ed export/backup espliciti completano il
+   perimetro. Nessun cloud entra nel runtime operativo per default.
+2. **Cifratura clinica per campo a riposo**: i campi configurati e gli artifact
+   documentali sensibili persistono cifrati lato client. Il file SQLite non è
+   cifrato integralmente.
 3. **Home-base opt-in**: esiste una slice `network-home-base` su
    `/api/v1/network/*` con read pazienti, write versionati su
    profilo/status, diario, terapie, checkup e osservazioni, mentre hard delete
@@ -63,8 +65,8 @@ Per la mappa documentale completa usa [docs/README.md](./README.md) e [docs/mark
 
 ## 🔒 Dati e cifratura
 
-Tutto cio che e clinicamente sensibile viene cifrato lato client prima della
-persistenza. Questo include:
+I campi configurati come sensibili vengono cifrati lato client prima della
+persistenza. Il mapping corrente include:
 
 - campi paziente (`address`, `phone`, `notes`, `aiSummary`, `documentInsights`)
 - contenuti del diario clinico
@@ -79,7 +81,9 @@ ENC:<iv_b64>:<cipher_b64>
 ```
 
 Il server non possiede la chiave in chiaro; la master key vive solo nella
-sessione attiva del browser/client. Il soft-delete paziente (ADR 0066) scrive un
+sessione attiva del browser/client. Identificativi e alcuni metadati restano
+fuori dal mapping: il PIN non equivale a zero-knowledge sull'intero database.
+Il soft-delete paziente (ADR 0066) scrive un
 tombstone reversibile (`deletedAt` / `deletionReason`) con version guard e non
 orfana i figli clinici; il dato cifrato non viene mai sovrascritto dal
 placeholder `[LOCKED DATA]`, che resta solo di presentazione.

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -253,11 +253,15 @@ revisione operatore.
 - la cancellazione paziente e un soft-delete reversibile (ADR 0066): scrive un
   tombstone (`deletedAt` / `deletionReason`) con version guard, non orfana i
   figli clinici e lascia invariato il contratto API. L'erasure GDPR esplicita
-  resta un'azione admin separata (`purge-patient` con dry-run, `restore-patient`)
+  resta un'azione admin separata (`purge-patient` con dry-run, `restore-patient`);
+  la purge agisce sul database live e non raggiunge backup gia esportati
 
 ### Cifratura lato client (web)
 
-Il server non vede i dati in chiaro. La cifratura avviene nel browser prima della scrittura:
+I campi elencati in `lib/db.ts` (`ENCRYPTED_FIELDS`) vengono cifrati nel browser
+prima della scrittura e arrivano al server come ciphertext. Identificativi e
+alcuni metadati restano fuori da quel mapping: il file SQLite non è cifrato
+integralmente e il PIN non abilita un claim zero-knowledge whole-database.
 
 ```
 Dato originale -> AES-256-GCM -> "ENC:<iv_b64>:<cipher_b64>" -> DB

--- a/scripts/check-claims-guard.mjs
+++ b/scripts/check-claims-guard.mjs
@@ -6,16 +6,21 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const includePublication = process.argv.includes('--include-publication');
 const roots = [
   'README.md', 'ARCHITECTURE.md', 'SECURITY.md', 'CONTRIBUTING.md',
   'docs/README.md', 'docs/markdown-index.md', 'docs/FAQ.md', 'docs/ROADMAP.md',
   'docs/STATE_OF_THE_SYSTEM.md', 'docs/walkthrough.md', 'docs/system_architecture.md',
   'docs/ARCHITETTURA.md', 'docs/COMPLIANCE.md', 'docs/MANUALE.md', 'docs/NATIVE.md',
+  'docs/FSE2-terminology-roadmap.md', 'docs/product_roadmap.md',
   'docs/topologia-dati-flussi.md', 'docs/design',
+  'docs/adr/0006-terminology-plugin-and-fse-profiles.md',
   'docs/adr/0065-intended-purpose-and-claims-guard.md',
   'app', 'components', 'oss-assets',
 ];
+const publicationRoots = ['whitepaper'];
 const extensions = new Set(['.md', '.mdx', '.ts', '.tsx', '.js', '.jsx', '.mjs', '.html', '.swift']);
+const documentExtensions = new Set(['.md', '.mdx', '.html']);
 const skipped = ['.git', '.next', 'node_modules', 'e2e', 'coverage', 'dist', 'out']
   .map((item) => `${path.sep}${item.replaceAll('/', path.sep)}${path.sep}`);
 
@@ -35,7 +40,24 @@ const rules = [
   ['CLAIM-CLOUD-DEFAULT', 'cloud / privacy',
     'Cloud processing or sync must not be described as default for clinical data.',
     /\b(?:cloud|telemetry|telemetria|AI remot[ao])\b.{0,96}\b(?:default|automatic[ao]|obbligatori[ao]|sempre attiv[ao]|dati clinici|PHI|PII|prompt clinici)/iu],
-].map(([id, category, description, pattern]) => ({ id, category, description, pattern }));
+  ['CLAIM-FULL-DB-ENCRYPTION', 'encryption / at rest',
+    'Field-level encryption must not be presented as whole-database encryption or zero knowledge.',
+    /(?:\b(?:(?:inter[oa]\s+)?database|file SQLite|SQLite|dati clinici sul disco|tutto)\b.{0,112}\b(?:cifrat[oaie]|illeggibil[ei]|non (?:e|è) leggibil[ei]|non si (?:legge|leggono)|zero[- ]knowledge|zero conoscenza)\b|\b(?:zero[- ]knowledge|zero conoscenza)\b.{0,80}\b(?:a riposo|database|SQLite|attiv[oa]|non negoziabil\w*)\b|\b(?:se\s+)?perdi il PIN\b.{0,48}\bperdi (?:(?:tutti )?i )?dati\b)/iu, true],
+  ['CLAIM-FHIR-CONFORMANCE', 'FHIR / interoperability',
+    'FHIR export must not imply conformance, portability, or third-party ingestion without evidence.',
+    /(?:\bFHIR(?: R4)?\b.{0,120}\b(?:compatibil[ei]|conform(?:e|ita|ità)|interoperabil(?:e|ita|ità)|portabilit[aà]|leggibil[ei] da altr[io] sistem\w*|riusabil[ei]|lock-in)|\b(?:compatibil[ei]|conform(?:e|ita|ità)|interoperabil(?:e|ita|ità)|portabilit[aà]|leggibil[ei] da altr[io] sistem\w*|riusabil[ei]|lock-in)\b.{0,120}\bFHIR(?: R4)?\b)/iu, true],
+  ['CLAIM-GDPR-GUARANTEE', 'GDPR / roles / rights',
+    'Product features must not certify GDPR compliance, assign roles categorically, or guarantee rights.',
+    /(?:\b(?:MediFlow|software|prodotto|feature|funzionalit[aà])\b.{0,120}\b(?:garantisce|certifica|assicura|(?:e|è|risulta)\s+conforme)\b.{0,120}\b(?:GDPR|conformit[aà]|art(?:icolo|\.)?\s*(?:17|20|32))\b|\b(?:medico|professionista)\b.{0,80}\b(?:resta|e|è)\b.{0,24}\btitolare del trattamento\b|\btitolare del trattamento\b.{0,48}\bresta\b.{0,32}\b(?:medico|professionista)\b|\b(?:diritt[io]|GDPR|art(?:icolo|\.)?\s*(?:17|20|32))\b.{0,96}\b(?:garantit[ioe]|conform[ei]|certificat[oaie]|assicurat[ioe])\b)/iu, true],
+  ['CLAIM-ONE-DEVICE-ABSOLUTE', 'local-first / topology',
+    'Local-first claims must name home-base and explicit paired, cache, export, or backup paths.',
+    /\b(?:i\s+|tutti i\s+)?dati(?: clinici| paziente)?\b.{0,56}\b(?:non (?:escono|lasciano)(?: mai)?|restano|rimangono|sono nel|stanno sul)\b.{0,64}\b(?:Mac|computer|dispositivo)\b/iu, true],
+  ['CLAIM-ICD-GUARANTEE', 'ICD / terminology',
+    'Optional terminology support must not imply that every diagnosis is coded or validated.',
+    /(?:\b(?:ogni|tutte le)\s+diagnos[ie]\b.{0,80}\b(?:codic|ICD-11|validat)\w*\b|\bdiagnos[ie]\b.{0,80}\b(?:usano|usa|sempre|solo)\b.{0,40}\bICD-11\b|\bdiagnos[ie]\b.{0,64}\bnon (?:restano|sono)\b.{0,24}\btesto libero\b)/iu, true],
+].map(([id, category, description, pattern, documentOnly = false]) => ({
+  id, category, description, pattern, documentOnly,
+}));
 
 const allowlist = [
   ['CLAIM-AI-AUTONOMY', 'diagnosi automatica'],
@@ -43,6 +65,13 @@ const allowlist = [
   ['CLAIM-SISS-FSE-INTEGRATION', 'SISS integrato'],
   ['CLAIM-REGIONAL-PRESCRIPTION', 'NRE'],
   ['CLAIM-CLOUD-DEFAULT', 'cloud AI'],
+  ['CLAIM-FULL-DB-ENCRYPTION', 'cifratura integrale del file SQLite'],
+  ['CLAIM-FULL-DB-ENCRYPTION', 'zero-knowledge whole-database'],
+  ['CLAIM-FHIR-CONFORMANCE', 'compatibilita, conformita, interoperabilita'],
+  ['CLAIM-GDPR-GUARANTEE', 'conformita GDPR certificata'],
+  ['CLAIM-GDPR-GUARANTEE', 'diritti dichiarati garantiti'],
+  ['CLAIM-ONE-DEVICE-ABSOLUTE', 'confinati a un solo dispositivo'],
+  ['CLAIM-ICD-GUARANTEE', 'ogni diagnosi dichiarata obbligatoriamente'],
 ].map(([ruleId, snippet]) => ({
   file: 'docs/adr/0065-intended-purpose-and-claims-guard.md',
   ruleId,
@@ -54,14 +83,15 @@ if (process.argv.includes('--self-test')) runSelfTest();
 else runRepositoryScan();
 
 function runRepositoryScan() {
-  const files = roots.flatMap(collectFiles).sort();
+  const activeRoots = includePublication ? [...roots, ...publicationRoots] : roots;
+  const files = activeRoots.flatMap(collectFiles).sort();
   const findings = [];
 
   for (const file of files) {
     const lines = fs.readFileSync(path.join(repoRoot, file), 'utf8').split(/\r?\n/);
     lines.forEach((line, index) => {
       const context = lines.slice(Math.max(0, index - 5), index + 2).join(' ');
-      for (const rule of matchingRules(line, context)) {
+      for (const rule of matchingRules(line, context, file)) {
         const match = rule.pattern.exec(line)?.[0] ?? line;
         if (!isAllowlisted(file, rule.id, line, match)) {
           findings.push({ rule, file, line: index + 1, snippet: compact(match) });
@@ -72,6 +102,9 @@ function runRepositoryScan() {
 
   if (findings.length === 0) {
     console.log(`Claims guard passed: scanned ${files.length} file(s), 0 high-risk claim(s).`);
+    if (!includePublication) {
+      console.log('Phase B dependency: whitepaper/ is not enforced yet; rerun with --include-publication after its copy converges.');
+    }
     return;
   }
   console.error(`Claims guard failed: ${findings.length} high-risk claim(s) need review.`);
@@ -90,6 +123,18 @@ function runSelfTest() {
     ['regional sync claim', 'Il modulo SISS integrato consente writeback e sync certificato.', 'CLAIM-SISS-FSE-INTEGRATION'],
     ['official prescription claim', 'MediFlow genera NRE e invia ricette regionali direttamente.', 'CLAIM-REGIONAL-PRESCRIPTION'],
     ['cloud default claim', 'La cloud AI e attiva di default per prompt clinici e dati PHI.', 'CLAIM-CLOUD-DEFAULT'],
+    ['whole database encryption claim', 'Il database SQLite e cifrato e illeggibile senza PIN.', 'CLAIM-FULL-DB-ENCRYPTION'],
+    ['zero-knowledge invariant claim', 'Architettura local-first e zero-knowledge non negoziabile.', 'CLAIM-FULL-DB-ENCRYPTION'],
+    ['PIN total loss claim', 'Se perdi il PIN, perdi i dati.', 'CLAIM-FULL-DB-ENCRYPTION'],
+    ['FHIR conformance claim', 'L export FHIR R4 e compatibile e leggibile da altri sistemi.', 'CLAIM-FHIR-CONFORMANCE'],
+    ['FHIR ingestion claim', 'Il bundle FHIR R4 e leggibile da altri sistemi.', 'CLAIM-FHIR-CONFORMANCE'],
+    ['reverse FHIR compatibility claim', 'Viene generato un pacchetto JSON compatibile FHIR R4.', 'CLAIM-FHIR-CONFORMANCE'],
+    ['reverse FHIR interoperability claim', 'Esporta un formato interoperabile FHIR R4.', 'CLAIM-FHIR-CONFORMANCE'],
+    ['GDPR role claim', 'Il professionista resta il titolare del trattamento.', 'CLAIM-GDPR-GUARANTEE'],
+    ['GDPR reverse role claim', 'Il titolare del trattamento resta il professionista.', 'CLAIM-GDPR-GUARANTEE'],
+    ['GDPR conformity claim', 'MediFlow e conforme al GDPR.', 'CLAIM-GDPR-GUARANTEE'],
+    ['single device claim', 'I dati clinici non lasciano mai il dispositivo.', 'CLAIM-ONE-DEVICE-ABSOLUTE'],
+    ['ICD guarantee claim', 'Ogni diagnosi ha un codice ICD-11 validato.', 'CLAIM-ICD-GUARANTEE'],
   ];
   const failures = [];
   for (const [name, line, expected] of required) {
@@ -100,6 +145,12 @@ function runSelfTest() {
   const allowed = [
     'MediFlow usa handoff webapp-assisted SISS/FSE e non dichiara integrazione certificata.',
     'MediFlow non genera NRE e non invia ricette regionali direttamente.',
+    'MediFlow cifra lato client i campi clinici sensibili; il file SQLite non e cifrato integralmente.',
+    'Il PIN non viene persistito; questo non equivale a zero-knowledge sull intero database.',
+    'MediFlow genera una mappatura FHIR R4 export-only v0 che non attesta conformita completa.',
+    'Le misure tecniche possono supportare il GDPR; ruoli e obblighi dipendono dal deployment.',
+    'Lo storage autorevole resta sul nodo home-base; client paired, cache ed export sono percorsi espliciti.',
+    'Il resolver ICD-11 e opzionale e i problemi free-text restano reviewable.',
   ];
   for (const line of allowed) {
     const matched = matchingRules(line).map((rule) => rule.id);
@@ -121,14 +172,33 @@ function runSelfTest() {
   process.exit(1);
 }
 
-function matchingRules(line, context = line) {
+function matchingRules(line, context = line, file = 'self-test.md') {
   return rules.filter((rule) => {
     rule.pattern.lastIndex = 0;
-    return rule.pattern.test(line) && !isContextAllowed(rule.id, line, context);
+    return (!rule.documentOnly || isDocumentSurface(file))
+      && rule.pattern.test(line)
+      && !isContextAllowed(rule.id, line, context);
   });
 }
 
 function isContextAllowed(ruleId, line, context) {
+  const boundaryText = context.toLocaleLowerCase('it-IT');
+  if (ruleId === 'CLAIM-FULL-DB-ENCRYPTION') {
+    return /\b(?:campi\b.{0,48}\bcifrat\w*|cifratura\b.{0,32}\bper campo|field-level|non presentare|non deve descrivere|non equivale|non rientr\w*|non (?:e|è) cifrat[oa] integralmente|non sono tutti coperti|non ["“]?intero database|senza estendere|non abilita|finche\b.{0,96}\bperimetro)\b/u.test(boundaryText);
+  }
+  if (ruleId === 'CLAIM-FHIR-CONFORMANCE') {
+    return (line.includes('|') && line.includes(']('))
+      || /\b(?:export-only v0|mappatura export-only|senza claim|non (?:attesta|prova|dichiara|garantisce)|nessuna garanzia)\b/u.test(boundaryText);
+  }
+  if (ruleId === 'CLAIM-GDPR-GUARANTEE') {
+    return /\b(?:pu[oò] supportare|possono supportare|non (?:certifica|prova|assegna)|dipendono dal deployment|valutazione del caso)\b/u.test(boundaryText);
+  }
+  if (ruleId === 'CLAIM-ONE-DEVICE-ABSOLUTE') {
+    return /\b(?:home-base|client paired|cache|export|backup|storage autorevole)\b/u.test(boundaryText);
+  }
+  if (ruleId === 'CLAIM-ICD-GUARANTEE') {
+    return /\b(?:opzional|possono|free-text|reviewable|non (?:ogni|tutte))\w*\b/u.test(boundaryText);
+  }
   if (ruleId === 'CLAIM-AUTO-APPLY') return false;
   const text = context.toLocaleLowerCase('it-IT');
   if (hasBoundaryNegation(text)) return true;
@@ -136,8 +206,13 @@ function isContextAllowed(ruleId, line, context) {
   return /\b(corpus|documental[ei]|sorgent[ei]|manifest|mcp|fetch\/sync|source sync|siss-corpus:sync|gia sincronizzato|già sincronizzato)\b/iu.test(line);
 }
 
+function isDocumentSurface(file) {
+  return documentExtensions.has(path.extname(file));
+}
+
 function hasBoundaryNegation(text) {
   return /\bnon (?:sono|e|è) ammessi\b/u.test(text)
+    || /\bnon (?:sono|e|è) attiv[io]\b/u.test(text)
     || /\bfallisce se trova\b/u.test(text)
     || /\bnon (?:dichiara|introduce|usa|invia|genera|automatizza|prescrive|sostituisce|promuove|applica|accetta)\b/u.test(text)
     || /\bnessun[ao]?\b.{0,64}\b(?:cloud|egress|sync|telemetry|telemetria|writeback|invio|accesso diretto)\b/u.test(text)

--- a/scripts/check-claims-guard.mjs
+++ b/scripts/check-claims-guard.mjs
@@ -177,8 +177,22 @@ function runSelfTest() {
     failures.push('unrelated negation suppressed CLAIM-REGIONAL-PRESCRIPTION');
   }
 
+  const contradictoryCases = [
+    ['field qualifier plus whole database claim', 'I campi sono cifrati lato client; il database SQLite e cifrato integralmente.', 'CLAIM-FULL-DB-ENCRYPTION'],
+    ['local-first plus NRE issuance', 'MediFlow e local-first; MediFlow genera NRE e invia ricette regionali.', 'CLAIM-REGIONAL-PRESCRIPTION'],
+    ['telemetry negation plus cloud default', 'Niente telemetria; la cloud AI e attiva di default.', 'CLAIM-CLOUD-DEFAULT'],
+    ['export-only plus FHIR guarantee', 'Mappatura export-only v0; il bundle FHIR R4 e interoperabile.', 'CLAIM-FHIR-CONFORMANCE'],
+    ['home-base alone plus single-device absolute', 'Storage home-base; tutti i dati restano sul computer.', 'CLAIM-ONE-DEVICE-ABSOLUTE'],
+    ['optional resolver plus universal ICD guarantee', 'Resolver opzionale; ogni diagnosi ha un codice ICD-11 validato.', 'CLAIM-ICD-GUARANTEE'],
+    ['support wording plus GDPR conformity', 'Le misure possono supportare il GDPR; MediFlow e conforme al GDPR.', 'CLAIM-GDPR-GUARANTEE'],
+  ];
+  for (const [name, source, expected] of contradictoryCases) {
+    const matched = findRuleMatches(source, 'self-test.md').map((item) => item.rule.id);
+    if (!matched.includes(expected)) failures.push(`${name}: expected ${expected}, got ${matched.join(', ') || 'none'}`);
+  }
+
   if (failures.length === 0) {
-    console.log(`Claims guard self-test passed: ${required.length} synthetic violation(s) detected and allowed boundary wording accepted.`);
+    console.log(`Claims guard self-test passed: ${required.length} synthetic violation(s) and ${contradictoryCases.length} masking regression(s) detected; allowed boundary wording accepted.`);
     return;
   }
   console.error('Claims guard self-test failed:');
@@ -191,10 +205,14 @@ function findRuleMatches(source, file) {
   const matches = [];
   for (const rule of rules) {
     const flags = rule.pattern.flags.includes('g') ? rule.pattern.flags : `${rule.pattern.flags}g`;
-    const pattern = new RegExp(rule.pattern.source, flags);
+    const clauseBoundedSource = rule.pattern.source.replace(
+      /\.\{0,(\d+)\}/gu,
+      String.raw`(?:(?![.!?](?:\s|$)|;|\n).){0,$1}`,
+    );
+    const pattern = new RegExp(clauseBoundedSource, flags);
     for (const match of scanText.matchAll(pattern)) {
       const offset = match.index ?? 0;
-      const context = logicalBlockAt(scanText, offset);
+      const context = claimClauseAt(scanText, offset);
       if (!isContextAllowed(rule.id, match[0], context)) {
         matches.push({
           rule,
@@ -228,10 +246,12 @@ function shouldJoinLine(line, next) {
   return !/^\s*(?:#{1,6}\s|[-*+]\s|\d+[.)]\s|>|\||<\/?[A-Za-z])/u.test(next);
 }
 
-function logicalBlockAt(scanText, offset) {
-  const start = scanText.lastIndexOf('\n', offset - 1) + 1;
-  const nextBreak = scanText.indexOf('\n', offset);
-  const end = nextBreak === -1 ? scanText.length : nextBreak;
+function claimClauseAt(scanText, offset) {
+  const boundaries = [...scanText.matchAll(/[;\n]|[.!?](?=\s|$)/gu)].map((match) => match.index ?? 0);
+  const previous = boundaries.filter((position) => position < offset);
+  const following = boundaries.filter((position) => position >= offset);
+  const start = (previous.at(-1) ?? -1) + 1;
+  const end = following[0] ?? scanText.length;
   return scanText.slice(start, end);
 }
 
@@ -242,19 +262,29 @@ function lineNumberAt(source, offset) {
 function isContextAllowed(ruleId, line, context) {
   const boundaryText = context.toLocaleLowerCase('it-IT');
   if (ruleId === 'CLAIM-FULL-DB-ENCRYPTION') {
-    return /\b(?:campi\b.{0,48}\bcifrat\w*|cifratura\b.{0,32}\bper campo|field-level|non presentare|non deve descrivere|non equivale|non rientr\w*|non (?:e|è) cifrat[oa] integralmente|non sono tutti coperti|non ["“]?intero database|senza estendere|non abilita|finche\b.{0,96}\bperimetro)\b/u.test(boundaryText);
+    const explicitlyQualified = /\b(?:non\s+presentare|non\s+deve\s+descrivere|non\s+equivale|non\s+rientr\w*|non\s+(?:e|è)\s+cifrat[oa](?:\s+integralmente)?|non\s+sono\s+tutti\s+coperti|non\s+["“]?intero\s+database|senza\s+(?:claim|estendere)|non\s+abilita|finche\b.{0,96}\bperimetro)\b/u.test(boundaryText);
+    const fieldOnly = /\b(?:campi?\b.{0,48}\bcifrat\w*|cifratura\b.{0,32}\bper campo|field-level)\b/u.test(boundaryText)
+      && !/\b(?:integral\w*|intero database|zero[- ]knowledge|zero conoscenza|illeggibil\w*|tutto cifrato)\b/u.test(boundaryText);
+    return explicitlyQualified || fieldOnly;
   }
   if (ruleId === 'CLAIM-FHIR-CONFORMANCE') {
-    return /\b(?:export-only v0|mappatura export-only|senza claim|non (?:attesta|prova|dichiara|garantisce)|nessuna garanzia|quadro (?:compliance|documentale))\b/u.test(boundaryText);
+    const qualifiedExport = /\b(?:export-only v0|mappatura export-only)\b/u.test(boundaryText)
+      && /\b(?:senza claim|non (?:attesta|prova|dichiara|garantisce)|nessuna garanzia)\b/u.test(boundaryText);
+    return qualifiedExport || /\bquadro (?:compliance|documentale)\b/u.test(boundaryText);
   }
   if (ruleId === 'CLAIM-GDPR-GUARANTEE') {
-    return /\b(?:pu[oò] supportare|possono supportare|non (?:certifica|prova|assegna)|dipendono dal deployment|valutazione del caso)\b/u.test(boundaryText);
+    const supportIsQualified = /\b(?:pu[oò]|possono) supportare\b/u.test(boundaryText)
+      && /\b(?:non (?:certifica|prova|assegna)|dipendono dal deployment|valutazione del caso)\b/u.test(boundaryText);
+    return supportIsQualified || /\bnon (?:certifica|prova|assegna)\b/u.test(boundaryText);
   }
   if (ruleId === 'CLAIM-ONE-DEVICE-ABSOLUTE') {
-    return /\b(?:home-base|client paired|cache|export|backup|storage autorevole)\b/u.test(boundaryText);
+    return /\bhome-base\b/u.test(boundaryText)
+      && /\b(?:client paired|cache|export|backup)\b/u.test(boundaryText);
   }
   if (ruleId === 'CLAIM-ICD-GUARANTEE') {
-    return /\b(?:opzional|possono|free-text|reviewable|non (?:ogni|tutte))\w*\b/u.test(boundaryText);
+    if (/\b(?:ogni|tutte le)\s+diagnos[ie]\b/u.test(line.toLocaleLowerCase('it-IT'))) return false;
+    return /\bopzional\w*\b/u.test(boundaryText)
+      && /\b(?:free-text|reviewable|non (?:ogni|tutte))\w*\b/u.test(boundaryText);
   }
   const text = context.toLocaleLowerCase('it-IT');
   if (hasBoundaryNegation(text)) return true;
@@ -273,10 +303,7 @@ function hasBoundaryNegation(text) {
     || /\bno\b.{0,64}\b(?:cloud|egress|sync|telemetry|telemetria|writeback|invio|accesso diretto)\b/u.test(text)
     || /\bsenza\b.{0,64}\b(?:cloud|egress|telemetry|telemetria|sync|writeback|adr|canale qualificato|review|conferma|integrazione|auto-write|scritture)\b/u.test(text)
     || /\b(fuori|fuori scope|vieta|vietato|vietata|vietati|vietate|esclude|escluso|esclusa|not)\b/u.test(text)
-    || text.includes('local-first')
-    || text.includes('solo se scelto')
-    || text.includes('solo opt-in')
-    || text.includes('opt-in');
+    || /\b(?:solo se scelto|solo opt-in|opt-in)\b.{0,48}\b(?:cloud|egress|sync|telemetry|telemetria)\b/u.test(text);
 }
 
 function collectFiles(root) {

--- a/scripts/check-claims-guard.mjs
+++ b/scripts/check-claims-guard.mjs
@@ -47,7 +47,7 @@ const rules = [
     /(?:\bFHIR(?: R4)?\b.{0,120}\b(?:compatibil[ei]|conform(?:e|ita|ità)|interoperabil(?:e|ita|ità)|portabilit[aà]|leggibil[ei] da altr[io] sistem\w*|riusabil[ei]|lock-in)|\b(?:compatibil[ei]|conform(?:e|ita|ità)|interoperabil(?:e|ita|ità)|portabilit[aà]|leggibil[ei] da altr[io] sistem\w*|riusabil[ei]|lock-in)\b.{0,120}\bFHIR(?: R4)?\b)/iu],
   ['CLAIM-GDPR-GUARANTEE', 'GDPR / roles / rights',
     'Product features must not certify GDPR compliance, assign roles categorically, or guarantee rights.',
-    /(?:\b(?:MediFlow|software|prodotto|feature|funzionalit[aà])\b.{0,120}\b(?:garantisce|certifica|assicura|(?:e|è|risulta)\s+conforme)\b.{0,120}\b(?:GDPR|conformit[aà]|art(?:icolo|\.)?\s*(?:17|20|32))\b|\b(?:medico|professionista)\b.{0,80}\b(?:resta|e|è)\b.{0,24}\btitolare del trattamento\b|\btitolare del trattamento\b.{0,48}\bresta\b.{0,32}\b(?:medico|professionista)\b|\b(?:diritt[io]|GDPR|art(?:icolo|\.)?\s*(?:17|20|32))\b.{0,96}\b(?:garantit[ioe]|conform[ei]|certificat[oaie]|assicurat[ioe])\b)/iu],
+    /(?:\b(?:MediFlow|software|prodotto|feature|funzionalit[aà])\b.{0,120}(?:\b(?:garantisce|certifica|assicura)\b|(?:\be\b|è|\brisulta\b)\s+conforme).{0,120}\b(?:GDPR|conformit[aà]|art(?:icolo|\.)?\s*(?:17|20|32))\b|\b(?:medico|professionista)\b.{0,80}(?:\b(?:resta|e)\b|è).{0,24}\btitolare del trattamento\b|\btitolare del trattamento\b.{0,48}\bresta\b.{0,32}\b(?:medico|professionista)\b|\b(?:diritt[io]|GDPR|art(?:icolo|\.)?\s*(?:17|20|32))\b.{0,96}\b(?:garantit[ioe]|conform[ei]|certificat[oaie]|assicurat[ioe])\b)/iu],
   ['CLAIM-ONE-DEVICE-ABSOLUTE', 'local-first / topology',
     'Local-first claims must name home-base and explicit paired, cache, export, or backup paths.',
     /\b(?:i\s+|tutti i\s+)?dati(?: clinici| paziente)?\b.{0,56}\b(?:non (?:escono|lasciano)(?: mai)?|restano|rimangono|sono nel|stanno sul)\b.{0,64}\b(?:Mac|computer|dispositivo)\b/iu],
@@ -185,6 +185,9 @@ function runSelfTest() {
     ['home-base alone plus single-device absolute', 'Storage home-base; tutti i dati restano sul computer.', 'CLAIM-ONE-DEVICE-ABSOLUTE'],
     ['optional resolver plus universal ICD guarantee', 'Resolver opzionale; ogni diagnosi ha un codice ICD-11 validato.', 'CLAIM-ICD-GUARANTEE'],
     ['support wording plus GDPR conformity', 'Le misure possono supportare il GDPR; MediFlow e conforme al GDPR.', 'CLAIM-GDPR-GUARANTEE'],
+    ['accented GDPR conformity', 'MediFlow è conforme al GDPR.', 'CLAIM-GDPR-GUARANTEE'],
+    ['PIN qualifier plus comma contrast', 'Il PIN non equivale a zero-knowledge, ma il database SQLite è cifrato integralmente.', 'CLAIM-FULL-DB-ENCRYPTION'],
+    ['negative encryption plus comma contrast', 'Il file SQLite non è cifrato integralmente, ma il database SQLite è cifrato integralmente.', 'CLAIM-FULL-DB-ENCRYPTION'],
   ];
   for (const [name, source, expected] of contradictoryCases) {
     const matched = findRuleMatches(source, 'self-test.md').map((item) => item.rule.id);
@@ -207,7 +210,7 @@ function findRuleMatches(source, file) {
     const flags = rule.pattern.flags.includes('g') ? rule.pattern.flags : `${rule.pattern.flags}g`;
     const clauseBoundedSource = rule.pattern.source.replace(
       /\.\{0,(\d+)\}/gu,
-      String.raw`(?:(?![.!?](?:\s|$)|;|\n).){0,$1}`,
+      String.raw`(?:(?![.!?](?:\s|$)|;|\n|,\s*(?:ma|però|tuttavia|mentre)\b).){0,$1}`,
     );
     const pattern = new RegExp(clauseBoundedSource, flags);
     for (const match of scanText.matchAll(pattern)) {
@@ -247,7 +250,8 @@ function shouldJoinLine(line, next) {
 }
 
 function claimClauseAt(scanText, offset) {
-  const boundaries = [...scanText.matchAll(/[;\n]|[.!?](?=\s|$)/gu)].map((match) => match.index ?? 0);
+  const boundaries = [...scanText.matchAll(/[;\n]|[.!?](?=\s|$)|,(?=\s*(?:ma|però|tuttavia|mentre)\b)/giu)]
+    .map((match) => match.index ?? 0);
   const previous = boundaries.filter((position) => position < offset);
   const following = boundaries.filter((position) => position >= offset);
   const start = (previous.at(-1) ?? -1) + 1;

--- a/scripts/check-claims-guard.mjs
+++ b/scripts/check-claims-guard.mjs
@@ -16,11 +16,10 @@ const roots = [
   'docs/topologia-dati-flussi.md', 'docs/design',
   'docs/adr/0006-terminology-plugin-and-fse-profiles.md',
   'docs/adr/0065-intended-purpose-and-claims-guard.md',
-  'app', 'components', 'oss-assets',
+  'app', 'components', 'native', 'oss-assets',
 ];
 const publicationRoots = ['whitepaper'];
 const extensions = new Set(['.md', '.mdx', '.ts', '.tsx', '.js', '.jsx', '.mjs', '.html', '.swift']);
-const documentExtensions = new Set(['.md', '.mdx', '.html']);
 const skipped = ['.git', '.next', 'node_modules', 'e2e', 'coverage', 'dist', 'out']
   .map((item) => `${path.sep}${item.replaceAll('/', path.sep)}${path.sep}`);
 
@@ -42,22 +41,20 @@ const rules = [
     /\b(?:cloud|telemetry|telemetria|AI remot[ao])\b.{0,96}\b(?:default|automatic[ao]|obbligatori[ao]|sempre attiv[ao]|dati clinici|PHI|PII|prompt clinici)/iu],
   ['CLAIM-FULL-DB-ENCRYPTION', 'encryption / at rest',
     'Field-level encryption must not be presented as whole-database encryption or zero knowledge.',
-    /(?:\b(?:(?:inter[oa]\s+)?database|file SQLite|SQLite|dati clinici sul disco|tutto)\b.{0,112}\b(?:cifrat[oaie]|illeggibil[ei]|non (?:e|è) leggibil[ei]|non si (?:legge|leggono)|zero[- ]knowledge|zero conoscenza)\b|\b(?:zero[- ]knowledge|zero conoscenza)\b.{0,80}\b(?:a riposo|database|SQLite|attiv[oa]|non negoziabil\w*)\b|\b(?:se\s+)?perdi il PIN\b.{0,48}\bperdi (?:(?:tutti )?i )?dati\b)/iu, true],
+    /(?:\b(?:(?:inter[oa]\s+)?database|file SQLite|SQLite|dati clinici sul disco|tutto)\b.{0,112}\b(?:cifrat[oaie]|illeggibil[ei]|non (?:e|è) leggibil[ei]|non si (?:legge|leggono)|zero[- ]knowledge|zero conoscenza)\b|\b(?:zero[- ]knowledge|zero conoscenza)\b.{0,80}\b(?:a riposo|database|SQLite|attiv[oa]|non negoziabil\w*)\b|\b(?:se\s+)?perdi il PIN\b.{0,48}\bperdi (?:(?:tutti )?i )?dati\b|\b(?:se\s+)?perdi il PIN\b.{0,48}\bperdi tutto\b)/iu],
   ['CLAIM-FHIR-CONFORMANCE', 'FHIR / interoperability',
     'FHIR export must not imply conformance, portability, or third-party ingestion without evidence.',
-    /(?:\bFHIR(?: R4)?\b.{0,120}\b(?:compatibil[ei]|conform(?:e|ita|ità)|interoperabil(?:e|ita|ità)|portabilit[aà]|leggibil[ei] da altr[io] sistem\w*|riusabil[ei]|lock-in)|\b(?:compatibil[ei]|conform(?:e|ita|ità)|interoperabil(?:e|ita|ità)|portabilit[aà]|leggibil[ei] da altr[io] sistem\w*|riusabil[ei]|lock-in)\b.{0,120}\bFHIR(?: R4)?\b)/iu, true],
+    /(?:\bFHIR(?: R4)?\b.{0,120}\b(?:compatibil[ei]|conform(?:e|ita|ità)|interoperabil(?:e|ita|ità)|portabilit[aà]|leggibil[ei] da altr[io] sistem\w*|riusabil[ei]|lock-in)|\b(?:compatibil[ei]|conform(?:e|ita|ità)|interoperabil(?:e|ita|ità)|portabilit[aà]|leggibil[ei] da altr[io] sistem\w*|riusabil[ei]|lock-in)\b.{0,120}\bFHIR(?: R4)?\b)/iu],
   ['CLAIM-GDPR-GUARANTEE', 'GDPR / roles / rights',
     'Product features must not certify GDPR compliance, assign roles categorically, or guarantee rights.',
-    /(?:\b(?:MediFlow|software|prodotto|feature|funzionalit[aà])\b.{0,120}\b(?:garantisce|certifica|assicura|(?:e|è|risulta)\s+conforme)\b.{0,120}\b(?:GDPR|conformit[aà]|art(?:icolo|\.)?\s*(?:17|20|32))\b|\b(?:medico|professionista)\b.{0,80}\b(?:resta|e|è)\b.{0,24}\btitolare del trattamento\b|\btitolare del trattamento\b.{0,48}\bresta\b.{0,32}\b(?:medico|professionista)\b|\b(?:diritt[io]|GDPR|art(?:icolo|\.)?\s*(?:17|20|32))\b.{0,96}\b(?:garantit[ioe]|conform[ei]|certificat[oaie]|assicurat[ioe])\b)/iu, true],
+    /(?:\b(?:MediFlow|software|prodotto|feature|funzionalit[aà])\b.{0,120}\b(?:garantisce|certifica|assicura|(?:e|è|risulta)\s+conforme)\b.{0,120}\b(?:GDPR|conformit[aà]|art(?:icolo|\.)?\s*(?:17|20|32))\b|\b(?:medico|professionista)\b.{0,80}\b(?:resta|e|è)\b.{0,24}\btitolare del trattamento\b|\btitolare del trattamento\b.{0,48}\bresta\b.{0,32}\b(?:medico|professionista)\b|\b(?:diritt[io]|GDPR|art(?:icolo|\.)?\s*(?:17|20|32))\b.{0,96}\b(?:garantit[ioe]|conform[ei]|certificat[oaie]|assicurat[ioe])\b)/iu],
   ['CLAIM-ONE-DEVICE-ABSOLUTE', 'local-first / topology',
     'Local-first claims must name home-base and explicit paired, cache, export, or backup paths.',
-    /\b(?:i\s+|tutti i\s+)?dati(?: clinici| paziente)?\b.{0,56}\b(?:non (?:escono|lasciano)(?: mai)?|restano|rimangono|sono nel|stanno sul)\b.{0,64}\b(?:Mac|computer|dispositivo)\b/iu, true],
+    /\b(?:i\s+|tutti i\s+)?dati(?: clinici| paziente)?\b.{0,56}\b(?:non (?:escono|lasciano)(?: mai)?|restano|rimangono|sono nel|stanno sul)\b.{0,64}\b(?:Mac|computer|dispositivo)\b/iu],
   ['CLAIM-ICD-GUARANTEE', 'ICD / terminology',
     'Optional terminology support must not imply that every diagnosis is coded or validated.',
-    /(?:\b(?:ogni|tutte le)\s+diagnos[ie]\b.{0,80}\b(?:codic|ICD-11|validat)\w*\b|\bdiagnos[ie]\b.{0,80}\b(?:usano|usa|sempre|solo)\b.{0,40}\bICD-11\b|\bdiagnos[ie]\b.{0,64}\bnon (?:restano|sono)\b.{0,24}\btesto libero\b)/iu, true],
-].map(([id, category, description, pattern, documentOnly = false]) => ({
-  id, category, description, pattern, documentOnly,
-}));
+    /(?:\b(?:ogni|tutte le)\s+diagnos[ie]\b.{0,80}\b(?:codic|ICD-11|validat)\w*\b|\bdiagnos[ie]\b.{0,80}\b(?:usano|usa|sempre|solo)\b.{0,40}\bICD-11\b|\bdiagnos[ie]\b.{0,64}\bnon (?:restano|sono)\b.{0,24}\btesto libero\b)/iu],
+].map(([id, category, description, pattern]) => ({ id, category, description, pattern }));
 
 const allowlist = [
   ['CLAIM-AI-AUTONOMY', 'diagnosi automatica'],
@@ -67,6 +64,7 @@ const allowlist = [
   ['CLAIM-CLOUD-DEFAULT', 'cloud AI'],
   ['CLAIM-FULL-DB-ENCRYPTION', 'cifratura integrale del file SQLite'],
   ['CLAIM-FULL-DB-ENCRYPTION', 'zero-knowledge whole-database'],
+  ['CLAIM-FULL-DB-ENCRYPTION', "zero-knowledge sull'intero database"],
   ['CLAIM-FHIR-CONFORMANCE', 'compatibilita, conformita, interoperabilita'],
   ['CLAIM-GDPR-GUARANTEE', 'conformita GDPR certificata'],
   ['CLAIM-GDPR-GUARANTEE', 'diritti dichiarati garantiti'],
@@ -88,16 +86,10 @@ function runRepositoryScan() {
   const findings = [];
 
   for (const file of files) {
-    const lines = fs.readFileSync(path.join(repoRoot, file), 'utf8').split(/\r?\n/);
-    lines.forEach((line, index) => {
-      const context = lines.slice(Math.max(0, index - 5), index + 2).join(' ');
-      for (const rule of matchingRules(line, context, file)) {
-        const match = rule.pattern.exec(line)?.[0] ?? line;
-        if (!isAllowlisted(file, rule.id, line, match)) {
-          findings.push({ rule, file, line: index + 1, snippet: compact(match) });
-        }
-      }
-    });
+    const source = fs.readFileSync(path.join(repoRoot, file), 'utf8').replaceAll('\r\n', '\n');
+    for (const item of findRuleMatches(source, file)) {
+      if (!isAllowlisted(file, item.rule.id, item.context, item.match)) findings.push(item);
+    }
   }
 
   if (findings.length === 0) {
@@ -126,6 +118,7 @@ function runSelfTest() {
     ['whole database encryption claim', 'Il database SQLite e cifrato e illeggibile senza PIN.', 'CLAIM-FULL-DB-ENCRYPTION'],
     ['zero-knowledge invariant claim', 'Architettura local-first e zero-knowledge non negoziabile.', 'CLAIM-FULL-DB-ENCRYPTION'],
     ['PIN total loss claim', 'Se perdi il PIN, perdi i dati.', 'CLAIM-FULL-DB-ENCRYPTION'],
+    ['PIN everything loss claim', 'Ora se perdi il PIN perdi tutto.', 'CLAIM-FULL-DB-ENCRYPTION'],
     ['FHIR conformance claim', 'L export FHIR R4 e compatibile e leggibile da altri sistemi.', 'CLAIM-FHIR-CONFORMANCE'],
     ['FHIR ingestion claim', 'Il bundle FHIR R4 e leggibile da altri sistemi.', 'CLAIM-FHIR-CONFORMANCE'],
     ['reverse FHIR compatibility claim', 'Viene generato un pacchetto JSON compatibile FHIR R4.', 'CLAIM-FHIR-CONFORMANCE'],
@@ -138,7 +131,7 @@ function runSelfTest() {
   ];
   const failures = [];
   for (const [name, line, expected] of required) {
-    const matched = matchingRules(line).map((rule) => rule.id);
+    const matched = findRuleMatches(line, 'self-test.md').map((item) => item.rule.id);
     if (!matched.includes(expected)) failures.push(`${name}: expected ${expected}, got ${matched.join(', ') || 'none'}`);
   }
 
@@ -151,15 +144,36 @@ function runSelfTest() {
     'Le misure tecniche possono supportare il GDPR; ruoli e obblighi dipendono dal deployment.',
     'Lo storage autorevole resta sul nodo home-base; client paired, cache ed export sono percorsi espliciti.',
     'Il resolver ICD-11 e opzionale e i problemi free-text restano reviewable.',
+    'Niente telemetria, cloud o egress dati e attivo per default.',
   ];
   for (const line of allowed) {
-    const matched = matchingRules(line).map((rule) => rule.id);
+    const matched = findRuleMatches(line, 'self-test.md').map((item) => item.rule.id);
     if (matched.length > 0) failures.push(`allowed boundary phrase matched ${matched.join(', ')}`);
   }
 
-  const unrelatedContext = 'Non e solo un database locale.\nMediFlow genera NRE e invia ricette regionali direttamente.';
-  const unrelated = matchingRules('MediFlow genera NRE e invia ricette regionali direttamente.', unrelatedContext);
-  if (!unrelated.some((rule) => rule.id === 'CLAIM-REGIONAL-PRESCRIPTION')) {
+  const unrelatedContext = '- I campi clinici sono cifrati lato client.\n- Il database SQLite e cifrato integralmente.';
+  const unrelated = findRuleMatches(unrelatedContext, 'self-test.md');
+  if (!unrelated.some((item) => item.rule.id === 'CLAIM-FULL-DB-ENCRYPTION')) {
+    failures.push('qualification in a previous list item suppressed CLAIM-FULL-DB-ENCRYPTION');
+  }
+
+  const multiline = findRuleMatches('Il database SQLite e\ncifrato integralmente.', 'self-test.md');
+  if (!multiline.some((item) => item.rule.id === 'CLAIM-FULL-DB-ENCRYPTION')) {
+    failures.push('multiline claim bypassed CLAIM-FULL-DB-ENCRYPTION');
+  }
+
+  const linkedTable = findRuleMatches('| [FHIR R4](./spec.md) | formato interoperabile |', 'self-test.md');
+  if (!linkedTable.some((item) => item.rule.id === 'CLAIM-FHIR-CONFORMANCE')) {
+    failures.push('linked Markdown table bypassed CLAIM-FHIR-CONFORMANCE');
+  }
+
+  const uiClaim = findRuleMatches('export const Claim = () => <p>Il database SQLite e cifrato integralmente.</p>;', 'claim.tsx');
+  if (!uiClaim.some((item) => item.rule.id === 'CLAIM-FULL-DB-ENCRYPTION')) {
+    failures.push('UI source bypassed CLAIM-FULL-DB-ENCRYPTION');
+  }
+
+  const unrelatedNegation = findRuleMatches('Non e solo un database locale.\nMediFlow genera NRE e invia ricette regionali direttamente.', 'self-test.md');
+  if (!unrelatedNegation.some((item) => item.rule.id === 'CLAIM-REGIONAL-PRESCRIPTION')) {
     failures.push('unrelated negation suppressed CLAIM-REGIONAL-PRESCRIPTION');
   }
 
@@ -172,13 +186,57 @@ function runSelfTest() {
   process.exit(1);
 }
 
-function matchingRules(line, context = line, file = 'self-test.md') {
-  return rules.filter((rule) => {
-    rule.pattern.lastIndex = 0;
-    return (!rule.documentOnly || isDocumentSurface(file))
-      && rule.pattern.test(line)
-      && !isContextAllowed(rule.id, line, context);
-  });
+function findRuleMatches(source, file) {
+  const scanText = joinWrappedLines(source);
+  const matches = [];
+  for (const rule of rules) {
+    const flags = rule.pattern.flags.includes('g') ? rule.pattern.flags : `${rule.pattern.flags}g`;
+    const pattern = new RegExp(rule.pattern.source, flags);
+    for (const match of scanText.matchAll(pattern)) {
+      const offset = match.index ?? 0;
+      const context = logicalBlockAt(scanText, offset);
+      if (!isContextAllowed(rule.id, match[0], context)) {
+        matches.push({
+          rule,
+          file,
+          line: lineNumberAt(source, offset),
+          match: match[0],
+          context,
+          snippet: compact(match[0]),
+        });
+      }
+    }
+  }
+  return matches;
+}
+
+function joinWrappedLines(source) {
+  const lines = source.split('\n');
+  let inFence = false;
+  return lines.map((line, index) => {
+    const isFence = /^\s*```/u.test(line);
+    const preserveBreak = inFence || isFence;
+    if (isFence) inFence = !inFence;
+    if (index === lines.length - 1) return line;
+    const next = lines[index + 1];
+    return `${line}${!preserveBreak && shouldJoinLine(line, next) ? ' ' : '\n'}`;
+  }).join('');
+}
+
+function shouldJoinLine(line, next) {
+  if (line.trim() === '' || next.trim() === '') return false;
+  return !/^\s*(?:#{1,6}\s|[-*+]\s|\d+[.)]\s|>|\||<\/?[A-Za-z])/u.test(next);
+}
+
+function logicalBlockAt(scanText, offset) {
+  const start = scanText.lastIndexOf('\n', offset - 1) + 1;
+  const nextBreak = scanText.indexOf('\n', offset);
+  const end = nextBreak === -1 ? scanText.length : nextBreak;
+  return scanText.slice(start, end);
+}
+
+function lineNumberAt(source, offset) {
+  return source.slice(0, offset).split('\n').length;
 }
 
 function isContextAllowed(ruleId, line, context) {
@@ -187,8 +245,7 @@ function isContextAllowed(ruleId, line, context) {
     return /\b(?:campi\b.{0,48}\bcifrat\w*|cifratura\b.{0,32}\bper campo|field-level|non presentare|non deve descrivere|non equivale|non rientr\w*|non (?:e|è) cifrat[oa] integralmente|non sono tutti coperti|non ["“]?intero database|senza estendere|non abilita|finche\b.{0,96}\bperimetro)\b/u.test(boundaryText);
   }
   if (ruleId === 'CLAIM-FHIR-CONFORMANCE') {
-    return (line.includes('|') && line.includes(']('))
-      || /\b(?:export-only v0|mappatura export-only|senza claim|non (?:attesta|prova|dichiara|garantisce)|nessuna garanzia)\b/u.test(boundaryText);
+    return /\b(?:export-only v0|mappatura export-only|senza claim|non (?:attesta|prova|dichiara|garantisce)|nessuna garanzia|quadro (?:compliance|documentale))\b/u.test(boundaryText);
   }
   if (ruleId === 'CLAIM-GDPR-GUARANTEE') {
     return /\b(?:pu[oò] supportare|possono supportare|non (?:certifica|prova|assegna)|dipendono dal deployment|valutazione del caso)\b/u.test(boundaryText);
@@ -199,23 +256,20 @@ function isContextAllowed(ruleId, line, context) {
   if (ruleId === 'CLAIM-ICD-GUARANTEE') {
     return /\b(?:opzional|possono|free-text|reviewable|non (?:ogni|tutte))\w*\b/u.test(boundaryText);
   }
-  if (ruleId === 'CLAIM-AUTO-APPLY') return false;
   const text = context.toLocaleLowerCase('it-IT');
   if (hasBoundaryNegation(text)) return true;
   if (ruleId !== 'CLAIM-SISS-FSE-INTEGRATION') return false;
-  return /\b(corpus|documental[ei]|sorgent[ei]|manifest|mcp|fetch\/sync|source sync|siss-corpus:sync|gia sincronizzato|già sincronizzato)\b/iu.test(line);
-}
-
-function isDocumentSurface(file) {
-  return documentExtensions.has(path.extname(file));
+  return /\b(corpus|documental[ei]|sorgent[ei]|manifest|mcp|fetch\/sync|source sync|siss-corpus:sync|gia sincronizzato|già sincronizzato)\b/iu.test(context);
 }
 
 function hasBoundaryNegation(text) {
   return /\bnon (?:sono|e|è) ammessi\b/u.test(text)
     || /\bnon (?:sono|e|è) attiv[io]\b/u.test(text)
+    || /\bnon esiste\b/u.test(text)
     || /\bfallisce se trova\b/u.test(text)
-    || /\bnon (?:dichiara|introduce|usa|invia|genera|automatizza|prescrive|sostituisce|promuove|applica|accetta)\b/u.test(text)
-    || /\bnessun[ao]?\b.{0,64}\b(?:cloud|egress|sync|telemetry|telemetria|writeback|invio|accesso diretto)\b/u.test(text)
+    || /\bnon (?:dichiara|introduce|usa|usare|invia|genera|automatizza|prescrive|sostituisce|promuove|applica|accetta)\b/u.test(text)
+    || /\bnessun[ao]?\b.{0,64}\b(?:cloud|egress|sync|telemetry|telemetria|writeback|invio|accesso diretto|integrazione)\b/u.test(text)
+    || /\bniente\b.{0,64}\b(?:cloud|egress|sync|telemetry|telemetria|writeback|invio|accesso diretto)\b/u.test(text)
     || /\bno\b.{0,64}\b(?:cloud|egress|sync|telemetry|telemetria|writeback|invio|accesso diretto)\b/u.test(text)
     || /\bsenza\b.{0,64}\b(?:cloud|egress|telemetry|telemetria|sync|writeback|adr|canale qualificato|review|conferma|integrazione|auto-write|scritture)\b/u.test(text)
     || /\b(fuori|fuori scope|vieta|vietato|vietata|vietati|vietate|esclude|escluso|esclusa|not)\b/u.test(text)

--- a/scripts/check-claims-guard.mjs
+++ b/scripts/check-claims-guard.mjs
@@ -188,6 +188,7 @@ function runSelfTest() {
     ['accented GDPR conformity', 'MediFlow è conforme al GDPR.', 'CLAIM-GDPR-GUARANTEE'],
     ['PIN qualifier plus comma contrast', 'Il PIN non equivale a zero-knowledge, ma il database SQLite è cifrato integralmente.', 'CLAIM-FULL-DB-ENCRYPTION'],
     ['negative encryption plus comma contrast', 'Il file SQLite non è cifrato integralmente, ma il database SQLite è cifrato integralmente.', 'CLAIM-FULL-DB-ENCRYPTION'],
+    ['accented comma contrast', 'Il PIN non equivale a zero-knowledge, però il database SQLite è cifrato integralmente.', 'CLAIM-FULL-DB-ENCRYPTION'],
   ];
   for (const [name, source, expected] of contradictoryCases) {
     const matched = findRuleMatches(source, 'self-test.md').map((item) => item.rule.id);
@@ -210,7 +211,7 @@ function findRuleMatches(source, file) {
     const flags = rule.pattern.flags.includes('g') ? rule.pattern.flags : `${rule.pattern.flags}g`;
     const clauseBoundedSource = rule.pattern.source.replace(
       /\.\{0,(\d+)\}/gu,
-      String.raw`(?:(?![.!?](?:\s|$)|;|\n|,\s*(?:ma|però|tuttavia|mentre)\b).){0,$1}`,
+      String.raw`(?:(?![.!?](?:\s|$)|;|\n|,\s*(?:(?:ma|tuttavia|mentre)\b|però(?=\s|$))).){0,$1}`,
     );
     const pattern = new RegExp(clauseBoundedSource, flags);
     for (const match of scanText.matchAll(pattern)) {
@@ -250,7 +251,7 @@ function shouldJoinLine(line, next) {
 }
 
 function claimClauseAt(scanText, offset) {
-  const boundaries = [...scanText.matchAll(/[;\n]|[.!?](?=\s|$)|,(?=\s*(?:ma|però|tuttavia|mentre)\b)/giu)]
+  const boundaries = [...scanText.matchAll(/[;\n]|[.!?](?=\s|$)|,(?=\s*(?:(?:ma|tuttavia|mentre)\b|però(?=\s|$)))/giu)]
     .map((match) => match.index ?? 0);
   const previous = boundaries.filter((position) => position < offset);
   const following = boundaries.filter((position) => position >= offset);


### PR DESCRIPTION
## Summary
- Qualifica cifratura, FHIR, GDPR, topologia home-base e terminologie nelle fonti pubbliche, distinguendo capacità reali da garanzie non dimostrate.
- Corregge la copy runtime single-device e annota esplicitamente i claim superati nella roadmap storica.
- Estende il claims guard a documentazione, UI e native, con matching multilinea e confini di clausola Unicode-safe.
- Mantiene la whitepaper come Phase B esplicita: la publication root entra nel guard solo con il flag dedicato finché il copy non converge.

## Verification
- `git diff --check`
- `rg --files -g "*.md" | sort` (134 file)
- `node --check scripts/check-claims-guard.mjs`
- `node scripts/check-claims-guard.mjs --self-test` (18 violazioni sintetiche + 11 regressioni di masking)
- `npm run check:claims` (441 file, 0 finding)
- `npm run check:never-regress`
- `npm run lint`
- `npm run typecheck`
- Verifica indipendente read-only: PASS sullo SHA `ddb1326bc`.
- CI GitHub fresca sullo stesso SHA: 7/7 check verdi, inclusi E2E e build macOS/Ubuntu/Windows.
- `node scripts/check-claims-guard.mjs --include-publication` fallisce intenzionalmente con 19 finding limitati a `whitepaper/index.html`, dipendenza esplicita della Phase B.

## Risk / Notes
- `whitepaper/index.html` resta intatto in questa PR e deve convergere nella lane WUL-481 prima di abilitare la publication root per default.
- Il gate non dimostra conformità normativa, interoperabilità FHIR completa, cifratura integrale del database o parity UI completa.
- Nessuna PHI/PII, credenziale, database clinico o screenshot reale.

## Ticket
Refs WUL-354