### PR TITLE
fix(db): serializza il bootstrap SQLite multiprocesso

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,6 +193,13 @@ Documentazione tecnica:
 
 ## 🗄️ Modifiche database (Drizzle / SQLite)
 
+Le schema guard additive di `lib/db-server.ts` sono serializzate con una
+transazione SQLite `IMMEDIATE`. Questo vincolo vale anche durante `next build`,
+che valuta i moduli server con piu processi: non introdurre guard che aprono una
+seconda connessione o aggirano la transazione. La regressione dedicata e
+`npm run test:db-bootstrap-concurrency` e usa solo un database temporaneo
+sintetico.
+
 Fonti autorevoli:
 - Schema: `lib/schema.ts`
 - Migrazioni: `drizzle/`

--- a/docs/adr/0080-serialize-sqlite-schema-guards-at-bootstrap.md
+++ b/docs/adr/0080-serialize-sqlite-schema-guards-at-bootstrap.md
@@ -1,0 +1,70 @@
+# ADR 0080: serializzare le schema guard SQLite al bootstrap
+
+Date: 2026-07-15  
+Status: Proposed
+
+Related: [ADR 0066](./0066-patient-soft-delete-lifecycle.md), [ADR 0068](./0068-cross-platform-runtime-windows-linux.md)
+
+---
+
+## Problema
+
+`next build` valuta i moduli server in piu processi. Ogni import di
+`lib/db-server.ts` apre lo stesso database locale, imposta i pragma e applica
+le schema guard additive. I worker possono quindi eseguire contemporaneamente
+`journal_mode`, `ALTER TABLE` e `CREATE INDEX`, producendo errori intermittenti
+`SQLITE_BUSY` o avvisi `duplicate column` durante una build altrimenti valida.
+
+## Contesto
+
+SQLite resta l'unico storage autorevole e le schema guard runtime restano il
+meccanismo operativo per aggiornare database esistenti. La soluzione deve
+funzionare per build, avvio e reopen dopo repair, senza leggere dati reali nei
+test, senza lockfile esterni e senza disabilitare le guard durante il runtime.
+
+## Opzioni
+
+1. Limitare Next.js a un solo worker durante ogni build.
+2. Dare a ogni worker un database sintetico separato.
+3. Impostare prima il `busy_timeout` e serializzare le schema guard nello stesso
+   database con una transazione SQLite `IMMEDIATE`.
+
+## Trade-off
+
+- Opzione 1: riduce il parallelismo e dipende da un controllo non canonico del
+  framework, senza proteggere altri bootstrap multiprocesso.
+- Opzione 2: isola bene la build, ma introduce una seconda procedura di
+  provisioning e non irrobustisce l'avvio concorrente sul database reale.
+- Opzione 3: usa l'arbitraggio nativo del file SQLite, conserva un solo percorso
+  di bootstrap e fa attendere i processi concorrenti invece di farli scrivere
+  insieme; il costo e una breve serializzazione solo all'apertura.
+
+## Decisione
+
+Adottiamo l'opzione 3.
+
+- `busy_timeout` viene configurato prima del primo pragma che puo richiedere un
+  lock di scrittura.
+- Il passaggio a WAL ritenta soltanto errori SQLite di lock entro lo stesso
+  limite di cinque secondi; errori diversi o lock persistenti restano espliciti.
+- L'intera batteria di schema guard viene eseguita dentro una transazione
+  `IMMEDIATE`, cosi un solo processo alla volta puo controllare e modificare lo
+  schema.
+- Lo stesso helper viene usato al boot e dopo un database swap.
+- Le singole guard restano additive e idempotenti; nessun errore di schema viene
+  nascosto o trasformato in una modifica distruttiva.
+
+## Conseguenze
+
+Build e avvii multiprocesso non eseguono piu migrazioni concorrenti sullo stesso
+file. Un bootstrap attende il writer corrente entro il timeout dichiarato; un
+lock che supera il timeout continua a fallire in modo esplicito. Il throughput
+runtime dopo il bootstrap non cambia.
+
+## First Thin Slice
+
+1. Riordinare i pragma per configurare il timeout prima di `journal_mode`.
+2. Serializzare `applySchemaGuards()` con una transazione `IMMEDIATE` al boot e
+   al reopen.
+3. Aggiungere una regressione multiprocesso sullo stesso database sintetico e
+   verificare tre build standard consecutive piu il bundle macOS Release.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -6,7 +6,7 @@ Questa cartella contiene le decisioni di MediFlow (web + native).
 
 ## ADR piu recente
 
-- [0079-local-open-loops-and-result-link.md](./0079-local-open-loops-and-result-link.md): adotta attese locali deterministiche e collegamento manuale tra prestazione e risultato; la prima slice web locale e consegnata.
+- [0080-serialize-sqlite-schema-guards-at-bootstrap.md](./0080-serialize-sqlite-schema-guards-at-bootstrap.md): propone di serializzare le schema guard SQLite al bootstrap per eliminare le scritture concorrenti durante build e avvio multiprocesso.
 
 ---
 

