### PR TITLE
chore(release): prepara i metadata v0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ e questo progetto aderisce al [Semantic Versioning](https://semver.org/spec/v2.0
 
 ## [Unreleased]
 
+## [0.7.3] - 2026-07-13
+
+> Nota release: la `0.7.3` consolida la linea local-first con un'adozione
+> progressiva di Lume, uno stack AI locale più modulare e nuovi gate sui claim
+> pubblici. La migrazione Lume completa e il verbale manuale P6 sul Mac
+> sbloccato restano fuori da questa release.
+
+### Aggiunto
+
+- **Lume, adozione progressiva**: ADR 0078 `Accepted`, token condivisi e prime
+  superfici web su cockpit, workspace clinico e lock screen; sul client nativo
+  è presente la card clinica opaca. Settings, componenti interni e QA manuale
+  completa restano aperti.
+- **Stack AI locale modulare**: `OllamaAdapter`, `AIService`, contratti di task
+  e router documentale `shadow` preparano provider e control-flow separati.
+  Ollama resta l'unico provider operativo e il gate egress resta chiuso in
+  attesa della redaction lane.
+- **Claims guard pubblico**: controllo automatico di README, documentazione,
+  UI, client nativo, asset OSS e white paper contro claim non dimostrati su AI,
+  FHIR, GDPR, cifratura, cloud e integrazioni regionali.
+- **Tooling P6 ripetibile**: bundle, fixture sintetiche, probe di accessibilità
+  e runbook per la verifica packaged. Il verbale manuale sul Mac sbloccato
+  resta governato da `WUL-481` e non è sostituito dai test sintetici.
+
+### Migliorato
+
+- **Affidabilità locale**: hardening di backup, cifratura, rollback delle
+  transazioni, ricerca farmaci, campi nativi bloccati, dipendenze di produzione
+  e runtime PM2, con test di regressione dedicati.
+- **Flussi review-first**: il control-flow documentale può evitare il modello
+  solo per casi eleggibili ad alta confidenza; attese e salvataggi clinici
+  restano espliciti e revisionabili.
+- **White paper**: nuova direzione Lume opaca, copy riallineato allo stato reale
+  e metadata aggiornati alla linea `0.7.3`.
+- **Topologia repository**: `Wulfgardr/mediflow` pubblica è l'unica fonte
+  operativa per sviluppo, issue, branch, tag e release.
+
+### Confini
+
+- Lume è parzialmente implementato: nessun claim di parity UI completa.
+- FHIR resta una mappatura export-only v0; non è dichiarata conformità completa
+  né ingestione garantita da sistemi terzi.
+- Il percorso SISS/FSE resta contestuale e `webapp-assisted`, senza
+  sincronizzazione, writeback o invio prescrittivo diretto certificati.
+- Nessun cloud o provider AI remoto è attivo di default; nessuna scrittura
+  clinica viene applicata senza revisione esplicita.
+
 ## [0.7.2] - 2026-07-09
 
 > Nota release: la `0.7.2` chiude la parità del boundary paired per il client

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ _by Ordito & Concilio_
 
 Dati vicini al medico, flusso rapido, privacy come impostazione di base.
 
-[![Versione](https://img.shields.io/badge/versione-0.7.2-1f6feb)](./CHANGELOG.md)
+[![Versione](https://img.shields.io/badge/versione-0.7.3-1f6feb)](./CHANGELOG.md)
 [![Licenza](https://img.shields.io/badge/licenza-MIT-2ea043)](./LICENSE)
 [![Local-first](https://img.shields.io/badge/dati-local--first-8957e5)](#confini-dichiarati)
-[![Core tri-OS](https://img.shields.io/badge/core%20Swift-macOS%20%7C%20Linux%20%7C%20Windows-6e7681)](#la-071-in-breve)
+[![Core tri-OS](https://img.shields.io/badge/core%20Swift-macOS%20%7C%20Linux%20%7C%20Windows-6e7681)](#la-073-in-breve)
 
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-Anthropic-D97757?logo=claude&logoColor=white)](https://claude.com/claude-code)
 [![Codex](https://img.shields.io/badge/Codex-OpenAI-412991?logo=openai&logoColor=white)](https://openai.com/codex)
 
-[Perché](#perché-mediflow) · [Screenshot](#come-si-presenta) · [Architettura](#come-è-fatto) · [0.7.2](#la-072-in-breve) · [Confini](#confini-dichiarati) · [Avvio](#avvio-rapido) · [AI e trasparenza](#come-è-stato-costruito)
+[Perché](#perché-mediflow) · [Screenshot](#come-si-presenta) · [Architettura](#come-è-fatto) · [0.7.3](#la-073-in-breve) · [Confini](#confini-dichiarati) · [Avvio](#avvio-rapido) · [AI e trasparenza](#come-è-stato-costruito)
 
 </div>
 
@@ -118,36 +118,12 @@ flowchart LR
 
 Il cloud non compare nel diagramma: nessun egress di default, il percorso resta local-first.
 
-## La 0.7.2 in breve
+## La 0.7.3 in breve
 
-La `0.7.2` chiude la parità del boundary paired: il client Apple raggiunge la web
-app sul ciclo di vita del paziente e sulle famiglie cliniche mancanti
-(prestazioni, protesica, export FHIR), sempre entro i confini local-first e senza
-hard delete remoto. Restano le fondamenta della `0.7.1`, che ha portato il ramo
-Apple/native sul mainline con macOS come fronte più avanzato e iPhone e iPad come
-client paired sul modello `home-base`.
-
-- **ciclo di vita paziente sul boundary paired**: creazione, cestino con soft-delete e ripristino dal client Apple, con concorrenza ottimistica e senza accesso diretto al database;
-- **prestazioni, protesica ed export FHIR sul client paired**: nuove famiglie cliniche sul boundary con concorrenza ottimistica, e mappatura export-only v0 in un Bundle FHIR R4 `collection` generato on-device con pre-check FSE locale, senza claim di conformità completa a profili o ingestione di terze parti;
-- **web app locale** come superficie primaria di lavoro sul Mac;
-- **Kree8 cockpit** come root web live, con una direzione visuale unica e senza selector persistiti: copy asciutto, palette semantica sobria, dark mode completa e flusso a un clic verso la Scheda paziente;
-- **campi clinici sensibili cifrati lato client** con AES-256-GCM; il PIN non viene persistito, ma il file SQLite, gli identificativi, alcuni metadati e i backup non rientrano tutti in un perimetro whole-database cifrato verificato;
-- **backup, audit e contratto `/api/v1`** resi più chiari ed espliciti;
-- **AI locale** per insight e OCR, senza egress di default;
-- **import documentale reviewable**, con Smart Import prudente, artifact `parse/evidence`, ancore fonte e benchmark di assorbimento evidenza;
-- **prescrizioni di prestazione** separate dalle terapie farmacologiche, con item codificabili e matching repertorio preparato in modo bounded;
-- **app Apple/native** con macOS come fronte più maturo, shell home-base, core Swift condiviso e target iPhone/iPad paired senza accesso diretto al DB;
-- **core tri-OS** costruito e testato su macOS, Linux e Windows: oggi prova di portabilità del core, non promessa di app desktop complete su ogni piattaforma;
-- **runtime cross-platform**: launcher per macOS, Windows e Linux, scheduler di backup adattivo (launchd, Task Scheduler, systemd/cron) e degradazione esplicita delle funzioni solo-Mac;
-- **boundary SISS/FSE realistico**: handoff contestuale e percorso prescrittivo `webapp-assisted`, non integrazione regionale nativa già risolta.
-
-Il dettaglio completo è nel [CHANGELOG](./CHANGELOG.md).
-
-### Il ciclo 0.7.3 su `main`
-
-Il `main` successivo alla `0.7.2` conserva il boundary paired già consegnato e
-sta consolidando due avanzamenti distinti: l'adozione progressiva di Lume e uno
-stack intelligente più modulare, ma ancora locale, fail-closed e review-first.
+La `0.7.3` consolida la linea local-first sopra il boundary paired della
+`0.7.2`: adotta progressivamente Lume, rende più modulare lo stack AI locale,
+rafforza affidabilità e packaging e applica un guardrail automatico ai claim
+pubblici. Non chiude la migrazione UI completa né il gate manuale P6.
 
 - **Lume in adozione progressiva**: ADR 0078 è `Accepted`; canone L0, token
   L1a, convivenza web L1b, cockpit, workspace clinico e lock screen sono su
@@ -161,10 +137,22 @@ stack intelligente più modulare, ma ancora locale, fail-closed e review-first.
   come default e può evitare il modello solo nei casi eleggibili ad alta
   confidenza. Le attese locali vivono oggi nel solo web e ogni salvataggio
   resta esplicito.
+- **Affidabilità e distribuzione**: backup, cifratura, transazioni, ricerca
+  farmaci, campi nativi bloccati, dipendenze di produzione e runtime PM2 sono
+  stati irrobustiti con test e controlli dedicati.
+- **Repository e claim pubblici**: la repository pubblica è l'unica fonte
+  operativa; README, documentazione e white paper sono verificati dal claims
+  guard, che impedisce promesse non dimostrate su AI, FHIR, GDPR, cifratura,
+  cloud e integrazioni regionali.
+- **Boundary regionale realistico**: SISS e FSE restano un handoff contestuale
+  `webapp-assisted`; MediFlow non effettua invii o scritture nei sistemi
+  regionali.
 - **P6 preparata, non certificata**: PR #21 e `WUL-401`, ora completata, hanno
   consegnato il tooling di base: bundle, fixture, probe AX e runbook. `WUL-481`
   conserva i prerequisiti operativi ancora bloccati e il verbale manuale sul
   Mac sbloccato, quindi MediFlow non dichiara parity UI completa.
+
+Il dettaglio completo è nel [CHANGELOG](./CHANGELOG.md).
 
 ## Confini dichiarati
 
@@ -172,7 +160,7 @@ MediFlow non vuole raccontare più di quanto possa dimostrare.
 
 - **Nessun cloud obbligatorio**: il default resta locale.
 - **Nessuna app iPad/iPhone dichiarata come già completa**: il perimetro operativo è `home-base + paired client`; lifecycle paziente, moduli clinici non-AI, cataloghi, prestazioni/protesica e upload documentale manuale hanno workflow online governati, mentre cache offline, click-map UI e superfici document-derived restano parziali o host-only.
-- **Nessuna parity Windows/Linux dichiarata oggi**: la 0.7.2 prova il core tri-OS e il runtime di base, non app complete su ogni piattaforma.
+- **Nessuna parity Windows/Linux dichiarata oggi**: la 0.7.3 prova il core tri-OS e il runtime di base, non app complete su ogni piattaforma.
 - **Nessuna integrazione SISS/FSE certificata dichiarata senza prove**: il percorso attuale è contestuale e `webapp-assisted`, usando i canali ufficiali; MediFlow non dichiara sincronizzazione FSE, writeback regionale o invio prescrittivo diretto.
 - **Nessuna delega cieca all'AI**: l'AI locale può aiutare, ma non sostituisce revisione, giudizio clinico e responsabilità professionale.
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -11,45 +11,38 @@ No, di default no.
 
 Il progetto nasce `local-first`: database locale, AI locale, servizi locali. Se esistono lane di confronto o shadow evaluation, restano opt-in, separate e non fanno parte del runtime clinico ordinario.
 
-## 🧭 Che cosa porta `v0.7.2`?
+## 🧭 Che cosa porta `v0.7.3`?
 
-`v0.7.2` chiude la parità del boundary paired sopra la base multi-superficie
-consolidata con la `0.7.1`:
+`v0.7.3` consolida la base multi-superficie senza ampliare i claim oltre le
+prove disponibili:
 
-- ciclo di vita paziente, prestazioni, protesica ed export FHIR dal client Apple paired;
-- storage e sicurezza più solidi;
-- contratto locale `/api/v1` più chiaro;
-- backup, audit e guardrail più espliciti;
-- import documentale e AI più reviewable;
-- Mac `home-base` packaged e app Apple/native molto più concreta su macOS;
-- core Swift condiviso costruito e testato anche su Linux e Windows;
-- document intelligence `artifact-first` con fonti e conflitti più espliciti;
-- prescrizioni di prestazione separate dalle terapie farmacologiche;
-- root web sul cockpit Kree8 live, senza selector di shell su `main`;
-- boundary SISS/FSE raccontati senza scorciatoie narrative.
+- adozione progressiva di Lume su prime superfici web e card clinica nativa;
+- stack AI locale più modulare, con Ollama come unico provider operativo e gate
+  egress ancora chiuso;
+- control-flow documentale `shadow` e attese locali sempre review-first;
+- hardening di backup, cifratura, transazioni, ricerca farmaci, campi nativi
+  bloccati, dipendenze di produzione e runtime PM2;
+- claims guard esteso al white paper e alle altre superfici pubbliche;
+- tooling packaged P6 con fixture sintetiche, probe e runbook;
+- repository pubblica unica come fonte di sviluppo e rilascio.
 
-La differenza principale rispetto alla 0.7.0 e il consolidamento Apple/native:
-macOS e il fronte piu maturo, iPhone/iPad restano client paired, mentre
-Windows/Linux provano oggi portabilita del core e CI, non parity applicativa
-completa.
+Restano le capacità paired della `0.7.2`: ciclo di vita paziente, prestazioni,
+protesica ed export FHIR dal client Apple, entro contratti locali versionati.
 
 Per il quadro dettagliato, inclusi runtime reale, home-base, document
-intelligence, AI locale, SISS/FSE, Apple clients e split pubblico/privato, vedi
+intelligence, AI locale, SISS/FSE e Apple clients, vedi
 [docs/STATE_OF_THE_SYSTEM.md](./STATE_OF_THE_SYSTEM.md).
 
-## ✨ Cosa e gia su `main` nel ciclo 0.7.3?
+## ✨ Cosa resta aperto dopo `v0.7.3`?
 
-La `v0.7.2` resta la release pubblicata corrente. Sul `main` successivo:
-
-- ADR 0078 e `Accepted` e Lume e in adozione progressiva: prime superfici web
-  e card clinica opaca nativa sono consegnate, non l'intera migrazione L0-L6;
-- `OllamaAdapter` e `AIService` introducono lo scaffold provider, ma Ollama
-  resta l'unico provider e il gate egress rimane chiuso;
-- il control-flow documentale usa `shadow` come default e la prima slice web
-  delle attese locali mantiene review e salvataggio espliciti;
-- PR #21 e `WUL-401` hanno consegnato il tooling P6 di base; prerequisiti
-  operativi e verbale manuale sul Mac sbloccato restano un gate di `WUL-481`,
-  quindi non dichiariamo parity UI piena.
+- **Lume**: componenti interni, filo, tipografia, Settings scene e QA manuale
+  completa non sono ancora chiusi.
+- **P6 / `WUL-481`**: il tooling sintetico non sostituisce il verbale manuale
+  sul bundle macOS con macchina sbloccata; nessuna parity UI piena è dichiarata.
+- **AI e cloud**: registry, provider alternativi, redaction lane e consenso
+  cloud non sono consegnati. Nessun provider remoto è attivo di default.
+- **Client paired**: offline, click-map UI e superfici derivate dai documenti
+  restano parziali o host-only.
 
 ## 🍎 Posso usarlo su Mac, iPad o iPhone?
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -8,7 +8,7 @@ read_when:
 # 🧭 Roadmap MediFlow
 
 > **Dove siamo e dove vogliamo andare.**
-> v0.7.2 resta la release corrente; il `main` e nel ciclo v0.7.3 senza dichiarare parity UI completa. Ultimo aggiornamento: 2026-07-13.
+> v0.7.3 e la linea corrente, senza dichiarare parity UI completa. Ultimo aggiornamento: 2026-07-13.
 > Fonte roadmap prodotto canonica (vedi anche [docs/STATE_OF_THE_SYSTEM.md](./STATE_OF_THE_SYSTEM.md) per la lettura completa corrente e [docs/README.md](./README.md) per mappa completa documenti).
 
 > [!NOTE]
@@ -146,14 +146,18 @@ testato anche su Linux/Windows.
 
 ---
 
-## 🚧 In corso (ciclo v0.7.3 su `main`)
+## ✅ Consegnato nella linea v0.7.3
 
-La `v0.7.2` resta la release pubblicata corrente. La lettura operativa piu
-completa del ciclo v0.7.3 su `main` e ora
+La lettura operativa piu completa della linea v0.7.3 e
 [docs/STATE_OF_THE_SYSTEM.md](./STATE_OF_THE_SYSTEM.md): questo file resta la
 roadmap prodotto, mentre lo stato del sistema tiene insieme runtime effettivo,
 boundary, document intelligence, home-base, Apple clients e governance della
 repository pubblica.
+
+La linea consegna le prime superfici Lume, lo scaffold AI locale modulare, il
+control-flow documentale review-first, hardening di runtime e dati, il claims
+guard pubblico e il tooling P6 sintetico. La migrazione Lume completa e il
+verbale manuale di `WUL-481` restano lavoro successivo, non claim di release.
 
 ### Modalita network home-base
 

--- a/docs/STATE_OF_THE_SYSTEM.md
+++ b/docs/STATE_OF_THE_SYSTEM.md
@@ -18,7 +18,7 @@ read_when:
 > prevalgono [AGENTS.md](../AGENTS.md) e
 > [docs/repository-topology.md](./repository-topology.md).
 
-Ultimo aggiornamento: 2026-07-13 (ciclo v0.7.3 su `main`; release pubblicata v0.7.2)
+Ultimo aggiornamento: 2026-07-13 (linea v0.7.3; parity UI completa non dichiarata)
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "medical-record-app",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "medical-record-app",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@tailwindcss/typography": "^0.5.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medical-record-app",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "private": false,
   "scripts": {
     "dev": "next dev --turbopack --hostname 127.0.0.1 --port 3000",

--- a/scripts/check-claims-guard.mjs
+++ b/scripts/check-claims-guard.mjs
@@ -6,7 +6,6 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const includePublication = process.argv.includes('--include-publication');
 const roots = [
   'README.md', 'ARCHITECTURE.md', 'SECURITY.md', 'CONTRIBUTING.md',
   'docs/README.md', 'docs/markdown-index.md', 'docs/FAQ.md', 'docs/ROADMAP.md',
@@ -16,9 +15,8 @@ const roots = [
   'docs/topologia-dati-flussi.md', 'docs/design',
   'docs/adr/0006-terminology-plugin-and-fse-profiles.md',
   'docs/adr/0065-intended-purpose-and-claims-guard.md',
-  'app', 'components', 'native', 'oss-assets',
+  'app', 'components', 'native', 'oss-assets', 'whitepaper',
 ];
-const publicationRoots = ['whitepaper'];
 const extensions = new Set(['.md', '.mdx', '.ts', '.tsx', '.js', '.jsx', '.mjs', '.html', '.swift']);
 const skipped = ['.git', '.next', 'node_modules', 'e2e', 'coverage', 'dist', 'out']
   .map((item) => `${path.sep}${item.replaceAll('/', path.sep)}${path.sep}`);
@@ -81,8 +79,7 @@ if (process.argv.includes('--self-test')) runSelfTest();
 else runRepositoryScan();
 
 function runRepositoryScan() {
-  const activeRoots = includePublication ? [...roots, ...publicationRoots] : roots;
-  const files = activeRoots.flatMap(collectFiles).sort();
+  const files = roots.flatMap(collectFiles).sort();
   const findings = [];
 
   for (const file of files) {
@@ -94,9 +91,6 @@ function runRepositoryScan() {
 
   if (findings.length === 0) {
     console.log(`Claims guard passed: scanned ${files.length} file(s), 0 high-risk claim(s).`);
-    if (!includePublication) {
-      console.log('Phase B dependency: whitepaper/ is not enforced yet; rerun with --include-publication after its copy converges.');
-    }
     return;
   }
   console.error(`Claims guard failed: ${findings.length} high-risk claim(s) need review.`);

--- a/whitepaper/index.html
+++ b/whitepaper/index.html
@@ -405,7 +405,7 @@ code{ font-family:var(--mono); font-size:.92em; color:var(--accent); background:
     <a class="brand" href="#top">
       <span class="brand-mark"></span>
       <span>MediFlow</span>
-      <span class="badge">v0.6.0</span>
+      <span class="badge">v0.7.3</span>
     </a>
     <nav class="links">
       <a href="#cosa">Cos'è</a>
@@ -424,7 +424,7 @@ code{ font-family:var(--mono); font-size:.92em; color:var(--accent); background:
 <a id="top"></a>
 <section class="hero">
   <div class="wrap">
-    <span class="eyebrow"><span class="dot"></span> White paper · Maggio 2026</span>
+    <span class="eyebrow"><span class="dot"></span> White paper · Luglio 2026</span>
     <h1 class="title">Una cartella clinica<br/>che resta a casa tua.</h1>
     <p class="lede">
       MediFlow è una cartella clinica local-first per il singolo professionista e per piccoli ambulatori.
@@ -982,7 +982,7 @@ code{ font-family:var(--mono); font-size:.92em; color:var(--accent); background:
       </div>
 
       <div class="tl-item">
-        <div class="ver"><b>v0.6.0</b> · release corrente · Maggio 2026</div>
+        <div class="ver"><b>v0.6.0</b> · Maggio 2026</div>
         <h4>Mac home-base e famiglia Apple</h4>
         <ul>
           <li>Mac come nodo autorevole: pairing, capability discovery, primi write versionati</li>
@@ -993,15 +993,26 @@ code{ font-family:var(--mono); font-size:.92em; color:var(--accent); background:
         </ul>
       </div>
 
-      <div class="tl-item future">
-        <div class="ver"><b>post-v0.6</b> <span class="pill">in corso</span></div>
-        <h4>Network home-base più ampia, nuova shell macOS, vocale</h4>
+      <div class="tl-item">
+        <div class="ver"><b>v0.7.3</b> · linea corrente · Luglio 2026</div>
+        <h4>Lume progressivo, AI locale modulare, affidabilità</h4>
         <ul>
+          <li>Prime superfici Lume su web e card clinica opaca nativa; migrazione completa ancora aperta</li>
+          <li>Stack AI locale modulare con Ollama operativo e gate egress chiuso</li>
+          <li>Control-flow documentale e attese locali review-first</li>
+          <li>Hardening di backup, cifratura, transazioni, ricerca e runtime packaged</li>
+          <li>Claims guard pubblico e tooling P6 sintetico; QA manuale completa ancora aperta</li>
+        </ul>
+      </div>
+
+      <div class="tl-item future">
+        <div class="ver"><b>post-v0.7.3</b> <span class="pill">in corso</span></div>
+        <h4>Completamento Lume, offline governato, QA manuale</h4>
+        <ul>
+          <li>Componenti interni, Settings scene, filo e tipografia Lume</li>
           <li>Replica e fallback offline tra dispositivi con riconciliazione esplicita</li>
-          <li>Runtime AI centralizzabile per client meno potenti, senza egress</li>
-          <li>Decision layer documentale separato (governance, recency, esclusioni)</li>
-          <li>Nuova shell macOS home-base, packaged, indipendente dal terminale</li>
-          <li>Dettatura locale (Whisper) e chat conversazionale con la cartella</li>
+          <li>Provider AI alternativi solo dopo redaction lane, consenso e gate espliciti</li>
+          <li>Verbale manuale P6 sul bundle macOS e chiusura dei residui WUL-481</li>
         </ul>
       </div>
 
@@ -1168,7 +1179,7 @@ code{ font-family:var(--mono); font-size:.92em; color:var(--accent); background:
       </div>
     </div>
     <div class="bottom">
-      <span class="muted">White paper · v0.6.0 · Maggio 2026</span>
+      <span class="muted">White paper · v0.7.3 · Luglio 2026</span>
       <span class="muted">© MediFlow · distribuito come progetto open source</span>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Allinea package, lockfile, changelog, README, FAQ, roadmap, stato canonico e white paper alla linea 0.7.3.
- Attiva il claims guard sul white paper per impostazione predefinita mantenendo compatibile il flag storico.
- Mantiene espliciti i confini: Lume parziale, FHIR export-only v0, SISS/FSE assisted handoff, Ollama locale e gate manuale WUL-481 ancora aperto.
- Include evidenza packaged sintetica del bundle macOS con WebRuntime, senza credenziali o dati reali.

## Verification
- npm ci con Node 24.18.0
- npm run lint
- npm run typecheck
- npm run build
- npm run test:unit (672 test)
- npm run test:native
- npm run check:openapi:drift
- npm run check:schema-drift
- npm run check:standalone-runtime-bundle
- npm run check:lume-tokens e npm run test:lume-tokens
- npm run check:apple-wide-qa
- claims guard: default e compatibilità 0 finding; self-test 18 violazioni + 11 regressioni
- build Debug macOS packaged: WebRuntime/server.js presente nel bundle
- verifica indipendente Sol-high: PASS sul commit cd327b0773202823a76cf171d7c0cab3b99c6833

## Risk / Notes
- Il probe AX e il verbale manuale sul Mac sbloccato non sono stati eseguiti: restano governati da WUL-481 e non bloccano i claim limitati di questa PR.
- Il primo npm ci con Node 26.4 ha fallito perché better-sqlite3 non supporta quel runtime; i gate sono stati ripetuti con la toolchain Node 24 usata dalla CI.
- npm ci riporta 11 advisory già presenti; nessun npm audit fix è incluso in questa PR.
- Nessuna PHI/PII, database clinico, screenshot reale, credenziale o egress cloud è stato usato.
- Questa PR prepara la release: non dichiara tag, pubblicazione o merge completati.

## Ticket
- Refs WUL-481