### PR TITLE
fix(native): stabilizza la selezione paziente

### DIFF
--- a/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/PairedPatientsWorkspaceModel.swift
+++ b/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/PairedPatientsWorkspaceModel.swift
@@ -28,12 +28,23 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
     @Published var pairedClientToken = ""
     @Published var username = ""
     @Published var password = ""
-    @Published var ambulatoryId = ""
+    @Published var ambulatoryId = "" {
+        didSet { if oldValue.trimmedOrNil != ambulatoryId.trimmedOrNil { clearSelectedPatientWorkspace() } } // @Codex
+    }
     @Published private(set) var availableAmbulatories: [NetworkAmbulatorySummary] = []
     @Published private(set) var patients: [HomeBasePatientSummary] = []
+    /* @Codex */
+    @Published private(set) var selectedPatientID: String?
     @Published private(set) var selectedPatient: HomeBasePatientDetail? {
         didSet {
-            guard oldValue?.id != selectedPatient?.id else { return }
+            let previousID = oldValue?.id
+            let currentID = selectedPatient?.id
+            if let currentID {
+                selectedPatientID = currentID
+            } else if selectedPatientID == previousID {
+                selectedPatientID = nil
+            }
+            guard previousID != currentID else { return }
             /* @Codex */
             editablePatientFields = [:]
             lockedPatientFields = []
@@ -343,7 +354,10 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
         sessionCookie: String = "sid=test",
         masterKey: SymmetricKey? = nil,
         patients: [HomeBasePatientSummary] = [],
-        selectedPatient: HomeBasePatientDetail? = nil
+        selectedPatient: HomeBasePatientDetail? = nil,
+        entries: [HomeBaseEntrySummary] = [],
+        therapies: [HomeBaseTherapySummary] = [],
+        attachments: [HomeBaseAttachmentSummary] = []
     ) {
         self.pairedClientId = credentials.clientId
         self.pairedClientToken = credentials.clientToken
@@ -351,7 +365,28 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
         self.masterKey = masterKey
         self.patients = patients
         self.selectedPatient = selectedPatient
+        self.entries = entries
+        self.therapies = therapies
+        self.attachments = attachments
+        self.attachmentsPatientId = attachments.isEmpty ? nil : selectedPatient?.id
         self.connectionState = .pairedOnline
+    }
+
+    /* @Codex */
+    func applyPatientRefreshForSelectionTests(_ refreshedPatients: [HomeBasePatientSummary]) {
+        patients = refreshedPatients
+        reconcilePatientSelection(selectedPatientID, in: refreshedPatients)
+    }
+
+    func applyPatientRevisionRefreshForSelectionTests(_ refreshedPatients: [HomeBasePatientSummary]) { // @Codex
+        patients = refreshedPatients
+        reconcilePatientSelection(selectedPatientID, in: refreshedPatients, invalidatingWorkspace: false)
+    }
+
+    /* @Codex */
+    func applyPatientTrashRefreshForSelectionTests(_ refreshedPatients: [HomeBasePatientSummary]) {
+        patients = refreshedPatients
+        clearSelectedPatientWorkspace()
     }
     #endif
 
@@ -696,6 +731,7 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
             errorMessage = "Inserisci le credenziali paired rilasciate dal Mac."
             return
         }
