### PR TITLE
fix(native): allinea i toni clinici ai token Lume

### DIFF
--- a/docs/design/lume/05-app-native.md
+++ b/docs/design/lume/05-app-native.md
@@ -34,7 +34,7 @@ Lume nasce multipiattaforma per costruzione, ma la delivery corrente e Apple-fir
 | --- | --- | --- |
 | `VetroGlassModifier` | `LumeSurface(zone:)` | Rende canvas/field/focal/chrome; niente `glassEffect` sulle superfici strutturali; la guardia `accessibilityReduceTransparency` resta per gli overlay |
 | `GlassCard` | `LumeCard(zone:)` | Opaca, bordo 1px, ombra solo se focale |
-| `StatusBadge`, `VetroTone`/`VetroPalette` | Invariati nei valori, rinominati `LumeTone`/`LumePalette` | Badge su superficie field opaca; il segnale clinico resta soltanto su testo o glifo |
+| `StatusBadge`, `VetroTone`/`VetroPalette` | `LumeTone`/`LumePalette`, con alias Vetro di compatibilità | Mapping register-aware: neutral -> `ink.muted`, info/amministrativo -> `accent.minerale`, positive -> `signal.success`, attention -> `signal.warning`, critical -> `signal.critical`. Per la resa dei tre signal, il seed DTCG viene miscelato in sRGB al 60% con il 40% di `ink.primary`: il minimo misurato su `field` è 5,41:1 nei tre registri. I badge restano opachi e conservano testo o glifo; `signal.plum` non rappresenta alcun tono finché manca uno stato strutturato dedicato |
 | `InfoRow` | `RigaLista` | Altezza 44pt touch, fuoco di selezione reso con la luce, cifre tabellari |
 | (nuovo) | `TestataPaziente` | Identità verificabile: nome e anno in compact; dettagli espandibili e identificativo abbreviato sotto il privacy shield. Il glifo allergie compare solo quando esiste un dato strutturato affidabile |
 | (nuovo) | `RigaLaboratorio` | Anatomia canonica: nome (Voce), valore (Registro), unità, banda di range + banda personale (Canvas/Gauge custom), delta, data |
@@ -45,7 +45,7 @@ Lume nasce multipiattaforma per costruzione, ma la delivery corrente e Apple-fir
 
 Il commit semantics sul nativo segue l'inchiostro: una bozza (voce diario proposta, prescrizione in preparazione) usa `ink-muted` con una micro-etichetta onesta; un'azione esplicita "Firma" la consolida e l'inchiostro asciuga a contrasto pieno, come definito in [07-gesto-e-movimento.md](./07-gesto-e-movimento.md) par. 3. `confirmationDialog` con ruolo `.destructive` resta per le distruttive; un inserimento errato si marca, non si cancella (pattern Canvas, coerente con l'audit locale).
 
-La palette nativa è code-first nel package condiviso, senza asset catalog. I valori restano nella sorgente unica `tokens/lume.tokens.json`; un test XCTest risolve quel file da `#filePath` e confronta ogni token. Qualunque drift fallisce in modo chiuso e ne elenca i nomi.
+La palette nativa è code-first nel package condiviso, senza asset catalog. I valori restano nella sorgente unica `tokens/lume.tokens.json`; i test XCTest risolvono quel file da `#filePath`, confrontano ogni token e attraversano ogni combinazione registro x `LumeTone`. Qualunque drift o nuovo tono senza mapping fallisce in modo chiuso e ne elenca il token atteso.
 
 ## 3. La grammatica compatta (iPhone)
 