--- a/docs/markdown-index.md
+++ b/docs/markdown-index.md
@@ -11,7 +11,7 @@ read_when:
 > GitHub mostra in alto solo alcuni file speciali (`README`, `CONTRIBUTING`, `SECURITY`, ecc.).
 > Questo file elenca invece **tutti** i `.md` tracciati nella repository con una sintesi rapida d'uso.
 
-Ultimo aggiornamento: 2026-07-13
+Ultimo aggiornamento: 2026-07-15
 
 ## 📚 Come usare questo indice
 
@@ -160,6 +160,7 @@ Ultimo aggiornamento: 2026-07-13
 | [docs/adr/0077-ai-provider-abstraction-and-egress-anonymization-boundary.md](./adr/0077-ai-provider-abstraction-and-egress-anonymization-boundary.md) | Accetta il boundary provider/egress: adapter Ollama e gate fail-closed consegnati, registry e provider alternativi pendenti. |
 | [docs/adr/0078-lume-lingua-di-design-di-destinazione.md](./adr/0078-lume-lingua-di-design-di-destinazione.md) | Decisione `Accepted`: adotta Lume come lingua di destinazione multipiattaforma, con Vetro Clinico transitorio e migrazione L0-L6 ancora parziale. |
 | [docs/adr/0079-local-open-loops-and-result-link.md](./adr/0079-local-open-loops-and-result-link.md) | Accetta le attese locali deterministiche: prima slice web consegnata, salvataggio esplicito e nessuna estensione paired. |
+| [docs/adr/0080-serialize-sqlite-schema-guards-at-bootstrap.md](./adr/0080-serialize-sqlite-schema-guards-at-bootstrap.md) | Propone di serializzare le schema guard SQLite al bootstrap per rendere deterministici build e avvii multiprocesso. |
 | [docs/adr/0050-functional-preview-profiles-retired-on-mainline.md](./adr/0050-functional-preview-profiles-retired-on-mainline.md) | Fissa `WUL-199`: i preview profiles funzionali vengono ritirati da `main`, con AI e Smart Import gia live e il contesto paziente SISS promosso a parte stabile della scheda paziente. |
 | [docs/adr/0048-apple-shared-client-architecture-and-home-base-runtime.md](./adr/0048-apple-shared-client-architecture-and-home-base-runtime.md) | Formalizza `WUL-188`: family Apple ricostruita con core Swift condiviso, shell distinte per macOS/iPhone/iPad, Mac packaged come `home-base` autorevole e mobile paired senza accesso diretto a SQLite. |
 | [docs/adr/0049-siss-fse-document-corpus-and-local-mcp-layer.md](./adr/0049-siss-fse-document-corpus-and-local-mcp-layer.md) | Formalizza `WUL-176`: corpus documentale locale SISS/FSE con manifest versionato, fetch/sync fuori Git e futuro MCP ammesso solo sopra un corpus approvato. |

--- a/lib/db-server-bootstrap-concurrency.test.ts
+++ b/lib/db-server-bootstrap-concurrency.test.ts
@@ -1,0 +1,84 @@
+/* @Codex */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+
+const ROOT_DIR = process.cwd();
+const WORKER_COUNT = 13;
+
+function applyBaseMigrations(dbPath: string): void {
+    const db = new Database(dbPath);
+    const migrationFiles = fs
+        .readdirSync(path.join(ROOT_DIR, 'drizzle'))
+        .filter((file) => file.endsWith('.sql'))
+        .sort((left, right) => left.localeCompare(right));
+
+    db.pragma('foreign_keys = OFF');
+    try {
+        for (const fileName of migrationFiles) {
+            const sql = fs
+                .readFileSync(path.join(ROOT_DIR, 'drizzle', fileName), 'utf8')
+                .replace(/^-->\s+statement-breakpoint\s*$/gm, '');
+            if (sql.trim().length > 0) db.exec(sql);
+        }
+    } finally {
+        db.close();
+    }
+}
+
+function runBootstrapWorker(dataDir: string): Promise<{ code: number | null; output: string }> {
+    return new Promise((resolve, reject) => {
+        const child = spawn(
+            process.execPath,
+            [
+                path.join(ROOT_DIR, 'scripts/run-strip-types.mjs'),
+                path.join(ROOT_DIR, 'scripts/db-server-bootstrap-worker.mjs'),
+            ],
+            {
+                cwd: ROOT_DIR,
+                env: { ...process.env, MEDIFLOW_DATA_DIR: dataDir },
+                stdio: ['ignore', 'pipe', 'pipe'],
+            },
+        );
+        let output = '';
+        child.stdout.on('data', (chunk) => { output += String(chunk); });
+        child.stderr.on('data', (chunk) => { output += String(chunk); });
+        child.once('error', reject);
+        child.once('close', (code) => resolve({ code, output }));
+    });
+}
+
+test('schema guards serialize across Next-style build workers', { timeout: 30_000 }, async () => {
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mediflow-db-bootstrap-'));
+    const dbPath = path.join(dataDir, 'medical.db');
+
+    try {
+        applyBaseMigrations(dbPath);
+        const results = await Promise.all(
+            Array.from({ length: WORKER_COUNT }, () => runBootstrapWorker(dataDir)),
+        );
+
+        for (const [index, result] of results.entries()) {
+            assert.equal(result.code, 0, `worker ${index} failed:\n${result.output}`);
+            assert.doesNotMatch(result.output, /SQLITE_BUSY|database is locked|duplicate column/i);
+        }
+
+        const db = new Database(dbPath, { readonly: true, fileMustExist: true });
+        try {
+            const patientColumns = db
+                .prepare('PRAGMA table_info(patients)')
+                .all()
+                .map((row) => (row as { name: string }).name);
+            assert.ok(patientColumns.includes('monitoring_profile'));
+        } finally {
+            db.close();
+        }
+    } finally {
+        fs.rmSync(dataDir, { recursive: true, force: true });
+    }
+});

