### PR TITLE
docs(design): la grammatica del gesto e del movimento di Lume (07 + dimostratori)

### DIFF
--- a/docs/adr/0078-lume-lingua-di-design-di-destinazione.md
+++ b/docs/adr/0078-lume-lingua-di-design-di-destinazione.md
@@ -133,6 +133,13 @@ Consegnate:
   (`clinicalCardStyle()`, alias `cardStyle()`, `GlassCard` deprecata e resa
   opaca) con test sintetico light/dark (`ClinicalCardStyleTests`) e build del
   bundle (PR #46).
+- **Grammatica del gesto e del movimento (canone e dimostratori)**:
+  `07-gesto-e-movimento.md` distilla il livello di interazione e motion con una
+  resa rivista del filo (la luce marca il fuoco, l'inchiostro porta lo stato, il
+  filo resta connettore come geometria SVG), con cinque dimostratori interattivi
+  in `mockups/`. Revisiona la resa descritta in `01-lingua.md` par. 3 e 7. Resta
+  specifica e dimostratore, non implementazione: i consumatori web e nativi
+  restano da migrare.
 
 Aperte:
 

--- a/docs/design/lume/01-lingua.md
+++ b/docs/design/lume/01-lingua.md
@@ -13,7 +13,7 @@ In ogni istante l'interfaccia ha un solo **fuoco**: l'oggetto clinico in lavoraz
 
 | Zona | Cosa contiene | Resa |
 | --- | --- | --- |
-| **Fuoco** | L'oggetto in lavorazione | Superficie più chiara e leggermente più calda, contrasto pieno, ombra corta che la solleva, filo pieno sul bordo sinistro |
+| **Fuoco** | L'oggetto in lavorazione | Superficie più chiara e leggermente più calda, contrasto pieno, ombra corta che la solleva |
 | **Penombra** | Il contesto di lavoro (worklist, pannelli vicini) | Superficie neutra, contrasto pieno del testo ma cromatismo trattenuto, nessuna ombra |
 | **Buio operativo** | Il telaio (rail, barre, chrome) | Superficie leggermente più scura e più fredda, contenuti attenuati, zero ornamento |
 
@@ -58,16 +58,17 @@ Il blur resta ammesso in un solo punto: gli overlay transitori (modale, popover)
 
 ## 3. Il filo
 
+> Revisione 2026-07-14: la resa di questa sezione è aggiornata da [07-gesto-e-movimento.md](./07-gesto-e-movimento.md). Il fuoco si marca con la luce (par. 1), non con il filo; lo stato epistemico si rende con l'inchiostro (tono e asciugatura della firma), non con il tratteggio. Il filo resta la firma grafica solo dove connette davvero, come geometria SVG continua.
+
 La firma grafica di Lume è una linea sottile (1px, `accent.minerale` o tono semantico) con un solo significato: la continuità della cura.
 
 | Dove | Cosa fa |
 | --- | --- |
-| Bordo sinistro dell'oggetto focale | Marca il fuoco (al posto delle campiture di selezione) |
 | Spina della timeline del diario | Le voci si appendono al filo, in ordine di tempo |
 | Storia di un valore di laboratorio | Il filo collega le rilevazioni, con la banda di riferimento dietro |
 | Connettore di provenienza | Lega un contenuto alla sua fonte (referto, trascrizione) |
 
-**Il tratto è lo stato epistemico, e il tratto pieno è il commit**: tratteggiato = bozza (contenuto proposto o non ancora rivisto), pieno = firmato dal medico. Niente parte (prescrizione, ordine, invio) finché il tratto non è pieno; un inserimento errato si marca come tale, non si cancella. Una regola sola, applicata ovunque: si vede a colpo d'occhio cosa è consolidato e cosa no, senza badge chiassosi. I contenuti proposti dagli strumenti di supporto seguono la stessa regola: entrano tratteggiati e diventano pieni solo con la revisione esplicita del medico. E ogni inferenza o sintesi apre le sue fonti con un gesto (documento, data, frammento): il filo di provenienza è un contratto, non una decorazione (vedi [04-perlustrazione.md](./04-perlustrazione.md)).
+**Lo stato epistemico è un contratto, e la firma è il commit**: un contenuto proposto o non ancora rivisto è bozza, quello firmato dal medico è consolidato. La resa di questo passaggio è l'inchiostro che asciuga, non più il tratteggio del filo (vedi [07-gesto-e-movimento.md](./07-gesto-e-movimento.md)). Niente parte (prescrizione, ordine, invio) finché il tratto non è pieno; un inserimento errato si marca come tale, non si cancella. Una regola sola, applicata ovunque: si vede a colpo d'occhio cosa è consolidato e cosa no, senza badge chiassosi. I contenuti proposti dagli strumenti di supporto seguono la stessa regola: entrano come bozza in inchiostro tenue e diventano pieni solo con la revisione esplicita del medico. E ogni inferenza o sintesi apre le sue fonti con un gesto (documento, data, frammento): il filo di provenienza è un contratto, non una decorazione (vedi [04-perlustrazione.md](./04-perlustrazione.md)).
 
 Il filo non si moltiplica: mai più di un filo per contenitore. Non è un divisore (i divisori restano bordi neutri): se una linea è `accent.minerale`, porta significato.
 
@@ -109,7 +110,7 @@ Il layout di Lume non presenta dati: presenta decisioni.
 
 ## 7. Motion: la luce si sposta
 
-- Quando il fuoco cambia, si muove la luce, non le superfici: cross-fade di luminanza e temperatura (150-200ms, ease-out) dal vecchio al nuovo fuoco; il filo si ridisegna sul nuovo bordo.
+- Quando il fuoco cambia, si muove la luce, non le superfici: cross-fade di luminanza e temperatura (150-200ms, ease-out) dal vecchio al nuovo fuoco. Il fuoco è la luce, non un filo sul bordo; i connettori (spina, provenienza) si ridisegnano come geometria SVG (vedi [07-gesto-e-movimento.md](./07-gesto-e-movimento.md)).
 - Il filo può estendersi (una linea che si allunga, 200ms) per esprimere continuità: Quadro -> Scheda è il filo che prosegue, non una pagina che vola.
 - La manipolazione diretta (drag, riordino) mantiene le spring interrompibili di Vetro Clinico ([../vetro-clinico/04-interazione.md](../vetro-clinico/04-interazione.md)): la fisica resta dove c'è un gesto.
 - Niente parallasse, niente morphing di superfici, niente blur animato. Reduce Motion è quasi già soddisfatto per costruzione: il cross-fade è il comportamento di default, non il fallback.

--- a/docs/design/lume/07-gesto-e-movimento.md
+++ b/docs/design/lume/07-gesto-e-movimento.md
@@ -1,0 +1,83 @@
+---
+summary: "Lume gesture and motion grammar: light carries focus, ink carries state, il filo connects only where connection is real. Interaction-triggered vitality (never ambient loops), the signing gesture as drying ink, refined replacements for the side-line filo, and honest heuristic proactivity."
+read_when:
+  - "Implementing or prototyping any Lume interaction, motion, field, or state transition."
+  - "Deciding how focus, draft/signed state, continuity, or provenance should be rendered and animated."
+  - "Reconciling the rendering of il filo and motion described in 01-lingua sections 3 and 7."
+---
+
+# Il gesto e il movimento
+
+Il capitolo [01-lingua.md](./01-lingua.md) ha fissato la materia, il filo, le due voci e la grammatica dell'attenzione, ma ha lasciato aperto il livello che rende Lume viva: come si muovono le cose, e come una interazione elementare (aprire un campo, firmare una voce, cambiare ambulatorio) diventa un gesto raffinato invece di un cambio di stato meccanico.
+
+Questo capitolo distilla quel livello e **corregge la resa** di due punti di 01-lingua: il filo come segno sul bordo dei riquadri (par. 3) e il motion focale (par. 7). La correzione non tocca i concetti (fuoco, stato epistemico, continuita della cura, provenienza): sposta il modo in cui si rendono. La ragione e semplice e va scritta: un tratto disegnato sul lato di un riquadro, e ancora di piu quando tratteggiato, legge come un solco di diff, uno skeleton di caricamento o un abbozzo di wireframe. Sa di procedurale e di non finito. In un prodotto clinico che deve trasmettere fiducia, e il contrario di cio che serve. E soprattutto tradisce la legge madre di 01-lingua: *il fuoco non si assegna col colore ne con un segno, ma con la luce*.
+
+## 1. Principio: tre portatori, tre lavori
+
+Lume ha tre modi di dire le cose in movimento, e non si sovrappongono mai.
+
+| Portatore | Lavoro | Resa |
+| --- | --- | --- |
+| **La luce** | Il fuoco (cosa e in lavorazione adesso) | La superficie sale nella luce: luminanza e temperatura appena piu alte, ombra corta. Nessuna linea. |
+| **L'inchiostro** | Lo stato epistemico (bozza o firmato) | Il tono del testo: la bozza e a contrasto piu basso con una micro-etichetta onesta; il firmato e a contrasto pieno. La firma e il gesto che asciuga l'inchiostro. |
+| **Il filo** | La connessione, dove e reale | Una hairline continua resa come geometria SVG che si disegna: la spina della timeline, il connettore di provenienza, la storia di un valore. Mai sul lato di un riquadro. |
+
+La regola che tiene tutto: **il fuoco non porta mai una linea, e la linea non marca mai un fuoco.** Se una superficie deve dire "sono io che conti adesso", lo dice con la luce. Se una linea compare, sta collegando due cose reali nel tempo o nella provenienza, e porta significato (mai un divisore, mai una decorazione).
+
+## 2. Leggi di movimento
+
+1. **La vitalita risponde al gesto, non va in loop.** Nessuna animazione ambientale, nessun respiro perenne, nessuno shimmer di attesa: sono proprio i movimenti che-vanno-avanti-da-soli a leggere come procedurali e da intelligenza artificiale. Il movimento nasce quando l'utente agisce (sposta il fuoco, firma, preme, trascina) e finisce.
+2. **La luce si sposta, non le superfici.** Quando il fuoco cambia, la luce fa un cross-fade di luminanza e temperatura (150-200ms, ease-out). La velocita e proporzionale alla scala del salto: riga vicina, breve; Quadro verso Scheda, piu lungo ma entro 250ms. Le variabili di luce si registrano via `@property` cosi da interpolare in modo pulito, oppure scattano; non si "trascinano" a caso.
+3. **La conferma e transiente.** L'accento non resta come peso persistente: lampeggia brevemente per dare sicurezza e si spegne (una pulsazione di ombra e di alone minerale, ~300ms). E l'opposto della stanghetta fissa.
+4. **Il filo si disegna.** I connettori sono `stroke` SVG che entrano con `stroke-dashoffset` (draw-on), non `border-left`. "Il filo che prosegue" da Quadro a Scheda e una linea che si allunga, non una pagina che vola. Nota: draw-on non vuol dire aspetto tratteggiato; la linea a riposo e continua e piena.
+5. **I controlli sono materia reattiva.** Press `scale(0.97)` ~150ms su `:active`; l'azione emette un anello che parte dal punto del tocco e si spegne; hover = un lift sottile. La fisica (spring interrompibili) resta dove c'e un gesto diretto (riordino, drag).
+6. **Togliere il movimento dove e ad alta frequenza.** Comandi, menu da tastiera, navigazione rapida: meglio lo scatto. Dopo cento ripetizioni un'animazione diventa attrito, non piacere.
+7. **Reduce-motion per costruzione.** Senza moto lo stato resta leggibile lo stesso: la bozza e comunque inchiostro tenue con etichetta, il fuoco e comunque superficie sollevata, il tick di firma e comunque presente. Il moto e il default, non il fallback.
+8. **Budget di movimento come invariante.** Ogni vista dichiara quanti elementi possono muoversi insieme; si conta in CI. La calma e una regola, non una speranza.
+
+## 3. Gli atomi in movimento
+
+- **Campo di testo.** Si apre con la luce (il campo entra in fuoco). Mentre si scrive, l'inchiostro e tenue: e una bozza. Il salvataggio si dichiara in modo sobrio e onesto ("salvato", con l'ora nel Registro), non con un badge chiassoso. Il contenuto diventa pieno solo quando e firmato.
+- **Campo codificato (ICD, LOINC, AIC, catalogo).** La ricerca e inline; le candidate stanno in penombra sotto il campo; la disambiguazione si fa li, senza modale in cascata. Il codice scelto si posa nel Registro (cifre tabellari) con la sua etichetta nella Voce. Confermare non e firmare: il codice entra come bozza finche la voce che lo contiene non e firmata.
+- **Impostazione.** Cambia con anteprima immediata e reversibile: l'effetto si vede subito nella vista, non si descrive a parole. Nessuno stato disabilitato muto: se una impostazione non si applica ora, spiega perche o non compare.
+- **Menu.** La personalizzazione e manipolazione diretta: la voce trascinata resta sotto il dito con spring interrompibile, le altre si scostano. Nessun pannello di configurazione separato per un gesto che puo essere diretto.
+- **Funzione intelligente / campo AI dinamico.** Quando lo strumento ha qualcosa da offrire, la materia si illumina appena: e luce, non calore semantico (il calore appartiene al fuoco, prenderlo in prestito farebbe segnale-AI). Il suggerimento entra come **inchiostro tenue**, cioe bozza, e diventa pieno solo con la firma esplicita del medico. Ogni inferenza apre le sue fonti con un gesto. Claims guard (ADR 0065): la superficie non vanta un motore, si comporta bene.
+- **Allegato.** Il documento cade nella penombra, viene assorbito, e un connettore SVG si disegna dalla voce che lo cita verso la fonte: la provenienza e il filo reso contratto, non una graffetta decorativa.
+
+## 4. Le scene
+
+- **Cambio ambulatorio.** La luce dell'intero telaio si ricalibra con un cross-fade e il contesto si rimonta gia pronto (agenda, worklist, coda). Non una pagina che vola via: e lo stesso strumento che cambia stanza. La testata invariabile resta ferma e leggibile per tutto il passaggio.
+- **Inserimento dati paziente.** Sequenza verticale di campi, errori accanto al dato, mai disabled opachi. L'inchiostro asciuga man mano che le parti vengono confermate; con contesto paziente incerto le azioni cliniche restano bloccate (la testata e anche sicurezza).
+- **Campo AI dinamico.** La coreografia del par. 3: illuminazione appena percettibile, inchiostro tenue del suggerimento, firma che asciuga. Le fonti a un gesto.
+- **Microfono e cattura visita (ADR 0072).** A riposo il pulsante e quieto. L'avvio accende la materia (luce, piu un indicatore di livello sobrio: nessun ornamento, nessuna onda decorativa). Durante la cattura lo stato e evidente ma calmo. Alla fine la trascrizione entra sul filo del diario come **bozza tenue**, e la revisione del medico la asciuga a firmata: il confine e fluido e review-first per costruzione.
+- **Impostazioni sartoriali.** Dentro ADR 0047 (nessun selettore di stile UI persistito, i registri di luce seguono il sistema): la sartorialita e densita (comoda/densa), scorciatoie, viste salvate, default di ambulatorio, routing della coda, ordine delle voci di menu. Il rapporto conflittuale con le impostazioni si scioglie perche ogni opzione e ispezionabile, reversibile e con anteprima: niente e nascosto, niente e irreversibile, niente restyling travestito da personalizzazione.
+
+## 5. La proattivita agentica per euristica
+
+L'interfaccia deve sembrare orchestrata da un modello che serve la cosa giusta al momento giusto, prima che un motore esista. La sensazione nasce da euristiche oneste, non dalla simulazione di una intelligenza.
+
+- La coda decisionale riordina e propone l'azione probabile; ogni voce dichiara perche e li, chi la possiede, entro quando. Le voci gia valutate non tornano uguali.
+- L'app ricorda la luce dell'ultimo contesto e apre dove il lavoro era rimasto.
+- Cosa NON si fa: pre-illuminare "il prossimo fuoco probabile" o mettere in scena una preveggenza. Sarebbe vantare un motore che non c'e (ADR 0065). La proattivita e servire bene cio che le euristiche sanno davvero, e ammettere il resto con stati vuoti onesti.
+
+## 6. Primitive tecniche (come si implementa)
+
+Queste primitive derivano dalla review di design del 2026-07-13, riconciliate alla direzione luce+inchiostro: quello che era pensato per far vivere la linea qui fa vivere la luce, l'inchiostro e il connettore.
+
+- **Variabili di luce registrate.** Le variabili di zona (`--surface-l` luminanza, `--surface-temp` temperatura) si dichiarano con `@property` a syntax tipata, cosi interpolano davvero durante il cross-fade; senza registrazione scattano invece di transire. Il cross-fade del fuoco anima queste, non un `translate` di superfici.
+- **L'ombra non si anima.** Il sollevamento del fuoco (profondita 0 verso 1) anima l'`opacity` di uno strato-ombra pre-renderizzato (pseudo-elemento), non `box-shadow` diretto, che e paint-bound.
+- **Il filo e geometria vettoriale.** Un `<line>` o `<rect>` SVG (o `Path.trim` sul nativo), mai un bordo animato. Crescita lungo un asse dritto (la spina del diario che si allunga) uguale `transform: scaleY`, compositor-friendly; percorso non lineare (la provenienza) uguale `stroke-dashoffset`. Mai `opacity` da 0 a 1 su un filo: un filo che sfuma tradisce il suo significato di continuita.
+- **`--filo-fill` per il connettore che si completa.** Proprieta registrata `@property --filo-fill { syntax: '<percentage>'; inherits: false; initial-value: 0% }`, da 0 a 100% in ~200ms ease-out. In luce+inchiostro serve al FILO-CONNETTORE (la provenienza che si riempie fonte per fonte, 33/66/100, man mano che il medico conferma ciascuna; la spina che si completa), NON allo stato epistemico: lo stato resta inchiostro che asciuga (par. 1 e 3). Il riempimento e legato al gesto, mai temporizzato.
+- **Curve e tempi.** Easing di base `cubic-bezier(0.22, 0.61, 0.36, 1)`. Velocita proporzionale alla scala del salto: traversata di lista 90-110ms; cambio di fuoco o di contesto 150-180ms; asciugatura della firma e riempimento del connettore 200-220ms. Press `scale(0.97)` in ~100ms al pointer-down.
+- **La fisica vive solo sotto il dito.** Drag, riordino, assorbimento allegato uguale spring interrompibili (response 0.30-0.35s, smorzamento pieno, zero overshoot), sempre dal valore corrente a schermo. Comparse e cambi di fuoco usano cross-fade temporizzato, mai una molla.
+- **Feedback al tocco, commit al gesto.** `:active { transform: scale(0.97) }` alla pressione, ma lo stato passa a firmato solo con il gesto di firma (per esempio `Cmd+Invio`), mai al rilascio del dito. La fisica del dito e la fisica del dato sono separate: toccare non e mai firmare.
+- **Un solo primitivo per famiglia.** Il campo codificato (ICD, farmaco, esenzione) e UN combobox condiviso, non implementazioni parallele. La lista di disambiguazione non sbuca: e una penombra che si schiarisce sotto il campo (cross-fade 150ms, superficie opaca, nessun blur strutturale); la luce di riga scivola in 90-110ms, mai un rettangolo colorato che salta.
+- **Budget di movimento verificabile.** Fuori dai gesti diretti, un solo elemento in moto per viewport; se il fuoco si sposta mentre un connettore si sta ancora riempiendo, il precedente si tronca al valore corrente (interrompibile) e il token passa. Un test di regressione conta le `transition` e `animation` attive e fallisce la CI se due animazioni fuori-gesto girano nello stesso fotogramma: la calma diventa un contratto.
+- **Reduce Motion.** Sopprime i respiri e le corse (il connettore appare gia completo, lo stato gia asciutto) e dimezza le durate. E il default per costruzione, non un ramo di fallback.
+
+## 7. Note per piattaforma e accessibilita
+
+- **Web** (implementazione di riferimento): variabili di luce via `@property`, connettori come SVG con draw-on, font della Voce impacchettato (nessun fetch remoto). Riferimento vivo: [mockups/lume-dinamica.html](./mockups/lume-dinamica.html).
+- **Apple**: SF Pro e SF Mono; `matchedGeometryEffect` solo per il connettore che prosegue; overlay come sheet di sistema.
+- **Windows / Linux**: la resa degrada per costruzione perche e opaca e piatta; il filo e un accent, non un materiale da rimuovere.
+- **Accessibilita**: WCAG 2.2 AA, focus sempre visibile, tutto raggiungibile da tastiera, mai disabled opachi muti. Con reduce-motion lo stato resta leggibile per tono, etichetta e superficie (par. 2.7). I segnali clinici (colore = semantica) non partecipano mai a questa grammatica: restano invarianti.

--- a/docs/design/lume/README.md
+++ b/docs/design/lume/README.md
@@ -18,7 +18,7 @@ Vetro Clinico ha dato a MediFlow una disciplina dei materiali: vetro per il tela
 Quattro rotture rispetto al paradigma attuale, tutte motivate dalla ricerca:
 
 1. **La luce sostituisce il vetro come sistema di gerarchia.** Profondità e importanza si esprimono con luminanza, temperatura e ombre brevi, non con blur e trasparenza. Il vetro si ritira a rendering opzionale degli overlay transitori. È la direzione post-glass della frontiera 2026 e la lezione della stessa Apple, che ha ridotto la trasparenza di default un anno dopo averla lanciata.
-2. **Il filo è la firma grafica.** Una sola linea sottile porta il significato di continuità della cura: spina della timeline, bordo dell'oggetto focale, connettore della storia di un valore. E il suo tratto codifica lo stato epistemico: tratteggiato è bozza, pieno è firmato. Niente ornamento: la linea è dato.
+2. **Il filo è la firma grafica, e connette.** Una sola linea sottile porta il significato di continuità della cura, resa come geometria SVG continua: spina della timeline, connettore della storia di un valore, legame di provenienza. Il fuoco però si marca con la luce, non con il filo, e lo stato epistemico (bozza o firmato) si rende con l'inchiostro, non con il tratteggio: la resa è fissata in [07-gesto-e-movimento.md](./07-gesto-e-movimento.md). Niente ornamento: la linea è dato.
 3. **Due voci tipografiche.** La Voce (sans umanista, con optical sizing dove disponibile) parla; il Registro (mono) certifica. Ogni atomo verificabile della clinica (dose, valore, codice, orario) è composto nel Registro con cifre tabellari: si riconosce a colpo d'occhio cosa è dato e cosa è discorso.
 4. **La grammatica dell'attenzione.** Testata paziente invariabile, colonna di ciò che richiede attenzione (non di tutto ciò che esiste), baseline personale prima del benchmark, provenienza sempre visibile. Il layout non presenta dati: presenta decisioni da prendere.
 
@@ -32,7 +32,8 @@ Ciò che NON cambia: le leggi cliniche di Vetro Clinico restano fondamenta anche
 4. [04-perlustrazione.md](./04-perlustrazione.md): la perlustrazione EHR/provider e le 12 integrazioni normative alla grammatica.
 5. [05-app-native.md](./05-app-native.md): mappa generale delle app native, grammatica compatta iPhone e note tri-OS prospettiche.
 6. [06-macos-apple-contract.md](./06-macos-apple-contract.md): contratto di destinazione macOS, fonti Apple, availability, disposizione, materiali, debito corrente e sequenza verificabile.
-7. [mockups/lume.html](./mockups/lume.html): dimostratore interattivo (aprire nel browser, nessuna dipendenza): modello focale, filo, due voci, registri giorno/grafite/guardia.
+7. [07-gesto-e-movimento.md](./07-gesto-e-movimento.md): la grammatica del gesto e del movimento: luce per il fuoco, inchiostro per lo stato, filo come connettore SVG; leggi di moto, atomi, scene, primitive tecniche.
+8. [mockups/](./mockups/): dimostratori interattivi (aprire nel browser, nessuna dipendenza). `lume.html`: modello focale, due voci, registri giorno/grafite/guardia. `lume-dinamica.html`: studio prima/dopo (filo lineare contro luce e inchiostro). `lume-cockpit-vivo.html`, `lume-campi.html`, `lume-voce.html`, `lume-impostazioni.html`: le movenze nel linguaggio luce e inchiostro.
 
 ## Rapporto con il canone
 