--- a/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/PairedPatientClinicalSections.swift
+++ b/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/PairedPatientClinicalSections.swift
@@ -9,6 +9,8 @@ struct PairedPatientClinicalSections: View {
     @Binding var checkupDeletionCandidateId: String?
     @Binding var confirmsDeletingObservation: Bool
     @Binding var observationDeletionCandidateId: String?
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.lumeGuardia) private var isGuardia
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -184,8 +186,14 @@ struct PairedPatientClinicalSections: View {
     /* @Codex */
 
     private func checkupStatusColor(_ checkup: HomeBaseCheckupSummary) -> Color {
-        if checkup.deletedAt != nil { return VetroPalette.tint(for: .attention) }
-        return VetroPalette.tint(for: PairedCheckupStatus(rawValue: checkup.status)?.tone ?? .neutral)
+        if checkup.deletedAt != nil { return toneColor(.attention) }
+        return toneColor(PairedCheckupStatus(rawValue: checkup.status)?.tone ?? .neutral)
+    }
+
+    /* @Codex */
+    private func toneColor(_ tone: LumeTone) -> Color {
+        let palette = LumePalette.palette(for: colorScheme, isGuardia: isGuardia)
+        return LumePalette.tint(for: tone, using: palette)
     }
 
     private func checkupRow(_ checkup: HomeBaseCheckupSummary) -> some View {
@@ -211,7 +219,7 @@ struct PairedPatientClinicalSections: View {
             if checkup.deletedAt != nil {
                 Text("Controllo annullato")
                     .font(.caption2.weight(.semibold))
-                    .foregroundStyle(.orange)
+                    .foregroundStyle(toneColor(.attention))
             } else if model.canMutateCheckup(checkup) {
                 HStack(spacing: 8) {
                     Button {
@@ -282,7 +290,7 @@ struct PairedPatientClinicalSections: View {
             if observation.deletedAt != nil {
                 Text("Osservazione annullata")
                     .font(.caption2.weight(.semibold))
-                    .foregroundStyle(.orange)
+                    .foregroundStyle(toneColor(.attention))
             } else if model.canMutateObservation(observation) {
                 HStack(spacing: 8) {
                     Button {

--- a/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/PairedPatientTherapiesSection.swift
+++ b/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/PairedPatientTherapiesSection.swift
@@ -6,6 +6,8 @@ struct PairedPatientTherapiesSection: View {
     @Binding var therapyStatusFilter: TherapyStatusFilter
     @Binding var confirmsDeletingTherapy: Bool
     @Binding var therapyDeletionCandidateId: String?
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.lumeGuardia) private var isGuardia
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -152,12 +154,18 @@ struct PairedPatientTherapiesSection: View {
         }
     }
 
-    // Semantic status color (Vetro Clinico tone), or attention if soft-deleted.
+    // Semantic Lume status color, or attention if soft-deleted.
     // Kept as tinted text rather than a glass badge: Liquid Glass is for the
     // control/navigation layer, not every content row.
     private func therapyStatusColor(_ therapy: HomeBaseTherapySummary) -> Color {
-        if therapy.deletedAt != nil { return VetroPalette.tint(for: .attention) }
-        return VetroPalette.tint(for: PairedTherapyStatus(rawValue: therapy.status)?.tone ?? .neutral)
+        if therapy.deletedAt != nil { return toneColor(.attention) }
+        return toneColor(PairedTherapyStatus(rawValue: therapy.status)?.tone ?? .neutral)
+    }
+
+    /* @Codex */
+    private func toneColor(_ tone: LumeTone) -> Color {
+        let palette = LumePalette.palette(for: colorScheme, isGuardia: isGuardia)
+        return LumePalette.tint(for: tone, using: palette)
     }
 
     /* @Codex */
@@ -211,7 +219,7 @@ struct PairedPatientTherapiesSection: View {
             if therapy.deletedAt != nil {
                 Text("Terapia annullata")
                     .font(.caption2.weight(.semibold))
-                    .foregroundStyle(.orange)
+                    .foregroundStyle(toneColor(.attention))
             } else if model.canMutateTherapy(therapy) {
                 HStack(spacing: 8) {
                     Button {

--- a/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/PairedPatientsWorkspaceSupport.swift
+++ b/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/PairedPatientsWorkspaceSupport.swift
@@ -79,6 +79,8 @@ func cleanedPatientWorkspaceValue(_ value: String?) -> String? {
 struct PairedPatientFlagChip: View {
     let text: String
     let tone: VetroTone
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.lumeGuardia) private var isGuardia
 
     init(_ text: String, tone: VetroTone) {
         self.text = text
@@ -86,12 +88,15 @@ struct PairedPatientFlagChip: View {
     }
 
     var body: some View {
+        let palette = LumePalette.palette(for: colorScheme, isGuardia: isGuardia)
+        let toneColor = LumePalette.tint(for: tone, using: palette)
         Text(text)
             .font(.caption2.weight(.semibold))
-            .foregroundStyle(VetroPalette.tint(for: tone))
+            .foregroundStyle(toneColor)
             .padding(.horizontal, 8)
             .padding(.vertical, 3)
-            .background(VetroPalette.tint(for: tone).opacity(0.12), in: Capsule())
+            .background(palette.field, in: Capsule())
+            .overlay(Capsule().strokeBorder(toneColor.opacity(0.4), lineWidth: 0.5))
     }
 }
 

--- a/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/PairedScalesSection.swift
+++ b/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/PairedScalesSection.swift
@@ -7,6 +7,8 @@ struct PairedScalesSection: View {
     let hasSelectedPatient: Bool
     let onRefresh: () -> Void
     let onStartScale: (ClinicalScaleDefinition) -> Void
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.lumeGuardia) private var isGuardia
 
     private var historyItems: [ScaleHistoryItem] {
         ScaleHistoryPresentation.items(from: entries)
@@ -135,12 +137,15 @@ struct PairedScalesSection: View {
     }
 
     private func scaleChip(_ text: String, tone: VetroTone) -> some View {
-        Text(text)
+        let palette = LumePalette.palette(for: colorScheme, isGuardia: isGuardia)
+        let toneColor = LumePalette.tint(for: tone, using: palette)
+        return Text(text)
             .font(.caption2.weight(.semibold))
-            .foregroundStyle(VetroPalette.tint(for: tone))
+            .foregroundStyle(toneColor)
             .padding(.horizontal, 8)
             .padding(.vertical, 3)
-            .background(VetroPalette.tint(for: tone).opacity(0.12), in: Capsule())
+            .background(palette.field, in: Capsule())
+            .overlay(Capsule().strokeBorder(toneColor.opacity(0.4), lineWidth: 0.5))
     }
 
     static func area(for scaleId: String) -> String {

--- a/native/MediFlowMac/Sources/MediFlowAppleShared/Lume.swift
+++ b/native/MediFlowMac/Sources/MediFlowAppleShared/Lume.swift
@@ -1,9 +1,10 @@
 // @Codex
 // LumeKit: opaque clinical surfaces and platform-native transient chrome for
 // the universal Apple app.
+import Foundation
 import SwiftUI
 
-public enum LumeTone: Equatable {
+public enum LumeTone: CaseIterable, Hashable, Sendable {
     case neutral
     case info
     case positive
@@ -86,15 +87,48 @@ public enum LumePalette {
     public static var success: Color { Color(lumeHex: successHex) }
     public static var plum: Color { Color(lumeHex: plumHex) }
 
-    /// Keeps the existing clinical tone mapping stable during the rename.
-    public static func tint(for tone: LumeTone) -> Color {
+    /// Resolves a clinical tone to its canonical DTCG value. Neutral and
+    /// informational tones follow the active register; clinical signals stay
+    /// register-independent. Plum remains outside this mapping until a
+    /// structured state explicitly adopts it.
+    public static func hex(for tone: LumeTone, using palette: LumeRegisterPalette) -> String {
         switch tone {
-        case .neutral: return .secondary
-        case .info: return .blue
-        case .positive: return .green
-        case .attention: return .orange
-        case .critical: return .red
+        case .neutral: return palette.inkMutedHex
+        case .info: return palette.mineraleHex
+        case .positive: return successHex
+        case .attention: return warningHex
+        case .critical: return criticalHex
         }
+    }
+
+    /// The exact sRGB value rendered by `tint(for:using:)`; internal so tests
+    /// can fail closed on the derived signal, not only on its DTCG seed.
+    static func resolvedHex(for tone: LumeTone, using palette: LumeRegisterPalette) -> String {
+        let seed = hex(for: tone, using: palette)
+        switch tone {
+        case .neutral, .info:
+            return seed
+        case .positive, .attention, .critical:
+            return mix(seed, with: palette.inkPrimaryHex, seedWeight: 0.6)
+        }
+    }
+
+    public static func tint(for tone: LumeTone, using palette: LumeRegisterPalette) -> Color {
+        Color(lumeHex: resolvedHex(for: tone, using: palette))
+    }
+
+    /// Mirrors the web status derivation: preserve the canonical signal seed,
+    /// then mix it with register ink so status text remains readable at night.
+    private static func mix(_ seed: String, with ink: String, seedWeight: Double) -> String {
+        guard
+            let seedRGB = UInt64(seed.dropFirst(), radix: 16),
+            let inkRGB = UInt64(ink.dropFirst(), radix: 16)
+        else { preconditionFailure("Invalid Lume signal or ink hex") }
+        let channel: (Int) -> Int = { shift in
+            Int((Double((seedRGB >> shift) & 0xff) * seedWeight
+                + Double((inkRGB >> shift) & 0xff) * (1 - seedWeight)).rounded())
+        }
+        return String(format: "#%02x%02x%02x", channel(16), channel(8), channel(0))
     }
 
     public static func palette(for colorScheme: ColorScheme, isGuardia: Bool) -> LumeRegisterPalette {

--- a/native/MediFlowMac/Sources/MediFlowAppleShared/Lume.swift
+++ b/native/MediFlowMac/Sources/MediFlowAppleShared/Lume.swift
@@ -124,9 +124,12 @@ public enum LumePalette {
             let seedRGB = UInt64(seed.dropFirst(), radix: 16),
             let inkRGB = UInt64(ink.dropFirst(), radix: 16)
         else { preconditionFailure("Invalid Lume signal or ink hex") }
+        let inkWeight = 1 - seedWeight
         let channel: (Int) -> Int = { shift in
-            Int((Double((seedRGB >> shift) & 0xff) * seedWeight
-                + Double((inkRGB >> shift) & 0xff) * (1 - seedWeight)).rounded())
+            let seedByte = Double((seedRGB >> shift) & 0xff)
+            let inkByte = Double((inkRGB >> shift) & 0xff)
+            let weightedValue = seedByte * seedWeight + inkByte * inkWeight
+            return Int(weightedValue.rounded())
         }
         return String(format: "#%02x%02x%02x", channel(16), channel(8), channel(0))
     }

--- a/native/MediFlowMac/Sources/MediFlowAppleShared/VetroClinico.swift
+++ b/native/MediFlowMac/Sources/MediFlowAppleShared/VetroClinico.swift
@@ -75,13 +75,15 @@ public struct StatusBadge: View {
     public var body: some View {
         /* @Codex */
         let palette = LumePalette.palette(for: colorScheme, isGuardia: isGuardia)
+        let toneColor = LumePalette.tint(for: tone, using: palette)
         Text(text)
             .font(.caption.weight(.semibold))
-            .foregroundStyle(VetroPalette.tint(for: tone))
+            .foregroundStyle(toneColor)
             .padding(.horizontal, 10)
             .padding(.vertical, 5)
             .background(palette.field, in: Capsule())
-            .overlay(Capsule().strokeBorder(palette.inkMuted.opacity(0.28), lineWidth: 0.5))
+            .overlay(Capsule().strokeBorder(toneColor.opacity(0.4), lineWidth: 0.5))
+            .accessibilityLabel(text)
     }
 }
 

--- a/native/MediFlowMac/Tests/MediFlowAppleSharedTests/LumeToneMappingTests.swift
+++ b/native/MediFlowMac/Tests/MediFlowAppleSharedTests/LumeToneMappingTests.swift
@@ -1,0 +1,187 @@
+// @Codex
+import Foundation
+import SwiftUI
+import XCTest
+@testable import MediFlowAppleShared
+
+#if os(macOS)
+import AppKit
+#endif
+
+final class LumeToneMappingTests: XCTestCase {
+    private let registers: [(name: String, palette: LumeRegisterPalette)] = [
+        ("giorno", LumePalette.giorno), ("grafite", LumePalette.grafite),
+        ("guardia", LumePalette.guardia),
+    ]
+    private let signalTones: [LumeTone] = [.positive, .attention, .critical]
+
+    func testEveryToneMapsToItsCanonicalDTCGTokenInEveryRegister() throws {
+        let canonical = try canonicalHexTokens()
+        let expectedTones: Set<LumeTone> = [.neutral, .info, .positive, .attention, .critical]
+        XCTAssertEqual(Set(LumeTone.allCases), expectedTones)
+
+        for register in registers {
+            for tone in LumeTone.allCases {
+                let tokenPath = expectedTokenPath(for: tone, registerName: register.name)
+                let expected = try XCTUnwrap(canonical[tokenPath], "Missing DTCG token: \(tokenPath)")
+                XCTAssertEqual(LumePalette.hex(for: tone, using: register.palette).lowercased(),
+                               expected.lowercased(),
+                               "\(register.name).\(tone) must resolve to \(tokenPath)")
+            }
+        }
+    }
+
+    func testPlumIsNotUsedByAnyClinicalTone() throws {
+        let plum = try XCTUnwrap(canonicalHexTokens()["signal.plum"]).lowercased()
+        for register in registers {
+            for tone in LumeTone.allCases {
+                XCTAssertNotEqual(LumePalette.hex(for: tone, using: register.palette).lowercased(),
+                                  plum,
+                                  "signal.plum requires a structured state; it cannot back \(tone)")
+            }
+        }
+    }
+
+    func testRenderedSignalsUseSixtyFortySRGBAndMeetFieldContrast() throws {
+        for register in registers {
+            for tone in signalTones {
+                let seed = LumePalette.hex(for: tone, using: register.palette)
+                let expected = mixedHex(seed: seed, ink: register.palette.inkPrimaryHex)
+                let actual = LumePalette.resolvedHex(for: tone, using: register.palette)
+                XCTAssertEqual(actual, expected, "\(register.name).\(tone) must use the 60/40 sRGB mix")
+                XCTAssertGreaterThanOrEqual(contrastRatio(actual, register.palette.fieldHex), 4.5,
+                                            "\(register.name).\(tone) must remain readable on field")
+                #if os(macOS)
+                XCTAssertEqual(try renderedHex(LumePalette.tint(for: tone, using: register.palette)),
+                               expected,
+                               "\(register.name).\(tone) tint must render the resolved sRGB value")
+                #endif
+            }
+        }
+    }
+
+    #if os(macOS)
+    @MainActor
+    func testSyntheticToneMatrixRendersAcrossAllRegisters() throws {
+        let content = LumeToneEvidenceMatrix().frame(width: 960, height: 360)
+            .dynamicTypeSize(.accessibility1)
+        let renderer = ImageRenderer(content: content)
+        renderer.scale = 2
+        let image = try XCTUnwrap(renderer.cgImage)
+        XCTAssertEqual(image.width, 1_920)
+        XCTAssertEqual(image.height, 720)
+
+        guard let path = ProcessInfo.processInfo.environment["LUME_TONE_EVIDENCE_PATH"] else { return }
+        let outputURL = URL(fileURLWithPath: path)
+        try FileManager.default.createDirectory(at: outputURL.deletingLastPathComponent(),
+                                                withIntermediateDirectories: true)
+        let png = try XCTUnwrap(NSBitmapImageRep(cgImage: image).representation(using: .png, properties: [:]))
+        try png.write(to: outputURL, options: .atomic)
+    }
+    #endif
+
+    private func expectedTokenPath(for tone: LumeTone, registerName: String) -> String {
+        switch tone {
+        case .neutral: return "register.\(registerName).ink.muted"
+        case .info: return "register.\(registerName).accent.minerale"
+        case .positive: return "signal.success"
+        case .attention: return "signal.warning"
+        case .critical: return "signal.critical"
+        }
+    }
+
+    private func canonicalHexTokens() throws -> [String: String] {
+        let data = try Data(contentsOf: canonicalTokenURL())
+        let root = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        var canonical: [String: String] = [:]
+        collectHexTokens(in: root, path: [], into: &canonical)
+        return canonical
+    }
+
+    private func canonicalTokenURL() throws -> URL {
+        var directory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        while directory.path != "/" {
+            let candidate = directory.appendingPathComponent("docs/design/lume/tokens/lume.tokens.json")
+            if FileManager.default.fileExists(atPath: candidate.path) { return candidate }
+            directory.deleteLastPathComponent()
+        }
+        throw NSError(domain: "LumeToneMappingTests", code: 1,
+                      userInfo: [NSLocalizedDescriptionKey: "Canonical Lume token JSON not found from #filePath"])
+    }
+
+    private func collectHexTokens(in node: [String: Any], path: [String],
+                                  into tokens: inout [String: String]) {
+        if let value = node["$value"] as? String {
+            tokens[path.joined(separator: ".")] = value
+            return
+        }
+        for key in node.keys.sorted() where !key.hasPrefix("$") {
+            guard let child = node[key] as? [String: Any] else { continue }
+            collectHexTokens(in: child, path: path + [key], into: &tokens)
+        }
+    }
+
+    private func channels(_ hex: String) -> [Double] {
+        guard hex.count == 7, let value = UInt64(hex.dropFirst(), radix: 16) else {
+            XCTFail("Invalid test hex: \(hex)")
+            return [0, 0, 0]
+        }
+        return [16, 8, 0].map { Double((value >> $0) & 0xff) }
+    }
+
+    private func mixedHex(seed: String, ink: String) -> String {
+        let mixed = zip(channels(seed), channels(ink)).map { Int(($0 * 0.6 + $1 * 0.4).rounded()) }
+        return String(format: "#%02x%02x%02x", mixed[0], mixed[1], mixed[2])
+    }
+
+    private func contrastRatio(_ foreground: String, _ background: String) -> Double {
+        let values = [foreground, background].map(relativeLuminance)
+        return (max(values[0], values[1]) + 0.05) / (min(values[0], values[1]) + 0.05)
+    }
+
+    private func relativeLuminance(_ hex: String) -> Double {
+        let linear = channels(hex).map { channel -> Double in
+            let value = channel / 255
+            return value <= 0.04045 ? value / 12.92 : pow((value + 0.055) / 1.055, 2.4)
+        }
+        return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2]
+    }
+
+    #if os(macOS)
+    private func renderedHex(_ color: Color) throws -> String {
+        let value = try XCTUnwrap(NSColor(color).usingColorSpace(.sRGB))
+        let channels = [value.redComponent, value.greenComponent, value.blueComponent].map { Int(($0 * 255).rounded()) }
+        return String(format: "#%02x%02x%02x", channels[0], channels[1], channels[2])
+    }
+    #endif
+}
+
+#if os(macOS)
+private struct LumeToneEvidenceMatrix: View {
+    var body: some View {
+        HStack(spacing: 16) {
+            register("Giorno", colorScheme: .light, isGuardia: false)
+            register("Grafite", colorScheme: .dark, isGuardia: false)
+            register("Guardia", colorScheme: .dark, isGuardia: true)
+        }
+        .padding(20)
+        .background(Color.black.opacity(0.08))
+    }
+
+    private func register(_ title: String, colorScheme: ColorScheme, isGuardia: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(title).font(.headline)
+            StatusBadge("Neutro", tone: .neutral)
+            StatusBadge("Informativo", tone: .info)
+            StatusBadge("Positivo", tone: .positive)
+            StatusBadge("Attenzione", tone: .attention)
+            StatusBadge("Critico", tone: .critical)
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .lumeSurface(zone: .field)
+        .environment(\.colorScheme, colorScheme)
+        .lumeGuardia(isGuardia)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- sostituisce il routing nativo su colori di sistema con la mappa Lume DTCG register-aware
- mantiene badge e chip clinici opachi e conserva testo oltre al segnale cromatico
- rende fail-closed la tinta 60/40 realmente renderizzata, inclusi contrasto e parità `NSColor`
- riallinea il claim puntuale della documentazione nativa

## Verification
- `LumeToneMappingTests`: 4/4 su SwiftPM e Xcode 27 dopo il fix di compatibilità
- `npm run test:native`: 353/353 sul nuovo head locale
- `npm run test:native:xcode`: 353/353, `TEST SUCCEEDED` sul candidato precedente; il nuovo head ricompila e passa i 4 test mirati
- build reale `MediFlowMacApp` con `CODE_SIGNING_ALLOWED=NO`: `BUILD SUCCEEDED`
- `npm run test:lume-tokens`: 23/23
- `npm run check:lume-tokens`: 42 coppie di contrasto, 0 violazioni
- GitHub `native-build-test` su Xcode 26.3: SwiftPM, build macOS e build iOS `SUCCESS`
- review indipendente del bundle: PASS, confidence 0.97; review fresca del fix Xcode: PASS, confidence 0.99

## Risk / Notes
- diff al limite del packet: 302 gross LOC; nessun allargamento di dominio
- `signal.plum` resta intenzionalmente inutilizzato finché manca uno stato strutturato
- non dichiara completati workspace, VoiceOver end-to-end o debito colore globale
- nessuna PHI/PII e nessun dato paziente reale

## Ticket
Fixes #72
Refs #68