--- a/lib/db-server.ts
+++ b/lib/db-server.ts
@@ -492,7 +492,17 @@ function applySchemaGuards() {
         console.warn('[MediFlow] Audit schema check skipped:', error);
     }
 }
-applySchemaGuards();
+
+/* @Codex */
+function applySchemaGuardsSerially(): void {
+    // Next.js production builds load server modules in multiple processes.
+    // BEGIN IMMEDIATE lets SQLite arbitrate one schema writer while the other
+    // workers wait under busy_timeout, preventing concurrent check-then-ALTER
+    // races and duplicate-column warnings.
+    sqlite.transaction(applySchemaGuards).immediate();
+}
+
+applySchemaGuardsSerially();
 
 /**
  * Replaces the SQLite file from sourcePath without writing under the open
@@ -514,7 +524,7 @@ export async function swapDatabaseFromFile(sourcePath: string, backupPath: strin
         reopenConnection: () => {
             sqlite = new Database(dbPath);
             initSqlitePragmas(sqlite);
-            applySchemaGuards();
+            applySchemaGuardsSerially();
         },
     });
 }

--- a/lib/sqlite-pragmas.test.ts
+++ b/lib/sqlite-pragmas.test.ts
@@ -14,6 +14,48 @@ function tempDbPath(): string {
     return path.join(dir, 'test.db');
 }
 
+test('initSqlitePragmas configures busy_timeout before the WAL write lock', () => {
+    const calls: string[] = [];
+    const connection = {
+        pragma(statement: string) {
+            calls.push(statement);
+            return statement === 'foreign_key_check' ? [] : undefined;
+        },
+    } as unknown as Database.Database;
+
+    initSqlitePragmas(connection);
+
+    assert.deepEqual(calls.slice(0, 2), ['busy_timeout = 5000', 'journal_mode = WAL']);
+});
+
+test('initSqlitePragmas retries a transient WAL lock without hiding other errors', () => {
+    let walAttempts = 0;
+    const connection = {
+        pragma(statement: string) {
+            if (statement === 'journal_mode = WAL') {
+                walAttempts += 1;
+                if (walAttempts < 3) {
+                    throw Object.assign(new Error('database is locked'), { code: 'SQLITE_BUSY' });
+                }
+            }
+            return statement === 'foreign_key_check' ? [] : undefined;
+        },
+    } as unknown as Database.Database;
+
+    assert.doesNotThrow(() => initSqlitePragmas(connection));
+    assert.equal(walAttempts, 3);
+
+    const invalidConnection = {
+        pragma(statement: string) {
+            if (statement === 'journal_mode = WAL') {
+                throw Object.assign(new Error('invalid database'), { code: 'SQLITE_CORRUPT' });
+            }
+            return undefined;
+        },
+    } as unknown as Database.Database;
+    assert.throws(() => initSqlitePragmas(invalidConnection), /invalid database/);
+});
+
 test('initSqlitePragmas sets WAL, busy_timeout, synchronous NORMAL and foreign_keys ON', () => {
     const db = new Database(tempDbPath());
     try {

--- a/lib/sqlite-pragmas.ts
+++ b/lib/sqlite-pragmas.ts
@@ -14,9 +14,36 @@ import type Database from 'better-sqlite3';
 
 type ForeignKeyViolationRow = { table: string };
 
+const SQLITE_LOCK_RETRY_MS = 50;
+const SQLITE_LOCK_TIMEOUT_MS = 5000;
+const sqliteLockWaiter = new Int32Array(new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT));
+
+function isSqliteLockError(error: unknown): boolean {
+    if (!error || typeof error !== 'object' || !('code' in error)) return false;
+    const code = String((error as { code: unknown }).code);
+    return code.startsWith('SQLITE_BUSY') || code.startsWith('SQLITE_LOCKED');
+}
+
+/* @Codex */
+function enableWalWithBoundedRetry(connection: Database.Database): void {
+    const deadline = Date.now() + SQLITE_LOCK_TIMEOUT_MS;
+    while (true) {
+        try {
+            connection.pragma('journal_mode = WAL');
+            return;
+        } catch (error) {
+            if (!isSqliteLockError(error) || Date.now() >= deadline) throw error;
+            Atomics.wait(sqliteLockWaiter, 0, 0, SQLITE_LOCK_RETRY_MS);
+        }
+    }
+}
+
 export function initSqlitePragmas(connection: Database.Database): void {
-    connection.pragma('journal_mode = WAL');
+    // @Codex Configure waiting before the first pragma that may need the
+    // database write lock. Next.js evaluates server modules in parallel build
+    // workers, so setting WAL first would otherwise fail immediately.
     connection.pragma('busy_timeout = 5000');
+    enableWalWithBoundedRetry(connection);
     connection.pragma('synchronous = NORMAL');
 
     try {

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "test:audit": "bash scripts/audit-test.sh",
     "test:sqlite-repair": "bash scripts/sqlite-repair-test.sh",
     "test:sqlite-pragmas": "node scripts/run-strip-types.mjs --test lib/sqlite-pragmas.test.ts",
+    "test:db-bootstrap-concurrency": "node scripts/run-strip-types.mjs --test lib/db-server-bootstrap-concurrency.test.ts",
     "test:db-transaction-rollback": "node scripts/run-strip-types.mjs --test lib/db-transaction-rollback.test.ts",
     "test:schema-drift": "node scripts/run-strip-types.mjs --test scripts/check-schema-drift.test.ts",
     "benchmark:clinical-facts:observations": "node scripts/run-strip-types.mjs scripts/benchmark-observation-facts.mjs",

--- a/scripts/db-server-bootstrap-worker.mjs
+++ b/scripts/db-server-bootstrap-worker.mjs
@@ -1,0 +1,8 @@
+/* @Codex */
+
+// Importing db-server executes the real pragma and schema-guard bootstrap.
+// This worker exists only so the concurrency regression can launch the same
+// boundary in multiple operating-system processes.
+await import('@/lib/db-server');
+
+console.log('[db-bootstrap-worker] ready');


### PR DESCRIPTION
## Summary
- Serializza le schema guard SQLite al bootstrap con una transazione `IMMEDIATE`.
- Applica `busy_timeout` prima del passaggio a WAL e limita il retry ai soli errori `SQLITE_BUSY*`/`SQLITE_LOCKED*` con budget finito.
- Aggiunge un test reale con 13 processi concorrenti sulla stessa fixture sintetica.
- Documenta il boundary e la decisione nell'ADR 0080 e negli indici canonici.

## Verification
- `npm ci` pulito con Node 24.18.0 / ABI 137: PASS.
- `test:sqlite-pragmas`: 4/4 PASS.
- `test:db-bootstrap-concurrency`: 1/1 PASS con 13 processi reali.
- `test:node-runtime-contract`, lint, typecheck e schema drift: PASS.
- Tre `npm run build -- --webpack` standard consecutive sullo stesso database sintetico: PASS, senza `SQLITE_BUSY`, `database is locked` o `duplicate column`.
- `scripts/build-apple-macos-app.sh` Release completo: PASS, web build incluso e `BUILD SUCCEEDED`.
- Manifest Node 24.18.0 / ABI 137 / darwin arm64, binding arm64 e query SQLite `:memory:` dal WebRuntime: PASS.
- Verifier indipendente sul combined HEAD `de629bb82`: PASS; worktree detached pulito e nessun processo residuo.
- Autoreview `gpt-5.6-sol high`: clean, 0 finding azionabili.

## Risk / Notes
- Draft PR stacked sopra `codex/wul-376-node-abi-hardening`; deve essere revisionata e integrata rispettando questa dipendenza.
- L'ADR 0080 resta `Proposed` fino alla review.
- La creazione di un issue Linear separato e' stata bloccata dal limite del workspace gratuito; workstream locale esplicito: `WUL-376-BUILD-RACE`.
- Nessun cambiamento di schema clinico o dato reale; prove eseguite solo su fixture sintetiche/SQLite `:memory:`.
- Preparazione e pubblicazione della draft PR non equivalgono a merge o release.

## Ticket
Refs WUL-376