+        let selectionBeforeRefresh = selectedPatientID
         await runTask {
             do {
                 self.patients = try await self.makeClient().fetchPatients(
@@ -712,21 +748,7 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
                 }
                 throw error
             }
-            self.selectedPatient = nil
-            self.entries = []
-            self.therapies = []
-            self.checkups = []
-            self.observations = []
-            self.patientReportURL = nil
-            self.servicePrescriptions = []
-            self.servicePrescriptionItems = []
-            self.prostheticPrescriptions = []
-            self.patientFHIRExportURL = nil
-            self.pendingFHIRWarningValidation = nil
-            self.cancelEditingEntry()
-            self.cancelEditingTherapy()
-            self.cancelEditingCheckup()
-            self.cancelEditingObservation()
+            self.reconcilePatientSelection(selectionBeforeRefresh, in: self.patients)
             // Best-effort: populate the scope picker. A failure here must not
             // break the patient load, so keep whatever list we already have.
             self.availableAmbulatories = (try? await self.makeClient().fetchNetworkAmbulatories(
@@ -756,30 +778,17 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
     /* @Codex */
     func loadPatientTrash() async {
         await loadPatients(includeDeleted: true)
-        selectedPatient = nil
-        entries = []
-        therapies = []
-        checkups = []
-        observations = []
-        patientReportURL = nil
-        servicePrescriptions = []
-        servicePrescriptionItems = []
-        prostheticPrescriptions = []
-        patientFHIRExportURL = nil
-        pendingFHIRWarningValidation = nil
-        attachments = []
-        selectedAttachmentDetail = nil
-        attachmentShareURL = nil
-        fseDocumentValidationResult = nil
-        fseDocumentValidationTargetLabel = nil
+        clearSelectedPatientWorkspace()
     }
 
     func loadPatient(_ patient: HomeBasePatientSummary) async {
+        let previousSelectionID = selectedPatientID
         if selectedPatient?.id != patient.id {
             invalidateAttachmentPatientState()
         }
         #if DEBUG
         if let detail = Self.uiTestSeededDetail(for: patient) {
+            selectedPatientID = patient.id
             setSelectedPatient(detail) // @Codex
             entries = Self.uiTestSeededEntries(patientId: patient.id)
             therapies = Self.uiTestSeededTherapies(patientId: patient.id)
@@ -796,6 +805,7 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
         }
         #endif
         guard let sessionCookie, let credentials = pairedCredentials else { return }
+        selectedPatientID = patient.id
         await runTask {
             self.patientReportURL = nil
             self.patientFHIRExportURL = nil
@@ -858,6 +868,9 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
             self.cancelEditingCheckup()
             self.cancelEditingObservation()
             self.statusMessage = "Dettaglio \(patient.lastName) aperto."
+        }
+        if selectedPatient?.id != patient.id {
+            selectedPatientID = selectedPatient?.id ?? previousSelectionID
         }
     }
 
@@ -3123,6 +3136,7 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
             ambulatoryId = ""
             patients = []
             selectedPatient = nil
+            selectedPatientID = nil // @Codex
             entries = []
             therapies = []
             checkups = []
@@ -3737,8 +3751,17 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
         credentials: HomeBasePairedCredentials,
         sessionCookie: String
     ) async throws {
-        if let current = selectedPatient {
-            let patientId = current.id
+        let selectionBeforeRefresh = selectedPatientID
+        patients = try await makeClient().fetchPatients(
+            credentials: credentials,
+            sessionCookie: sessionCookie,
+            ambulatoryId: ambulatoryId.trimmedOrNil,
+            includeDeleted: false
+        )
+        .map { PatientFieldCrypto.decryptSummary($0, masterKey: masterKey) }
+        if let patientId = reconcilePatientSelection(
+            selectionBeforeRefresh, in: patients, invalidatingWorkspace: false
+        ) {
             let fetchedDetail = try await makeClient().fetchPatient(
                 id: patientId,
                 credentials: credentials,
@@ -3755,14 +3778,6 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
             prostheticPrescriptions = try await fetchProstheticPrescriptions(patientId: patientId, credentials: credentials, sessionCookie: sessionCookie, ambulatoryId: ambulatoryId.trimmedOrNil)
             patientReportURL = nil
             patientFHIRExportURL = nil
-        } else {
-            patients = try await makeClient().fetchPatients(
-                credentials: credentials,
-                sessionCookie: sessionCookie,
-                ambulatoryId: ambulatoryId.trimmedOrNil,
-                includeDeleted: false
-            )
-            .map { PatientFieldCrypto.decryptSummary($0, masterKey: masterKey) }
         }
     }
 
@@ -3812,16 +3827,9 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
             ) else {
                 return false
             }
+            let selectionBeforeRefresh = selectedPatientID
             patients = snapshot.patients
-            selectedPatient = nil
-            entries = []
-            therapies = []
-            checkups = []
-            observations = []
-            cancelEditingEntry()
-            cancelEditingTherapy()
-            cancelEditingCheckup()
-            cancelEditingObservation()
+            reconcilePatientSelection(selectionBeforeRefresh, in: patients)
             connectionState = markOffline ? .pairedOfflineDegraded : .cached
             statusMessage = markOffline ? "\(snapshot.reviewLine) Home-base non raggiungibile." : snapshot.reviewLine
             reconciliationLine = markOffline
@@ -3832,6 +3840,59 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
             errorMessage = "Cache locale non leggibile: \(error.localizedDescription)"
             return false
         }
+    }
+
+    static func reconciledPatientSelectionID( // @Codex
+        _ currentID: String?,
+        in patients: [HomeBasePatientSummary]
+    ) -> String? {
+        guard let currentID, patients.contains(where: { $0.id == currentID }) else {
+            return nil
+        }
+        return currentID
+    }
+
+    @discardableResult // @Codex
+    private func reconcilePatientSelection(
+        _ currentID: String?, in patients: [HomeBasePatientSummary],
+        invalidatingWorkspace: Bool = true
+    ) -> String? {
+        let reconciledID = Self.reconciledPatientSelectionID(currentID, in: patients)
+        guard let reconciledID else {
+            if currentID != nil {
+                clearSelectedPatientWorkspace()
+            }
+            return nil
+        }
+
+        selectedPatientID = reconciledID
+        if invalidatingWorkspace { clearSelectedPatientWorkspace(preservingSelectionID: reconciledID) }
+        return reconciledID
+    }
+
+    /* @Codex */
+    private func clearSelectedPatientWorkspace(preservingSelectionID: String? = nil) {
+        let needsDirectPatientStateInvalidation = selectedPatient == nil
+        selectedPatient = nil
+        selectedPatientID = preservingSelectionID
+        if needsDirectPatientStateInvalidation {
+            invalidateAttachmentPatientState()
+            invalidatePatientBoundNewEntryState()
+        }
+        entries = []
+        therapies = []
+        checkups = []
+        observations = []
+        patientReportURL = nil
+        servicePrescriptions = []
+        servicePrescriptionItems = []
+        prostheticPrescriptions = []
+        patientFHIRExportURL = nil
+        pendingFHIRWarningValidation = nil
+        cancelEditingEntry()
+        cancelEditingTherapy()
+        cancelEditingCheckup()
+        cancelEditingObservation()
     }
 
     private func runTask(_ operation: @escaping () async throws -> Void) async {

--- a/native/MediFlowMac/Tests/MediFlowAppleSharedTests/PairedPatientsWorkspaceSelectionTests.swift
+++ b/native/MediFlowMac/Tests/MediFlowAppleSharedTests/PairedPatientsWorkspaceSelectionTests.swift
@@ -1,0 +1,142 @@
+import CryptoKit
+import XCTest
+@testable import MediFlowAppleShared
+/* @Codex */
+final class PairedPatientsWorkspaceSelectionTests: XCTestCase {
+    @MainActor func testSelectionSurvivesSameVersionRefreshWhileWorkspaceIsInvalidated() {
+        let model = makeModel()
+        model.ambulatoryId = "scope-a"
+        model.configurePairedOnlineForTests(
+            patients: [summary(id: "patient-a", version: 1), summary(id: "patient-b", version: 1)],
+            selectedPatient: detail(id: "patient-a", version: 1), entries: [entry(patientID: "patient-a")])
+        model.ambulatoryId = " scope-a "
+        model.applyPatientRefreshForSelectionTests([summary(id: "patient-b", version: 2), summary(id: "patient-a", version: 1)])
+        XCTAssertEqual(model.selectedPatientID, "patient-a")
+        XCTAssertNil(model.selectedPatient)
+        XCTAssertTrue(model.entries.isEmpty)
+    }
+    @MainActor func testRevisionIdentityRefreshKeepsWorkspaceUntilReloadCommits() {
+        let model = makeModel()
+        model.configurePairedOnlineForTests(
+            patients: [summary(id: "patient-a", version: 1)],
+            selectedPatient: detail(id: "patient-a", version: 1), entries: [entry(patientID: "patient-a")])
+        model.applyPatientRevisionRefreshForSelectionTests([summary(id: "patient-a", version: 1)])
+        XCTAssertEqual(model.selectedPatientID, "patient-a")
+        XCTAssertEqual(model.selectedPatient?.id, "patient-a")
+        XCTAssertEqual(model.entries.map(\.id), ["entry-a"])
+    }
+    @MainActor func testFilteringDoesNotMutateStableSelection() {
+        let patients = [summary(id: "patient-a", version: 1, lastName: "Rossi"), summary(id: "patient-b", version: 1, lastName: "Bianchi")]
+        let model = makeModel()
+        model.configurePairedOnlineForTests(patients: patients, selectedPatient: detail(id: "patient-a", version: 1))
+        let filtered = PatientsFiltering.apply(patients: patients, query: "Bianchi", viewMode: .active, sortMode: .alpha)
+        XCTAssertEqual(filtered.map(\.id), ["patient-b"])
+        XCTAssertEqual(model.selectedPatientID, "patient-a")
+    }
+    @MainActor func testVersionChangeInvalidatesDetailButRetainsStableSelectionID() {
+        let model = makeModel()
+        model.configurePairedOnlineForTests(patients: [summary(id: "patient-a", version: 1)],
+            selectedPatient: detail(id: "patient-a", version: 1), entries: [entry(patientID: "patient-a")])
+        model.applyPatientRefreshForSelectionTests([summary(id: "patient-a", version: 2)])
+        XCTAssertEqual(model.selectedPatientID, "patient-a")
+        XCTAssertNil(model.selectedPatient)
+        XCTAssertTrue(model.entries.isEmpty)
+    }
+    @MainActor func testClearPairingDropsRetainedSelectionIDInGlobalScope() async {
+        let model = makeModel()
+        model.configurePairedOnlineForTests(patients: [summary(id: "patient-a", version: 1)],
+            selectedPatient: detail(id: "patient-a", version: 1))
+        model.applyPatientRefreshForSelectionTests([summary(id: "patient-a", version: 2)])
+        XCTAssertEqual(model.ambulatoryId, "")
+        XCTAssertEqual(model.selectedPatientID, "patient-a")
+        await model.clearPairing()
+        XCTAssertNil(model.selectedPatientID)
+    }
+    @MainActor func testRefreshClearsSelectionWhenPatientDisappears() {
+        let model = makeModel()
+        model.configurePairedOnlineForTests(patients: [summary(id: "patient-a", version: 1)],
+            selectedPatient: detail(id: "patient-a", version: 1))
+        model.applyPatientRefreshForSelectionTests([summary(id: "patient-b", version: 1)])
+        XCTAssertNil(model.selectedPatientID)
+        XCTAssertNil(model.selectedPatient)
+    }
+    @MainActor func testTrashTransitionClearsSelectionDespiteActiveSummaryRemaining() {
+        let model = makeModel()
+        model.configurePairedOnlineForTests(
+            patients: [summary(id: "patient-a", version: 1)],
+            selectedPatient: detail(id: "patient-a", version: 1), entries: [entry(patientID: "patient-a")])
+        model.applyPatientTrashRefreshForSelectionTests([summary(id: "patient-a", version: 1), summary(id: "patient-deleted", version: 2, deleted: true)])
+        XCTAssertEqual(model.patients.map(\.id), ["patient-a", "patient-deleted"])
+        XCTAssertNil(model.selectedPatientID)
+        XCTAssertNil(model.selectedPatient)
+        XCTAssertTrue(model.entries.isEmpty)
+    }
+    @MainActor func testDirectAmbulatoryScopeMutationClearsStateBeforeSamePatientVersionRefresh() {
+        let patient = summary(id: "patient-a", version: 1)
+        let model = makeModel()
+        model.ambulatoryId = "scope-a"
+        model.configurePairedOnlineForTests(
+            patients: [patient], selectedPatient: detail(id: patient.id, version: 1, ambulatoryID: "scope-a"),
+            entries: [entry(patientID: patient.id)], therapies: [therapy(patientID: patient.id)],
+            attachments: [attachment(patientID: patient.id)])
+        model.newEntryTitle = "Bozza sintetica"
+        model.newEntryVisitTranscript = "Trascrizione sintetica"
+        model.newEntryVisitDraftReviewed = true
+        model.newEntryAttachmentIds = ["attachment-a"]
+        XCTAssertTrue(model.selectedPatient != nil && !model.entries.isEmpty && !model.therapies.isEmpty && !model.attachments.isEmpty && model.newEntryVisitDraftReviewed)
+        model.ambulatoryId = "scope-b"
+        model.applyPatientRefreshForSelectionTests([patient])
+        XCTAssertEqual(model.ambulatoryId, "scope-b")
+        XCTAssertEqual(model.patients.first?.version, 1)
+        XCTAssertNil(model.selectedPatientID)
+        XCTAssertNil(model.selectedPatient)
+        XCTAssertTrue(model.entries.isEmpty && model.therapies.isEmpty)
+        XCTAssertTrue(model.attachments.isEmpty && model.newEntryAttachmentIds.isEmpty)
+        XCTAssertNil(model.attachmentsPatientId)
+        XCTAssertEqual(model.newEntryTitle, "")
+        XCTAssertEqual(model.newEntryVisitTranscript, "")
+        XCTAssertFalse(model.newEntryVisitDraftReviewed)
+    }
+    @MainActor private func makeModel() -> PairedPatientsWorkspaceModel {
+        let defaults = UserDefaults(suiteName: "PairedPatientsWorkspaceSelectionTests.\(UUID().uuidString)")!
+        let pairedStore = HomeBasePairedStore(
+            userDefaults: defaults, keychainReader: { _, _ in .success(nil) },
+            keychainWriter: { _, _, _ in .success(()) }, keychainDeleter: { _, _ in .success(()) })
+        let cacheStore = HomeBasePatientCacheStore(
+            cacheDirectory: FileManager.default.temporaryDirectory.appendingPathComponent("PairedPatientsWorkspaceSelectionTests-\(UUID().uuidString)"), keyProvider: { SymmetricKey(data: Data(repeating: 9, count: 32)) })
+        return PairedPatientsWorkspaceModel(pairedStore: pairedStore, cacheStore: cacheStore)
+    }
+    private func summary(id: String, version: Int, lastName: String = "Rossi", deleted: Bool = false) -> HomeBasePatientSummary {
+        HomeBasePatientSummary(
+            id: id, firstName: "Mario", lastName: lastName, birthDate: nil,
+            taxCode: "SYNTHETIC-\(id)", isAdi: false, isArchived: false,
+            version: version, updatedAt: Date(timeIntervalSince1970: TimeInterval(version)),
+            deletedAt: deleted ? Date(timeIntervalSince1970: 10) : nil, deletionReason: deleted ? "fixture sintetica" : nil)
+    }
+    private func entry(patientID: String) -> HomeBaseEntrySummary {
+        HomeBaseEntrySummary(
+            id: "entry-a", patientId: patientID, type: "note", title: "Nota sintetica",
+            date: Date(timeIntervalSince1970: 1), content: "Contenuto sintetico", setting: nil, metadata: nil, attachments: nil, deletedAt: nil,
+            deletionReason: nil, version: 1, createdAt: nil, updatedAt: nil)
+    }
+    private func therapy(patientID: String) -> HomeBaseTherapySummary {
+        HomeBaseTherapySummary(
+            id: "therapy-a", patientId: patientID, drugName: "Sintetico", aic: nil, atc: nil,
+            activePrinciple: nil, dosage: "1", motivation: nil, diagnosisCode: nil, diagnosisName: nil,
+            status: "active", startDate: Date(timeIntervalSince1970: 1), endDate: nil, version: 1, createdAt: nil, updatedAt: nil, deletedAt: nil, deletionReason: nil)
+    }
+    private func attachment(patientID: String) -> HomeBaseAttachmentSummary {
+        HomeBaseAttachmentSummary(
+            id: "attachment-a", patientId: patientID, name: "Sintetico", type: "text/plain", size: 1,
+            path: "synthetic", summarySnapshot: nil, parseEvidenceArtifactSnapshot: nil, ocrQueueState: nil, ocrQueueReason: nil, ocrQueueUpdatedAt: nil,
+            ocrReplayArtifactSnapshot: nil, createdAt: nil)
+    }
+    private func detail(id: String, version: Int, ambulatoryID: String = "synthetic") -> HomeBasePatientDetail {
+        HomeBasePatientDetail(
+            id: id, firstName: "Mario", lastName: "Rossi", birthDate: nil,
+            taxCode: "SYNTHETIC-\(id)", address: nil, phone: nil, caregiver: nil,
+            exemptions: nil, diagnoses: nil, monitoringProfile: nil, statusReason: nil, notes: nil, aiSummary: nil, documentInsights: nil, isAdi: false,
+            isArchived: false, version: version, ambulatoryId: ambulatoryID,
+            createdAt: nil, updatedAt: nil)
+    }
+}


### PR DESCRIPTION
## Summary
- Introduce selectedPatientID come identità stabile della selezione e riconcilia refresh, rimozione, cestino, pairing e cambio ambulatorio.
- Preserva solo ID durante il refresh remoto, invalidando dettaglio e raccolte cliniche non dimostrate fresche.
- Mantiene non distruttivi i filtri UI e preserva il workspace durante il prefetch del refresh di revisione.
- Aggiunge test deterministici del contratto model-only; view, worklist e documentazione restano fuori scope.

## Verification
- PairedPatientsWorkspaceSelectionTests: 8/8.
- npm run test:native: 361/361.
- Build Release universale macOS senza firma: SUCCESS.
- git diff --check: clean.
- Review indipendente sul freeze c1dce715561d055e2ec3c1324fbccf853bb5513a729358d480f3e40228963e01: nessun finding azionabile nello scope.

## Risk / Notes
- Diff: 309 gross LOC, stretta eccezione al target circa 300 per copertura regressiva del confine di selezione.
- #76 resta responsabile del caricamento atomico latest-request-wins; #74 applica selectedPatientID a NavigationSplitView e List(selection:).
- Nessuna PHI/PII; solo fixture sintetiche.

## Ticket
Fixes #73
Refs #68