--- a/docs/design/lume/mockups/lume-campi.html
+++ b/docs/design/lume/mockups/lume-campi.html
@@ -1,0 +1,293 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Lume: i campi in movimento (luce e inchiostro)</title>
+<style>
+/* ============================================================
+   Lume, i campi in movimento.
+   Gli atomi di inserimento dati nel linguaggio luce e inchiostro:
+     - campo di testo: si scrive in inchiostro tenue (bozza),
+       la firma lo asciuga a pieno;
+     - campo codificato: ricerca inline in penombra, il codice
+       si posa nel Registro;
+     - campo AI dinamico: la materia si illumina (luce, non calore),
+       il suggerimento entra come inchiostro tenue e la firma lo asciuga;
+     - allegato: il documento cade in penombra e un connettore SVG
+       di provenienza si disegna verso la voce che lo cita.
+   Vitalita solo in risposta al gesto: nessun loop, nessuno shimmer.
+   File autonomo, nessun font remoto. Dati esclusivamente dimostrativi.
+   Canone: docs/design/lume/07-gesto-e-movimento.md
+   ============================================================ */
+
+:root {
+  --canvas:#eef0f2; --field:#f5f5f4; --focal:#fbfaf7; --chrome:#e6e8eb;
+  --ink:#1a1c1e; --ink-muted:#5c6772; --minerale:#33506b;
+  --warning:#9a6a2f; --critical:#a33a2f; --success:#4b6354; --plum:#555161;
+  --warning-tint:rgba(154,106,47,0.10); --critical-tint:rgba(163,58,47,0.10); --success-tint:rgba(75,99,84,0.12);
+  --minerale-tint:rgba(51,80,107,0.10);
+  --border:rgba(26,28,30,0.10); --border-chrome:rgba(26,28,30,0.06);
+  --shadow-focal:0 2px 8px rgba(26,28,30,0.10); --shadow-lift:0 6px 20px rgba(26,28,30,0.12);
+  --r-panel:20px; --r-card:14px; --r-control:10px;
+  --voce:-apple-system,BlinkMacSystemFont,"SF Pro Text","Segoe UI","Inter",sans-serif;
+  --registro:ui-monospace,"SF Mono","IBM Plex Mono","Cascadia Mono",Menlo,monospace;
+  --focus-ring:0 0 0 2px var(--canvas),0 0 0 4px var(--minerale);
+  --warm:rgba(154,106,47,0.05);
+}
+.grafite { --canvas:#121417; --field:#191c21; --focal:#22252b; --chrome:#0e1013; --ink:#e9ecef; --ink-muted:#8f9aa6; --minerale:#8fb0cc; --warning:#c89c5a; --critical:#d67668; --success:#7e9e8a; --plum:#9691a5; --warning-tint:rgba(200,156,90,0.14); --critical-tint:rgba(214,118,104,0.14); --success-tint:rgba(126,158,138,0.16); --minerale-tint:rgba(143,176,204,0.14); --border:rgba(233,236,239,0.10); --border-chrome:rgba(233,236,239,0.05); --shadow-focal:0 2px 10px rgba(0,0,0,0.5); --shadow-lift:0 8px 26px rgba(0,0,0,0.6); --warm:rgba(200,156,90,0.06); }
+.guardia { --canvas:#0c0e12; --field:#14171d; --focal:#1a1e26; --chrome:#090b0e; --ink:#e3e8ee; --ink-muted:#8792a3; --minerale:#7fa0bc; --warning:#cfa35f; --critical:#d98a7d; --success:#85a291; --plum:#9691a5; --warning-tint:rgba(207,163,95,0.14); --critical-tint:rgba(217,138,125,0.14); --success-tint:rgba(133,162,145,0.16); --minerale-tint:rgba(127,160,188,0.14); --border:rgba(227,232,238,0.09); --border-chrome:rgba(227,232,238,0.04); --shadow-focal:0 2px 10px rgba(0,0,0,0.6); --shadow-lift:0 8px 26px rgba(0,0,0,0.7); --warm:rgba(207,163,95,0.06); }
+
+* { margin:0; padding:0; box-sizing:border-box; }
+body { font-family:var(--voce); background:var(--canvas); color:var(--ink); font-size:14px; line-height:1.5; min-height:100vh; transition:background 200ms ease-out, color 200ms ease-out; }
+.reg { font-family:var(--registro); font-variant-numeric:tabular-nums; font-size:0.95em; }
+
+.bar { position:sticky; top:0; z-index:60; display:flex; align-items:center; gap:16px; flex-wrap:wrap; padding:10px 20px; background:var(--chrome); border-bottom:1px solid var(--border-chrome); }
+.bar h1 { font-size:13.5px; font-weight:650; letter-spacing:-0.01em; }
+.seg-label { font-size:10px; font-weight:650; letter-spacing:0.07em; text-transform:uppercase; color:var(--ink-muted); }
+.seg { display:flex; gap:3px; background:var(--canvas); border-radius:999px; padding:3px; }
+.seg button { border:0; background:transparent; color:var(--ink-muted); font:inherit; font-size:12px; font-weight:500; padding:5px 13px; border-radius:999px; cursor:pointer; transition:color 150ms ease-out; }
+.seg button:focus-visible { outline:none; box-shadow:var(--focus-ring); }
+.seg button[aria-pressed="true"] { background:var(--focal); color:var(--ink); box-shadow:0 1px 2px rgba(0,0,0,0.10); }
+.bar .nota { font-size:11px; color:var(--ink-muted); max-width:40ch; margin-left:auto; }
+
+.testata { position:sticky; top:45px; z-index:55; display:flex; align-items:baseline; gap:8px 16px; flex-wrap:wrap; padding:11px 20px; background:var(--field); border-bottom:1px solid var(--border); }
+.testata .nome { font-size:16px; font-weight:650; letter-spacing:-0.01em; }
+.testata .dato { font-size:12px; color:var(--ink-muted); }
+.testata .allergia { font-size:12px; font-weight:650; color:var(--critical); }
+
+.stage { max-width:760px; margin:16px auto 60px; padding:0 16px; }
+.viewnote { font-size:12px; color:var(--ink-muted); margin:0 2px 16px; }
+
+.card { position:relative; background:var(--field); border:1px solid var(--border); border-radius:var(--r-panel); padding:16px 18px; margin-bottom:14px; transition:background 180ms ease-out, box-shadow 180ms ease-out; }
+.card[data-fuoco="true"] { background:linear-gradient(var(--warm),var(--warm)),var(--focal); box-shadow:var(--shadow-focal); }
+.card.assicura { animation:assicura 320ms ease-out; }
+@keyframes assicura { 0%{ box-shadow:var(--shadow-focal),0 0 0 0 var(--minerale-tint);} 35%{ box-shadow:var(--shadow-lift),0 0 0 6px var(--minerale-tint);} 100%{ box-shadow:var(--shadow-focal),0 0 0 0 rgba(0,0,0,0);} }
+.card h2 { font-size:11px; font-weight:650; letter-spacing:0.07em; text-transform:uppercase; color:var(--ink-muted); margin-bottom:2px; }
+.card .desc { font-size:12px; color:var(--ink-muted); margin-bottom:12px; }
+.label { display:block; font-size:12px; font-weight:600; margin-bottom:6px; }
+.stato { font-size:10.5px; font-weight:600; margin-left:8px; }
+.stato.bozza { color:var(--warning); } .stato.firmata { color:var(--success); }
+
+.inp, .ta { width:100%; font:inherit; color:var(--ink); background:var(--focal); border:1px solid var(--border); border-radius:var(--r-control); padding:10px 12px; transition:box-shadow 150ms ease-out, border-color 150ms ease-out; }
+.ta { min-height:74px; resize:vertical; line-height:1.55; }
+.inp:focus, .ta:focus { outline:none; border-color:var(--minerale); box-shadow:0 0 0 3px var(--minerale-tint); }
+.ta.bozza { color:var(--ink-muted); }
+.ta.firmata { color:var(--ink); }
+.savenote { font-size:10.5px; color:var(--ink-muted); margin-top:6px; }
+.tick { display:inline-block; height:2px; width:0; background:var(--success); border-radius:2px; vertical-align:middle; margin-left:8px; transition:width 360ms ease-out; }
+.tick.on { width:26px; }
+
+.row-actions { display:flex; gap:8px; align-items:center; margin-top:10px; flex-wrap:wrap; }
+.btn { position:relative; overflow:hidden; border:0; cursor:pointer; font:inherit; font-weight:600; font-size:12.5px; color:var(--focal); background:var(--minerale); padding:8px 15px; border-radius:var(--r-control); transition:transform 150ms cubic-bezier(0.2,0,0,1), filter 150ms ease-out; }
+.btn:hover { filter:brightness(1.06); } .btn:active { transform:scale(0.97); }
+.btn:focus-visible { outline:none; box-shadow:var(--focus-ring); }
+.btn-quiet { border:1px solid var(--border); background:transparent; color:var(--ink); font:inherit; font-size:12px; font-weight:550; cursor:pointer; padding:7px 13px; border-radius:999px; transition:transform 150ms cubic-bezier(0.2,0,0,1), background 150ms ease-out; }
+.btn-quiet:hover { background:var(--canvas); } .btn-quiet:active { transform:scale(0.97); }
+.btn-quiet:focus-visible { outline:none; box-shadow:var(--focus-ring); }
+.ripple { position:absolute; border-radius:50%; transform:translate(-50%,-50%) scale(0); background:rgba(255,255,255,0.5); pointer-events:none; }
+@keyframes onda { to { transform:translate(-50%,-50%) scale(1); opacity:0; } }
+.ripple.go { animation:onda 460ms ease-out forwards; }
+
+.combo { position:relative; }
+.pop { position:absolute; left:0; right:0; top:calc(100% + 6px); z-index:5; background:var(--focal); border:1px solid var(--border); border-radius:var(--r-card); box-shadow:var(--shadow-lift); padding:4px; overflow:hidden; opacity:0; transform:translateY(-4px); pointer-events:none; transition:opacity 150ms ease-out, transform 150ms ease-out; }
+.pop.open { opacity:1; transform:translateY(0); pointer-events:auto; }
+.opt { display:flex; align-items:center; gap:10px; padding:8px 10px; border-radius:var(--r-control); cursor:pointer; transition:background 90ms ease-out; }
+.opt:hover, .opt.hl { background:var(--field); }
+.opt .code { font-family:var(--registro); font-variant-numeric:tabular-nums; font-size:12.5px; font-weight:650; color:var(--minerale); min-width:64px; }
+.opt .nome { font-size:13px; }
+.empty { padding:12px 10px; font-size:12px; color:var(--ink-muted); }
+.chosen { display:flex; align-items:center; gap:10px; margin-top:10px; padding:9px 11px; background:var(--focal); border:1px solid var(--border); border-radius:var(--r-control); }
+.chosen .code { font-family:var(--registro); font-variant-numeric:tabular-nums; font-weight:650; color:var(--minerale); }
+.chosen .x { margin-left:auto; border:0; background:transparent; color:var(--ink-muted); font:inherit; cursor:pointer; font-size:16px; line-height:1; padding:2px 6px; border-radius:6px; }
+.chosen .x:hover { background:var(--field); color:var(--ink); }
+.chosen .x:focus-visible { outline:none; box-shadow:var(--focus-ring); }
+
+.ai-field { border:1px solid var(--border); border-radius:var(--r-control); background:var(--focal); padding:12px; transition:box-shadow 180ms ease-out, background 180ms ease-out; }
+.ai-field.pronto { box-shadow:var(--shadow-focal); background:linear-gradient(var(--warm),var(--warm)),var(--focal); }
+.ai-head { display:flex; align-items:center; gap:8px; }
+.ai-mark { width:16px; height:16px; border-radius:50%; border:1.5px solid var(--minerale); display:grid; place-items:center; flex:none; transition:background 180ms ease-out; }
+.ai-field.pronto .ai-mark { background:var(--minerale-tint); }
+.ai-mark span { width:5px; height:5px; border-radius:50%; background:var(--minerale); }
+.ai-hint { font-size:11px; color:var(--ink-muted); }
+.ai-hint b { color:var(--minerale); font-weight:650; }
+.ai-body { font-size:13.5px; color:var(--ink-muted); margin-top:10px; max-height:0; overflow:hidden; transition:max-height 220ms ease-out, color 380ms ease-out; }
+.ai-field.pronto .ai-body { max-height:170px; }
+.ai-field.firmata .ai-body { color:var(--ink); }
+.ai-src { display:inline-flex; align-items:center; gap:6px; margin-top:8px; font-size:11px; color:var(--minerale); cursor:pointer; background:transparent; border:0; font-family:inherit; padding:2px 0; }
+.ai-src:focus-visible { outline:none; box-shadow:var(--focus-ring); border-radius:4px; }
+.ai-srcbox { max-height:0; overflow:hidden; transition:max-height 200ms ease-out; }
+.ai-srcbox.open { max-height:90px; }
+.ai-srcbox .line { font-size:11px; color:var(--ink-muted); padding:6px 0 0; }
+
+.drop { border:1px solid var(--border); border-radius:var(--r-card); background:var(--focal); padding:16px; text-align:center; cursor:pointer; transition:box-shadow 180ms ease-out, background 180ms ease-out, transform 150ms ease-out; }
+.drop:hover, .drop.over { box-shadow:var(--shadow-focal); background:linear-gradient(var(--warm),var(--warm)),var(--focal); }
+.drop:active { transform:scale(0.995); }
+.drop:focus-visible { outline:none; box-shadow:var(--focus-ring); }
+.drop .big { font-size:13px; font-weight:600; } .drop .sub { font-size:11px; color:var(--ink-muted); margin-top:2px; }
+.prov-wrap { position:relative; margin-top:12px; padding-left:22px; }
+.prov-svg { position:absolute; left:6px; top:0; width:16px; height:100%; overflow:visible; }
+.prov-svg line { stroke:var(--minerale); stroke-width:1.5; opacity:0.6; }
+.doc { display:flex; align-items:center; gap:10px; padding:9px 11px; background:var(--field); border:1px solid var(--border); border-radius:var(--r-control); opacity:0; transform:translateY(4px); transition:opacity 200ms ease-out, transform 200ms ease-out; }
+.doc.in { opacity:1; transform:translateY(0); }
+.doc .nome { font-size:13px; font-weight:550; } .doc .meta { font-size:10.5px; color:var(--ink-muted); }
+.cite { font-size:12px; color:var(--ink-muted); margin-top:10px; }
+.cite b { color:var(--ink); font-weight:600; }
+
+@media (prefers-reduced-motion: reduce) { * { transition:none !important; animation:none !important; } }
+</style>
+</head>
+<body class="giorno">
+
+<div class="bar">
+  <h1>Lume, i campi in movimento</h1>
+  <div class="seg-label">Registro di luce</div>
+  <div class="seg" role="group" aria-label="Registro di luce">
+    <button data-reg="giorno" aria-pressed="true">Giorno</button>
+    <button data-reg="grafite" aria-pressed="false">Grafite</button>
+    <button data-reg="guardia" aria-pressed="false">Guardia</button>
+  </div>
+  <span class="nota">Lo switch e solo di demo: nel prodotto i registri seguono il sistema (ADR 0047).</span>
+</div>
+
+<div class="testata" role="banner">
+  <span class="nome">Bianchi Aurora (demo)</span>
+  <span class="dato reg">1954</span>
+  <span class="dato">dati dimostrativi</span>
+  <span class="allergia">Allergia: penicillina</span>
+</div>
+
+<div class="stage">
+  <p class="viewnote">Quattro atomi di inserimento, nella stessa lingua: la luce porta il fuoco, l inchiostro porta lo stato, il filo connette solo dove connette davvero. Prova a scrivere, cercare un codice, chiedere un suggerimento, allegare un documento.</p>
+
+  <section class="card" data-fuoco="false" data-atom="testo" tabindex="0">
+    <h2>Campo di testo</h2>
+    <p class="desc">La prosa clinica si scrive in inchiostro tenue: e bozza. La firma la asciuga a pieno.</p>
+    <label class="label" for="ta1">Voce di diario <span class="stato bozza" id="ta1-stato">bozza</span><span class="tick" id="ta1-tick" aria-hidden="true"></span></label>
+    <textarea class="ta bozza" id="ta1" rows="3">Controllo pressorio. Riferisce cefalea mattutina saltuaria, PA domiciliare in salita nell ultima settimana.</textarea>
+    <div class="savenote" id="ta1-save">salvato in bozza, <span class="reg">09:07</span></div>
+    <div class="row-actions">
+      <button class="btn" id="ta1-firma">Firma la voce</button>
+      <button class="btn-quiet" id="ta1-reset">Riporta a bozza</button>
+    </div>
+  </section>
+
+  <section class="card" data-fuoco="false" data-atom="codice" tabindex="0">
+    <h2>Campo codificato</h2>
+    <p class="desc">La ricerca appare in penombra sotto il campo. Il codice scelto si posa nel Registro, senza modale.</p>
+    <label class="label" for="cod">Diagnosi (ICD-10)</label>
+    <div class="combo">
+      <input class="inp reg" id="cod" type="text" autocomplete="off" placeholder="digita: iperten, diabete, fibrilla..." aria-expanded="false" aria-controls="cod-pop" role="combobox">
+      <div class="pop" id="cod-pop" role="listbox" aria-label="Codici corrispondenti"></div>
+    </div>
+    <div id="cod-chosen"></div>
+  </section>
+
+  <section class="card" data-fuoco="false" data-atom="ai" tabindex="0">
+    <h2>Campo AI dinamico</h2>
+    <p class="desc">Quando lo strumento ha qualcosa, la materia si illumina appena. Il suggerimento entra come inchiostro tenue, e solo la firma lo rende pieno.</p>
+    <div class="ai-field" id="ai">
+      <div class="ai-head">
+        <span class="ai-mark" aria-hidden="true"><span></span></span>
+        <span class="ai-hint" id="ai-hint">A riposo. Chiedi un aiuto quando ti serve.</span>
+      </div>
+      <div class="ai-body" id="ai-body"></div>
+      <button class="ai-src" id="ai-src" hidden>Mostra le fonti</button>
+      <div class="ai-srcbox" id="ai-srcbox"><div class="line">Referto cardiologico del <span class="reg">02/07/2026</span>, sezione conclusioni. Linee guida ESC 2024 sulla gestione della pressione.</div></div>
+      <div class="row-actions">
+        <button class="btn-quiet" id="ai-ask">Chiedi un suggerimento</button>
+        <button class="btn" id="ai-firma" hidden>Firma il suggerimento</button>
+        <button class="btn-quiet" id="ai-scarta" hidden>Scarta</button>
+        <span class="stato bozza" id="ai-stato" hidden>bozza, proposto</span>
+      </div>
+    </div>
+  </section>
+
+  <section class="card" data-fuoco="false" data-atom="allegato" tabindex="0">
+    <h2>Allegato</h2>
+    <p class="desc">Il documento cade in penombra, viene assorbito, e un connettore si disegna verso la voce che lo cita: la provenienza.</p>
+    <div class="drop" id="drop" tabindex="0" role="button" aria-label="Aggiungi un allegato">
+      <div class="big">Trascina qui, o premi per aggiungere</div>
+      <div class="sub">un referto, una lettera, un esame</div>
+    </div>
+    <div class="prov-wrap" id="prov-wrap">
+      <svg class="prov-svg" id="prov-svg" preserveAspectRatio="none" aria-hidden="true"><line id="prov-line" x1="8" y1="0" x2="8" y2="0"></line></svg>
+      <div class="doc" id="doc"><span class="nome">referto-cardiologico.pdf</span><span class="meta reg">02/07/2026 &middot; 2 pagine</span></div>
+      <div class="cite" id="cite" hidden>Citato nella voce di diario del <b class="reg">11/07/2026</b>. Il connettore lega il contenuto alla sua fonte.</div>
+    </div>
+  </section>
+</div>
+
+<script>
+(function(){
+  var body=document.body;
+  document.querySelectorAll('[data-reg]').forEach(function(b){
+    b.addEventListener('click', function(){ body.className=b.dataset.reg; document.querySelectorAll('[data-reg]').forEach(function(x){ x.setAttribute('aria-pressed', String(x===b)); }); });
+  });
+
+  var cards=document.querySelectorAll('.card[data-atom]');
+  function pulse(el){ el.classList.remove('assicura'); void el.offsetWidth; el.classList.add('assicura'); }
+  function focusCard(t){ cards.forEach(function(c){ c.setAttribute('data-fuoco', String(c===t)); }); pulse(t); }
+  cards.forEach(function(c){ c.addEventListener('focusin', function(){ if(c.getAttribute('data-fuoco')!=='true') focusCard(c); }); });
+  document.querySelector('[data-atom="testo"]').setAttribute('data-fuoco','true');
+
+  function ripple(btn,e){ var r=document.createElement('span'); r.className='ripple'; var b=btn.getBoundingClientRect(); var d=Math.max(b.width,b.height)*2; r.style.width=r.style.height=d+'px'; r.style.left=((e.clientX||b.left+b.width/2)-b.left)+'px'; r.style.top=((e.clientY||b.top+b.height/2)-b.top)+'px'; btn.appendChild(r); void r.offsetWidth; r.classList.add('go'); setTimeout(function(){ r.remove(); },500); }
+
+  var ta=document.getElementById('ta1'), taStato=document.getElementById('ta1-stato'), taTick=document.getElementById('ta1-tick'), taSave=document.getElementById('ta1-save');
+  document.getElementById('ta1-firma').addEventListener('click', function(e){ ripple(this,e); ta.classList.remove('bozza'); ta.classList.add('firmata'); ta.readOnly=true; taStato.textContent='firmata'; taStato.className='stato firmata'; taTick.classList.add('on'); taSave.innerHTML='firmata, <span class="reg">09:09</span>'; this.hidden=true; });
+  document.getElementById('ta1-reset').addEventListener('click', function(e){ ripple(this,e); ta.classList.add('bozza'); ta.classList.remove('firmata'); ta.readOnly=false; taStato.textContent='bozza'; taStato.className='stato bozza'; taTick.classList.remove('on'); taSave.innerHTML='salvato in bozza, <span class="reg">09:07</span>'; document.getElementById('ta1-firma').hidden=false; });
+
+  var ICD=[
+    {c:'I10',n:'Ipertensione essenziale (primaria)'},
+    {c:'I48.91',n:'Fibrillazione atriale non specificata'},
+    {c:'E11.9',n:'Diabete mellito tipo 2 senza complicanze'},
+    {c:'E78.5',n:'Iperlipidemia non specificata'},
+    {c:'I50.9',n:'Insufficienza cardiaca non specificata'},
+    {c:'N18.3',n:'Malattia renale cronica, stadio 3'},
+    {c:'J44.9',n:'Broncopneumopatia cronica ostruttiva'}
+  ];
+  var cod=document.getElementById('cod'), pop=document.getElementById('cod-pop'), chosen=document.getElementById('cod-chosen'), hl=-1, shown=[];
+  function render(q){
+    q=q.trim().toLowerCase();
+    shown = q ? ICD.filter(function(x){ return x.n.toLowerCase().indexOf(q)>=0 || x.c.toLowerCase().indexOf(q)>=0; }) : [];
+    if(!q){ pop.classList.remove('open'); cod.setAttribute('aria-expanded','false'); pop.innerHTML=''; return; }
+    if(!shown.length){ pop.innerHTML='<div class="empty">Nessun codice per "'+q.replace(/[<>&]/g,'')+'". Prova un altro termine.</div>'; }
+    else { pop.innerHTML=shown.map(function(x,i){ return '<div class="opt" role="option" data-i="'+i+'"><span class="code">'+x.c+'</span><span class="nome">'+x.n+'</span></div>'; }).join(''); }
+    hl=-1; pop.classList.add('open'); cod.setAttribute('aria-expanded','true');
+    pop.querySelectorAll('.opt').forEach(function(o){ o.addEventListener('mousedown', function(ev){ ev.preventDefault(); pick(shown[+o.dataset.i]); }); });
+  }
+  function pick(x){ if(!x) return; chosen.innerHTML='<div class="chosen"><span class="code">'+x.c+'</span><span class="nome">'+x.n+'</span><button class="x" aria-label="Rimuovi il codice">&times;</button></div>'; chosen.querySelector('.x').addEventListener('click', function(){ chosen.innerHTML=''; cod.value=''; cod.focus(); }); cod.value=''; pop.classList.remove('open'); cod.setAttribute('aria-expanded','false'); }
+  cod.addEventListener('input', function(){ render(cod.value); });
+  cod.addEventListener('keydown', function(e){
+    var opts=pop.querySelectorAll('.opt'); if(!opts.length) return;
+    if(e.key==='ArrowDown'){ e.preventDefault(); hl=(hl+1)%opts.length; }
+    else if(e.key==='ArrowUp'){ e.preventDefault(); hl=(hl-1+opts.length)%opts.length; }
+    else if(e.key==='Enter'){ e.preventDefault(); if(hl>=0) pick(shown[hl]); return; }
+    else return;
+    opts.forEach(function(o,i){ o.classList.toggle('hl', i===hl); });
+  });
+  cod.addEventListener('blur', function(){ setTimeout(function(){ pop.classList.remove('open'); cod.setAttribute('aria-expanded','false'); }, 150); });
+
+  var ai=document.getElementById('ai'), aiHint=document.getElementById('ai-hint'), aiBody=document.getElementById('ai-body');
+  var aiAsk=document.getElementById('ai-ask'), aiFirma=document.getElementById('ai-firma'), aiScarta=document.getElementById('ai-scarta'), aiStato=document.getElementById('ai-stato'), aiSrc=document.getElementById('ai-src'), aiSrcbox=document.getElementById('ai-srcbox');
+  aiAsk.addEventListener('click', function(e){ ripple(this,e); ai.classList.add('pronto'); aiHint.innerHTML='<b>Suggerimento pronto</b>, da rivedere'; aiBody.textContent='Valutare aggiustamento della terapia serale e richiamo a 7 giorni con diario pressorio domiciliare. La pressione e sopra la baseline personale da due rilevazioni.'; aiFirma.hidden=false; aiScarta.hidden=false; aiStato.hidden=false; aiSrc.hidden=false; this.hidden=true; });
+  aiSrc.addEventListener('click', function(){ var open=aiSrcbox.classList.toggle('open'); this.textContent = open ? 'Nascondi le fonti' : 'Mostra le fonti'; });
+  aiFirma.addEventListener('click', function(e){ ripple(this,e); ai.classList.add('firmata'); aiHint.innerHTML='Rivisto e <b>firmato</b>'; aiStato.textContent='firmato'; aiStato.className='stato firmata'; this.hidden=true; aiScarta.hidden=true; });
+  aiScarta.addEventListener('click', function(e){ ripple(this,e); ai.classList.remove('pronto','firmata'); aiHint.textContent='A riposo. Chiedi un aiuto quando ti serve.'; aiBody.textContent=''; aiFirma.hidden=true; aiScarta.hidden=true; aiStato.hidden=true; aiSrc.hidden=true; aiSrcbox.classList.remove('open'); aiSrc.textContent='Mostra le fonti'; aiAsk.hidden=false; });
+
+  var drop=document.getElementById('drop'), doc=document.getElementById('doc'), cite=document.getElementById('cite'), provLine=document.getElementById('prov-line'), provSvg=document.getElementById('prov-svg');
+  function absorb(){
+    doc.classList.add('in');
+    setTimeout(function(){ var h=provSvg.getBoundingClientRect().height || 44; provLine.setAttribute('y2', String(h)); cite.hidden=false; }, 180);
+    drop.querySelector('.big').textContent='Aggiunto. Assorbito nel diario.';
+    drop.querySelector('.sub').textContent='premi di nuovo per ripristinare';
+  }
+  function resetDrop(){ doc.classList.remove('in'); cite.hidden=true; provLine.setAttribute('y2','0'); drop.querySelector('.big').textContent='Trascina qui, o premi per aggiungere'; drop.querySelector('.sub').textContent='un referto, una lettera, un esame'; }
+  drop.addEventListener('click', function(){ if(doc.classList.contains('in')) resetDrop(); else absorb(); });
+  drop.addEventListener('keydown', function(e){ if(e.key==='Enter'||e.key===' '){ e.preventDefault(); drop.click(); } });
+  ['dragover','dragenter'].forEach(function(ev){ drop.addEventListener(ev, function(e){ e.preventDefault(); drop.classList.add('over'); }); });
+  ['dragleave','drop'].forEach(function(ev){ drop.addEventListener(ev, function(e){ e.preventDefault(); drop.classList.remove('over'); if(ev==='drop') absorb(); }); });
+})();
+</script>
+</body>
+</html>

--- a/docs/design/lume/mockups/lume-cockpit-vivo.html
+++ b/docs/design/lume/mockups/lume-cockpit-vivo.html
@@ -1,0 +1,752 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Lume: cockpit vivo (luce e inchiostro in movimento)</title>
+<style>
+/* ============================================================
+   Lume, cockpit vivo.
+   Il cockpit completo in movimento: rail (buio operativo),
+   worklist (penombra), Quadro (fuoco), coda dell attenzione.
+   Tre portatori, tre lavori, nessuna sovrapposizione:
+     la LUCE porta il fuoco (mai una linea),
+     l INCHIOSTRO porta lo stato (bozza tenue, firma che asciuga),
+     il FILO connette solo dove connette davvero (spina del diario,
+       provenienza), reso come geometria SVG che si disegna.
+   Vitalita solo in risposta al gesto: nessun loop, nessun respiro,
+   nessuno shimmer di attesa.
+   File autonomo, nessuna dipendenza, nessun font remoto.
+   Dati esclusivamente dimostrativi.
+   Canone: docs/design/lume/07-gesto-e-movimento.md
+   ============================================================ */
+
+:root {
+  --canvas:#eef0f2; --field:#f5f5f4; --focal:#fbfaf7; --chrome:#e6e8eb;
+  --ink:#1a1c1e; --ink-muted:#5c6772; --minerale:#33506b;
+  --warning:#9a6a2f; --critical:#a33a2f; --success:#4b6354; --plum:#555161;
+  --warning-tint:rgba(154,106,47,0.10); --critical-tint:rgba(163,58,47,0.10); --success-tint:rgba(75,99,84,0.12);
+  --minerale-tint:rgba(51,80,107,0.10);
+  --border:rgba(26,28,30,0.10); --border-chrome:rgba(26,28,30,0.06);
+  --shadow-focal:0 2px 8px rgba(26,28,30,0.10); --shadow-lift:0 6px 20px rgba(26,28,30,0.12);
+  --r-panel:20px; --r-card:14px; --r-control:10px;
+  --voce:-apple-system,BlinkMacSystemFont,"SF Pro Text","Segoe UI","Inter",sans-serif;
+  --registro:ui-monospace,"SF Mono","IBM Plex Mono","Cascadia Mono",Menlo,monospace;
+  --focus-ring:0 0 0 2px var(--canvas),0 0 0 4px var(--minerale);
+  --warm:rgba(154,106,47,0.05);
+}
+.grafite { --canvas:#121417; --field:#191c21; --focal:#22252b; --chrome:#0e1013; --ink:#e9ecef; --ink-muted:#8f9aa6; --minerale:#8fb0cc; --warning:#c89c5a; --critical:#d67668; --success:#7e9e8a; --plum:#9691a5; --warning-tint:rgba(200,156,90,0.14); --critical-tint:rgba(214,118,104,0.14); --success-tint:rgba(126,158,138,0.16); --minerale-tint:rgba(143,176,204,0.14); --border:rgba(233,236,239,0.10); --border-chrome:rgba(233,236,239,0.05); --shadow-focal:0 2px 10px rgba(0,0,0,0.5); --shadow-lift:0 8px 26px rgba(0,0,0,0.6); --warm:rgba(200,156,90,0.06); }
+.guardia { --canvas:#0c0e12; --field:#14171d; --focal:#1a1e26; --chrome:#090b0e; --ink:#e3e8ee; --ink-muted:#8792a3; --minerale:#7fa0bc; --warning:#cfa35f; --critical:#d98a7d; --success:#85a291; --plum:#9691a5; --warning-tint:rgba(207,163,95,0.14); --critical-tint:rgba(217,138,125,0.14); --success-tint:rgba(133,162,145,0.16); --minerale-tint:rgba(127,160,188,0.14); --border:rgba(227,232,238,0.09); --border-chrome:rgba(227,232,238,0.04); --shadow-focal:0 2px 10px rgba(0,0,0,0.6); --shadow-lift:0 8px 26px rgba(0,0,0,0.7); --warm:rgba(207,163,95,0.06); }
+
+* { margin:0; padding:0; box-sizing:border-box; }
+html, body { min-height:100%; }
+body {
+  font-family:var(--voce); background:var(--canvas); color:var(--ink);
+  font-size:14px; line-height:1.5;
+  transition:background 200ms ease-out, color 200ms ease-out;
+}
+.reg { font-family:var(--registro); font-variant-numeric:tabular-nums; font-size:0.95em; }
+
+/* ---------- Barra di controllo della demo (buio operativo) ---------- */
+.bar {
+  position:sticky; top:0; z-index:60; display:flex; align-items:center; gap:16px 20px; flex-wrap:wrap;
+  padding:10px 20px; background:var(--chrome); border-bottom:1px solid var(--border-chrome);
+}
+.bar h1 { font-size:13.5px; font-weight:650; letter-spacing:-0.01em; }
+.bar .grp { display:flex; align-items:center; gap:8px; }
+.seg-label { font-size:10px; font-weight:650; letter-spacing:0.07em; text-transform:uppercase; color:var(--ink-muted); }
+.seg { display:flex; gap:3px; background:var(--canvas); border-radius:999px; padding:3px; }
+.seg button {
+  border:0; background:transparent; color:var(--ink-muted); font:inherit; font-size:12px; font-weight:500;
+  padding:5px 13px; border-radius:999px; cursor:pointer; transition:color 150ms ease-out;
+}
+.seg button:focus-visible { outline:none; box-shadow:var(--focus-ring); }
+.seg button[aria-pressed="true"] { background:var(--focal); color:var(--ink); box-shadow:0 1px 2px rgba(0,0,0,0.10); }
+.bar .nota { font-size:11px; color:var(--ink-muted); max-width:44ch; margin-left:auto; }
+
+/* ---------- Testata invariabile: sempre ferma e leggibile ---------- */
+.testata {
+  position:sticky; top:46px; z-index:55;
+  display:flex; align-items:baseline; gap:8px 16px; flex-wrap:wrap;
+  padding:11px 20px; background:var(--field); border-bottom:1px solid var(--border);
+}
+.testata .nome { font-size:16px; font-weight:650; letter-spacing:-0.01em; }
+.testata .dato { font-size:12px; color:var(--ink-muted); }
+.testata .allergia { font-size:12px; font-weight:650; color:var(--critical); }
+
+/* ---------- Cockpit ---------- */
+.cockpit { display:flex; gap:12px; padding:12px; align-items:flex-start; flex-wrap:wrap; }
+.cockpit.ricalibra { animation:ricalibra 260ms ease-out; }
+/* Cambio ambulatorio: la luce dell intero telaio si ricalibra (transiente),
+   poi torna. Non una pagina che vola: e lo stesso strumento che cambia stanza. */
+@keyframes ricalibra {
+  0% { filter:brightness(1); }
+  45% { filter:brightness(0.965); }
+  100% { filter:brightness(1); }
+}
+
+/* Rail: buio operativo */
+.rail {
+  flex:0 0 154px; align-self:stretch; min-height:520px;
+  background:var(--chrome); border:1px solid var(--border-chrome); border-radius:var(--r-panel);
+  padding:14px 12px; display:flex; flex-direction:column; gap:14px;
+}
+.rail .mark { font-size:14px; font-weight:700; letter-spacing:0.02em; padding:2px 4px; }
+.rail .mark span { color:var(--minerale); }
+.rail .cap { font-size:10px; font-weight:650; letter-spacing:0.07em; text-transform:uppercase; color:var(--ink-muted); padding:0 4px; }
+.roomswitch { display:flex; flex-direction:column; gap:6px; }
+.roomswitch button {
+  position:relative; overflow:hidden; text-align:left; border:1px solid var(--border-chrome);
+  background:var(--canvas); color:var(--ink-muted); font:inherit; font-size:12.5px; font-weight:600;
+  padding:9px 11px; border-radius:var(--r-control); cursor:pointer;
+  transition:transform 150ms cubic-bezier(0.2,0,0,1), background 160ms ease-out, color 160ms ease-out, box-shadow 160ms ease-out;
+}
+.roomswitch button small { display:block; font-weight:450; font-size:10.5px; color:var(--ink-muted); margin-top:1px; }
+.roomswitch button:hover { transform:translateY(-1px); }
+.roomswitch button:active { transform:scale(0.97); }
+.roomswitch button:focus-visible { outline:none; box-shadow:var(--focus-ring); }
+/* La stanza scelta sale nella luce: superficie, non stanghetta. */
+.roomswitch button[aria-pressed="true"] { background:linear-gradient(var(--warm),var(--warm)),var(--focal); color:var(--ink); box-shadow:var(--shadow-focal); }
+.rail .foot { margin-top:auto; font-size:10px; color:var(--ink-muted); padding:0 4px; line-height:1.4; }
+
+/* Pannelli di contenuto */
+.pan {
+  position:relative; background:var(--field); border:1px solid var(--border); border-radius:var(--r-panel);
+  padding:16px; min-height:520px;
+  transition:background 180ms ease-out, box-shadow 180ms ease-out;
+}
+.pan:focus-visible { outline:none; box-shadow:var(--focus-ring); }
+.worklist { flex:0 0 286px; }
+.quadro { flex:1 1 440px; min-width:340px; }
+.attn { flex:0 0 322px; }
+@media (max-width:1180px){ .attn { flex:1 1 100%; min-height:auto; } }
+@media (max-width:900px){ .worklist { flex:1 1 100%; } .rail { flex:1 1 100%; flex-direction:row; align-items:center; min-height:auto; flex-wrap:wrap; } .rail .foot { display:none; } .roomswitch { flex-direction:row; } }
+
+/* Il fuoco: solo luce (luminanza+temperatura appena piu alte, ombra breve).
+   Mai una linea, mai una stanghetta sul bordo. */
+.pan[data-fuoco="true"] { background:linear-gradient(var(--warm),var(--warm)),var(--focal); box-shadow:var(--shadow-focal); }
+
+.pan-h { display:flex; align-items:baseline; justify-content:space-between; gap:10px; margin-bottom:4px; }
+.pan-h h2 { font-size:15px; font-weight:650; letter-spacing:-0.01em; }
+.pan-h .sub { font-size:11px; color:var(--ink-muted); }
+
+/* La pulsazione di conferma: transiente, poi si spegne.
+   L accento lampeggia per dare sicurezza, non resta come peso. */
+@keyframes assicura {
+  0% { box-shadow:var(--shadow-focal), 0 0 0 0 var(--minerale-tint); }
+  35% { box-shadow:var(--shadow-lift), 0 0 0 6px var(--minerale-tint); }
+  100% { box-shadow:var(--shadow-focal), 0 0 0 0 rgba(0,0,0,0); }
+}
+.pan.assicura { animation:assicura 320ms ease-out; }
+.row.assicura { animation:assicura 300ms ease-out; }
+
+@keyframes montare { from { opacity:0; } to { opacity:1; } }
+.montare { animation:montare 200ms ease-out; }
+
+/* ---------- Worklist (penombra) ---------- */
+.wl { margin-top:8px; display:flex; flex-direction:column; gap:2px; }
+.row { position:relative; overflow:hidden; display:flex; align-items:center; gap:9px; min-height:46px; padding:6px 10px;
+  border-radius:var(--r-control); cursor:pointer; background:transparent;
+  transition:background 150ms ease-out, box-shadow 150ms ease-out, transform 150ms cubic-bezier(0.2,0,0,1); }
+.row:hover { background:rgba(120,132,144,0.08); }
+.row:active { transform:scale(0.985); }
+.row:focus-visible { outline:none; box-shadow:var(--focus-ring); }
+.row .glyph { width:8px; height:8px; border-radius:50%; flex:none; }
+.row .who { flex:1; min-width:0; }
+.row .who b { display:block; font-weight:600; font-size:13.5px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.row .who span { font-size:11px; color:var(--ink-muted); }
+/* La riga scelta sale nella luce: fill focal + ombra breve, niente barra. */
+.row[aria-selected="true"] { background:linear-gradient(var(--warm),var(--warm)),var(--focal); box-shadow:var(--shadow-focal); }
+.chip { display:inline-flex; align-items:center; gap:5px; font-size:10px; font-weight:600; letter-spacing:0.02em; padding:2px 8px; border-radius:999px; flex:none; }
+.chip.critical { color:var(--critical); background:var(--critical-tint); }
+.chip.warning { color:var(--warning); background:var(--warning-tint); }
+.empty { padding:12px 6px; font-size:12px; color:var(--ink-muted); }
+
+/* ---------- Quadro (fuoco) ---------- */
+.sez { margin-top:20px; }
+.sez h3 { font-size:10.5px; font-weight:650; letter-spacing:0.07em; text-transform:uppercase; color:var(--ink-muted); margin-bottom:8px; }
+.dx { font-size:11px; color:var(--ink-muted); }
+
+/* Un valore, con la sua fonte. Provenienza a richiesta: il filo si disegna. */
+.lab { display:grid; grid-template-columns:1fr auto auto; gap:2px 14px; align-items:center; padding:9px 2px; }
+.lab .nome-t { font-size:13.5px; font-weight:550; }
+.lab .fonte { font-size:10.5px; color:var(--ink-muted); }
+.lab .valore { text-align:right; font-size:15px; font-weight:650; white-space:nowrap; }
+.lab .valore small { font-weight:400; color:var(--ink-muted); font-size:11px; }
+.lab .delta { font-size:11px; text-align:right; min-width:58px; }
+.lab .delta.warning { color:var(--warning); }
+.lab .delta.critical { color:var(--critical); }
+.lab .delta.success { color:var(--success); }
+/* Il connettore di provenienza: geometria SVG continua che si disegna al
+   passaggio. Il filo qui ha diritto di esistere perche connette davvero. */
+.prov { grid-column:1 / -1; height:0; overflow:hidden; transition:height 220ms ease-out; }
+.lab:hover .prov, .lab:focus-within .prov { height:26px; }
+.prov .wrap { display:flex; align-items:center; gap:8px; padding-top:5px; }
+.prov svg { flex:none; display:block; width:46px; height:8px; }
+.prov svg path { fill:none; stroke:var(--minerale); stroke-width:1.2; stroke-linecap:round; opacity:0.7;
+  stroke-dasharray:1; stroke-dashoffset:1; transition:stroke-dashoffset 300ms ease-out; }
+.lab:hover .prov svg path, .lab:focus-within .prov svg path { stroke-dashoffset:0; }
+.prov .txt { font-size:10.5px; color:var(--ink-muted); }
+
+/* ---------- Diario: la spina e il filo, reso SVG che si disegna ---------- */
+.diario { position:relative; margin-top:6px; padding-left:26px; }
+.diario .spine { position:absolute; left:0; top:0; overflow:visible; pointer-events:none; }
+.diario .spine .thread { fill:none; stroke:var(--minerale); stroke-width:1.4; opacity:0.55;
+  stroke-dasharray:1; stroke-dashoffset:1; transition:stroke-dashoffset 520ms ease-out; }
+.diario.drawn .spine .thread { stroke-dashoffset:0; }
+.diario .spine .node { transition:opacity 260ms ease-out; opacity:0; stroke-width:1.5; }
+.diario.drawn .spine .node { opacity:1; }
+/* Il nodo e filo, non inchiostro: connette e basta, mai porta lo stato.
+   Tono neutro del filo (minerale), identico per bozza e firmata. Lo stato
+   lo dice l inchiostro del testo, non il nodo sulla spina. */
+.node.bozza, .node.firmata { stroke:var(--minerale); fill:var(--minerale); }
+
+.entry { position:relative; padding:8px 0 16px; }
+.entry .meta { display:flex; align-items:center; gap:8px; flex-wrap:wrap; }
+.entry .quando { font-size:10.5px; color:var(--ink-muted); }
+/* Lo stato e inchiostro, mai colore clinico: la micro-etichetta e in tono
+   inchiostro tenue; con la firma asciuga verso l inchiostro pieno insieme al
+   testo. Il colore resta riservato alla semantica clinica (valore, delta). */
+.entry .stato { font-size:10.5px; font-weight:650; color:var(--ink-muted); transition:color 380ms ease-out; }
+.entry.firmata .stato { color:var(--ink); }
+/* Lo stato e inchiostro: la bozza e a contrasto piu basso con etichetta onesta;
+   la firma asciuga l inchiostro (il testo torna pieno). Mai tratteggio,
+   mai la firma via opacita. */
+.entry .body { font-size:13px; margin-top:3px; transition:color 380ms ease-out; }
+.entry.bozza .body { color:var(--ink-muted); }
+.entry.firmata .body { color:var(--ink); }
+/* Il tick di firma: si disegna in tono success (draw-on), non appare di colpo. */
+.tick { width:22px; height:12px; margin-left:2px; overflow:visible; vertical-align:middle; }
+.tick path { fill:none; stroke:var(--success); stroke-width:2; stroke-linecap:round; stroke-linejoin:round;
+  stroke-dasharray:1; stroke-dashoffset:1; transition:stroke-dashoffset 380ms ease-out; }
+.entry.firmata .tick path { stroke-dashoffset:0; }
+.entry .azioni { margin-top:10px; display:flex; gap:8px; align-items:center; }
+
+/* ---------- Coda dell attenzione (penombra, proattiva per euristica) ---------- */
+.queue-note { font-size:11.5px; color:var(--ink-muted); margin:8px 2px 10px; }
+.at { display:flex; flex-direction:column; gap:9px; }
+.aitem { position:relative; border:1px solid var(--border); border-radius:var(--r-card); padding:11px 12px; background:var(--canvas);
+  transition:box-shadow 160ms ease-out, transform 160ms ease-out, opacity 200ms ease-out; }
+.aitem:hover { transform:translateY(-1px); box-shadow:var(--shadow-focal); }
+.aitem .t { font-size:13px; font-weight:650; }
+.aitem .why { font-size:11.5px; color:var(--ink-muted); margin-top:3px; }
+.aitem .meta2 { display:flex; align-items:center; justify-content:space-between; gap:8px; margin-top:9px; }
+.aitem .chi { font-size:10.5px; color:var(--ink-muted); }
+/* Le etichette di stato di workflow (da firmare, scadenza, tendenza, in carico)
+   restano in tono inchiostro neutro: il colore clinico non marca il workflow,
+   cosi il canale d allarme non si diluisce. Solo il rilievo clinico vero
+   (flag.critical) porta il colore. */
+.aitem .flag { font-size:10px; font-weight:650; letter-spacing:0.02em; padding:2px 8px; border-radius:999px; color:var(--ink-muted); background:rgba(120,132,144,0.12); }
+.aitem .flag.critical { color:var(--critical); background:var(--critical-tint); }
+/* Una voce gia valutata non torna uguale: passa in carico, inchiostro piu tenue,
+   e non ripropone la stessa azione. */
+.aitem.vista { background:transparent; }
+.aitem.vista .t, .aitem.vista .why { color:var(--ink-muted); }
+
+/* ---------- Bottoni vivi ---------- */
+.btn { position:relative; overflow:hidden; border:0; cursor:pointer; font:inherit; font-weight:600; font-size:12.5px;
+  color:var(--focal); background:var(--minerale); padding:8px 15px; border-radius:var(--r-control);
+  transition:transform 150ms cubic-bezier(0.2,0,0,1), filter 150ms ease-out; }
+.btn:hover { filter:brightness(1.06); }
+.btn:active { transform:scale(0.97); }
+.btn:focus-visible { outline:none; box-shadow:var(--focus-ring); }
+.btn-quiet { position:relative; overflow:hidden; border:1px solid var(--border); background:transparent; color:var(--ink); font:inherit; font-size:12px;
+  font-weight:550; cursor:pointer; padding:7px 13px; border-radius:999px;
+  transition:transform 150ms cubic-bezier(0.2,0,0,1), background 150ms ease-out; }
+.btn-quiet:hover { background:var(--canvas); }
+.btn-quiet:active { transform:scale(0.97); }
+.btn-quiet:focus-visible { outline:none; box-shadow:var(--focus-ring); }
+.btn-go { position:relative; overflow:hidden; border:1px solid var(--border); background:transparent; color:var(--minerale); font:inherit; font-size:12px; font-weight:650;
+  cursor:pointer; padding:6px 13px; border-radius:999px;
+  transition:transform 150ms cubic-bezier(0.2,0,0,1), background 150ms ease-out; }
+.btn-go:hover { background:var(--minerale-tint); }
+.btn-go:active { transform:scale(0.97); }
+.btn-go:focus-visible { outline:none; box-shadow:var(--focus-ring); }
+
+/* Il tocco lascia un anello che si spegne, dal punto dell azione. */
+.ripple { position:absolute; border-radius:50%; transform:translate(-50%,-50%) scale(0); pointer-events:none; background:rgba(255,255,255,0.5); }
+.ripple.soft { background:var(--minerale); opacity:0.20; }
+@keyframes onda { to { transform:translate(-50%,-50%) scale(1); opacity:0; } }
+.ripple.go { animation:onda 460ms ease-out forwards; }
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { transition:none !important; animation:none !important; }
+  .diario .spine .thread { stroke-dashoffset:0 !important; }
+  .diario .spine .node { opacity:1 !important; }
+  .entry.firmata .tick path { stroke-dashoffset:0 !important; }
+  .lab:hover .prov svg path, .lab:focus-within .prov svg path { stroke-dashoffset:0 !important; }
+}
+</style>
+</head>
+<body class="giorno">
+
+<div class="bar">
+  <h1>Lume, cockpit vivo</h1>
+  <div class="grp">
+    <span class="seg-label">Registro di luce</span>
+    <div class="seg" role="group" aria-label="Registro di luce">
+      <button data-reg="giorno" aria-pressed="true">Giorno</button>
+      <button data-reg="grafite" aria-pressed="false">Grafite</button>
+      <button data-reg="guardia" aria-pressed="false">Guardia</button>
+    </div>
+  </div>
+  <p class="nota">I registri di luce sono un controllo di questa demo. Nel prodotto seguono il sistema (ADR 0047). Dati dimostrativi.</p>
+</div>
+
+<div class="testata" role="banner" aria-live="off">
+  <span class="nome" id="t-nome">Bianchi Aurora (demo)</span>
+  <span class="dato reg" id="t-anno">1954</span>
+  <span class="dato">dati dimostrativi</span>
+  <span class="allergia" id="t-allergia">Allergia: penicillina</span>
+  <span class="dato">Terapie attive: <span class="reg" id="t-terapie">3</span></span>
+</div>
+
+<div class="cockpit" id="cockpit">
+
+  <nav class="rail" aria-label="Ambulatorio">
+    <div class="mark">Lu<span>me</span></div>
+    <div class="cap">Ambulatorio</div>
+    <div class="roomswitch" id="roomswitch" role="group" aria-label="Cambio ambulatorio">
+      <button data-room="A" aria-pressed="true">Cardiologia (demo)<small>Oggi in sede</small></button>
+      <button data-room="B" aria-pressed="false">Diabetologia (demo)<small>Oggi in sede</small></button>
+    </div>
+    <div class="foot">Cambia stanza: la luce del telaio si ricalibra e la worklist si rimonta. La testata resta ferma.</div>
+  </nav>
+
+  <section class="pan worklist" data-panel="worklist" data-fuoco="false" tabindex="0" aria-label="Lista di lavoro">
+    <div class="pan-h">
+      <h2 id="wl-titolo">Cardiologia</h2>
+      <span class="sub" id="wl-sub">Oggi, 4 in lista</span>
+    </div>
+    <div class="wl" id="wl" role="listbox" aria-label="Pazienti in lista" tabindex="-1"></div>
+  </section>
+
+  <section class="pan quadro" data-panel="quadro" data-fuoco="true" tabindex="0" aria-label="Quadro paziente">
+    <div id="qd"></div>
+  </section>
+
+  <aside class="pan attn" data-panel="attn" data-fuoco="false" tabindex="0" aria-label="Coda dell attenzione">
+    <div class="pan-h">
+      <h2>Coda dell attenzione</h2>
+      <span class="sub" id="at-sub"></span>
+    </div>
+    <p class="queue-note">Ogni voce dice perche e li e propone l azione. Le voci gia in carico non tornano uguali.</p>
+    <div class="at" id="at"></div>
+  </aside>
+
+</div>
+
+<script>
+(function(){
+  var RM = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  var SVGNS = 'http://www.w3.org/2000/svg';
+
+  /* ---------- Dati dimostrativi ---------- */
+  var DATA = {
+    A: {
+      titolo:'Cardiologia', label:'Cardiologia (demo)',
+      pazienti:[
+        { id:'bianchi', nome:'Bianchi Aurora (demo)', anno:'1954', motivo:'Controllo pressorio', ora:'09:00',
+          glyph:'critical', chip:{cls:'critical', txt:'PA'}, allergia:'Allergia: penicillina', terapie:'3',
+          dx:'Ipertensione essenziale in follow-up',
+          lab:{ nome:'PA sistolica', valore:'158', unita:'mmHg', delta:'+16', deltaTone:'critical',
+                fonte:'ambulatorio, 09:05', prov:'Misurata in sede con bracciale validato. Terza rilevazione oltre soglia in 7 giorni.' },
+          diario:[
+            { data:'04/07/2026', kind:'firmata', body:'Controllo programmato. Riferisce cefalea mattutina saltuaria. PA domiciliare in salita nell ultima settimana.' },
+            { data:'11/07/2026', kind:'bozza', body:'Proposta di richiamo a 7 giorni con diario pressorio. Valutare aggiustamento della terapia serale.' }
+          ] },
+        { id:'ferri', nome:'Ferri Giacomo (demo)', anno:'1948', motivo:'Rinnovo piano terapeutico', ora:'09:30',
+          glyph:'warning', chip:null, allergia:'', terapie:'5',
+          dx:'Scompenso cardiaco, classe NYHA II',
+          lab:{ nome:'Peso corporeo', valore:'78.4', unita:'kg', delta:'+1.2', deltaTone:'warning',
+                fonte:'domicilio, 08:00', prov:'Bilancia domiciliare, serie di 7 giorni caricata dal paziente.' },
+          diario:[
+            { data:'27/06/2026', kind:'firmata', body:'Compenso stabile. Diuretico invariato. Edemi declivi assenti.' },
+            { data:'12/07/2026', kind:'bozza', body:'Piano terapeutico in scadenza il 19/07. Bozza di rinnovo con rivalutazione del diuretico.' }
+          ] },
+        { id:'conti', nome:'Conti Elena (demo)', anno:'1971', motivo:'Esiti rientrati', ora:'10:00',
+          glyph:'success', chip:null, allergia:'', terapie:'1',
+          dx:'Controllo post-ablazione, ritmo sinusale',
+          lab:{ nome:'FC media', valore:'68', unita:'bpm', delta:'stabile', deltaTone:'success',
+                fonte:'Holter, ieri', prov:'Holter delle 24 ore refertato. Nessuna recidiva registrata.' },
+          diario:[
+            { data:'10/07/2026', kind:'firmata', body:'Holter senza recidive aritmiche. Riferito buon controllo dei sintomi.' }
+          ] },
+        { id:'riva', nome:'Riva Pietro (demo)', anno:'1990', motivo:'Prima visita', ora:'10:30',
+          glyph:'plum', chip:null, allergia:'', terapie:'0',
+          dx:'Prima valutazione, cardiopalmo riferito',
+          lab:{ nome:'PA sistolica', valore:'124', unita:'mmHg', delta:'primo dato', deltaTone:'success',
+                fonte:'ambulatorio, 10:32', prov:'Prima misurazione in sede. Nessun dato storico disponibile.' },
+          diario:[] }
+      ],
+      attn:[
+        { id:'a1', t:'PA sistolica in salita', why:'Terza misurazione oltre soglia in 7 giorni per Bianchi Aurora (158 mmHg).', chi:'tu, entro oggi', flag:{cls:'critical', txt:'clinico'}, patient:'bianchi', azione:'Vai al quadro' },
+        { id:'a2', t:'Voce di diario in bozza', why:'Proposta di richiamo per Bianchi Aurora non ancora firmata dal 11/07.', chi:'tu, da firmare', flag:{cls:'warning', txt:'da firmare'}, patient:'bianchi', azione:'Apri e firma' },
+        { id:'a3', t:'Piano terapeutico in scadenza', why:'Rinnovo entro il 19/07 per Ferri Giacomo.', chi:'tu, entro 19/07', flag:{cls:'minerale', txt:'scadenza'}, patient:'ferri', azione:'Vai al quadro' }
+      ]
+    },
+    B: {
+      titolo:'Diabetologia', label:'Diabetologia (demo)',
+      pazienti:[
+        { id:'greco', nome:'Greco Marta (demo)', anno:'1962', motivo:'Aggiustamento terapia', ora:'11:00',
+          glyph:'critical', chip:{cls:'critical', txt:'HbA1c'}, allergia:'', terapie:'4',
+          dx:'Diabete tipo 2 in scompenso glicemico',
+          lab:{ nome:'HbA1c', valore:'8.9', unita:'%', delta:'+0.7', deltaTone:'critical',
+                fonte:'laboratorio, ieri', prov:'Prelievo venoso refertato. Confronto con controllo di aprile.' },
+          diario:[
+            { data:'05/07/2026', kind:'firmata', body:'Aderenza parziale riferita. Ipoglicemie notturne assenti.' },
+            { data:'13/07/2026', kind:'bozza', body:'Bozza: intensificazione della terapia basale e rinforzo educativo. Ricontrollo a 4 settimane.' }
+          ] },
+        { id:'neri', nome:'Neri Luca (demo)', anno:'1985', motivo:'Educazione terapeutica', ora:'11:30',
+          glyph:'warning', chip:null, allergia:'', terapie:'2',
+          dx:'Diabete tipo 1, conteggio dei carboidrati',
+          lab:{ nome:'Tempo in range', valore:'61', unita:'%', delta:'-6', deltaTone:'warning',
+                fonte:'sensore, 14 giorni', prov:'Scarico del sensore glicemico, finestra di 14 giorni.' },
+          diario:[
+            { data:'12/07/2026', kind:'bozza', body:'Bozza: revisione dei rapporti insulina, carboidrati per il pasto serale.' }
+          ] },
+        { id:'sala', nome:'Sala Ida (demo)', anno:'1957', motivo:'Controllo del piede', ora:'12:00',
+          glyph:'success', chip:null, allergia:'', terapie:'3',
+          dx:'Screening del piede diabetico',
+          lab:{ nome:'Monofilamento', valore:'10/10', unita:'siti', delta:'stabile', deltaTone:'success',
+                fonte:'ambulatorio, 12:04', prov:'Test del monofilamento eseguito in sede. Confronto con il precedente.' },
+          diario:[
+            { data:'09/07/2026', kind:'firmata', body:'Sensibilita conservata. Cute integra. Educazione alla cura del piede rinforzata.' }
+          ] }
+      ],
+      attn:[
+        { id:'b1', t:'HbA1c oltre il target', why:'8.9% contro obiettivo 7.0% per Greco Marta.', chi:'tu, entro oggi', flag:{cls:'critical', txt:'clinico'}, patient:'greco', azione:'Vai al quadro' },
+        { id:'b2', t:'Piano educativo da firmare', why:'Bozza di intensificazione per Greco Marta in attesa di firma.', chi:'tu, da firmare', flag:{cls:'warning', txt:'da firmare'}, patient:'greco', azione:'Apri e firma' },
+        { id:'b3', t:'Tempo in range in calo', why:'Da 67% a 61% in 14 giorni per Neri Luca.', chi:'tu, questa settimana', flag:{cls:'minerale', txt:'tendenza'}, patient:'neri', azione:'Vai al quadro' }
+      ]
+    }
+  };
+
+  /* ---------- Stato ---------- */
+  var state = { room:'A', patientId:'bianchi', evaluated:{} };
+
+  var cockpit = document.getElementById('cockpit');
+  var panels = document.querySelectorAll('.pan[data-panel]');
+  var qdPanel = document.querySelector('.pan[data-panel="quadro"]');
+  var wlEl = document.getElementById('wl');
+  var qdEl = document.getElementById('qd');
+  var atEl = document.getElementById('at');
+
+  function curRoom(){ return DATA[state.room]; }
+  function patientById(id){ return curRoom().pazienti.filter(function(p){ return p.id===id; })[0]; }
+  function esc(s){ return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
+  /* Ogni atomo verificabile va nel Registro (mono, tabular): orari HH:MM e date
+     gg/mm[/aaaa] passano in .reg anche quando cadono dentro la prosa. Va
+     applicata SOLO a testo gia sfuggito con esc(). */
+  function regAtoms(s){
+    return String(s)
+      .replace(/(\d{1,2}:\d{2})/g, '<span class="reg">$1</span>')
+      .replace(/(\d{1,2}\/\d{1,2}(?:\/\d{2,4})?)/g, '<span class="reg">$1</span>');
+  }
+
+  /* ---------- Anello dal punto del tocco ---------- */
+  function onda(btn, e, soft){
+    var r = document.createElement('span');
+    r.className = 'ripple' + (soft ? ' soft' : '');
+    var b = btn.getBoundingClientRect();
+    var d = Math.max(b.width, b.height) * 2;
+    r.style.width = r.style.height = d + 'px';
+    r.style.left = ((e && e.clientX ? e.clientX : b.left + b.width/2) - b.left) + 'px';
+    r.style.top = ((e && e.clientY ? e.clientY : b.top + b.height/2) - b.top) + 'px';
+    btn.appendChild(r);
+    void r.offsetWidth; r.classList.add('go');
+    setTimeout(function(){ if(r.parentNode) r.remove(); }, 500);
+  }
+
+  /* ---------- Il fuoco si sposta con la luce ---------- */
+  function pulse(el){ if(RM) return; el.classList.remove('assicura'); void el.offsetWidth; el.classList.add('assicura'); }
+  function setFuoco(panelEl){
+    panels.forEach(function(p){ p.setAttribute('data-fuoco', String(p===panelEl)); });
+    pulse(panelEl);
+  }
+
+  /* ---------- Testata invariabile ---------- */
+  function updateTestata(p){
+    document.getElementById('t-nome').textContent = p.nome;
+    document.getElementById('t-anno').textContent = p.anno;
+    document.getElementById('t-terapie').textContent = p.terapie;
+    var al = document.getElementById('t-allergia');
+    if(p.allergia){ al.textContent = p.allergia; al.style.display = ''; }
+    else { al.textContent = 'Nessuna allergia nota'; al.style.color = 'var(--ink-muted)'; al.classList.remove('allergia'); al.classList.add('dato'); }
+    if(p.allergia){ al.classList.add('allergia'); al.classList.remove('dato'); al.style.color = ''; }
+  }
+
+  /* ---------- Worklist ---------- */
+  function renderWorklist(fade){
+    var room = curRoom();
+    document.getElementById('wl-titolo').textContent = room.titolo;
+    document.getElementById('wl-sub').textContent = 'Oggi, ' + room.pazienti.length + ' in lista';
+    var html = '';
+    room.pazienti.forEach(function(p){
+      var sel = (p.id===state.patientId);
+      html += '<div class="row" role="option" tabindex="'+(sel?'0':'-1')+'" data-pid="'+p.id+'" aria-selected="'+sel+'">'
+        + '<span class="glyph" style="background:var(--'+p.glyph+')"></span>'
+        + '<span class="who"><b>'+esc(p.nome)+'</b><span>'+esc(p.motivo)+', <span class="reg">'+esc(p.ora)+'</span></span></span>'
+        + (p.chip ? '<span class="chip '+p.chip.cls+'">'+esc(p.chip.txt)+'</span>' : '')
+        + '</div>';
+    });
+    html += '<div class="empty">Fine della lista di oggi.</div>';
+    wlEl.innerHTML = html;
+    if(fade && !RM){ wlEl.classList.remove('montare'); void wlEl.offsetWidth; wlEl.classList.add('montare'); }
+    bindRows();
+  }
+
+  function bindRows(){
+    var rows = wlEl.querySelectorAll('.row');
+    rows.forEach(function(r){
+      r.addEventListener('click', function(e){ e.stopPropagation(); selectRow(r, e); });
+      r.addEventListener('keydown', function(e){
+        if(e.key==='Enter' || e.key===' '){ e.preventDefault(); selectRow(r, e); }
+        else if(e.key==='ArrowDown' || e.key==='ArrowUp'){
+          e.preventDefault();
+          var list = Array.prototype.slice.call(rows);
+          var i = list.indexOf(r);
+          var n = e.key==='ArrowDown' ? Math.min(i+1, list.length-1) : Math.max(i-1, 0);
+          // roving tabindex: un solo tab-stop, il fuoco di tastiera lo porta la riga corrente
+          list.forEach(function(x){ x.setAttribute('tabindex','-1'); });
+          list[n].setAttribute('tabindex','0');
+          list[n].focus();
+        }
+      });
+      r.addEventListener('focus', function(e){ e.stopPropagation(); });
+    });
+  }
+
+  function selectRow(r, e){
+    var pid = r.getAttribute('data-pid');
+    onda(r, e, true);
+    focusPatient(pid, true);
+  }
+
+  /* ---------- Quadro ---------- */
+  function renderQuadro(p, fade){
+    var lab = p.lab;
+    var html = ''
+      + '<div class="pan-h"><h2>Quadro</h2><span class="sub reg">'+esc(p.ora)+'</span></div>'
+      + '<p class="dx">'+esc(p.dx)+'</p>'
+      + '<div class="sez"><h3>Un valore, con la sua fonte</h3>'
+      +   '<div class="lab" tabindex="0">'
+      +     '<div><div class="nome-t">'+esc(lab.nome)+'</div><div class="fonte">'+regAtoms(esc(lab.fonte))+' · apri per la provenienza</div></div>'
+      +     '<div class="valore reg">'+esc(lab.valore)+' <small>'+esc(lab.unita)+'</small></div>'
+      +     '<div class="delta reg '+lab.deltaTone+'">'+esc(lab.delta)+'</div>'
+      +     '<div class="prov"><div class="wrap"><svg viewBox="0 0 46 8" aria-hidden="true"><path d="M1 4 H45" pathLength="1"/></svg><span class="txt">'+esc(lab.prov)+'</span></div></div>'
+      +   '</div>'
+      + '</div>'
+      + '<div class="sez"><h3>Diario</h3>' + renderDiario(p) + '</div>';
+    qdEl.innerHTML = html;
+    if(fade && !RM){ qdEl.classList.remove('montare'); void qdEl.offsetWidth; qdEl.classList.add('montare'); }
+    bindDiario(p);
+    buildSpine(qdEl.querySelector('.diario'));
+  }
+
+  function renderDiario(p){
+    if(!p.diario.length){
+      return '<div class="empty">Nessuna voce nel diario. La prima visita non ha ancora prodotto note.</div>';
+    }
+    var out = '<div class="diario">';
+    p.diario.forEach(function(en, i){
+      var isBozza = en.kind==='bozza';
+      out += '<div class="entry '+en.kind+'" data-idx="'+i+'">'
+        + '<div class="meta"><span class="quando reg">'+esc(en.data)+'</span>'
+        + '<span class="stato">'+(isBozza ? 'bozza, da rivedere' : 'firmata')+'</span>'
+        + '<svg class="tick" viewBox="0 0 22 12" aria-hidden="true"><path d="M1 6 L8 11 L21 1" pathLength="1"/></svg></div>'
+        + '<div class="body">'+regAtoms(esc(en.body))+'</div>'
+        + (isBozza
+            ? '<div class="azioni"><button class="btn" data-firma="'+i+'">Firma la voce</button><button class="btn-quiet" data-reset="'+i+'">Riporta a bozza</button></div>'
+            : '')
+        + '</div>';
+    });
+    out += '</div>';
+    return out;
+  }
+
+  /* La firma: l inchiostro asciuga, il tick si disegna, l anello dal tocco. */
+  function bindDiario(p){
+    qdEl.querySelectorAll('[data-firma]').forEach(function(btn){
+      btn.addEventListener('click', function(e){
+        var i = +btn.getAttribute('data-firma');
+        var entry = btn.closest('.entry');
+        onda(btn, e, false);
+        p.diario[i].kind = 'firmata';
+        entry.classList.remove('bozza'); entry.classList.add('firmata');
+        entry.querySelector('.stato').textContent = 'firmata';
+        entry.querySelector('.azioni').innerHTML = '<button class="btn-quiet" data-reset="'+i+'">Riporta a bozza</button>';
+        var node = entry._node;
+        if(node){ node.setAttribute('class','node firmata'); }
+        rebindReset(p, entry);
+        pulse(qdPanel);
+      });
+    });
+    qdEl.querySelectorAll('[data-reset]').forEach(function(btn){ attachReset(p, btn); });
+  }
+  function attachReset(p, btn){
+    btn.addEventListener('click', function(e){
+      var i = +btn.getAttribute('data-reset');
+      var entry = btn.closest('.entry');
+      onda(btn, e, true);
+      p.diario[i].kind = 'bozza';
+      entry.classList.remove('firmata'); entry.classList.add('bozza');
+      entry.querySelector('.stato').textContent = 'bozza, da rivedere';
+      entry.querySelector('.azioni').innerHTML = '<button class="btn" data-firma="'+i+'">Firma la voce</button><button class="btn-quiet" data-reset="'+i+'">Riporta a bozza</button>';
+      var node = entry._node;
+      if(node){ node.setAttribute('class','node bozza'); }
+      bindDiario(p);
+    });
+  }
+  function rebindReset(p, entry){
+    var btn = entry.querySelector('[data-reset]');
+    if(btn) attachReset(p, btn);
+  }
+
+  /* ---------- Il filo: spina del diario resa SVG che si disegna ---------- */
+  function buildSpine(diario){
+    if(!diario) return;
+    var old = diario.querySelector('.spine'); if(old) old.remove();
+    var entries = diario.querySelectorAll('.entry');
+    if(entries.length < 1) return;
+    var x = 9;
+    var ys = [];
+    entries.forEach(function(en){ ys.push(en.offsetTop + 16); });
+    var top = ys[0], bottom = ys[ys.length-1];
+    var svg = document.createElementNS(SVGNS, 'svg');
+    svg.setAttribute('class', 'spine');
+    svg.setAttribute('width', '20');
+    svg.setAttribute('height', String(diario.scrollHeight));
+    if(ys.length > 1){
+      var path = document.createElementNS(SVGNS, 'path');
+      path.setAttribute('class', 'thread');
+      path.setAttribute('d', 'M ' + x + ' ' + top + ' L ' + x + ' ' + bottom);
+      path.setAttribute('pathLength', '1');
+      svg.appendChild(path);
+    }
+    entries.forEach(function(en, i){
+      var c = document.createElementNS(SVGNS, 'circle');
+      c.setAttribute('cx', String(x));
+      c.setAttribute('cy', String(ys[i]));
+      c.setAttribute('r', '4.5');
+      c.setAttribute('class', 'node ' + (en.classList.contains('firmata') ? 'firmata' : 'bozza'));
+      svg.appendChild(c);
+      en._node = c;
+    });
+    diario.insertBefore(svg, diario.firstChild);
+    if(RM){ diario.classList.add('drawn'); return; }
+    diario.classList.remove('drawn');
+    requestAnimationFrame(function(){ requestAnimationFrame(function(){ diario.classList.add('drawn'); }); });
+  }
+
+  /* ---------- Coda dell attenzione ---------- */
+  function renderAttn(){
+    var room = curRoom();
+    var items = room.attn.slice();
+    items.sort(function(a,b){ return (state.evaluated[a.id]?1:0) - (state.evaluated[b.id]?1:0); });
+    var pending = items.filter(function(it){ return !state.evaluated[it.id]; }).length;
+    document.getElementById('at-sub').textContent = pending + (pending===1 ? ' voce' : ' voci');
+    var html = '';
+    if(pending===0){
+      html += '<div class="empty">Tutte le voci sono in carico. Niente altro in attesa adesso.</div>';
+    }
+    items.forEach(function(it){
+      var done = !!state.evaluated[it.id];
+      html += '<div class="aitem'+(done?' vista':'')+'" data-aid="'+it.id+'">'
+        + '<div class="t">'+esc(it.t)+'</div>'
+        + '<div class="why">'+esc(it.why)+'</div>'
+        + '<div class="meta2">'
+        +   '<span class="chi">'+esc(it.chi)+'</span>'
+        +   (done ? '<span class="flag done">in carico</span>' : '<span class="flag '+it.flag.cls+'">'+esc(it.flag.txt)+'</span>')
+        + '</div>'
+        + '<div class="meta2">'
+        +   (done
+              ? '<button class="btn-quiet" data-riapri="'+it.id+'">Riapri la voce</button>'
+              : '<button class="btn-go" data-vai="'+it.id+'">'+esc(it.azione)+'</button>')
+        +   '<span></span>'
+        + '</div>'
+        + '</div>';
+    });
+    atEl.innerHTML = html;
+    bindAttn();
+  }
+  function bindAttn(){
+    atEl.querySelectorAll('[data-vai]').forEach(function(btn){
+      btn.addEventListener('click', function(e){
+        var id = btn.getAttribute('data-vai');
+        var it = curRoom().attn.filter(function(x){ return x.id===id; })[0];
+        onda(btn, e, true);
+        focusPatient(it.patient, true);
+        state.evaluated[id] = true;
+        renderAttn();
+      });
+    });
+    atEl.querySelectorAll('[data-riapri]').forEach(function(btn){
+      btn.addEventListener('click', function(e){
+        var id = btn.getAttribute('data-riapri');
+        onda(btn, e, true);
+        delete state.evaluated[id];
+        renderAttn();
+      });
+    });
+  }
+
+  /* ---------- Il fuoco atterra sul quadro che e cambiato ---------- */
+  function focusPatient(pid, land){
+    state.patientId = pid;
+    var p = patientById(pid);
+    updateTestata(p);
+    // aggiorna la selezione nella worklist senza rimontarla tutta
+    wlEl.querySelectorAll('.row').forEach(function(r){
+      var on = r.getAttribute('data-pid')===pid;
+      r.setAttribute('aria-selected', String(on));
+      r.setAttribute('tabindex', on ? '0' : '-1');
+    });
+    renderQuadro(p, true);
+    if(land){ setFuoco(qdPanel); }
+  }
+
+  /* ---------- Cambio ambulatorio: il telaio si ricalibra, il contesto si rimonta ---------- */
+  function switchRoom(room){
+    if(state.room===room) return;
+    state.room = room;
+    state.patientId = curRoom().pazienti[0].id;
+    document.querySelectorAll('[data-room]').forEach(function(b){ b.setAttribute('aria-pressed', String(b.getAttribute('data-room')===room)); });
+    if(!RM){ cockpit.classList.remove('ricalibra'); void cockpit.offsetWidth; cockpit.classList.add('ricalibra'); }
+    renderWorklist(true);
+    renderAttn();
+    var p = patientById(state.patientId);
+    updateTestata(p);
+    renderQuadro(p, true);
+    setFuoco(qdPanel);
+  }
+
+  /* ---------- Controlli globali ---------- */
+  document.querySelectorAll('[data-reg]').forEach(function(b){
+    b.addEventListener('click', function(){
+      var keep = ['giorno','grafite','guardia'];
+      keep.forEach(function(k){ document.body.classList.remove(k); });
+      document.body.classList.add(b.dataset.reg);
+      document.querySelectorAll('[data-reg]').forEach(function(x){ x.setAttribute('aria-pressed', String(x===b)); });
+    });
+  });
+  document.querySelectorAll('[data-room]').forEach(function(b){
+    b.addEventListener('click', function(e){ onda(b, e, false); switchRoom(b.getAttribute('data-room')); });
+  });
+
+  // Fuoco sui pannelli: click o focus da tastiera sul telaio del pannello.
+  panels.forEach(function(pn){
+    pn.addEventListener('click', function(){ setFuoco(pn); });
+    pn.addEventListener('focusin', function(e){ if(e.target===pn) setFuoco(pn); });
+  });
+
+  /* ---------- Avvio ---------- */
+  renderWorklist(false);
+  renderAttn();
+  var p0 = patientById(state.patientId);
+  updateTestata(p0);
+  renderQuadro(p0, false);
+})();
+</script>
+</body>
+</html>

--- a/docs/design/lume/mockups/lume-dinamica.html
+++ b/docs/design/lume/mockups/lume-dinamica.html
@@ -1,0 +1,395 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Lume: studio di dinamica (luce e inchiostro contro il filo lineare)</title>
+<style>
+/* ============================================================
+   Lume: studio di dinamica.
+   Confronto diretto fra due rese dello stesso stato:
+   v1 "Filo lineare"  = la stanghetta sul bordo (piena/tratteggiata)
+   v2 "Luce e inchiostro" = fuoco reso con la luce, stato reso con
+      il tono dell inchiostro; la vitalita nasce dal gesto, non da
+      animazioni in loop.
+   File autonomo, nessuna dipendenza, nessun font remoto.
+   Dati esclusivamente dimostrativi.
+   ============================================================ */
+
+:root {
+  --canvas:#eef0f2; --field:#f5f5f4; --focal:#fbfaf7; --chrome:#e6e8eb;
+  --ink:#1a1c1e; --ink-muted:#5c6772; --minerale:#33506b;
+  --warning:#9a6a2f; --critical:#a33a2f; --success:#4b6354; --plum:#555161;
+  --warning-tint:rgba(154,106,47,0.10); --critical-tint:rgba(163,58,47,0.10); --success-tint:rgba(75,99,84,0.12);
+  --minerale-tint:rgba(51,80,107,0.10);
+  --border:rgba(26,28,30,0.10); --border-chrome:rgba(26,28,30,0.06);
+  --shadow-focal:0 2px 8px rgba(26,28,30,0.10); --shadow-lift:0 6px 20px rgba(26,28,30,0.12);
+  --band-lab:rgba(51,80,107,0.10); --band-personale:rgba(154,106,47,0.14);
+  --r-panel:20px; --r-card:14px; --r-control:10px;
+  --voce:-apple-system,BlinkMacSystemFont,"SF Pro Text","Segoe UI","Inter",sans-serif;
+  --registro:ui-monospace,"SF Mono","IBM Plex Mono","Cascadia Mono",Menlo,monospace;
+  --focus-ring:0 0 0 2px var(--canvas),0 0 0 4px var(--minerale);
+  /* la temperatura del fuoco: appena piu calda della penombra */
+  --warm:rgba(154,106,47,0.05);
+}
+.grafite {
+  --canvas:#121417; --field:#191c21; --focal:#22252b; --chrome:#0e1013;
+  --ink:#e9ecef; --ink-muted:#8f9aa6; --minerale:#8fb0cc;
+  --warning:#c89c5a; --critical:#d67668; --success:#7e9e8a; --plum:#9691a5;
+  --warning-tint:rgba(200,156,90,0.14); --critical-tint:rgba(214,118,104,0.14); --success-tint:rgba(126,158,138,0.16);
+  --minerale-tint:rgba(143,176,204,0.14);
+  --border:rgba(233,236,239,0.10); --border-chrome:rgba(233,236,239,0.05);
+  --shadow-focal:0 2px 10px rgba(0,0,0,0.5); --shadow-lift:0 8px 26px rgba(0,0,0,0.6);
+  --band-lab:rgba(143,176,204,0.12); --band-personale:rgba(200,156,90,0.16);
+  --warm:rgba(200,156,90,0.06);
+}
+.guardia {
+  --canvas:#0c0e12; --field:#14171d; --focal:#1a1e26; --chrome:#090b0e;
+  --ink:#e3e8ee; --ink-muted:#8792a3; --minerale:#7fa0bc;
+  --warning:#cfa35f; --critical:#d98a7d; --success:#85a291; --plum:#9691a5;
+  --warning-tint:rgba(207,163,95,0.14); --critical-tint:rgba(217,138,125,0.14); --success-tint:rgba(133,162,145,0.16);
+  --minerale-tint:rgba(127,160,188,0.14);
+  --border:rgba(227,232,238,0.09); --border-chrome:rgba(227,232,238,0.04);
+  --shadow-focal:0 2px 10px rgba(0,0,0,0.6); --shadow-lift:0 8px 26px rgba(0,0,0,0.7);
+  --band-lab:rgba(127,160,188,0.12); --band-personale:rgba(207,163,95,0.16);
+  --warm:rgba(207,163,95,0.06);
+}
+
+* { margin:0; padding:0; box-sizing:border-box; }
+body {
+  font-family:var(--voce); background:var(--canvas); color:var(--ink);
+  font-size:14px; line-height:1.5; min-height:100vh;
+  transition:background 200ms ease-out, color 200ms ease-out;
+}
+.reg { font-family:var(--registro); font-variant-numeric:tabular-nums; font-size:0.95em; }
+
+/* ---------- Barra di controllo dello studio (buio operativo) ---------- */
+.bar {
+  position:sticky; top:0; z-index:50; display:flex; align-items:center; gap:16px; flex-wrap:wrap;
+  padding:12px 22px; background:var(--chrome); border-bottom:1px solid var(--border-chrome);
+}
+.bar h1 { font-size:14px; font-weight:600; letter-spacing:-0.01em; }
+.bar .hint { font-size:11px; color:var(--ink-muted); max-width:52ch; }
+.seg { display:flex; gap:3px; background:var(--canvas); border-radius:999px; padding:3px; }
+.seg button {
+  border:0; background:transparent; color:var(--ink-muted); font:inherit; font-size:12px; font-weight:500;
+  padding:5px 14px; border-radius:999px; cursor:pointer; transition:color 150ms ease-out;
+}
+.seg button:focus-visible { outline:none; box-shadow:var(--focus-ring); }
+.seg button[aria-pressed="true"] { background:var(--focal); color:var(--ink); box-shadow:0 1px 2px rgba(0,0,0,0.10); }
+.seg-label { font-size:10.5px; font-weight:650; letter-spacing:0.06em; text-transform:uppercase; color:var(--ink-muted); }
+
+/* ---------- Testata invariabile ---------- */
+.testata {
+  max-width:1120px; margin:20px auto 0; padding:12px 18px; display:flex; align-items:baseline; gap:14px; flex-wrap:wrap;
+  background:var(--field); border:1px solid var(--border); border-radius:var(--r-card);
+}
+.testata .nome { font-size:17px; font-weight:650; letter-spacing:-0.01em; }
+.testata .dato { font-size:12px; color:var(--ink-muted); }
+.testata .allergia { font-size:12px; font-weight:600; color:var(--critical); }
+
+/* ---------- Palco ---------- */
+.stage { max-width:1120px; margin:14px auto 48px; }
+.viewnote { font-size:12px; color:var(--ink-muted); margin:0 2px 14px; max-width:82ch; }
+.cols { display:grid; grid-template-columns:300px 1fr; gap:14px; align-items:start; }
+@media (max-width:820px){ .cols { grid-template-columns:1fr; } }
+
+/* ---------- Pannelli ---------- */
+.panel { position:relative; background:var(--field); border:1px solid var(--border);
+  border-radius:var(--r-panel); padding:16px; min-height:420px;
+  transition:background 180ms ease-out, box-shadow 180ms ease-out; }
+.panel h2 { font-size:15px; font-weight:650; letter-spacing:-0.01em; }
+.panel .sub { font-size:11px; color:var(--ink-muted); margin-bottom:12px; }
+.sez { margin-top:18px; }
+.sez h3 { font-size:10.5px; font-weight:650; letter-spacing:0.07em; text-transform:uppercase; color:var(--ink-muted); margin-bottom:8px; }
+
+/* Il fuoco: nella modalita LUCE e solo luce (superficie + calore + ombra).
+   nella modalita FILO torna la stanghetta a sinistra. */
+.mode-luce .panel[data-fuoco="true"] {
+  background:linear-gradient(var(--warm), var(--warm)), var(--focal);
+  box-shadow:var(--shadow-focal);
+}
+.mode-filo .panel[data-fuoco="true"] { background:var(--focal); box-shadow:var(--shadow-focal); }
+.mode-filo .panel[data-fuoco="true"]::after {
+  content:""; position:absolute; left:-1px; top:14%; bottom:14%; width:2px; border-radius:2px; background:var(--minerale);
+}
+
+/* La pulsazione di conferma: transiente, poi si spegne (Rauno: l accento
+   lampeggia per dare conferma, non resta come peso). Solo nella modalita LUCE. */
+@keyframes assicura {
+  0% { box-shadow:var(--shadow-focal), 0 0 0 0 var(--minerale-tint); }
+  35% { box-shadow:var(--shadow-lift), 0 0 0 6px var(--minerale-tint); }
+  100% { box-shadow:var(--shadow-focal), 0 0 0 0 rgba(0,0,0,0); }
+}
+.mode-luce .panel.assicura { animation:assicura 320ms ease-out; }
+
+/* ---------- Worklist ---------- */
+.row { position:relative; display:flex; align-items:center; gap:9px; height:44px; padding:0 10px;
+  border-radius:var(--r-control); cursor:pointer; transition:background 150ms ease-out; }
+.row:hover { background:rgba(120,132,144,0.08); }
+.row:focus-visible { outline:none; box-shadow:var(--focus-ring); }
+.row .who { flex:1; min-width:0; }
+.row .who b { display:block; font-weight:600; font-size:13.5px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.row .who span { font-size:11px; color:var(--ink-muted); }
+.glyph { width:7px; height:7px; border-radius:50%; flex:none; }
+
+/* LUCE: la riga selezionata sale nella luce (fill focal + ombra breve), niente barra.
+   FILO: la barra a sinistra. */
+.mode-luce .row[aria-selected="true"] { background:var(--focal); box-shadow:var(--shadow-focal); }
+.mode-luce .row.assicura { animation:assicura 300ms ease-out; }
+.mode-filo .row[aria-selected="true"] { background:var(--focal); }
+.mode-filo .row[aria-selected="true"]::before {
+  content:""; position:absolute; left:-2px; top:20%; bottom:20%; width:2px; border-radius:2px; background:var(--minerale);
+}
+
+/* ---------- Diario: lo stato epistemico ---------- */
+.filo-tl { position:relative; margin:4px 0 0 7px; padding-left:20px; }
+/* Il filo come CONNETTORE vero: continuo, mai tratteggiato, in entrambe le modalita.
+   Qui il filo e legittimo perche lega davvero le voci nel tempo. */
+.filo-tl::before { content:""; position:absolute; left:0; top:8px; bottom:8px; width:1px; background:var(--minerale); opacity:0.55; }
+.entry { position:relative; padding:8px 0 14px; }
+.entry::before { content:""; position:absolute; left:-24px; top:12px; width:8px; height:8px; border-radius:50%;
+  background:var(--field); border:1.5px solid var(--minerale); transition:border-color 300ms ease-out, background 300ms ease-out; }
+.entry .quando { font-size:10.5px; color:var(--ink-muted); }
+.entry .stato { font-size:10.5px; margin-left:8px; font-weight:600; }
+.entry .body { font-size:13px; margin-top:2px; transition:color 380ms ease-out; }
+.entry .azioni { margin-top:8px; display:flex; gap:8px; align-items:center; }
+
+/* --- Stato BOZZA --- */
+/* LUCE: inchiostro non ancora asciutto = contrasto piu basso + etichetta onesta.
+   nessun tratteggio, nessun loop. la vita e nel gesto della firma. */
+.mode-luce .entry.bozza .body { color:var(--ink-muted); }
+.mode-luce .entry.bozza .stato { color:var(--warning); }
+.mode-luce .entry.firmata .stato { color:var(--success); }
+.mode-luce .entry.firmata .body { color:var(--ink); }
+.mode-luce .entry.bozza::before { border-color:var(--warning); background:var(--warm); }
+.mode-luce .entry.firmata::before { border-color:var(--success); background:var(--success); }
+
+/* Il momento della firma: l inchiostro asciuga. un tick in tono success si
+   disegna da sinistra (clip-path), l accento da conferma e si spegne. */
+.tick { display:inline-block; height:2px; width:0; background:var(--success); border-radius:2px; vertical-align:middle;
+  margin-left:8px; transition:width 360ms ease-out; }
+.mode-luce .entry.firmata .tick { width:26px; }
+
+/* FILO: la resa che stai valutando. pieno = firmato, tratteggiato = bozza. */
+.mode-filo .entry .stato { color:var(--ink-muted); }
+.mode-filo .entry.firmata::after {
+  content:""; position:absolute; left:-20px; top:20px; bottom:2px; width:1px; background:var(--minerale);
+}
+.mode-filo .entry.bozza::after {
+  content:""; position:absolute; left:-20px; top:20px; bottom:2px; width:1px;
+  background:repeating-linear-gradient(to bottom, var(--warning) 0 3px, transparent 3px 7px);
+}
+.mode-filo .entry.bozza::before { border-style:dashed; border-color:var(--warning); }
+.mode-filo .tick { display:none; }
+
+/* ---------- Riga di laboratorio + provenienza ---------- */
+.lab { display:grid; grid-template-columns:1fr auto auto; gap:2px 14px; align-items:center; padding:9px 2px; border-bottom:1px solid var(--border); }
+.lab .nome-t { font-size:13.5px; font-weight:550; }
+.lab .fonte { font-size:10.5px; color:var(--ink-muted); position:relative; cursor:help; }
+.lab .valore { text-align:right; font-size:14px; font-weight:650; }
+.lab .valore small { font-weight:400; color:var(--ink-muted); font-size:11px; }
+.lab .delta { font-size:11px; color:var(--warning); text-align:right; min-width:64px; }
+/* Provenienza a richiesta: una hairline continua si disegna verso la fonte al passaggio.
+   e un connettore vero, quindi il filo qui ha diritto di esistere. */
+.prov { grid-column:1 / -1; height:0; overflow:hidden; transition:height 220ms ease-out; }
+.prov .line { height:1px; background:var(--minerale); opacity:0.5; width:0; transition:width 300ms ease-out; margin:6px 0; }
+.lab:hover .prov { height:18px; }
+.lab:hover .prov .line { width:100%; }
+.prov .txt { font-size:10.5px; color:var(--ink-muted); }
+
+/* ---------- Bottoni vivi ---------- */
+.btn { position:relative; overflow:hidden; border:0; cursor:pointer; font:inherit; font-weight:600; font-size:12.5px;
+  color:var(--focal); background:var(--minerale); padding:8px 16px; border-radius:var(--r-control);
+  transition:transform 150ms cubic-bezier(0.2,0,0,1), filter 150ms ease-out; }
+.btn:hover { filter:brightness(1.06); }
+.btn:active { transform:scale(0.97); }
+.btn:focus-visible { outline:none; box-shadow:var(--focus-ring); }
+.btn-quiet { border:1px solid var(--border); background:transparent; color:var(--ink); font:inherit; font-size:12px;
+  font-weight:550; cursor:pointer; padding:7px 13px; border-radius:999px;
+  transition:transform 150ms cubic-bezier(0.2,0,0,1), background 150ms ease-out; }
+.btn-quiet:hover { background:var(--canvas); }
+.btn-quiet:active { transform:scale(0.97); }
+.btn-quiet:focus-visible { outline:none; box-shadow:var(--focus-ring); }
+/* Il tocco lascia un anello che si spegne: conferma dal punto dell azione. */
+.ripple { position:absolute; border-radius:50%; transform:translate(-50%,-50%) scale(0); background:rgba(255,255,255,0.5); pointer-events:none; }
+@keyframes onda { to { transform:translate(-50%,-50%) scale(1); opacity:0; } }
+.ripple.go { animation:onda 460ms ease-out forwards; }
+
+.empty { padding:14px 6px; font-size:12px; color:var(--ink-muted); }
+.chip { display:inline-flex; align-items:center; gap:5px; font-size:10.5px; font-weight:550; letter-spacing:0.02em; padding:2px 9px; border-radius:999px; }
+.chip.critical { color:var(--critical); background:var(--critical-tint); }
+
+@media (prefers-reduced-motion: reduce) {
+  * { transition:none !important; animation:none !important; }
+  .mode-luce .entry.firmata .tick { width:26px; }
+  .lab:hover .prov .line { width:100%; }
+}
+</style>
+</head>
+<body class="giorno">
+
+<div class="bar">
+  <h1>Lume, studio di dinamica</h1>
+  <div>
+    <div class="seg-label">Resa</div>
+    <div class="seg" role="group" aria-label="Resa">
+      <button data-mode="filo" aria-pressed="false">Filo lineare</button>
+      <button data-mode="luce" aria-pressed="true">Luce e inchiostro</button>
+    </div>
+  </div>
+  <div>
+    <div class="seg-label">Registro di luce</div>
+    <div class="seg" role="group" aria-label="Registro di luce">
+      <button data-reg="giorno" aria-pressed="true">Giorno</button>
+      <button data-reg="grafite" aria-pressed="false">Grafite</button>
+      <button data-reg="guardia" aria-pressed="false">Guardia</button>
+    </div>
+  </div>
+  <span class="hint">Cambia la resa e confronta lo stesso stato. Clicca le righe per spostare il fuoco, e Firma per far asciugare la bozza. Dati dimostrativi.</span>
+</div>
+
+<div class="testata" role="banner">
+  <span class="nome">Bianchi Aurora (demo)</span>
+  <span class="dato reg">1954</span>
+  <span class="dato">dati dimostrativi</span>
+  <span class="allergia">Allergia: penicillina</span>
+  <span class="dato">Terapie attive: <span class="reg">3</span></span>
+</div>
+
+<div class="stage mode-luce" id="stage">
+  <p class="viewnote">A sinistra la resa che stai valutando (Filo lineare): il fuoco e lo stato sono segnati da una stanghetta piena o tratteggiata sul bordo. A destra la proposta (Luce e inchiostro): il fuoco e solo luce, la bozza e inchiostro a contrasto piu basso, e la firma e un gesto che asciuga l inchiostro. Il filo resta solo dove lega davvero: la spina del diario e il connettore di provenienza, sempre continui.</p>
+
+  <div class="cols">
+    <section class="panel" data-fuoco="false" data-panel="lista" aria-label="Lista di lavoro" tabindex="0">
+      <h2>Ambulatorio</h2>
+      <p class="sub">Oggi, <span class="reg">5</span> in lista</p>
+      <div class="row" tabindex="0" aria-selected="true">
+        <span class="glyph" style="background:var(--critical)"></span>
+        <span class="who"><b>Bianchi Aurora (demo)</b><span>Controllo pressorio, <span class="reg">09:00</span></span></span>
+        <span class="chip critical">PA</span>
+      </div>
+      <div class="row" tabindex="0" aria-selected="false">
+        <span class="glyph" style="background:var(--warning)"></span>
+        <span class="who"><b>Ferri Giacomo (demo)</b><span>Rinnovo piano, <span class="reg">09:30</span></span></span>
+      </div>
+      <div class="row" tabindex="0" aria-selected="false">
+        <span class="glyph" style="background:var(--success)"></span>
+        <span class="who"><b>Conti Elena (demo)</b><span>Esiti rientrati, <span class="reg">10:00</span></span></span>
+      </div>
+      <div class="row" tabindex="0" aria-selected="false">
+        <span class="glyph" style="background:var(--plum)"></span>
+        <span class="who"><b>Riva Pietro (demo)</b><span>Prima visita, <span class="reg">10:30</span></span></span>
+      </div>
+      <div class="empty">Fine della lista di oggi.</div>
+    </section>
+
+    <section class="panel" data-fuoco="true" data-panel="quadro" aria-label="Quadro paziente" tabindex="0">
+      <h2>Quadro</h2>
+      <p class="sub">ipertensione in follow-up</p>
+
+      <div class="sez">
+        <h3>Un valore, con la sua fonte</h3>
+        <div class="lab">
+          <div><div class="nome-t">PA sistolica</div><div class="fonte">ambulatorio, <span class="reg">09:05</span> &middot; passa il mouse per la fonte</div></div>
+          <div class="valore reg">158 <small>mmHg</small></div>
+          <div class="delta reg">+16</div>
+          <div class="prov"><div class="line"></div></div>
+        </div>
+      </div>
+
+      <div class="sez">
+        <h3>Diario, sul filo</h3>
+        <div class="filo-tl">
+          <div class="entry firmata">
+            <span class="quando reg">04/07/2026</span><span class="stato">firmata</span><span class="tick" aria-hidden="true"></span>
+            <div class="body">Controllo programmato. Riferisce cefalea mattutina saltuaria. PA domiciliare in salita nell ultima settimana.</div>
+          </div>
+          <div class="entry bozza" id="bozza">
+            <span class="quando reg">11/07/2026</span><span class="stato">bozza, da rivedere</span><span class="tick" aria-hidden="true"></span>
+            <div class="body">Proposta di richiamo a 7 giorni con diario pressorio. Valutare aggiustamento della terapia serale.</div>
+            <div class="azioni">
+              <button class="btn" id="firma">Firma la voce</button>
+              <button class="btn-quiet" id="reset">Riporta a bozza</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+</div>
+
+<script>
+(function(){
+  var body = document.body, stage = document.getElementById('stage');
+
+  /* Registri di luce (alta frequenza: nessuna animazione di contenuto). */
+  document.querySelectorAll('[data-reg]').forEach(function(b){
+    b.addEventListener('click', function(){
+      var cls = stage.className; // conserva la modalita
+      body.className = b.dataset.reg;
+      stage.className = cls;
+      document.querySelectorAll('[data-reg]').forEach(function(x){ x.setAttribute('aria-pressed', String(x===b)); });
+    });
+  });
+
+  /* Resa: filo lineare  <->  luce e inchiostro */
+  document.querySelectorAll('[data-mode]').forEach(function(b){
+    b.addEventListener('click', function(){
+      stage.classList.remove('mode-filo','mode-luce');
+      stage.classList.add('mode-' + b.dataset.mode);
+      document.querySelectorAll('[data-mode]').forEach(function(x){ x.setAttribute('aria-pressed', String(x===b)); });
+    });
+  });
+
+  /* Fuoco: si sposta con la luce; in modalita LUCE lampeggia la conferma. */
+  var panels = document.querySelectorAll('.panel[data-panel]');
+  function pulse(el){ el.classList.remove('assicura'); void el.offsetWidth; el.classList.add('assicura'); }
+  function setFuoco(t){ panels.forEach(function(p){ p.setAttribute('data-fuoco', String(p===t)); }); if(stage.classList.contains('mode-luce')) pulse(t); }
+  panels.forEach(function(p){
+    p.addEventListener('click', function(){ setFuoco(p); });
+    p.addEventListener('focusin', function(){ setFuoco(p); });
+  });
+
+  /* Selezione riga: sale nella luce, con conferma transiente. */
+  var rows = document.querySelectorAll('.row');
+  rows.forEach(function(r){
+    r.addEventListener('click', function(e){
+      e.stopPropagation();
+      rows.forEach(function(x){ x.setAttribute('aria-selected', String(x===r)); });
+      if(stage.classList.contains('mode-luce')) pulse(r);
+      setFuoco(document.querySelector('[data-panel="lista"]'));
+    });
+  });
+
+  /* La firma: l inchiostro asciuga (il body torna a contrasto pieno),
+     il tick si disegna, l accento da conferma dal punto del tocco. */
+  var bozza = document.getElementById('bozza');
+  var firma = document.getElementById('firma');
+  var reset = document.getElementById('reset');
+  function onda(btn, e){
+    var r = document.createElement('span'); r.className = 'ripple';
+    var b = btn.getBoundingClientRect(); var d = Math.max(b.width,b.height)*2;
+    r.style.width = r.style.height = d + 'px';
+    r.style.left = ((e.clientX||b.left+b.width/2) - b.left) + 'px';
+    r.style.top = ((e.clientY||b.top+b.height/2) - b.top) + 'px';
+    btn.appendChild(r); void r.offsetWidth; r.classList.add('go');
+    setTimeout(function(){ r.remove(); }, 500);
+  }
+  firma.addEventListener('click', function(e){
+    onda(firma, e);
+    bozza.classList.remove('bozza'); bozza.classList.add('firmata');
+    bozza.querySelector('.stato').textContent = 'firmata';
+    firma.style.display = 'none'; reset.textContent = 'Riporta a bozza';
+  });
+  reset.addEventListener('click', function(e){
+    onda(reset, e);
+    bozza.classList.remove('firmata'); bozza.classList.add('bozza');
+    bozza.querySelector('.stato').textContent = 'bozza, da rivedere';
+    firma.style.display = '';
+  });
+  document.querySelectorAll('.btn-quiet').forEach(function(b){ if(b!==reset) b.addEventListener('click', function(e){ onda(b,e); }); });
+})();
+</script>
+</body>
+</html>

--- a/docs/design/lume/mockups/lume-impostazioni.html
+++ b/docs/design/lume/mockups/lume-impostazioni.html
@@ -1,0 +1,809 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Lume: impostazioni sartoriali (luce e inchiostro)</title>
+<style>
+/* ============================================================
+   Lume: impostazioni sartoriali.
+   La scena delle impostazioni dentro ADR 0047 (nessun selettore
+   di stile UI persistito). Ogni opzione ha anteprima immediata e
+   reversibile sul frammento di UI accanto. Il rapporto conflittuale
+   con le impostazioni si scioglie perche niente e nascosto o
+   irreversibile: la luce porta il fuoco, l'inchiostro porta lo
+   stato, il filo connette solo dove connette davvero.
+   File autonomo, nessuna dipendenza, nessun font remoto.
+   Dati esclusivamente dimostrativi.
+   ============================================================ */
+
+:root {
+  --canvas:#eef0f2; --field:#f5f5f4; --focal:#fbfaf7; --chrome:#e6e8eb;
+  --ink:#1a1c1e; --ink-muted:#5c6772; --minerale:#33506b;
+  --warning:#9a6a2f; --critical:#a33a2f; --success:#4b6354; --plum:#555161;
+  --warning-tint:rgba(154,106,47,0.10); --critical-tint:rgba(163,58,47,0.10); --success-tint:rgba(75,99,84,0.12);
+  --minerale-tint:rgba(51,80,107,0.10);
+  --border:rgba(26,28,30,0.10); --border-chrome:rgba(26,28,30,0.06);
+  --shadow-focal:0 2px 8px rgba(26,28,30,0.10); --shadow-lift:0 6px 20px rgba(26,28,30,0.12);
+  --r-panel:20px; --r-card:14px; --r-control:10px;
+  --voce:-apple-system,BlinkMacSystemFont,"SF Pro Text","Segoe UI","Inter",sans-serif;
+  --registro:ui-monospace,"SF Mono","IBM Plex Mono","Cascadia Mono",Menlo,monospace;
+  --focus-ring:0 0 0 2px var(--canvas),0 0 0 4px var(--minerale);
+  --warm:rgba(154,106,47,0.05);
+}
+.grafite { --canvas:#121417; --field:#191c21; --focal:#22252b; --chrome:#0e1013; --ink:#e9ecef; --ink-muted:#8f9aa6; --minerale:#8fb0cc; --warning:#c89c5a; --critical:#d67668; --success:#7e9e8a; --plum:#9691a5; --warning-tint:rgba(200,156,90,0.14); --critical-tint:rgba(214,118,104,0.14); --success-tint:rgba(126,158,138,0.16); --minerale-tint:rgba(143,176,204,0.14); --border:rgba(233,236,239,0.10); --border-chrome:rgba(233,236,239,0.05); --shadow-focal:0 2px 10px rgba(0,0,0,0.5); --shadow-lift:0 8px 26px rgba(0,0,0,0.6); --warm:rgba(200,156,90,0.06); }
+.guardia { --canvas:#0c0e12; --field:#14171d; --focal:#1a1e26; --chrome:#090b0e; --ink:#e3e8ee; --ink-muted:#8792a3; --minerale:#7fa0bc; --warning:#cfa35f; --critical:#d98a7d; --success:#85a291; --plum:#9691a5; --warning-tint:rgba(207,163,95,0.14); --critical-tint:rgba(217,138,125,0.14); --success-tint:rgba(133,162,145,0.16); --minerale-tint:rgba(127,160,188,0.14); --border:rgba(227,232,238,0.09); --border-chrome:rgba(227,232,238,0.04); --shadow-focal:0 2px 10px rgba(0,0,0,0.6); --shadow-lift:0 8px 26px rgba(0,0,0,0.7); --warm:rgba(207,163,95,0.06); }
+
+* { margin:0; padding:0; box-sizing:border-box; }
+body {
+  font-family:var(--voce); background:var(--canvas); color:var(--ink);
+  font-size:14px; line-height:1.5; min-height:100vh;
+  transition:background 200ms ease-out, color 200ms ease-out;
+}
+.reg { font-family:var(--registro); font-variant-numeric:tabular-nums; font-size:0.95em; }
+
+/* ---------- Barra di controllo (buio operativo) ---------- */
+.bar {
+  position:sticky; top:0; z-index:60; display:flex; align-items:center; gap:16px; flex-wrap:wrap;
+  padding:12px 22px; background:var(--chrome); border-bottom:1px solid var(--border-chrome);
+}
+.bar h1 { font-size:14px; font-weight:600; letter-spacing:-0.01em; }
+.bar .hint { font-size:11px; color:var(--ink-muted); max-width:46ch; }
+.seg { display:flex; gap:3px; background:var(--canvas); border-radius:999px; padding:3px; }
+.seg button {
+  border:0; background:transparent; color:var(--ink-muted); font:inherit; font-size:12px; font-weight:500;
+  padding:5px 14px; border-radius:999px; cursor:pointer; transition:color 150ms ease-out;
+}
+.seg button:focus-visible { outline:none; box-shadow:var(--focus-ring); }
+.seg button[aria-pressed="true"] { background:var(--focal); color:var(--ink); box-shadow:0 1px 2px rgba(0,0,0,0.10); }
+.seg-label { font-size:10.5px; font-weight:650; letter-spacing:0.06em; text-transform:uppercase; color:var(--ink-muted); }
+
+/* ---------- Testata invariabile ---------- */
+.testata {
+  max-width:1180px; margin:20px auto 0; padding:12px 18px; display:flex; align-items:baseline; gap:14px; flex-wrap:wrap;
+  background:var(--field); border:1px solid var(--border); border-radius:var(--r-card);
+}
+.testata .nome { font-size:17px; font-weight:650; letter-spacing:-0.01em; }
+.testata .dato { font-size:12px; color:var(--ink-muted); }
+.testata .allergia { font-size:12px; font-weight:600; color:var(--critical); }
+
+/* ---------- Palco ---------- */
+.stage { max-width:1180px; margin:14px auto 56px; position:relative; }
+.viewnote { font-size:12px; color:var(--ink-muted); margin:0 2px 14px; max-width:92ch; }
+.cols { position:relative; display:grid; grid-template-columns:1fr 372px; gap:16px; align-items:start; }
+@media (max-width:900px){ .cols { grid-template-columns:1fr; } .preview { position:static !important; } .filo-layer { display:none; } }
+
+/* ---------- Il filo: connettore SVG che si disegna (draw-on) ----------
+   Legittimo qui perche connette davvero: lega l'impostazione che tocchi
+   alla parte della UI che governa (la provenienza dell'effetto).
+   Continuo, mai tratteggiato, mai sul bordo di un riquadro. */
+.filo-layer { position:absolute; inset:0; width:100%; height:100%; pointer-events:none; z-index:5; overflow:visible; }
+.filo-layer path {
+  fill:none; stroke:var(--minerale); stroke-width:1.5; stroke-linecap:round; opacity:0;
+  transition:opacity 180ms ease-out;
+}
+.filo-layer path.vivo { opacity:0.62; }
+
+/* ---------- Colonna impostazioni ---------- */
+.settings { display:flex; flex-direction:column; gap:14px; }
+.section {
+  position:relative; background:var(--field); border:1px solid var(--border); border-radius:var(--r-card);
+  padding:15px 16px; transition:background 190ms ease-out, box-shadow 190ms ease-out;
+}
+/* La luce porta il fuoco: la sezione che stai regolando sale nella luce.
+   Nessuna linea, nessuna stanghetta sul bordo. Il calore appartiene solo al fuoco. */
+.section.attiva { background:linear-gradient(var(--warm), var(--warm)), var(--focal); box-shadow:var(--shadow-focal); }
+.section:focus-within { outline:none; }
+.section > .lbl { display:flex; align-items:baseline; gap:8px; }
+.section h2 { font-size:13.5px; font-weight:650; letter-spacing:-0.005em; }
+.section .num { font-size:10px; font-weight:700; color:var(--minerale); font-family:var(--registro); }
+.section .desc { font-size:11.5px; color:var(--ink-muted); margin:3px 0 12px; max-width:56ch; }
+
+/* La pulsazione di conferma: transiente, poi si spegne (~300ms). Mai un peso. */
+@keyframes assicura {
+  0% { box-shadow:var(--shadow-focal), 0 0 0 0 var(--minerale-tint); }
+  35% { box-shadow:var(--shadow-lift), 0 0 0 6px var(--minerale-tint); }
+  100% { box-shadow:var(--shadow-focal), 0 0 0 0 rgba(0,0,0,0); }
+}
+.section.assicura { animation:assicura 320ms ease-out; }
+
+/* ---------- Segmenti / opzioni ---------- */
+.opts { display:flex; gap:4px; background:var(--canvas); border-radius:999px; padding:4px; width:fit-content; }
+.opts button {
+  border:0; background:transparent; color:var(--ink-muted); font:inherit; font-size:12.5px; font-weight:550;
+  padding:6px 15px; border-radius:999px; cursor:pointer;
+  transition:color 150ms ease-out, transform 150ms cubic-bezier(0.2,0,0,1);
+}
+.opts button:active { transform:scale(0.97); }
+.opts button:focus-visible { outline:none; box-shadow:var(--focus-ring); }
+/* L'opzione scelta sale nella luce, con pulsazione transiente (in JS). */
+.opts button[aria-pressed="true"] { background:var(--focal); color:var(--ink); box-shadow:var(--shadow-focal); }
+@keyframes accendi { 0%{ box-shadow:var(--shadow-focal),0 0 0 0 var(--minerale-tint);} 40%{ box-shadow:var(--shadow-focal),0 0 0 5px var(--minerale-tint);} 100%{ box-shadow:var(--shadow-focal),0 0 0 0 rgba(0,0,0,0);} }
+.opts button.accendi { animation:accendi 300ms ease-out; }
+
+.hintline { font-size:11px; color:var(--ink-muted); margin-top:9px; }
+.hintline b { color:var(--ink); font-weight:600; }
+
+/* ---------- Viste salvate (chip) ---------- */
+.chips { display:flex; flex-wrap:wrap; gap:7px; }
+.vchip {
+  border:1px solid var(--border); background:transparent; color:var(--ink); font:inherit; font-size:12px; font-weight:550;
+  padding:6px 13px; border-radius:999px; cursor:pointer;
+  transition:background 150ms ease-out, box-shadow 190ms ease-out, transform 150ms cubic-bezier(0.2,0,0,1);
+}
+.vchip:hover { background:var(--canvas); }
+.vchip:active { transform:scale(0.97); }
+.vchip:focus-visible { outline:none; box-shadow:var(--focus-ring); }
+.vchip[aria-pressed="true"] { background:var(--focal); border-color:transparent; box-shadow:var(--shadow-focal); }
+.vchip .cnt { font-family:var(--registro); font-size:10.5px; color:var(--ink-muted); margin-left:5px; }
+
+/* ---------- Interruttori di routing (materia, non stanghetta) ---------- */
+.route { display:flex; flex-direction:column; gap:2px; }
+.route .r-row {
+  display:flex; align-items:center; gap:12px; padding:9px 4px; cursor:pointer; border-radius:var(--r-control);
+  transition:background 150ms ease-out;
+}
+.route .r-row:hover { background:var(--canvas); }
+.route .r-row:focus-visible { outline:none; box-shadow:var(--focus-ring); }
+.route .r-txt { flex:1; }
+.route .r-txt b { display:block; font-size:13px; font-weight:600; }
+.route .r-txt span { font-size:11px; color:var(--ink-muted); }
+/* Lo switch: la pastiglia scivola, niente lampeggio a loop. */
+.sw { width:40px; height:23px; border-radius:999px; background:var(--canvas); position:relative; flex:none; border:1px solid var(--border);
+  transition:background 180ms ease-out; }
+.sw::after { content:""; position:absolute; top:2px; left:2px; width:17px; height:17px; border-radius:50%; background:var(--ink-muted);
+  transition:transform 200ms cubic-bezier(0.2,0.9,0.2,1), background 180ms ease-out; }
+.r-row[aria-checked="true"] .sw { background:var(--minerale-tint); border-color:transparent; }
+.r-row[aria-checked="true"] .sw::after { transform:translateX(17px); background:var(--minerale); }
+
+/* ---------- Scorciatoie ---------- */
+.keys { display:flex; flex-direction:column; }
+.krow { display:grid; grid-template-columns:1fr auto; gap:8px 12px; align-items:center; padding:9px 2px; border-bottom:1px solid var(--border); }
+.krow:last-child { border-bottom:0; }
+.krow .k-what { font-size:13px; font-weight:550; }
+.krow .k-note { font-size:10.5px; color:var(--ink-muted); grid-column:1 / -1; margin-top:2px; }
+/* L'inchiostro porta lo stato: la nuova scorciatoia entra come bozza
+   (solo tono a contrasto piu basso) con etichetta onesta, e la firma la asciuga.
+   Niente calore, niente colore clinico: lo stato di editing e inchiostro. */
+.kbind { display:inline-flex; align-items:center; gap:8px; }
+.kcap {
+  font-family:var(--registro); font-size:12px; font-weight:600; color:var(--ink);
+  background:var(--canvas); border:1px solid var(--border); border-radius:7px; padding:3px 9px; min-width:30px; text-align:center;
+  transition:color 380ms ease-out;
+}
+.krow.bozza .kcap { color:var(--ink-muted); }
+.k-stato { font-size:10px; font-weight:600; color:var(--ink-muted); }
+.krow.firmata .k-stato { color:var(--success); }
+/* Il tick della firma: si disegna, non appare per opacita. Il success e la
+   conferma della firma (l'inchiostro asciuga), non un segnale di stato-bozza. */
+.ktick { display:inline-block; height:2px; width:0; background:var(--success); border-radius:2px; vertical-align:middle; transition:width 360ms ease-out; }
+.krow.firmata .ktick { width:20px; }
+.k-acts { display:flex; gap:6px; align-items:center; }
+.mini { border:1px solid var(--border); background:transparent; color:var(--ink); font:inherit; font-size:11px; font-weight:600;
+  padding:5px 10px; border-radius:999px; cursor:pointer; position:relative; overflow:hidden;
+  transition:background 150ms ease-out, transform 150ms cubic-bezier(0.2,0,0,1); }
+.mini:hover { background:var(--canvas); }
+.mini:active { transform:scale(0.97); }
+.mini:focus-visible { outline:none; box-shadow:var(--focus-ring); }
+.mini.primario { background:var(--minerale); border-color:transparent; color:var(--focal); }
+.mini.primario:hover { filter:brightness(1.06); background:var(--minerale); }
+
+/* ---------- Ordine menu: manipolazione diretta ---------- */
+.menulist { list-style:none; display:flex; flex-direction:column; gap:6px; touch-action:none; }
+.mitem {
+  display:flex; align-items:center; gap:10px; padding:9px 11px; background:var(--canvas); border:1px solid var(--border);
+  border-radius:var(--r-control); cursor:grab; user-select:none; will-change:transform;
+}
+.mitem:focus-visible { outline:none; box-shadow:var(--focus-ring); }
+.mitem .grip { display:flex; flex-direction:column; gap:2px; flex:none; }
+.mitem .grip i { display:block; width:14px; height:1.5px; border-radius:2px; background:var(--ink-muted); }
+.mitem .m-name { flex:1; font-size:13px; font-weight:600; }
+.mitem .m-ord { font-family:var(--registro); font-size:10.5px; color:var(--ink-muted); }
+/* La voce presa sale nella luce e resta sotto il dito; le altre si scostano
+   con una molla (spring interrompibile). Nessuna stanghetta, nessun tratteggio. */
+.mitem.dragging { cursor:grabbing; background:var(--focal); box-shadow:var(--shadow-lift); z-index:20; position:relative; }
+.mitem.shift { transition:transform 260ms cubic-bezier(0.2,0.9,0.2,1); }
+.mitem.settle { transition:transform 320ms cubic-bezier(0.2,1.2,0.3,1); }
+
+/* ---------- Azioni globali ---------- */
+.foot { display:flex; align-items:center; gap:12px; flex-wrap:wrap; margin-top:2px; }
+.note-adr { font-size:11px; color:var(--ink-muted); max-width:60ch; }
+.btn-quiet { border:1px solid var(--border); background:transparent; color:var(--ink); font:inherit; font-size:12px;
+  font-weight:600; cursor:pointer; padding:8px 15px; border-radius:999px; position:relative; overflow:hidden;
+  transition:transform 150ms cubic-bezier(0.2,0,0,1), background 150ms ease-out; }
+.btn-quiet:hover { background:var(--field); }
+.btn-quiet:active { transform:scale(0.97); }
+.btn-quiet:focus-visible { outline:none; box-shadow:var(--focus-ring); }
+
+/* Anello che si spegne dal punto del tocco. */
+.ripple { position:absolute; border-radius:50%; transform:translate(-50%,-50%) scale(0); background:currentColor; opacity:0.28; pointer-events:none; }
+@keyframes onda { to { transform:translate(-50%,-50%) scale(1); opacity:0; } }
+.ripple.go { animation:onda 460ms ease-out forwards; }
+
+/* ---------- Anteprima (frammento di UI, sticky) ---------- */
+.preview {
+  position:sticky; top:78px; background:var(--field); border:1px solid var(--border); border-radius:var(--r-panel);
+  padding:15px 16px; align-self:start;
+}
+.preview .pv-hd { display:flex; align-items:baseline; justify-content:space-between; gap:8px; }
+.preview h2 { font-size:14px; font-weight:650; }
+#pvContext { font-size:11.5px; color:var(--ink-muted); margin:4px 0 12px; transition:color 200ms ease-out, opacity 160ms ease-out; }
+#pvContext b { color:var(--ink); font-weight:600; }
+
+/* Menu strip dell'anteprima: rispecchia l'ordine delle voci. */
+.pv-menu { display:flex; gap:5px; flex-wrap:wrap; margin-bottom:12px; }
+.pv-menu .mtab { font-size:11.5px; font-weight:600; color:var(--ink-muted); padding:5px 10px; border-radius:999px; background:var(--canvas);
+  transition:transform 260ms cubic-bezier(0.2,0.9,0.2,1); }
+.pv-menu .mtab.primo { color:var(--ink); background:var(--focal); box-shadow:var(--shadow-focal); }
+
+.pv-sub { font-size:10px; font-weight:650; letter-spacing:0.06em; text-transform:uppercase; color:var(--ink-muted); margin:2px 0 6px; }
+
+/* Lista dell'anteprima: la densita cambia subito qui. */
+#pvList { display:flex; flex-direction:column; }
+.pv-row { display:flex; align-items:center; gap:9px; border-radius:var(--r-control);
+  transition:padding 200ms ease-out, background 150ms ease-out, box-shadow 190ms ease-out; }
+.stage.densa .pv-row { padding:4px 8px; }
+.stage.comoda .pv-row { padding:9px 8px; }
+.pv-row .glyph { width:7px; height:7px; border-radius:50%; flex:none; }
+.pv-row .who { flex:1; min-width:0; }
+.pv-row .who b { display:block; font-weight:600; font-size:13px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.pv-row .who span { font-size:11px; color:var(--ink-muted); }
+.stage.densa .pv-row .who span { display:none; }
+.pv-row .chip-c { font-size:10px; font-weight:650; padding:2px 8px; border-radius:999px; color:var(--critical); background:var(--critical-tint); }
+.pv-row.evidenza { background:var(--focal); box-shadow:var(--shadow-focal); }
+.pv-empty { font-size:11.5px; color:var(--ink-muted); padding:10px 8px; }
+
+/* Coda / promemoria: destinazione del routing. Come .pv-row.evidenza:
+   solo luce (--focal) e glyph semantico, mai calore persistente. */
+.pv-coda { margin-top:14px; padding-top:12px; border-top:1px solid var(--border); }
+.coda-item { display:flex; align-items:center; gap:8px; font-size:12px; padding:7px 8px; border-radius:var(--r-control);
+  background:var(--focal); box-shadow:var(--shadow-focal); margin-bottom:6px; }
+.coda-item .glyph { width:7px; height:7px; border-radius:50%; flex:none; }
+.coda-item .reg { color:var(--ink-muted); }
+.coda-vuota { font-size:11.5px; color:var(--ink-muted); padding:6px 8px; }
+
+/* La voce bozza dell'anteprima: inchiostro tenue + etichetta, mai tratteggio,
+   mai calore, mai colore clinico per uno stato di editing. */
+.pv-diario { margin-top:6px; }
+.pv-nota { font-size:12px; padding:7px 8px; border-radius:var(--r-control); background:var(--canvas); }
+.pv-nota .st { font-size:10px; font-weight:650; color:var(--ink-muted); }
+.pv-nota .body { color:var(--ink-muted); margin-top:1px; }
+
+@media (prefers-reduced-motion: reduce) {
+  * { transition:none !important; animation:none !important; }
+  .krow.firmata .ktick { width:20px; }
+  .filo-layer path.vivo { opacity:0.62; }
+}
+</style>
+</head>
+<body class="giorno">
+
+<div class="bar">
+  <h1>Lume, impostazioni sartoriali</h1>
+  <div>
+    <div class="seg-label">Registro di luce (solo demo)</div>
+    <div class="seg" role="group" aria-label="Registro di luce, controllo di demo">
+      <button data-reg="giorno" aria-pressed="true">Giorno</button>
+      <button data-reg="grafite" aria-pressed="false">Grafite</button>
+      <button data-reg="guardia" aria-pressed="false">Guardia</button>
+    </div>
+  </div>
+  <span class="hint">Il registro di luce qui e un controllo di demo. Nel prodotto segue il sistema, non e un selettore persistito (ADR 0047).</span>
+</div>
+
+<div class="testata" role="banner">
+  <span class="nome">Bianchi Aurora (demo)</span>
+  <span class="dato reg">1954</span>
+  <span class="dato">dati dimostrativi</span>
+  <span class="allergia">Allergia: penicillina</span>
+  <span class="dato">Ambulatorio: <span id="testataAmb">Poliambulatorio Nord (demo)</span></span>
+</div>
+
+<div class="stage comoda" id="stage">
+  <p class="viewnote">Ogni impostazione ha anteprima immediata e reversibile sul frammento a destra: quando tocchi un comando, la parte che governa sale nella luce e un filo continuo la collega al comando. Niente e nascosto, niente e irreversibile. Colore = solo semantica clinica. Dati dimostrativi.</p>
+
+  <div class="cols">
+    <svg class="filo-layer" id="filoLayer" aria-hidden="true"><path id="filoPath" d=""></path></svg>
+
+    <div class="settings">
+
+      <!-- 1. DENSITA -->
+      <section class="section" data-section data-governs="pvList" tabindex="-1" aria-labelledby="s1">
+        <div class="lbl"><span class="num">01</span><h2 id="s1">Densita</h2></div>
+        <p class="desc">Quanto respira la lista. Cambia subito qui accanto, e torni indietro con un tocco.</p>
+        <div class="opts" role="group" aria-label="Densita">
+          <button data-density="comoda" aria-pressed="true">Comoda</button>
+          <button data-density="densa" aria-pressed="false">Densa</button>
+        </div>
+        <p class="hintline">Ora: <b id="densLbl">comoda</b>. In densa la lista mostra piu righe e nasconde il sottotitolo.</p>
+      </section>
+
+      <!-- 2. SCORCIATOIE -->
+      <section class="section" data-section data-governs="pvList" tabindex="-1" aria-labelledby="s2">
+        <div class="lbl"><span class="num">02</span><h2 id="s2">Scorciatoie da tastiera</h2></div>
+        <p class="desc">Ogni scorciatoia e ispezionabile e ri-legabile. La nuova combinazione entra come bozza in inchiostro tenue: accettarla non e firmarla. La firma asciuga l'inchiostro.</p>
+        <div class="keys" id="keys">
+          <div class="krow firmata" data-key="fuoco">
+            <div class="k-what">Sposta il fuoco</div>
+            <div class="k-acts">
+              <span class="kbind"><span class="kcap">&uarr; &darr;</span><span class="k-stato">in vigore</span><span class="ktick" aria-hidden="true"></span></span>
+              <button class="mini" data-rebind>Rilega</button>
+            </div>
+          </div>
+          <div class="krow firmata" data-key="firma">
+            <div class="k-what">Firma la voce</div>
+            <div class="k-acts">
+              <span class="kbind"><span class="kcap">F</span><span class="k-stato">in vigore</span><span class="ktick" aria-hidden="true"></span></span>
+              <button class="mini" data-rebind>Rilega</button>
+            </div>
+          </div>
+          <div class="krow firmata" data-key="nuova">
+            <div class="k-what">Nuova voce</div>
+            <div class="k-acts">
+              <span class="kbind"><span class="kcap">N</span><span class="k-stato">in vigore</span><span class="ktick" aria-hidden="true"></span></span>
+              <button class="mini" data-rebind>Rilega</button>
+            </div>
+          </div>
+          <div class="krow firmata" data-key="cerca">
+            <div class="k-what">Cerca</div>
+            <div class="k-acts">
+              <span class="kbind"><span class="kcap">/</span><span class="k-stato">in vigore</span><span class="ktick" aria-hidden="true"></span></span>
+              <button class="mini" data-rebind>Rilega</button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- 3. VISTE SALVATE -->
+      <section class="section" data-section data-governs="pvList" tabindex="-1" aria-labelledby="s3">
+        <div class="lbl"><span class="num">03</span><h2 id="s3">Viste salvate</h2></div>
+        <p class="desc">Un filtro che ti sei costruito. Sceglierne una ricompone la lista accanto: la vista scelta sale nella luce.</p>
+        <div class="chips" role="group" aria-label="Viste salvate">
+          <button class="vchip" data-view="tutti" aria-pressed="true">Tutti<span class="cnt reg" data-cnt="tutti"></span></button>
+          <button class="vchip" data-view="critici" aria-pressed="false">Solo critici<span class="cnt reg" data-cnt="critici"></span></button>
+          <button class="vchip" data-view="dafirmare" aria-pressed="false">Da firmare<span class="cnt reg" data-cnt="dafirmare"></span></button>
+        </div>
+      </section>
+
+      <!-- 4. DEFAULT AMBULATORIO -->
+      <section class="section" data-section data-governs="pvContext" tabindex="-1" aria-labelledby="s4">
+        <div class="lbl"><span class="num">04</span><h2 id="s4">Default di ambulatorio</h2></div>
+        <p class="desc">Dove apre lo strumento all'avvio. La luce del contesto si ricalibra subito, la testata resta ferma e leggibile.</p>
+        <div class="opts" role="group" aria-label="Default di ambulatorio">
+          <button data-amb="Poliambulatorio Nord (demo)" aria-pressed="true">Nord</button>
+          <button data-amb="Sede Centro (demo)" aria-pressed="false">Centro</button>
+          <button data-amb="Domiciliare (demo)" aria-pressed="false">Domiciliare</button>
+        </div>
+      </section>
+
+      <!-- 5. ROUTING CODA / NOTIFICHE -->
+      <section class="section" data-section data-governs="pvCoda" tabindex="-1" aria-labelledby="s5">
+        <div class="lbl"><span class="num">05</span><h2 id="s5">Routing della coda e delle notifiche</h2></div>
+        <p class="desc">Dove finiscono i segnali. Ogni interruttore mostra subito il suo effetto nella coda dell'anteprima, e si annulla con un tocco.</p>
+        <div class="route" id="route">
+          <div class="r-row" role="switch" tabindex="0" aria-checked="true" data-route="critici">
+            <span class="r-txt"><b>Risultati critici in coda</b><span>Un valore fuori soglia entra nella coda in evidenza</span></span>
+            <span class="sw" aria-hidden="true"></span>
+          </div>
+          <div class="r-row" role="switch" tabindex="0" aria-checked="false" data-route="promemoria">
+            <span class="r-txt"><b>Promemoria nel diario</b><span>I richiami programmati entrano come bozza sul filo del diario</span></span>
+            <span class="sw" aria-hidden="true"></span>
+          </div>
+        </div>
+      </section>
+
+      <!-- 6. ORDINE VOCI DI MENU -->
+      <section class="section" data-section data-governs="pvMenu" tabindex="-1" aria-labelledby="s6">
+        <div class="lbl"><span class="num">06</span><h2 id="s6">Ordine delle voci di menu</h2></div>
+        <p class="desc">Manipolazione diretta: trascina una voce e resta sotto il dito, le altre si scostano con una molla. Con la tastiera, seleziona una voce e usa &uarr; &darr;. L'ordine si rispecchia subito nel menu dell'anteprima.</p>
+        <ul class="menulist" id="menulist" aria-label="Ordine delle voci di menu">
+          <li class="mitem" data-menu="Agenda" tabindex="0" aria-label="Agenda, posizione 1"><span class="grip" aria-hidden="true"><i></i><i></i><i></i></span><span class="m-name">Agenda</span><span class="m-ord reg">1</span></li>
+          <li class="mitem" data-menu="Coda" tabindex="0" aria-label="Coda, posizione 2"><span class="grip" aria-hidden="true"><i></i><i></i><i></i></span><span class="m-name">Coda</span><span class="m-ord reg">2</span></li>
+          <li class="mitem" data-menu="Diario" tabindex="0" aria-label="Diario, posizione 3"><span class="grip" aria-hidden="true"><i></i><i></i><i></i></span><span class="m-name">Diario</span><span class="m-ord reg">3</span></li>
+          <li class="mitem" data-menu="Referti" tabindex="0" aria-label="Referti, posizione 4"><span class="grip" aria-hidden="true"><i></i><i></i><i></i></span><span class="m-name">Referti</span><span class="m-ord reg">4</span></li>
+          <li class="mitem" data-menu="Terapie" tabindex="0" aria-label="Terapie, posizione 5"><span class="grip" aria-hidden="true"><i></i><i></i><i></i></span><span class="m-name">Terapie</span><span class="m-ord reg">5</span></li>
+        </ul>
+      </section>
+
+      <div class="foot">
+        <button class="btn-quiet" id="resetAll">Riporta tutto ai valori iniziali</button>
+        <span class="note-adr">Nessuna di queste scelte e un tema persistito: sono sartorialita di lavoro (densita, scorciatoie, viste, default, routing, ordine), tutte reversibili.</span>
+      </div>
+
+    </div>
+
+    <!-- ANTEPRIMA -->
+    <aside class="preview" id="preview" aria-label="Anteprima dell'effetto delle impostazioni">
+      <div class="pv-hd"><h2>Anteprima</h2></div>
+      <div id="pvContext">Apre su <b id="pvAmb">Poliambulatorio Nord (demo)</b>, vista <b id="pvView">Tutti</b>.</div>
+
+      <div class="pv-menu" id="pvMenu" aria-label="Menu, riflette l'ordine scelto"></div>
+
+      <div class="pv-sub">Ambulatorio</div>
+      <div id="pvList"></div>
+
+      <div class="pv-coda" id="pvCoda">
+        <div class="pv-sub">Coda e notifiche</div>
+        <div id="codaBox"></div>
+      </div>
+    </aside>
+
+  </div>
+</div>
+
+<script>
+(function(){
+  var body = document.body, stage = document.getElementById('stage');
+  var prefersReduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  /* ---------- utilita: anello dal punto del tocco ---------- */
+  function onda(btn, e){
+    if(prefersReduce) return;
+    var r = document.createElement('span'); r.className='ripple';
+    var b = btn.getBoundingClientRect(); var d = Math.max(b.width,b.height)*2;
+    r.style.width = r.style.height = d+'px';
+    r.style.left = ((e && e.clientX ? e.clientX : b.left+b.width/2) - b.left)+'px';
+    r.style.top  = ((e && e.clientY ? e.clientY : b.top+b.height/2) - b.top)+'px';
+    btn.appendChild(r); void r.offsetWidth; r.classList.add('go');
+    setTimeout(function(){ r.remove(); }, 500);
+  }
+  function pulse(el){ if(prefersReduce) return; el.classList.remove('assicura'); void el.offsetWidth; el.classList.add('assicura'); }
+  function accendi(el){ if(prefersReduce) return; el.classList.remove('accendi'); void el.offsetWidth; el.classList.add('accendi'); }
+
+  /* ---------- registro di luce (solo demo, alta frequenza: nessuna anim di contenuto) ---------- */
+  document.querySelectorAll('[data-reg]').forEach(function(bn){
+    bn.addEventListener('click', function(){
+      var keep = stage.className;
+      body.className = bn.dataset.reg;
+      stage.className = keep;
+      document.querySelectorAll('[data-reg]').forEach(function(x){ x.setAttribute('aria-pressed', String(x===bn)); });
+    });
+  });
+
+  /* ---------- IL FILO: connettore SVG che si disegna dall'impostazione alla parte che governa ---------- */
+  var layer = document.getElementById('filoLayer');
+  var fpath = document.getElementById('filoPath');
+  function drawFilo(fromEl, toEl){
+    if(!fromEl || !toEl || window.innerWidth <= 900) return;
+    var sr = layer.getBoundingClientRect();
+    var a = fromEl.getBoundingClientRect(), b = toEl.getBoundingClientRect();
+    var x1 = a.right - sr.left, y1 = a.top + a.height/2 - sr.top;
+    var x2 = b.left - sr.left,  y2 = b.top + b.height/2 - sr.top;
+    if(x2 < x1) x2 = b.right - sr.left; // se la preview sta a sinistra, aggancia il lato destro
+    var mx = x1 + (x2 - x1)*0.5;
+    fpath.setAttribute('d', 'M '+x1.toFixed(1)+' '+y1.toFixed(1)+' C '+mx.toFixed(1)+' '+y1.toFixed(1)+' '+mx.toFixed(1)+' '+y2.toFixed(1)+' '+x2.toFixed(1)+' '+y2.toFixed(1));
+    var len = fpath.getTotalLength();
+    if(prefersReduce){
+      fpath.style.strokeDasharray=''; fpath.style.strokeDashoffset=''; fpath.classList.add('vivo');
+    } else {
+      fpath.style.transition='none';
+      fpath.style.strokeDasharray=len; fpath.style.strokeDashoffset=len;
+      void fpath.getBoundingClientRect();
+      fpath.classList.add('vivo');
+      fpath.style.transition='stroke-dashoffset 340ms cubic-bezier(0.2,0.9,0.2,1)';
+      fpath.style.strokeDashoffset='0';
+    }
+  }
+  function clearFilo(){ fpath.classList.remove('vivo'); }
+
+  var lastSection = null;
+  function activateSection(sec){
+    if(lastSection && lastSection!==sec) lastSection.classList.remove('attiva');
+    sec.classList.add('attiva'); pulse(sec); lastSection = sec;
+    var target = document.getElementById(sec.dataset.governs);
+    drawFilo(sec, target);
+  }
+  document.querySelectorAll('[data-section]').forEach(function(sec){
+    // il fuoco segue dove lavori: interazione o focus dentro la sezione
+    sec.addEventListener('pointerdown', function(){ activateSection(sec); });
+    sec.addEventListener('focusin', function(){ activateSection(sec); });
+  });
+  // il filo e vitalita di gesto: se scorri, si spegne (niente linee stantie)
+  window.addEventListener('scroll', function(){ clearFilo(); }, {passive:true});
+  window.addEventListener('resize', function(){ clearFilo(); });
+
+  /* ---------- dati anteprima ----------
+     La gravita e SOLO clinica: sev != null solo quando c'e vera gravita
+     (Bianchi ha una PA fuori soglia). Le categorie non-cliniche (rinnovo
+     piano, esiti rientrati, prima visita) restano nel tono dell'inchiostro. */
+  var patients = [
+    { id:'bianchi', nome:'Bianchi Aurora (demo)', sub:'Controllo pressorio', ora:'09:00', sev:'critical', tags:['tutti','critici'], chip:'PA' },
+    { id:'ferri',   nome:'Ferri Giacomo (demo)',  sub:'Rinnovo piano',       ora:'09:30', sev:null,       tags:['tutti','dafirmare'] },
+    { id:'conti',   nome:'Conti Elena (demo)',    sub:'Esiti rientrati',     ora:'10:00', sev:null,       tags:['tutti'] },
+    { id:'riva',    nome:'Riva Pietro (demo)',    sub:'Prima visita',        ora:'10:30', sev:null,       tags:['tutti','dafirmare'] }
+  ];
+  var state = { view:'tutti', routeCritici:true, routePromemoria:false };
+  var pvList = document.getElementById('pvList');
+
+  function renderList(){
+    pvList.innerHTML='';
+    var shown = patients.filter(function(p){ return p.tags.indexOf(state.view)>-1; });
+    if(shown.length===0){
+      var e = document.createElement('div'); e.className='pv-empty';
+      e.textContent = 'Nessuna voce in questa vista, adesso.'; pvList.appendChild(e); return;
+    }
+    shown.forEach(function(p){
+      var row = document.createElement('div'); row.className='pv-row'; row.dataset.pid=p.id;
+      if(state.routeCritici && p.sev==='critical') row.classList.add('evidenza');
+      var g = document.createElement('span'); g.className='glyph';
+      // colore = solo semantica clinica: dot neutro (inchiostro) per le categorie
+      g.style.background = p.sev ? 'var(--'+p.sev+')' : 'var(--ink-muted)';
+      var who = document.createElement('span'); who.className='who';
+      who.innerHTML = '<b>'+p.nome+'</b><span>'+p.sub+', <span class="reg">'+p.ora+'</span></span>';
+      row.appendChild(g); row.appendChild(who);
+      if(p.chip){ var c=document.createElement('span'); c.className='chip-c'; c.textContent=p.chip; row.appendChild(c); }
+      pvList.appendChild(row);
+    });
+  }
+
+  // conteggi viste
+  document.querySelectorAll('[data-cnt]').forEach(function(el){
+    var v=el.dataset.cnt; el.textContent = patients.filter(function(p){return p.tags.indexOf(v)>-1;}).length;
+  });
+
+  /* ---------- coda / notifiche ---------- */
+  var codaBox = document.getElementById('codaBox');
+  function renderCoda(){
+    codaBox.innerHTML='';
+    if(state.routeCritici){
+      var it = document.createElement('div'); it.className='coda-item';
+      it.innerHTML='<span class="glyph" style="background:var(--critical)"></span><span>PA sistolica <span class="reg">158 mmHg</span>, Bianchi Aurora (demo)</span>';
+      codaBox.appendChild(it);
+    }
+    if(state.routePromemoria){
+      var nt = document.createElement('div'); nt.className='pv-nota';
+      nt.innerHTML='<span class="st">bozza, sul filo del diario</span><div class="body">Richiamo a <span class="reg">7</span> giorni con diario pressorio.</div>';
+      codaBox.appendChild(nt);
+    }
+    if(!state.routeCritici && !state.routePromemoria){
+      var v=document.createElement('div'); v.className='coda-vuota';
+      v.textContent='Nessun instradamento attivo: la coda resta vuota.'; codaBox.appendChild(v);
+    }
+  }
+
+  /* ---------- 1. DENSITA ---------- */
+  document.querySelectorAll('[data-density]').forEach(function(bn){
+    bn.addEventListener('click', function(){
+      stage.classList.remove('comoda','densa'); stage.classList.add(bn.dataset.density);
+      document.querySelectorAll('[data-density]').forEach(function(x){ x.setAttribute('aria-pressed', String(x===bn)); });
+      document.getElementById('densLbl').textContent = bn.dataset.density;
+      accendi(bn);
+    });
+  });
+
+  /* ---------- 3. VISTE SALVATE ---------- */
+  document.querySelectorAll('[data-view]').forEach(function(bn){
+    bn.addEventListener('click', function(){
+      state.view = bn.dataset.view;
+      document.querySelectorAll('[data-view]').forEach(function(x){ x.setAttribute('aria-pressed', String(x===bn)); });
+      document.getElementById('pvView').textContent = bn.textContent.replace(/\d+$/,'').trim();
+      accendi(bn); renderList();
+    });
+  });
+
+  /* ---------- 4. DEFAULT AMBULATORIO ---------- */
+  document.querySelectorAll('[data-amb]').forEach(function(bn){
+    bn.addEventListener('click', function(){
+      document.querySelectorAll('[data-amb]').forEach(function(x){ x.setAttribute('aria-pressed', String(x===bn)); });
+      var name = bn.dataset.amb;
+      // la luce del contesto si ricalibra: breve cross-fade, la testata resta ferma
+      var ctx = document.getElementById('pvContext');
+      if(!prefersReduce){ ctx.style.opacity='0'; setTimeout(function(){ ctx.style.opacity='1'; }, 140); }
+      document.getElementById('pvAmb').textContent = name;
+      document.getElementById('testataAmb').textContent = name;
+      accendi(bn);
+    });
+  });
+
+  /* ---------- 5. ROUTING ---------- */
+  document.querySelectorAll('#route .r-row').forEach(function(rw){
+    function toggle(){
+      var on = rw.getAttribute('aria-checked')!=='true';
+      rw.setAttribute('aria-checked', String(on));
+      if(rw.dataset.route==='critici') state.routeCritici = on;
+      if(rw.dataset.route==='promemoria') state.routePromemoria = on;
+      renderCoda(); renderList();
+    }
+    rw.addEventListener('click', toggle);
+    rw.addEventListener('keydown', function(e){ if(e.key===' '||e.key==='Enter'){ e.preventDefault(); toggle(); } });
+  });
+
+  /* ---------- 2. SCORCIATOIE: bozza in inchiostro tenue, firma che asciuga ---------- */
+  var recording = null;
+  function currentCaps(){
+    var m={}; document.querySelectorAll('#keys .krow').forEach(function(r){ m[r.dataset.key]=r.querySelector('.kcap').textContent.trim(); }); return m;
+  }
+  document.querySelectorAll('#keys .krow').forEach(function(row){
+    var acts = row.querySelector('.k-acts');
+    var rebindBtn = row.querySelector('[data-rebind]');
+    var stEl = row.querySelector('.k-stato');
+    var capEl = row.querySelector('.kcap');
+
+    function beginRecord(e){
+      if(recording) recording.cancel();
+      onda(rebindBtn, e);
+      row.classList.remove('firmata','conflitto'); row.classList.add('bozza');
+      var prev = capEl.textContent;
+      capEl.textContent='premi un tasto'; stEl.textContent='in ascolto';
+      // note riga
+      var note = document.createElement('div'); note.className='k-note'; note.textContent='In ascolto di un tasto. Esc per annullare.'; row.appendChild(note);
+      // rimpiazza azioni con annulla
+      acts.style.display='none';
+      var cancelWrap = document.createElement('div'); cancelWrap.className='k-acts';
+      var cancel = document.createElement('button'); cancel.className='mini'; cancel.textContent='Annulla';
+      cancelWrap.appendChild(cancel); row.appendChild(cancelWrap);
+
+      function cleanup(){ document.removeEventListener('keydown', onKey, true); note.remove(); cancelWrap.remove(); acts.style.display=''; recording=null; }
+      recording = { cancel: function(){ capEl.textContent=prev; row.classList.remove('bozza','conflitto'); row.classList.add('firmata'); stEl.textContent='in vigore'; cleanup(); } };
+      cancel.addEventListener('click', function(){ recording.cancel(); });
+
+      function onKey(ev){
+        if(ev.key==='Tab') return; // Tab non e firma, non lo catturiamo come binding
+        ev.preventDefault(); ev.stopPropagation();
+        if(ev.key==='Escape'){ recording.cancel(); return; }
+        var cap = ev.key===' ' ? 'Spazio' : (ev.key.length===1 ? ev.key.toUpperCase() : ev.key);
+        capEl.textContent = cap;
+        // conflitto onesto: nessun disabled muto, spieghiamo
+        var caps = currentCaps(); var conflict=null;
+        Object.keys(caps).forEach(function(k){ if(k!==row.dataset.key && caps[k].toUpperCase()===cap.toUpperCase()) conflict=k; });
+        cleanup();
+        // la nuova combinazione e BOZZA finche non la firmi
+        row.classList.add('bozza');
+        if(conflict){
+          row.classList.add('conflitto'); stEl.textContent='in conflitto';
+          var cnote=document.createElement('div'); cnote.className='k-note';
+          cnote.textContent='"'+cap+'" e gia legata a un\'altra azione. Scegline un\'altra o firma comunque per sostituirla.';
+          row.appendChild(cnote);
+          setTimeout(function(){ var n=row.querySelector('.k-note'); if(n) n.remove(); }, 4200);
+        } else {
+          stEl.textContent='bozza, da firmare';
+        }
+        // aggiungi bottoni Firma / Riporta
+        offerSign(prev);
+      }
+      document.addEventListener('keydown', onKey, true);
+    }
+
+    function offerSign(prev){
+      // sostituisci "Rilega" con Firma + Riporta finche la bozza non e risolta
+      var acts2 = row.querySelector('.k-acts');
+      acts2.innerHTML='';
+      var kb = document.createElement('span'); kb.className='kbind';
+      kb.appendChild(capEl); kb.appendChild(stEl);
+      var tick=document.createElement('span'); tick.className='ktick'; tick.setAttribute('aria-hidden','true'); kb.appendChild(tick);
+      acts2.appendChild(kb);
+      var firma=document.createElement('button'); firma.className='mini primario'; firma.textContent='Firma';
+      var back=document.createElement('button'); back.className='mini'; back.textContent='Riporta';
+      acts2.appendChild(firma); acts2.appendChild(back);
+      firma.addEventListener('click', function(e){
+        onda(firma,e);
+        row.classList.remove('bozza','conflitto'); row.classList.add('firmata');
+        stEl.textContent='in vigore';
+        var n=row.querySelector('.k-note'); if(n) n.remove();
+        restoreRebind();
+      });
+      back.addEventListener('click', function(e){
+        onda(back,e);
+        capEl.textContent=prev; row.classList.remove('bozza','conflitto'); row.classList.add('firmata'); stEl.textContent='in vigore';
+        var n=row.querySelector('.k-note'); if(n) n.remove();
+        restoreRebind();
+      });
+    }
+    function restoreRebind(){
+      var acts2=row.querySelector('.k-acts'); acts2.innerHTML='';
+      var kb=document.createElement('span'); kb.className='kbind';
+      kb.appendChild(capEl); kb.appendChild(stEl);
+      var tick=document.createElement('span'); tick.className='ktick'; tick.setAttribute('aria-hidden','true'); kb.appendChild(tick);
+      acts2.appendChild(kb);
+      var rb=document.createElement('button'); rb.className='mini'; rb.textContent='Rilega'; acts2.appendChild(rb);
+      rb.addEventListener('click', beginRecord);
+    }
+    rebindBtn.addEventListener('click', beginRecord);
+  });
+
+  /* ---------- 6. ORDINE MENU: manipolazione diretta, spring interrompibile ---------- */
+  var list = document.getElementById('menulist');
+  var pvMenu = document.getElementById('pvMenu');
+  function order(){ return Array.prototype.map.call(list.children, function(li){ return li.dataset.menu; }); }
+  function renumber(){ Array.prototype.forEach.call(list.children, function(li,i){ li.querySelector('.m-ord').textContent=i+1; li.setAttribute('aria-label', li.dataset.menu+', posizione '+(i+1)); }); }
+  function renderMenu(){
+    pvMenu.innerHTML='';
+    order().forEach(function(name,i){ var t=document.createElement('span'); t.className='mtab'+(i===0?' primo':''); t.textContent=name; pvMenu.appendChild(t); });
+  }
+  renderMenu();
+
+  // --- pointer drag ---
+  var drag = null;
+  list.addEventListener('pointerdown', function(e){
+    var li = e.target.closest('.mitem'); if(!li) return;
+    var items = Array.prototype.slice.call(list.children);
+    var rects = items.map(function(el){ return el.getBoundingClientRect(); });
+    var idx = items.indexOf(li);
+    drag = { li:li, items:items, rects:rects, startY:e.clientY, from:idx, to:idx, h:rects[0].height, gap:6 };
+    li.setPointerCapture(e.pointerId);
+    li.classList.add('dragging');
+    items.forEach(function(el){ if(el!==li) el.classList.add('shift'); });
+    e.preventDefault();
+  });
+  list.addEventListener('pointermove', function(e){
+    if(!drag) return;
+    var dy = e.clientY - drag.startY;
+    // la voce presa resta sotto il dito (nessuna transizione su di lei)
+    drag.li.style.transform = 'translateY('+dy+'px)';
+    var step = drag.h + drag.gap;
+    var to = drag.from + Math.round(dy/step);
+    to = Math.max(0, Math.min(drag.items.length-1, to));
+    if(to!==drag.to){
+      drag.to = to;
+      // le altre si scostano con la molla
+      drag.items.forEach(function(el, i){
+        if(el===drag.li) return;
+        var shift = 0;
+        if(drag.from < to && i>drag.from && i<=to) shift = -step;
+        else if(drag.from > to && i<drag.from && i>=to) shift = step;
+        el.style.transform = shift ? 'translateY('+shift+'px)' : '';
+      });
+    }
+  });
+  function endDrag(e){
+    if(!drag) return;
+    var d = drag; drag = null;
+    d.li.classList.remove('dragging');
+    d.items.forEach(function(el){ el.classList.remove('shift'); el.style.transform=''; });
+    if(d.to!==d.from){
+      // riordino reale nel DOM
+      if(d.to > d.from) list.insertBefore(d.li, d.items[d.to].nextSibling);
+      else list.insertBefore(d.li, d.items[d.to]);
+      // assestamento a molla della voce posata
+      if(!prefersReduce){
+        var prevY = e.clientY - d.startY - (d.to - d.from)*(d.h+d.gap);
+        d.li.style.transform='translateY('+prevY+'px)'; d.li.classList.add('settle');
+        void d.li.offsetWidth; d.li.style.transform='';
+        setTimeout(function(){ d.li.classList.remove('settle'); }, 340);
+      }
+      renumber(); renderMenu();
+    }
+  }
+  list.addEventListener('pointerup', endDrag);
+  list.addEventListener('pointercancel', endDrag);
+
+  // --- tastiera: sposta con le frecce ---
+  list.addEventListener('keydown', function(e){
+    var li = e.target.closest('.mitem'); if(!li) return;
+    if(e.key==='ArrowUp' && li.previousElementSibling){ e.preventDefault(); list.insertBefore(li, li.previousElementSibling); renumber(); renderMenu(); li.focus(); }
+    else if(e.key==='ArrowDown' && li.nextElementSibling){ e.preventDefault(); list.insertBefore(li.nextElementSibling, li); renumber(); renderMenu(); li.focus(); }
+  });
+
+  /* ---------- RIPORTA TUTTO ---------- */
+  document.getElementById('resetAll').addEventListener('click', function(e){
+    onda(this, e);
+    // densita
+    stage.classList.remove('densa'); stage.classList.add('comoda');
+    document.querySelectorAll('[data-density]').forEach(function(x){ x.setAttribute('aria-pressed', String(x.dataset.density==='comoda')); });
+    document.getElementById('densLbl').textContent='comoda';
+    // vista
+    state.view='tutti';
+    document.querySelectorAll('[data-view]').forEach(function(x){ x.setAttribute('aria-pressed', String(x.dataset.view==='tutti')); });
+    document.getElementById('pvView').textContent='Tutti';
+    // ambulatorio
+    document.querySelectorAll('[data-amb]').forEach(function(x){ x.setAttribute('aria-pressed', String(x.dataset.amb.indexOf('Nord')>-1)); });
+    document.getElementById('pvAmb').textContent='Poliambulatorio Nord (demo)';
+    document.getElementById('testataAmb').textContent='Poliambulatorio Nord (demo)';
+    // routing
+    state.routeCritici=true; state.routePromemoria=false;
+    document.querySelectorAll('#route .r-row').forEach(function(rw){ rw.setAttribute('aria-checked', String(rw.dataset.route==='critici')); });
+    // menu
+    ['Agenda','Coda','Diario','Referti','Terapie'].forEach(function(name){
+      var li = list.querySelector('[data-menu="'+name+'"]'); list.appendChild(li);
+    });
+    renumber(); renderMenu();
+    clearFilo();
+    renderList(); renderCoda();
+  });
+
+  /* ---------- primo render ---------- */
+  renumber(); renderList(); renderCoda();
+})();
+</script>
+</body>
+</html>

--- a/docs/design/lume/mockups/lume-voce.html
+++ b/docs/design/lume/mockups/lume-voce.html
@@ -1,0 +1,581 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Lume: La voce (microfono e cattura della visita, ADR 0072)</title>
+<style>
+/* ============================================================
+   Lume: "La voce".
+   Il microfono e la cattura della visita (ADR 0072).
+   Luce e inchiostro, mai il filo lineare:
+   - LA LUCE porta il FUOCO: la superficie della cattura sale nella
+     luce quando l avvio la accende. Mai una linea.
+   - L INCHIOSTRO porta lo STATO: la trascrizione entra come bozza in
+     inchiostro tenue con micro-etichetta onesta; "Rivedi e firma"
+     ASCIUGA l inchiostro (torna pieno, tick success, anello che si
+     spegne). Nessun tratteggio, nessun calore per lo stato.
+   - IL FILO connette e basta: la spina del diario e geometria SVG
+     continua che si disegna (draw-on). Mai un bordo, mai tratteggio.
+   Vitalita solo in risposta al gesto o a un ingresso reale: il metro
+   di livello vive solo durante la cattura ed e mosso dal microfono,
+   mai da un valore sintetico; mai loop/respiro/shimmer.
+   File autonomo, nessuna dipendenza, nessun font remoto.
+   Dati esclusivamente dimostrativi.
+   ============================================================ */
+
+:root {
+  --canvas:#eef0f2; --field:#f5f5f4; --focal:#fbfaf7; --chrome:#e6e8eb;
+  --ink:#1a1c1e; --ink-muted:#5c6772; --minerale:#33506b;
+  --warning:#9a6a2f; --critical:#a33a2f; --success:#4b6354; --plum:#555161;
+  --warning-tint:rgba(154,106,47,0.10); --critical-tint:rgba(163,58,47,0.10); --success-tint:rgba(75,99,84,0.12);
+  --minerale-tint:rgba(51,80,107,0.10);
+  --border:rgba(26,28,30,0.10); --border-chrome:rgba(26,28,30,0.06);
+  --shadow-focal:0 2px 8px rgba(26,28,30,0.10); --shadow-lift:0 6px 20px rgba(26,28,30,0.12);
+  --r-panel:20px; --r-card:14px; --r-control:10px;
+  --voce:-apple-system,BlinkMacSystemFont,"SF Pro Text","Segoe UI","Inter",sans-serif;
+  --registro:ui-monospace,"SF Mono","IBM Plex Mono","Cascadia Mono",Menlo,monospace;
+  --focus-ring:0 0 0 2px var(--canvas),0 0 0 4px var(--minerale);
+  --warm:rgba(154,106,47,0.05);
+}
+.grafite { --canvas:#121417; --field:#191c21; --focal:#22252b; --chrome:#0e1013; --ink:#e9ecef; --ink-muted:#8f9aa6; --minerale:#8fb0cc; --warning:#c89c5a; --critical:#d67668; --success:#7e9e8a; --plum:#9691a5; --warning-tint:rgba(200,156,90,0.14); --critical-tint:rgba(214,118,104,0.14); --success-tint:rgba(126,158,138,0.16); --minerale-tint:rgba(143,176,204,0.14); --border:rgba(233,236,239,0.10); --border-chrome:rgba(233,236,239,0.05); --shadow-focal:0 2px 10px rgba(0,0,0,0.5); --shadow-lift:0 8px 26px rgba(0,0,0,0.6); --warm:rgba(200,156,90,0.06); }
+.guardia { --canvas:#0c0e12; --field:#14171d; --focal:#1a1e26; --chrome:#090b0e; --ink:#e3e8ee; --ink-muted:#8792a3; --minerale:#7fa0bc; --warning:#cfa35f; --critical:#d98a7d; --success:#85a291; --plum:#9691a5; --warning-tint:rgba(207,163,95,0.14); --critical-tint:rgba(217,138,125,0.14); --success-tint:rgba(133,162,145,0.16); --minerale-tint:rgba(127,160,188,0.14); --border:rgba(227,232,238,0.09); --border-chrome:rgba(227,232,238,0.04); --shadow-focal:0 2px 10px rgba(0,0,0,0.6); --shadow-lift:0 8px 26px rgba(0,0,0,0.7); --warm:rgba(207,163,95,0.06); }
+
+* { margin:0; padding:0; box-sizing:border-box; }
+body {
+  font-family:var(--voce); background:var(--canvas); color:var(--ink);
+  font-size:14px; line-height:1.5; min-height:100vh;
+  transition:background 200ms ease-out, color 200ms ease-out;
+}
+.reg { font-family:var(--registro); font-variant-numeric:tabular-nums; font-size:0.95em; }
+.vh { position:absolute; width:1px; height:1px; overflow:hidden; clip:rect(0 0 0 0); white-space:nowrap; }
+
+/* ---------- Barra demo (buio operativo) ---------- */
+.bar {
+  position:sticky; top:0; z-index:50; display:flex; align-items:center; gap:18px; flex-wrap:wrap;
+  padding:12px 22px; background:var(--chrome); border-bottom:1px solid var(--border-chrome);
+}
+.bar h1 { font-size:14px; font-weight:600; letter-spacing:-0.01em; }
+.bar .hint { font-size:11px; color:var(--ink-muted); max-width:46ch; }
+.seg-label { font-size:10.5px; font-weight:650; letter-spacing:0.06em; text-transform:uppercase; color:var(--ink-muted); margin-bottom:3px; }
+.seg { display:flex; gap:3px; background:var(--canvas); border-radius:999px; padding:3px; }
+.seg button {
+  border:0; background:transparent; color:var(--ink-muted); font:inherit; font-size:12px; font-weight:500;
+  padding:5px 14px; border-radius:999px; cursor:pointer; transition:color 150ms ease-out;
+}
+.seg button:focus-visible { outline:none; box-shadow:var(--focus-ring); }
+.seg button[aria-pressed="true"] { background:var(--focal); color:var(--ink); box-shadow:0 1px 2px rgba(0,0,0,0.10); }
+
+/* ---------- Testata invariabile ---------- */
+.testata {
+  max-width:1040px; margin:20px auto 0; padding:12px 18px; display:flex; align-items:baseline; gap:14px; flex-wrap:wrap;
+  background:var(--field); border:1px solid var(--border); border-radius:var(--r-card);
+}
+.testata .nome { font-size:17px; font-weight:650; letter-spacing:-0.01em; }
+.testata .dato { font-size:12px; color:var(--ink-muted); }
+.testata .allergia { font-size:12px; font-weight:600; color:var(--critical); }
+
+/* ---------- Palco ---------- */
+.stage { max-width:1040px; margin:14px auto 56px; }
+.viewnote { font-size:12px; color:var(--ink-muted); margin:0 2px 14px; max-width:84ch; }
+.cols { display:grid; grid-template-columns:340px 1fr; gap:14px; align-items:start; }
+@media (max-width:780px){ .cols { grid-template-columns:1fr; } }
+
+.panel { position:relative; background:var(--field); border:1px solid var(--border);
+  border-radius:var(--r-panel); padding:18px; min-height:300px;
+  transition:background 180ms ease-out, box-shadow 180ms ease-out; }
+.panel h2 { font-size:15px; font-weight:650; letter-spacing:-0.01em; }
+.panel .sub { font-size:11px; color:var(--ink-muted); margin-bottom:14px; }
+
+/* Il fuoco e SOLO luce: la superficie sale (calore appena piu alto + ombra
+   breve), mai una linea sul bordo. */
+.panel[data-fuoco="true"] {
+  background:linear-gradient(var(--warm), var(--warm)), var(--focal);
+  box-shadow:var(--shadow-focal);
+}
+/* Conferma transiente al cambio fuoco: l accento lampeggia e si spegne. */
+@keyframes assicura {
+  0% { box-shadow:var(--shadow-focal), 0 0 0 0 var(--minerale-tint); }
+  35% { box-shadow:var(--shadow-lift), 0 0 0 6px var(--minerale-tint); }
+  100% { box-shadow:var(--shadow-focal), 0 0 0 0 rgba(0,0,0,0); }
+}
+.panel.assicura { animation:assicura 320ms ease-out; }
+/* Il focus di tastiera resta visibile (WCAG 2.2 AA, 2.4.7/2.4.11): un anello,
+   non la stanghetta vietata (quella e per fuoco/selezione, non per il focus). */
+.panel:focus-visible { outline:none; box-shadow:var(--focus-ring); }
+
+/* ---------- La voce: il controllo di cattura ---------- */
+.capta { display:flex; flex-direction:column; align-items:center; gap:16px; padding:6px 0 2px; }
+
+/* Pulsante microfono: a riposo quieto, in cattura sale nella luce. */
+.mic {
+  position:relative; width:112px; height:112px; border-radius:50%; border:1px solid var(--border);
+  background:var(--field); color:var(--minerale); cursor:pointer; overflow:hidden;
+  display:flex; align-items:center; justify-content:center;
+  transition:transform 150ms cubic-bezier(0.2,0,0,1), background 180ms ease-out, box-shadow 180ms ease-out, color 180ms ease-out;
+}
+.mic:hover { box-shadow:var(--shadow-focal); }
+.mic:active { transform:scale(0.97); }
+.mic:focus-visible { outline:none; box-shadow:var(--focus-ring); }
+.mic svg { width:40px; height:40px; }
+.mic .glyph-mic { display:block; }
+.mic .glyph-stop { display:none; }
+/* In cattura la materia si accende: focal + calore + ombra, mai un bordo. */
+.state-cattura .mic {
+  background:linear-gradient(var(--warm), var(--warm)), var(--focal);
+  box-shadow:var(--shadow-lift); color:var(--minerale); border-color:transparent;
+}
+.state-cattura .mic .glyph-mic { display:none; }
+.state-cattura .mic .glyph-stop { display:block; }
+
+/* Riga di stato: sobria, il tempo scorre nel Registro. */
+.statoline { display:flex; align-items:center; justify-content:center; gap:10px; min-height:22px; }
+.dot { width:8px; height:8px; border-radius:50%; background:var(--ink-muted); flex:none;
+  transition:background 180ms ease-out; }
+.state-cattura .dot { background:var(--minerale); }
+.state-fatto .dot { background:var(--success); }
+.statoline .label { font-size:12.5px; font-weight:600; }
+.statoline .tempo { color:var(--ink-muted); font-size:13px; }
+
+/* Indicatore di livello SOBRIO: un metro, non un onda. Vive solo in cattura,
+   mosso dall ingresso reale del microfono. Se il microfono non e disponibile
+   la barra resta ferma: nessun valore sintetico. A riposo e assente, non
+   "respira". */
+.meter-wrap { width:100%; max-width:230px; height:0; overflow:hidden; transition:height 200ms ease-out; }
+.state-cattura .meter-wrap { height:auto; }
+.meter {
+  position:relative; height:10px; border-radius:999px; background:var(--minerale-tint);
+  overflow:hidden;
+  /* tacche discrete: dice "metro", non "forma d onda" */
+  background-image:linear-gradient(90deg, var(--border) 0 1px, transparent 1px);
+  background-size:20px 100%;
+}
+.meter .fill { position:absolute; left:0; top:0; bottom:0; width:0%; background:var(--minerale);
+  border-radius:999px; opacity:0.85; }
+.meter-note { margin-top:7px; font-size:10.5px; color:var(--ink-muted); text-align:center; }
+
+.capta .aiuto { font-size:11px; color:var(--ink-muted); text-align:center; max-width:26ch; }
+
+/* ---------- Diario: la trascrizione entra sul filo ---------- */
+.diario { position:relative; padding-left:24px; margin-top:8px; }
+/* IL FILO: geometria SVG continua che si disegna. Mai un bordo, mai tratteggio. */
+.filo { position:absolute; left:0; top:0; width:24px; height:100%; overflow:visible; pointer-events:none; }
+.filo line { stroke:var(--minerale); stroke-width:1; opacity:0.55; }
+
+.entry { position:relative; padding:8px 0 16px; }
+/* Il nodo sulla spina: marcatore neutro, non linea, non calore. */
+.entry .nodo { position:absolute; left:-21px; top:12px; width:9px; height:9px; border-radius:50%;
+  background:var(--field); border:1.5px solid var(--minerale);
+  transition:border-color 340ms ease-out, background 340ms ease-out; }
+.entry .quando { font-size:10.5px; color:var(--ink-muted); }
+.entry .stato { font-size:10.5px; margin-left:8px; font-weight:600; }
+.entry .body { font-size:13px; margin-top:3px; transition:color 420ms ease-out; }
+.entry .azioni { margin-top:10px; display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
+
+/* STATO via inchiostro. Firmata = inchiostro pieno + nodo success. */
+.entry.firmata .stato { color:var(--success); }
+.entry.firmata .body { color:var(--ink); }
+.entry.firmata .nodo { border-color:var(--success); background:var(--success); }
+
+/* Bozza = inchiostro tenue + micro-etichetta onesta. Nessun tratteggio,
+   nessun calore (il calore appartiene solo al fuoco), nessun colore-cautela
+   clinico: lo stato lo porta l inchiostro, il nodo resta il marcatore neutro. */
+.entry.bozza .stato { color:var(--ink-muted); }
+.entry.bozza .body { color:var(--ink-muted); }
+
+/* La voce appena trascritta appare col gesto dello stop, poi resta ferma. */
+.entry.nuova { animation:posa 300ms ease-out; }
+@keyframes posa { from { opacity:0; transform:translateY(6px); } to { opacity:1; transform:none; } }
+
+/* La firma ASCIUGA l inchiostro: il tick success si disegna. */
+.tick { display:inline-block; height:2px; width:0; background:var(--success); border-radius:2px;
+  vertical-align:middle; margin-left:8px; transition:width 380ms ease-out; }
+.entry.firmata .tick { width:26px; }
+
+.empty { padding:6px 2px 2px; font-size:11.5px; color:var(--ink-muted); }
+
+/* ---------- Bottoni vivi ---------- */
+.btn { position:relative; overflow:hidden; border:0; cursor:pointer; font:inherit; font-weight:600; font-size:12.5px;
+  color:var(--focal); background:var(--minerale); padding:9px 16px; border-radius:var(--r-control);
+  transition:transform 150ms cubic-bezier(0.2,0,0,1), filter 150ms ease-out; }
+.btn:hover { filter:brightness(1.06); }
+.btn:active { transform:scale(0.97); }
+.btn:focus-visible { outline:none; box-shadow:var(--focus-ring); }
+.btn-quiet { position:relative; overflow:hidden; border:1px solid var(--border); background:transparent; color:var(--ink);
+  font:inherit; font-size:12px; font-weight:550; cursor:pointer; padding:8px 14px; border-radius:999px;
+  transition:transform 150ms cubic-bezier(0.2,0,0,1), background 150ms ease-out; }
+.btn-quiet:hover { background:var(--canvas); }
+.btn-quiet:active { transform:scale(0.97); }
+.btn-quiet:focus-visible { outline:none; box-shadow:var(--focus-ring); }
+
+/* Il tocco lascia un anello che si spegne, dal punto dell azione. */
+.ripple { position:absolute; border-radius:50%; transform:translate(-50%,-50%) scale(0); background:rgba(255,255,255,0.5); pointer-events:none; }
+.mic .ripple, .btn-quiet .ripple { background:var(--minerale-tint); }
+@keyframes onda { to { transform:translate(-50%,-50%) scale(1); opacity:0; } }
+.ripple.go { animation:onda 460ms ease-out forwards; }
+
+@media (prefers-reduced-motion: reduce) {
+  * { transition:none !important; animation:none !important; }
+  /* Lo stato resta leggibile senza moto: tono, etichetta, superficie, tick. */
+  .entry.firmata .tick { width:26px; }
+  .state-cattura .meter-wrap { height:auto; }
+}
+</style>
+</head>
+<body class="giorno">
+
+<div class="bar">
+  <h1>Lume, La voce</h1>
+  <div>
+    <div class="seg-label">Registro di luce</div>
+    <div class="seg" role="group" aria-label="Registro di luce">
+      <button data-reg="giorno" aria-pressed="true">Giorno</button>
+      <button data-reg="grafite" aria-pressed="false">Grafite</button>
+      <button data-reg="guardia" aria-pressed="false">Guardia</button>
+    </div>
+  </div>
+  <span class="hint">I registri di luce sono un controllo di questa demo. Nel prodotto seguono il sistema (ADR 0047). Dati dimostrativi.</span>
+</div>
+
+<div class="testata" role="banner">
+  <span class="nome">Bianchi Aurora (demo)</span>
+  <span class="dato reg">1954</span>
+  <span class="dato">dati dimostrativi</span>
+  <span class="allergia">Allergia: penicillina</span>
+  <span class="dato">Terapie attive: <span class="reg">3</span></span>
+</div>
+
+<div class="stage" id="stage">
+  <p class="viewnote">Avvia la cattura: la materia si accende con la luce e un indicatore di livello sobrio mosso dal microfono; il tempo scorre nel Registro. Allo stop la trascrizione entra sul filo del diario come bozza in inchiostro tenue. "Rivedi e firma" la asciuga a firmata. La trascrizione e proposta, non fatto, finche non e firmata.</p>
+
+  <div class="cols">
+
+    <section class="panel" id="panelVoce" data-fuoco="false" aria-labelledby="voceTitle" tabindex="0">
+      <h2 id="voceTitle">La voce</h2>
+      <p class="sub">cattura della visita, ADR 0072</p>
+
+      <div class="capta">
+        <button class="mic" id="mic" aria-pressed="false" aria-label="Avvia la cattura della visita">
+          <span class="glyph-mic" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="9" y="3" width="6" height="11" rx="3"></rect>
+              <path d="M6 11a6 6 0 0 0 12 0"></path>
+              <line x1="12" y1="17" x2="12" y2="21"></line>
+              <line x1="9" y1="21" x2="15" y2="21"></line>
+            </svg>
+          </span>
+          <span class="glyph-stop" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="currentColor" stroke="none">
+              <rect x="7" y="7" width="10" height="10" rx="2.5"></rect>
+            </svg>
+          </span>
+        </button>
+
+        <div class="statoline">
+          <span class="dot" aria-hidden="true"></span>
+          <span class="label" id="stateLabel">A riposo</span>
+          <span class="tempo reg" id="tempo" aria-hidden="true">00:00</span>
+        </div>
+
+        <div class="meter-wrap" id="meterWrap">
+          <div class="meter" aria-hidden="true"><div class="fill" id="meterFill"></div></div>
+          <div class="meter-note reg" id="meterNote">livello</div>
+        </div>
+
+        <p class="aiuto" id="aiuto">Premi per avviare. Premi di nuovo per fermare.</p>
+      </div>
+    </section>
+
+    <section class="panel" id="panelDiario" data-fuoco="true" aria-labelledby="diarioTitle" tabindex="0">
+      <h2 id="diarioTitle">Diario</h2>
+      <p class="sub">ipertensione in follow-up</p>
+
+      <div class="diario" id="diario">
+        <svg class="filo" id="filo" aria-hidden="true" preserveAspectRatio="none">
+          <line id="filoLine" x1="7" y1="0" x2="7" y2="0"></line>
+        </svg>
+
+        <div class="entry firmata">
+          <span class="nodo" aria-hidden="true"></span>
+          <span class="quando reg">04/07/2026</span><span class="stato">firmata</span><span class="tick" aria-hidden="true"></span>
+          <div class="body">Controllo programmato. Riferisce cefalea mattutina saltuaria. PA domiciliare in salita nell ultima settimana.</div>
+        </div>
+
+        <div class="entry firmata">
+          <span class="nodo" aria-hidden="true"></span>
+          <span class="quando reg">11/07/2026</span><span class="stato">firmata</span><span class="tick" aria-hidden="true"></span>
+          <div class="body">Richiamo a 7 giorni con diario pressorio. Confermato aggiustamento della terapia serale.</div>
+        </div>
+
+        <div class="entry bozza nuova" id="voceEntry" hidden>
+          <span class="nodo" aria-hidden="true"></span>
+          <span class="quando reg" id="voceQuando">oggi</span><span class="stato" id="voceStato">bozza, trascritta, da rivedere</span><span class="tick" aria-hidden="true"></span>
+          <div class="body" id="voceBody"></div>
+          <div class="azioni">
+            <button class="btn" id="firma">Rivedi e firma</button>
+            <button class="btn-quiet" id="scarta">Scarta la bozza</button>
+          </div>
+        </div>
+
+        <div class="empty" id="dEmpty">Nessuna voce in attesa.</div>
+      </div>
+    </section>
+
+  </div>
+</div>
+
+<div class="vh" role="status" aria-live="polite" id="live"></div>
+
+<script>
+(function(){
+  var body = document.body, stage = document.getElementById('stage');
+  var reduce = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  var live = document.getElementById('live');
+  function announce(t){ live.textContent = ''; setTimeout(function(){ live.textContent = t; }, 30); }
+
+  /* --- Registri di luce (alta frequenza: nessuna animazione di contenuto) --- */
+  document.querySelectorAll('[data-reg]').forEach(function(b){
+    b.addEventListener('click', function(){
+      body.className = b.dataset.reg;
+      document.querySelectorAll('[data-reg]').forEach(function(x){ x.setAttribute('aria-pressed', String(x===b)); });
+    });
+  });
+
+  /* --- Anello dal punto del tocco --- */
+  function onda(el, e){
+    if(reduce) return;
+    var r = document.createElement('span'); r.className = 'ripple';
+    var b = el.getBoundingClientRect(); var d = Math.max(b.width,b.height)*2;
+    r.style.width = r.style.height = d + 'px';
+    r.style.left = ((e && e.clientX ? e.clientX : b.left+b.width/2) - b.left) + 'px';
+    r.style.top = ((e && e.clientY ? e.clientY : b.top+b.height/2) - b.top) + 'px';
+    el.appendChild(r); void r.offsetWidth; r.classList.add('go');
+    setTimeout(function(){ r.remove(); }, 500);
+  }
+
+  /* --- Conferma transiente di fuoco --- */
+  var panels = [document.getElementById('panelVoce'), document.getElementById('panelDiario')];
+  function pulse(el){ if(reduce) return; el.classList.remove('assicura'); void el.offsetWidth; el.classList.add('assicura'); }
+  function setFuoco(t){ panels.forEach(function(p){ p.setAttribute('data-fuoco', String(p===t)); }); pulse(t); }
+  panels.forEach(function(p){ p.addEventListener('focusin', function(){ setFuoco(p); }); });
+
+  /* ============================================================
+     La cattura: riposo -> cattura -> stop -> bozza sul diario.
+     ============================================================ */
+  var mic = document.getElementById('mic');
+  var stateLabel = document.getElementById('stateLabel');
+  var tempoEl = document.getElementById('tempo');
+  var aiuto = document.getElementById('aiuto');
+  var meterFill = document.getElementById('meterFill');
+  var meterNote = document.getElementById('meterNote');
+  var panelVoce = document.getElementById('panelVoce');
+
+  var stateName = 'riposo';
+  var t0 = 0, tick = null;
+  var rafId = null, level = 0;
+  var audioCtx = null, analyser = null, micStream = null, buf = null, usingRealMic = false;
+
+  function setState(s){
+    stateName = s;
+    stage.classList.remove('state-riposo','state-cattura','state-fatto');
+    stage.classList.add('state-' + s);
+  }
+
+  function fmt(ms){
+    var tot = Math.floor(ms/1000);
+    var m = String(Math.floor(tot/60)).padStart(2,'0');
+    var sec = String(tot%60).padStart(2,'0');
+    return m + ':' + sec;
+  }
+
+  /* Il livello: metro sobrio mosso SOLO dall ingresso reale del microfono.
+     Se il microfono non e concesso la barra resta ferma: mai un valore
+     sintetico, che mostrerebbe un livello mentre non si ascolta nulla. */
+  function startLevel(){
+    level = 0; meterFill.style.width = '0%';
+    tryRealMic();
+    var loop = function(){
+      if(stateName !== 'cattura'){ return; }
+      if(usingRealMic && analyser){
+        analyser.getByteTimeDomainData(buf);
+        var sum = 0;
+        for(var i=0;i<buf.length;i++){ var v = (buf[i]-128)/128; sum += v*v; }
+        var rms = Math.sqrt(sum/buf.length);
+        level = Math.min(1, level + (Math.min(1, rms*3.2) - level)*0.35);
+        meterFill.style.width = Math.max(2, Math.round(level*100)) + '%';
+      }
+      /* senza microfono reale non si tocca la barra: nessun moto sintetico */
+      rafId = requestAnimationFrame(loop);
+    };
+    rafId = requestAnimationFrame(loop);
+  }
+  function stopLevel(){
+    if(rafId){ cancelAnimationFrame(rafId); rafId = null; }
+    if(micStream){ micStream.getTracks().forEach(function(tr){ tr.stop(); }); micStream = null; }
+    if(audioCtx){ try{ audioCtx.close(); }catch(e){} audioCtx = null; analyser = null; }
+    usingRealMic = false;
+    meterFill.style.width = '0%';
+  }
+  function tryRealMic(){
+    if(!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia){
+      meterNote.textContent = 'livello non disponibile'; return;
+    }
+    navigator.mediaDevices.getUserMedia({ audio:true }).then(function(stream){
+      if(stateName !== 'cattura'){ stream.getTracks().forEach(function(tr){ tr.stop(); }); return; }
+      micStream = stream;
+      var AC = window.AudioContext || window.webkitAudioContext;
+      audioCtx = new AC();
+      var src = audioCtx.createMediaStreamSource(stream);
+      analyser = audioCtx.createAnalyser(); analyser.fftSize = 512;
+      buf = new Uint8Array(analyser.fftSize);
+      src.connect(analyser);
+      usingRealMic = true;
+      meterNote.textContent = 'livello dal microfono';
+    }).catch(function(){
+      meterNote.textContent = 'livello non disponibile';
+    });
+  }
+
+  function startCapture(){
+    setState('cattura');
+    setFuoco(panelVoce);
+    mic.setAttribute('aria-pressed','true');
+    mic.setAttribute('aria-label','Ferma la cattura della visita');
+    stateLabel.textContent = 'In ascolto';
+    aiuto.textContent = 'La cattura e in corso. Premi per fermare.';
+    meterNote.textContent = 'livello';
+    t0 = Date.now(); tempoEl.textContent = '00:00';
+    tick = setInterval(function(){ tempoEl.textContent = fmt(Date.now()-t0); }, 250);
+    startLevel();
+    announce('Cattura avviata, in ascolto.');
+  }
+
+  function stopCapture(){
+    if(tick){ clearInterval(tick); tick = null; }
+    stopLevel();
+    setState('fatto');
+    mic.setAttribute('aria-pressed','false');
+    mic.setAttribute('aria-label','Avvia la cattura della visita');
+    var durata = fmt(Date.now()-t0);
+    stateLabel.textContent = 'Cattura conclusa';
+    aiuto.textContent = 'Trascrizione in bozza nel diario. Rivedi e firma per confermarla.';
+    depositaBozza(durata);
+    announce('Cattura conclusa dopo ' + durata + '. Trascrizione entrata come bozza, da rivedere.');
+  }
+
+  mic.addEventListener('click', function(e){
+    onda(mic, e);
+    if(stateName === 'cattura'){ stopCapture(); }
+    else { startCapture(); }
+  });
+
+  /* ============================================================
+     Il diario e il filo (SVG draw-on).
+     ============================================================ */
+  var diario = document.getElementById('diario');
+  var filo = document.getElementById('filo');
+  var filoLine = document.getElementById('filoLine');
+  var voceEntry = document.getElementById('voceEntry');
+  var voceBody = document.getElementById('voceBody');
+  var voceQuando = document.getElementById('voceQuando');
+  var voceStato = document.getElementById('voceStato');
+  var dEmpty = document.getElementById('dEmpty');
+  var firma = document.getElementById('firma');
+  var scarta = document.getElementById('scarta');
+
+  var TRASCRIZIONE = "Visita di controllo. La paziente riferisce che i valori pressori domiciliari restano elevati al mattino, con cefalea occasionale. Buona aderenza alla terapia. Si concorda un richiamo a 7 giorni con nuovo diario pressorio e rivalutazione della terapia serale.";
+
+  function nodeY(entry){
+    /* y del nodo relativo al contenitore diario. */
+    return entry.offsetTop + 12 + 4.5;
+  }
+
+  function drawFilo(reveal){
+    var visibili = Array.prototype.slice.call(diario.querySelectorAll('.entry')).filter(function(en){ return !en.hidden; });
+    if(visibili.length === 0){ filoLine.setAttribute('y2', filoLine.getAttribute('y1')); return; }
+    var y1 = nodeY(visibili[0]);
+    var yLast = nodeY(visibili[visibili.length-1]);
+    var h = diario.offsetHeight;
+    filo.setAttribute('viewBox', '0 0 24 ' + h);
+    filo.style.height = h + 'px';
+    filoLine.setAttribute('y1', y1);
+    filoLine.setAttribute('y2', yLast);
+    var total = Math.max(0, yLast - y1);
+    if(reveal && !reduce){
+      /* Il filo si disegna verso il nodo nuovo: dashoffset da segmento a 0. */
+      var prev = visibili.length >= 2 ? nodeY(visibili[visibili.length-2]) : y1;
+      var nuovoSeg = Math.max(0, yLast - prev);
+      filoLine.style.transition = 'none';
+      filoLine.style.strokeDasharray = total;
+      filoLine.style.strokeDashoffset = nuovoSeg;
+      void filoLine.getBoundingClientRect();
+      filoLine.style.transition = 'stroke-dashoffset 420ms ease-out';
+      requestAnimationFrame(function(){ filoLine.style.strokeDashoffset = 0; });
+    } else {
+      filoLine.style.transition = 'none';
+      filoLine.style.strokeDasharray = total;
+      filoLine.style.strokeDashoffset = 0;
+    }
+  }
+
+  function depositaBozza(durata){
+    dEmpty.hidden = true;
+    voceBody.textContent = TRASCRIZIONE;
+    voceQuando.textContent = 'oggi, ' + durata;
+    voceStato.textContent = 'bozza, trascritta, da rivedere';
+    voceEntry.classList.remove('firmata');
+    voceEntry.classList.add('bozza');
+    if(!reduce){ voceEntry.classList.remove('nuova'); void voceEntry.offsetWidth; voceEntry.classList.add('nuova'); }
+    voceEntry.hidden = false;
+    firma.style.display = '';
+    requestAnimationFrame(function(){ drawFilo(true); });
+  }
+
+  /* La firma ASCIUGA l inchiostro: torna pieno, tick success, nodo success,
+     anello che si spegne. Tab NON firma: serve un gesto esplicito qui. */
+  firma.addEventListener('click', function(e){
+    onda(firma, e);
+    voceEntry.classList.remove('bozza');
+    voceEntry.classList.add('firmata');
+    voceStato.textContent = 'firmata';
+    firma.style.display = 'none';
+    scarta.textContent = 'Riporta a bozza';
+    /* il pulsante appena nascosto teneva il focus: lo passiamo a un controllo vivo */
+    scarta.focus();
+    announce('Voce firmata. Inchiostro asciutto.');
+  });
+
+  scarta.addEventListener('click', function(e){
+    onda(scarta, e);
+    if(voceEntry.classList.contains('firmata')){
+      /* Riporta a bozza: l inchiostro torna tenue. */
+      voceEntry.classList.remove('firmata');
+      voceEntry.classList.add('bozza');
+      voceStato.textContent = 'bozza, trascritta, da rivedere';
+      firma.style.display = '';
+      scarta.textContent = 'Scarta la bozza';
+      firma.focus();
+      announce('Riportata a bozza, da rivedere.');
+    } else {
+      /* Scarta: la bozza esce, il diario torna in attesa. */
+      voceEntry.hidden = true;
+      dEmpty.hidden = false;
+      setState('riposo');
+      stateLabel.textContent = 'A riposo';
+      tempoEl.textContent = '00:00';
+      aiuto.textContent = 'Premi per avviare. Premi di nuovo per fermare.';
+      /* la voce nascosta teneva il focus: lo riportiamo al microfono */
+      mic.focus();
+      announce('Bozza scartata.');
+      requestAnimationFrame(function(){ drawFilo(false); });
+    }
+  });
+
+  /* Init */
+  setState('riposo');
+  window.addEventListener('resize', function(){ drawFilo(false); });
+  requestAnimationFrame(function(){ drawFilo(false); });
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Cosa

Distilla il livello di interazione e movimento di Lume, che `01-lingua` aveva lasciato aperto, e lo fissa nel capitolo canonico `07-gesto-e-movimento.md`. Tre portatori, tre lavori distinti, nessuna sovrapposizione:

- **La luce porta il fuoco** (superficie che sale, calore, ombra breve): mai una linea.
- **L'inchiostro porta lo stato**: la bozza e a contrasto piu basso con etichetta onesta; la firma e il gesto che asciuga l'inchiostro. Niente tratteggio.
- **Il filo connette e basta**, dove connette davvero (spina del diario, provenienza), reso come geometria SVG continua. Mai una stanghetta sul lato di un riquadro.

## Perche

La resa precedente del filo (una linea sul bordo dei riquadri, tratteggiata per la bozza) legge come un solco di diff o uno skeleton di caricamento: procedurale e non finito, il contrario della fiducia che serve a un prodotto clinico. E tradiva la legge madre di Lume: il fuoco si assegna con la luce, non con un segno.

## Cosa contiene

- `07-gesto-e-movimento.md`: leggi di moto (tempi, curve, reduce-motion per costruzione), gli atomi (testo, codificato, campo AI, allegato), le scene (cambio ambulatorio, voce, impostazioni sartoriali dentro ADR 0047), la proattivita per euristica onesta, e le primitive tecniche (`@property` per la luce, filo SVG, budget di movimento come test di CI).
- Revisione di `01-lingua.md` par. 1, 3 e 7 e del README: il fuoco non si marca piu con una linea, lo stato non col tratteggio.
- Ledger di ADR 0078 aggiornato.
- Cinque dimostratori interattivi autonomi in `mockups/` (nessuna dipendenza, dati esclusivamente dimostrativi):
  - `lume-dinamica.html`: studio prima/dopo, filo lineare contro luce e inchiostro.
  - `lume-cockpit-vivo.html`: cambio ambulatorio, coda dell'attenzione, fuoco per cross-fade.
  - `lume-campi.html`: testo, codificato ICD inline, campo AI come bozza tenue, allegato con provenienza.
  - `lume-voce.html`: microfono e cattura della visita (ADR 0072), trascrizione come bozza da firmare.
  - `lume-impostazioni.html`: densita, scorciatoie, viste, default ambulatorio, routing, con anteprima reversibile.

## Come revisionare

Solo documentazione e mockup: nessun codice di runtime toccato. Apri i file `mockups/*.html` nel browser e prova le movenze (nel cockpit il rail cambia ambulatorio; nei campi chiedi un suggerimento; la firma asciuga l'inchiostro). Documento applicato: Lume (ADR 0078). Resta specifica e dimostratore, non implementazione: i consumatori web e nativi restano da migrare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
