### PR TITLE
fix(ui): snellisci la microcopy del lock screen

### DIFF
--- a/components/kree8/kree8-lock-screen.module.css
+++ b/components/kree8/kree8-lock-screen.module.css
@@ -101,14 +101,6 @@
   gap: 12px;
 }
 
-.fieldLabel {
-  color: var(--ink-muted);
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-}
-
 .inputWrap {
   width: 100%;
 }

--- a/components/lock-screen.tsx
+++ b/components/lock-screen.tsx
@@ -11,7 +11,7 @@ export function LockScreen() {
     const [confirmPin, setConfirmPin] = useState('');
     const [error, setError] = useState('');
     const [loading, setLoading] = useState(false);
-    // WUL-55: ref + nonce to restore focus to the PIN operatore input after a failed login.
+    // WUL-55: ref + nonce to restore focus to the credential field after a failed login.
     const pinInputRef = useRef<HTMLInputElement>(null);
     const [failedAttempt, setFailedAttempt] = useState(0);
 
@@ -89,18 +89,15 @@ export function LockScreen() {
                 </div>
 
                 <form onSubmit={requiresSetup ? handleSetup : handleLogin} className={styles.form}>
-                    {requiresSetup && (
-                        <label className={styles.fieldLabel} htmlFor="mediflow-lock-pin">
-                            PIN operatore
-                        </label>
-                    )}
+                    {/* @Codex WUL-55: keep the field name for assistive tech without repeating visible copy. */}
+                    <label className="sr-only" htmlFor="mediflow-lock-pin">
+                        {requiresSetup ? 'Nuovo PIN' : 'PIN operatore'}
+                    </label>
                     <div className={styles.inputWrap}>
                         <input
                             id="mediflow-lock-pin"
                             ref={pinInputRef}
                             type="password"
-                            aria-label="PIN operatore"
-                            placeholder={requiresSetup ? 'Inserisci PIN' : undefined}
                             value={pin}
                             onChange={(e) => setPin(e.target.value)}
                             className={styles.pinInput}
@@ -116,9 +113,13 @@ export function LockScreen() {
 
                     {requiresSetup && (
                         <div className={styles.inputWrap}>
+                            <label className="sr-only" htmlFor="mediflow-lock-pin-confirm">
+                                Conferma PIN
+                            </label>
                             <input
+                                id="mediflow-lock-pin-confirm"
                                 type="password"
-                                placeholder="Conferma PIN"
+                                placeholder="Conferma"
                                 value={confirmPin}
                                 onChange={(e) => setConfirmPin(e.target.value)}
                                 className={styles.pinInput}
@@ -160,7 +161,7 @@ export function LockScreen() {
                                 {requiresSetup ? 'Sto configurando...' : 'Sto sbloccando...'}
                             </>
                         ) : requiresSetup ? (
-                            'Imposta PIN'
+                            'Imposta'
                         ) : (
                             <>
                                 <Unlock size={16} /> Sblocca

--- a/components/security-provider.tsx
+++ b/components/security-provider.tsx
@@ -155,7 +155,7 @@ export function SecurityProvider({ children }: { children: React.ReactNode }) {
             setActiveMasterKey(null);
             setIsAuthenticated(false);
             setIsLocked(true);
-            setAuthErrorMessage('Sessione scaduta. Inserisci il PIN per continuare.');
+            setAuthErrorMessage('Sessione scaduta.');
         };
 
         window.addEventListener(MEDIFLOW_API_AUTH_UNAVAILABLE_EVENT, handleApiAuthUnavailable);
@@ -427,7 +427,7 @@ export function SecurityProvider({ children }: { children: React.ReactNode }) {
                         setIsAuthenticated(false);
                         setIsLocked(true);
                         // Messaggio mostrato inline dalla LockScreen tramite authErrorMessage.
-                        setAuthErrorMessage("Setup già completato. Inserisci il PIN esistente.");
+                        setAuthErrorMessage("Accesso già configurato.");
                     }
                     return;
                 }

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -84,9 +84,9 @@ export async function setupPinLegacyIfNeeded(page: Page, pin: string): Promise<v
   const setupHeading = page.getByRole('heading', { name: 'Crea il tuo PIN' });
   if (!(await isVisible(setupHeading))) return;
 
-  const pinInput = page.locator('input[placeholder="Inserisci PIN"]:not([disabled])').first();
-  const confirmPinInput = page.locator('input[placeholder="Conferma PIN"]:not([disabled])').first();
-  const setupButton = page.getByRole('button', { name: /Imposta PIN/ }).first();
+  const pinInput = page.getByLabel('Nuovo PIN').first();
+  const confirmPinInput = page.getByLabel('Conferma PIN').first();
+  const setupButton = page.getByRole('button', { name: 'Imposta' }).first();
 
   await pinInput.fill(pin);
   await confirmPinInput.fill(pin);

--- a/e2e/web-smoke.spec.ts
+++ b/e2e/web-smoke.spec.ts
@@ -5,6 +5,16 @@ import { bootstrapUnlockedSession } from './utils';
 test('web smoke: unlock/setup + patients filters + settings navigation', async ({ page }) => {
   const pin = process.env.E2E_PIN || '1234';
 
+  // @Codex WUL-55: the locked surface stays terse while retaining an accessible field name.
+  await page.goto('/');
+  const lockScreen = page.getByLabel('MediFlow lock screen');
+  await expect(lockScreen).toBeVisible();
+  await expect(lockScreen.getByRole('heading', { name: 'Sblocca MediFlow' })).toBeVisible();
+  await expect(lockScreen.getByText(/sessione protetta/i)).toHaveCount(0);
+  await expect(lockScreen.getByText(/inserisci (il )?pin/i)).toHaveCount(0);
+  await expect(lockScreen.getByText('PIN operatore', { exact: true })).toHaveClass(/sr-only/);
+  await expect(lockScreen.getByLabel('PIN operatore')).toBeVisible();
+
   await bootstrapUnlockedSession(page, pin);
 
   // WUL-274/Kree8: the patients list moved into the cockpit "incarico" area


### PR DESCRIPTION
## Summary
- rimuove le ripetizioni visibili di PIN dal lock screen e dalla configurazione legacy
- mantiene etichette distinte per le tecnologie assistive senza aggiungere testo visibile
- abbrevia i messaggi di sessione e aggiorna gli helper E2E ai nomi accessibili
- aggiunge una regressione smoke contro le vecchie stringhe ridondanti

## Verification
- `git diff --check`
- `npm run typecheck` (Node 24)
- `npm run lint` (Node 24)
- `npm run check:claims`
- `npm run check:never-regress`
- smoke Playwright isolato su fixture sintetica: 1/1 PASS
- computer-use su preview sintetica: campo, focus e resa visiva verificati
- Opus 4.8 max: critique microcopy
- autoreview Codex gpt-5.6-sol high: clean, nessun finding azionabile
- verifier indipendente: PASS, nessun P0-P2

## Risk / Notes
- nessuna modifica alla semantica di autenticazione, al database o ai dati clinici
- test e preview hanno usato esclusivamente fixture sintetiche; nessuna PHI/PII
- preparazione PR completata; pubblicazione e merge sono azioni separate

## Ticket
- Micro-fix UI issue-less richiesto direttamente durante la convergenza 0.7.3.