### PR TITLE
fix(ui): stabilizza i gate Lume della PR 67

### DIFF
--- a/components/kree8/areas/incarico-area.tsx
+++ b/components/kree8/areas/incarico-area.tsx
@@ -265,6 +265,8 @@ function IncaricoArea({
                             <span className={styles.patientName}>{p.name}</span>
                             <span className={styles.patientCode}>{p.code} · {p.pathway}</span>
                           </span>
+                          {/* @Codex: dentro il button conserviamo il testo naturale;
+                              i ruoli annidati sarebbero presentazionali e non una lista reale. */}
                           <span className={styles.patientMeta}>
                             {p.diagnoses.map((d) => (
                               <span key={d} className={styles.patientDiagnosisPill}>
@@ -307,14 +309,19 @@ function IncaricoArea({
               {selected.ageLabel} · aggiornato {selected.lastTouch}
             </span>
           </div>
-          <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+          {/* @Codex */}
+          <ul aria-label={`Diagnosi e stato di ${selected.name}`} style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
             {selected.diagnoses.map((d) => (
-              <DiagnosisPill key={d} diagnosis={d} />
+              <li key={d} className={styles.patientDiagnosisPill}>
+                <DiagnosisPill diagnosis={d} />
+              </li>
             ))}
-            <PillBadge variant={selected.status}>
-              {selected.statusLabel}
-            </PillBadge>
-          </div>
+            <li>
+              <PillBadge variant={selected.status}>
+                {selected.statusLabel}
+              </PillBadge>
+            </li>
+          </ul>
           <p className={styles.rowSub} style={{ margin: 0, lineHeight: 1.6 }}>
             {selected.summary}
           </p>

--- a/components/kree8/areas/real-patient-area.tsx
+++ b/components/kree8/areas/real-patient-area.tsx
@@ -64,15 +64,21 @@ function RealPatientArea({
 
       <section className={styles.panel}>
         <div className={styles.identityDock}>
-          <div className={styles.identityChips}>
+          {/* @Codex: diagnosi e stato formano una lista nominata; i nomi delle
+              voci provengono dal contenuto visibile, non da aria-label. */}
+          <ul className={styles.identityChips} aria-label="Diagnosi e stato del paziente">
             {patient.diagnoses.map((diagnosis) => (
-              <DiagnosisPill key={diagnosis} diagnosis={diagnosis} />
+              <li key={diagnosis} className={styles.patientDiagnosisPill}>
+                <DiagnosisPill diagnosis={diagnosis} />
+              </li>
             ))}
-            <PillBadge variant={patient.status}>
-              {patient.statusLabel}
-            </PillBadge>
-            <PillBadge variant="neutral">{patient.code}</PillBadge>
-          </div>
+            <li>
+              <PillBadge variant={patient.status}>
+                {patient.statusLabel}
+              </PillBadge>
+            </li>
+            <li><PillBadge variant="neutral">{patient.code}</PillBadge></li>
+          </ul>
         </div>
 
         <div style={{ marginTop: 14 }}>

--- a/components/kree8/areas/scheda-area.tsx
+++ b/components/kree8/areas/scheda-area.tsx
@@ -112,14 +112,15 @@ function SchedaArea({
 
       <section className={styles.panel}>
         <div className={styles.identityDock}>
-          <div className={styles.identityChips}>
-            <DiagnosisPill diagnosis="Ipertensione" />
-            <DiagnosisPill diagnosis="Dislipidemia" />
-            <DiagnosisPill diagnosis="BPCO lieve" />
-            <PillBadge variant="neutral">PA 132/84</PillBadge>
-            <PillBadge variant="neutral">HR 76</PillBadge>
-            <PillBadge variant="neutral">SpO₂ 97%</PillBadge>
-          </div>
+          {/* @Codex */}
+          <ul className={styles.identityChips} aria-label="Diagnosi e stato del paziente">
+            <li className={styles.patientDiagnosisPill}><DiagnosisPill diagnosis="Ipertensione" /></li>
+            <li className={styles.patientDiagnosisPill}><DiagnosisPill diagnosis="Dislipidemia" /></li>
+            <li className={styles.patientDiagnosisPill}><DiagnosisPill diagnosis="BPCO lieve" /></li>
+            <li><PillBadge variant="neutral">PA 132/84</PillBadge></li>
+            <li><PillBadge variant="neutral">HR 76</PillBadge></li>
+            <li><PillBadge variant="neutral">SpO₂ 97%</PillBadge></li>
+          </ul>
           <span style={{ marginLeft: 'auto', display: 'inline-flex', gap: 6 }}>
             <PillBadge variant="success">
               <Sparkles size={11} />

--- a/components/kree8/cockpit-shared.tsx
+++ b/components/kree8/cockpit-shared.tsx
@@ -674,7 +674,6 @@ function DiagnosisPill({ diagnosis }: { diagnosis: string }) {
     <span
       className={classNames(styles.pill, styles.diagnosisPill)}
       title={diagnosis}
-      aria-label={diagnosis}
     >
       {code ? <span className={styles.diagnosisCode}>{code}</span> : null}
       {code ? <span aria-hidden>·</span> : null}

--- a/components/patient-identity-lens.tsx
+++ b/components/patient-identity-lens.tsx
@@ -187,22 +187,25 @@ export function PatientIdentityLens({
                                     )}
 
                                     {secondaryDiagnoses.length > 0 ? (
-                                        <div className="mt-2 flex flex-wrap gap-1.5">
+                                        /* @Codex: le diagnosi secondarie sono una lista informativa;
+                                           la semantica nativa rende verificabile il nome accessibile dei chip. */
+                                        <ul
+                                            aria-label="Diagnosi codificate secondarie"
+                                            className="mt-2 flex flex-wrap gap-1.5"
+                                        >
                                             {secondaryDiagnoses.map((diagnosis) => (
-                                                <span
+                                                <li
                                                     key={`${diagnosis.system}-${diagnosis.code}`}
-                                                    className="inline-flex max-w-full items-center gap-1.5 rounded-full border border-[color:color-mix(in_srgb,var(--lume-ink)_14%,transparent)] bg-[color:var(--lume-surface-field)] px-2.5 py-1 text-xs text-[color:var(--lume-ink)]"
-                                                    title={`${diagnosis.code} · ${diagnosis.description}`}
-                                                    aria-label={`${diagnosis.code} · ${diagnosis.description}`}
+                                                    className="inline-flex min-w-0 max-w-full items-center gap-1.5 rounded-full border border-[color:color-mix(in_srgb,var(--lume-ink)_14%,transparent)] bg-[color:var(--lume-surface-field)] px-2.5 py-1 text-xs text-[color:var(--lume-ink)]"
                                                 >
                                                     <span className="lume-registro font-semibold">{diagnosis.code}</span>
-                                                    <span className="truncate">{diagnosis.description}</span>
+                                                    <span className="truncate" title={diagnosis.description}>{diagnosis.description}</span>
                                                     <span className="shrink-0 text-[10px] uppercase tracking-[0.04em] text-[color:var(--lume-ink-muted)]">
                                                         {diagnosisSystemLabel(diagnosis.system)}
                                                     </span>
-                                                </span>
+                                                </li>
                                             ))}
-                                        </div>
+                                        </ul>
                                     ) : null}
 
                                     {remainingCodedCount > 0 ? (
@@ -311,28 +314,31 @@ export function PatientIdentityLens({
                             <p className="text-[10px] font-medium uppercase tracking-[0.08em] text-[color:var(--lume-ink-muted)]">
                                 Quadro clinico
                             </p>
-                            <div className="mt-3 flex flex-wrap gap-2">
-                                {diagnoses.length > 0 ? (
-                                    diagnoses.map((diagnosis) => (
-                                        <span
+                            {diagnoses.length > 0 ? (
+                                /* @Codex: il contenitore nomina la collezione; ogni voce
+                                   conserva codice, descrizione e sistema come contenuto naturale. */
+                                <ul
+                                    aria-label="Diagnosi del quadro clinico"
+                                    className="mt-3 flex flex-wrap gap-2"
+                                >
+                                    {diagnoses.map((diagnosis) => (
+                                        <li
                                             key={`${diagnosis.system}-${diagnosis.code}`}
-                                            className="inline-flex max-w-full items-center gap-1.5 rounded-full border border-[color:color-mix(in_srgb,var(--lume-ink)_14%,transparent)] bg-[color:var(--lume-surface-field)] px-3 py-1 text-[12px] font-medium text-[color:var(--lume-ink)]"
-                                            title={`${diagnosis.code} · ${diagnosis.description}`}
-                                            aria-label={`${diagnosis.code} · ${diagnosis.description}`}
+                                            className="inline-flex min-w-0 max-w-full items-center gap-1.5 rounded-full border border-[color:color-mix(in_srgb,var(--lume-ink)_14%,transparent)] bg-[color:var(--lume-surface-field)] px-3 py-1 text-[12px] font-medium text-[color:var(--lume-ink)]"
                                         >
                                             <span className="lume-registro shrink-0 font-semibold text-[color:var(--lume-ink)]">{diagnosis.code}</span>
-                                            <span className="min-w-0 truncate">{diagnosis.description}</span>
+                                            <span className="min-w-0 truncate" title={diagnosis.description}>{diagnosis.description}</span>
                                             <span className="shrink-0 text-[10px] uppercase tracking-[0.04em] text-[color:var(--lume-ink-muted)]">
                                                 {diagnosisSystemLabel(diagnosis.system)}
                                             </span>
-                                        </span>
-                                    ))
-                                ) : (
-                                    <p className="text-sm text-[color:var(--lume-ink-muted)]">
-                                        Nessuna diagnosi strutturata in primo piano.
-                                    </p>
-                                )}
-                            </div>
+                                        </li>
+                                    ))}
+                                </ul>
+                            ) : (
+                                <p className="mt-3 text-sm text-[color:var(--lume-ink-muted)]">
+                                    Nessuna diagnosi strutturata in primo piano.
+                                </p>
+                            )}
                         </div>
 
                         <div className="identity-lens-pane rounded-[var(--lume-radius-card)] border border-[color:color-mix(in_srgb,var(--lume-ink)_12%,transparent)] bg-[color:var(--lume-surface-field)] p-4">

--- a/components/settings/network-operating-mode-panel.tsx
+++ b/components/settings/network-operating-mode-panel.tsx
@@ -10,7 +10,9 @@ import {
     type NetworkOverviewPayload,
 } from '@/lib/network-operating-mode';
 
-const INPUT_SEGMENT_CLASS = 'inline-flex items-center rounded-full border px-3 py-1.5 text-xs font-semibold transition-colors';
+// @Codex: il fetch iniziale cambia tre colori per segmento senza un gesto;
+// questi controlli ad alta frequenza devono scattare, non animarsi in ambiente.
+const INPUT_SEGMENT_CLASS = 'inline-flex items-center rounded-full border px-3 py-1.5 text-xs font-semibold';
 
 function Badge({
     children,

--- a/e2e/patient-header.spec.ts
+++ b/e2e/patient-header.spec.ts
@@ -34,6 +34,7 @@ test('patient header renders ICD chips and explicit empty state', async ({ page 
   const pin = process.env.E2E_PIN || '1234';
   const suffix = `${Date.now()}`.slice(-4);
   const diagnosisDescription = 'Disturbo depressivo maggiore, episodio singolo lieve';
+  const secondaryDiagnosisDescription = 'Ipertensione essenziale primaria';
 
   await bootstrapUnlockedSession(page, pin);
 
@@ -51,6 +52,12 @@ test('patient header renders ICD chips and explicit empty state', async ({ page 
         description: diagnosisDescription,
         date: new Date().toISOString(),
       },
+      {
+        system: 'ICD-11',
+        code: 'BA00',
+        description: secondaryDiagnosisDescription,
+        date: new Date().toISOString(),
+      },
     ],
   });
 
@@ -64,17 +71,53 @@ test('patient header renders ICD chips and explicit empty state', async ({ page 
     diagnoses: [],
   });
 
-  const diagnosisChip = `EF00 · ${diagnosisDescription}`;
+  const diagnosisList = page.getByRole('list', {
+    name: 'Diagnosi e stato del paziente',
+    exact: true,
+  });
+  const diagnosisChip = diagnosisList
+    .getByRole('listitem')
+    .filter({ hasText: diagnosisDescription });
 
+  /* @Codex: il chip e' una voce di lista nominata dal contenuto visibile.
+     Il match esatto, lo snapshot ARIA e la cardinalita' esplicita evitano che
+     un attributo non esposto o un duplicato rendano verde il contratto. */
   await page.goto(`/patients/${patientWithDiagnosisId}`);
   await expect(page.getByText('Quadro paziente')).toBeVisible();
-  await expect(page.getByText(diagnosisChip)).toBeVisible();
+  await expect(diagnosisList).toHaveCount(1);
+  await expect(diagnosisChip).toHaveCount(1);
+  await expect(diagnosisChip).toBeVisible();
+  await expect(diagnosisChip).toHaveCSS('min-width', '0px');
+  await expect(diagnosisChip).toHaveCSS('max-width', '100%');
+  await expect(diagnosisChip).toContainText('EF00');
+  await expect(diagnosisChip).toContainText(diagnosisDescription);
+  await expect(diagnosisChip).toMatchAriaSnapshot(
+    `- listitem: EF00 ${diagnosisDescription}`
+  );
 
   await page.reload();
-  await expect(page.getByText(diagnosisChip)).toBeVisible();
+  await expect(diagnosisChip).toHaveCount(1);
+  await expect(diagnosisChip).toBeVisible();
+
+  /* @Codex: la lente clinica deve lasciare il listitem senza nome d'autore e
+     conservare codice, descrizione e sistema nel contenuto accessibile. */
+  await page.goto(`/patients/${patientWithDiagnosisId}/modules`);
+  const secondaryDiagnosisList = page.getByRole('list', {
+    name: 'Diagnosi codificate secondarie',
+    exact: true,
+  });
+  const secondaryDiagnosisItem = secondaryDiagnosisList
+    .getByRole('listitem')
+    .filter({ hasText: secondaryDiagnosisDescription });
+  await expect(secondaryDiagnosisList).toHaveCount(1);
+  await expect(secondaryDiagnosisItem).toHaveCount(1);
+  await expect(secondaryDiagnosisItem).not.toHaveAttribute('title');
+  await expect(secondaryDiagnosisItem).toMatchAriaSnapshot(
+    `- listitem: BA00 ${secondaryDiagnosisDescription} ICD-11`
+  );
 
   await page.goto(`/patients/${patientWithoutDiagnosisId}`);
   await expect(page.getByText('Quadro paziente')).toBeVisible();
   await expect(page.getByText('Profilo da completare')).toBeVisible();
-  await expect(page.getByText(diagnosisChip)).toHaveCount(0);
+  await expect(diagnosisChip).toHaveCount(0);
 });


### PR DESCRIPTION
## Summary
- rimuove le transizioni colore ambientali dai segmenti di modalità rete che rendevano instabile il motion budget Lume;
- rende le diagnosi collezioni semantiche con contenuto accessibile naturale, senza nomi autore non validi sui contenitori generici;
- rafforza il gate Playwright con cardinalità, persistenza, stato vuoto, confini di truncation e snapshot ARIA su cockpit e lente clinica;
- mantiene la slice impilata sulla PR #67: nessun cambiamento estraneo a questo gate.

## Verification
- `E2E_SPECS='e2e/motion-budget.spec.ts e2e/patient-header.spec.ts --repeat-each=5' npm run e2e:smoke` — 10/10;
- `npm run test:lume-tokens` — 23/23;
- `npm run check:lume-tokens` — 42 coppie contrasto, mirror e guard OK;
- `npm run test:motion-budget` — 9/9;
- `npm run check:motion-budget` — OK;
- `npm run lint`;
- `npm run typecheck`;
- `npm run test:unit` — 683/683;
- `npm run build` — 102 pagine, contratto Node 24.18.0/ABI 137 e bundle standalone OK;
- autoreview indipendenti finali Sol high e Terra high — 0 finding azionabili;
- verifica visiva sintetica — nessun marker, rientro o spostamento introdotto dalle liste.

## Risk / Notes
- PR draft stacked su `feat/lume-colore-semantica`; deve entrare prima in #67 e poi far rieseguire i check di #67.
- Il worktree originale di #67 con le due patch Claude resta intatto e non è stato promosso.
- Restano nel parent #67 i debiti dichiarati dal guard (1.694 occorrenze legacy, 328 clinico-visibili); questa PR non li amplia.
- Nessuna PHI/PII; fixture esclusivamente sintetiche.

## Ticket
- Fixes #69
- Refs #68