### PR TITLE
fix(native): rendi atomico il caricamento paziente

### DIFF
--- a/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/PairedPatientsWorkspaceModel.swift
+++ b/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/PairedPatientsWorkspaceModel.swift
@@ -295,6 +295,32 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
     /* @Codex */
     private var lastSeenNetworkFingerprint: String?
     private let dataSourceFactory: (@MainActor (PairedPatientsWorkspaceModel) -> any HomeBasePatientsDataSource)?
+    /* @Codex */
+    private struct PatientLoadContext {
+        let requestID: UUID
+        let patientID: String
+        let sessionCookie: String
+        let credentials: HomeBasePairedCredentials
+        let ambulatoryID: String?
+        let serverURL: String
+        let tlsPin: String
+        let connectionState: PairedPatientsConnectionState
+        let client: any HomeBasePatientsDataSource
+        let masterKey: SymmetricKey?
+    }
+    /* @Codex */
+    private struct PatientWorkspacePayload {
+        let detail: HomeBasePatientDetail
+        let entries: [HomeBaseEntrySummary]
+        let therapies: [HomeBaseTherapySummary]
+        let checkups: [HomeBaseCheckupSummary]
+        let observations: [HomeBaseObservationSummary]
+        let services: [HomeBaseServicePrescriptionSummary]
+        let serviceItems: [HomeBaseServicePrescriptionItemSummary]
+        let prosthetics: [HomeBaseProstheticPrescriptionSummary]
+    }
+    /* @Codex */
+    private var activePatientLoadRequestID: UUID?
     // S3 (D3, lane PRREG): injectable seam for the "Prescrittivo regionale"
     // handoff action (clipboard + external URL). Defaults to the real
     // implementation; tests inject a spy instead of touching the system
@@ -782,7 +808,6 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
     }
 
     func loadPatient(_ patient: HomeBasePatientSummary) async {
-        let previousSelectionID = selectedPatientID
         if selectedPatient?.id != patient.id {
             invalidateAttachmentPatientState()
         }
@@ -805,72 +830,33 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
         }
         #endif
         guard let sessionCookie, let credentials = pairedCredentials else { return }
-        selectedPatientID = patient.id
-        await runTask {
-            self.patientReportURL = nil
-            self.patientFHIRExportURL = nil
-            self.pendingFHIRWarningValidation = nil
-            self.selectedAttachmentDetail = nil
-            self.attachmentShareURL = nil
-            self.fseDocumentValidationResult = nil
-            self.fseDocumentValidationTargetLabel = nil
-            let fetchedDetail = try await self.makeClient().fetchPatient(
-                id: patient.id,
-                credentials: credentials,
-                sessionCookie: sessionCookie,
-                ambulatoryId: self.ambulatoryId.trimmedOrNil
-            )
-            self.setSelectedPatient(fetchedDetail) // @Codex
-            self.entries = try await self.fetchDecryptedEntries(
-                patientId: patient.id,
-                credentials: credentials,
-                sessionCookie: sessionCookie,
-                ambulatoryId: self.ambulatoryId.trimmedOrNil
-            )
-            self.therapies = try await self.fetchDecryptedTherapies(
-                patientId: patient.id,
-                credentials: credentials,
-                sessionCookie: sessionCookie,
-                ambulatoryId: self.ambulatoryId.trimmedOrNil
-            )
-            self.checkups = try await self.fetchDecryptedCheckups(
-                patientId: patient.id,
-                credentials: credentials,
-                sessionCookie: sessionCookie,
-                ambulatoryId: self.ambulatoryId.trimmedOrNil
-            )
-            self.observations = try await self.fetchDecryptedObservations(
-                patientId: patient.id,
-                credentials: credentials,
-                sessionCookie: sessionCookie,
-                ambulatoryId: self.ambulatoryId.trimmedOrNil
-            )
-            self.servicePrescriptions = try await self.fetchServicePrescriptions(
-                patientId: patient.id,
-                credentials: credentials,
-                sessionCookie: sessionCookie,
-                ambulatoryId: self.ambulatoryId.trimmedOrNil
-            )
-            self.servicePrescriptionItems = try await self.fetchServicePrescriptionItems(
-                patientId: patient.id,
-                credentials: credentials,
-                sessionCookie: sessionCookie,
-                ambulatoryId: self.ambulatoryId.trimmedOrNil
-            )
-            self.prostheticPrescriptions = try await self.fetchProstheticPrescriptions(
-                patientId: patient.id,
-                credentials: credentials,
-                sessionCookie: sessionCookie,
-                ambulatoryId: self.ambulatoryId.trimmedOrNil
-            )
-            self.cancelEditingEntry()
-            self.cancelEditingTherapy()
-            self.cancelEditingCheckup()
-            self.cancelEditingObservation()
-            self.statusMessage = "Dettaglio \(patient.lastName) aperto."
-        }
-        if selectedPatient?.id != patient.id {
-            selectedPatientID = selectedPatient?.id ?? previousSelectionID
+        let context = PatientLoadContext(
+            requestID: UUID(), patientID: patient.id, sessionCookie: sessionCookie,
+            credentials: credentials, ambulatoryID: ambulatoryId.trimmedOrNil,
+            serverURL: serverURL, tlsPin: tlsPin, connectionState: connectionState,
+            client: makeClient(), masterKey: masterKey)
+        activePatientLoadRequestID = context.requestID
+        clearSelectedPatientWorkspace(preservingSelectionID: patient.id)
+        isWorking = true
+        errorMessage = nil
+        pendingConflict = nil
+        do {
+            let payload = try await fetchPatientWorkspace(context)
+            guard canPublishPatientLoad(context) else { return }
+            setSelectedPatient(payload.detail, masterKey: context.masterKey)
+            entries = payload.entries
+            therapies = payload.therapies
+            checkups = payload.checkups
+            observations = payload.observations
+            servicePrescriptions = payload.services
+            servicePrescriptionItems = payload.serviceItems
+            prostheticPrescriptions = payload.prosthetics
+            statusMessage = "Dettaglio \(patient.lastName) aperto."
+            finishCurrentPatientLoad()
+        } catch {
+            guard canPublishPatientLoad(context) else { return }
+            finishCurrentPatientLoad()
+            applyPatientLoadFailure(error)
         }
     }
 
@@ -1645,6 +1631,11 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
 
     /* @Codex */
     private func setSelectedPatient(_ raw: HomeBasePatientDetail) {
+        setSelectedPatient(raw, masterKey: masterKey)
+    }
+
+    /* @Codex */
+    private func setSelectedPatient(_ raw: HomeBasePatientDetail, masterKey: SymmetricKey?) {
         let fields: [EncryptedPatientField: PatientFieldCrypto.EditableField] = [
             .address: PatientFieldCrypto.resolveStringField(raw.address, masterKey: masterKey),
             .phone: PatientFieldCrypto.resolveStringField(raw.phone, masterKey: masterKey),
@@ -3592,6 +3583,74 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
     private static var localAuthorityEnabled: Bool {
         let raw = ProcessInfo.processInfo.environment["MEDIFLOW_LOCAL_AUTHORITY"]?.lowercased()
         return raw == "1" || raw == "true" || raw == "yes"
+    }
+
+    /* @Codex */
+    private func fetchPatientWorkspace(_ context: PatientLoadContext) async throws -> PatientWorkspacePayload {
+        let client = context.client
+        let credentials = context.credentials
+        let cookie = context.sessionCookie
+        let scope = context.ambulatoryID
+        let patientID = context.patientID
+        let detail = try await client.fetchPatient(
+            id: patientID, credentials: credentials, sessionCookie: cookie, ambulatoryId: scope)
+        let entries = try await client.fetchEntries(
+            patientId: patientID, credentials: credentials, sessionCookie: cookie, ambulatoryId: scope)
+            .map { ClinicalFieldCrypto.decryptEntry($0, masterKey: context.masterKey) }
+        let therapies = try await client.fetchTherapies(
+            patientId: patientID, credentials: credentials, sessionCookie: cookie, ambulatoryId: scope)
+            .map { ClinicalFieldCrypto.decryptTherapy($0, masterKey: context.masterKey) }
+        let checkups = try await client.fetchCheckups(
+            patientId: patientID, credentials: credentials, sessionCookie: cookie, ambulatoryId: scope)
+            .map { ClinicalFieldCrypto.decryptCheckup($0, masterKey: context.masterKey) }
+        let observations = try await client.fetchObservations(
+            patientId: patientID, credentials: credentials, sessionCookie: cookie, ambulatoryId: scope)
+            .map { ClinicalFieldCrypto.decryptObservation($0, masterKey: context.masterKey) }
+        let services = ServicePrescriptionFiltering.sorted(try await client.fetchServicePrescriptions(
+            patientId: patientID, credentials: credentials, sessionCookie: cookie, ambulatoryId: scope))
+        let serviceItems = ServicePrescriptionFiltering.sortedItems(try await client.fetchServicePrescriptionItems(
+            patientId: patientID, prescriptionId: nil, credentials: credentials, sessionCookie: cookie, ambulatoryId: scope))
+        let prosthetics = ProstheticPrescriptionFiltering.sorted(try await client.fetchProstheticPrescriptions(
+            patientId: patientID, credentials: credentials, sessionCookie: cookie, ambulatoryId: scope))
+        return PatientWorkspacePayload(
+            detail: detail, entries: entries, therapies: therapies, checkups: checkups,
+            observations: observations, services: services, serviceItems: serviceItems,
+            prosthetics: prosthetics)
+    }
+
+    /* @Codex */
+    private func canPublishPatientLoad(_ context: PatientLoadContext) -> Bool {
+        guard activePatientLoadRequestID == context.requestID else { return false }
+        let contextIsCurrent = selectedPatientID == context.patientID
+            && sessionCookie == context.sessionCookie && pairedCredentials == context.credentials
+            && ambulatoryId.trimmedOrNil == context.ambulatoryID
+            && serverURL == context.serverURL && tlsPin == context.tlsPin
+            && connectionState == context.connectionState
+        guard contextIsCurrent else {
+            finishCurrentPatientLoad()
+            return false
+        }
+        return true
+    }
+
+    /* @Codex */
+    private func finishCurrentPatientLoad() {
+        activePatientLoadRequestID = nil
+        isWorking = false
+    }
+
+    /* @Codex */
+    private func applyPatientLoadFailure(_ error: Error) {
+        if case HomeBaseClientError.httpStatus(let status, _) = error, status == 401 {
+            connectionState = .sessionExpired
+            sessionCookie = nil
+            masterKey = nil
+            operatorIdentity = nil
+            statusMessage = "Sessione operatore scaduta. Accedi di nuovo per scrivere sul Mac."
+        } else if case HomeBaseClientError.httpStatus(let status, _) = error, status == 403 {
+            statusMessage = "Operazione non autorizzata nello scope paired corrente."
+        }
+        errorMessage = error.localizedDescription
     }
 
     /* @Codex */

--- a/native/MediFlowMac/Tests/MediFlowAppleSharedTests/PairedPatientsWorkspaceModelLifecycleTests.swift
+++ b/native/MediFlowMac/Tests/MediFlowAppleSharedTests/PairedPatientsWorkspaceModelLifecycleTests.swift
@@ -157,6 +157,68 @@ final class PairedPatientsWorkspaceModelLifecycleTests: XCTestCase {
         }
     }
 
+    func testOlderPatientLoadCannotReplaceNewerSelection() async {
+        let gate = LifecycleLoadGate(["patient:1"])
+        let source = LifecycleMockDataSource(details: ["a": detail(id: "a", archived: false, version: 1), "b": detail(id: "b", archived: false, version: 1)], loadGate: gate)
+        let model = await makeModel(source: source)
+        await model.configurePairedOnlineForTests()
+        let older = Task { await model.loadPatient(summary(id: "a", archived: false, version: 1)) }
+        await gate.wait(for: "patient:1")
+        await model.loadPatient(summary(id: "b", archived: false, version: 1))
+        await gate.release("patient:1"); await older.value
+        let state = await MainActor.run { (model.selectedPatientID, model.selectedPatient?.id, model.isWorking) }
+        XCTAssertEqual(state.0, "b"); XCTAssertEqual(state.1, "b"); XCTAssertFalse(state.2)
+    }
+
+    func testStaleFailureCannotFinishNewerLoadAndContextDriftClosesItsOwner() async {
+        let gate = LifecycleLoadGate(["patient:1", "patient:2"])
+        let source = LifecycleMockDataSource(details: ["b": detail(id: "b", archived: false, version: 1)], loadGate: gate)
+        let model = await makeModel(source: source); await model.configurePairedOnlineForTests()
+        let stale = Task { await model.loadPatient(summary(id: "a", archived: false, version: 1)) }
+        await gate.wait(for: "patient:1")
+        let current = Task { await model.loadPatient(summary(id: "b", archived: false, version: 1)) }
+        await gate.wait(for: "patient:2"); await gate.release("patient:1"); await stale.value
+        let during = await MainActor.run { (model.selectedPatientID, model.isWorking, model.errorMessage, model.statusMessage) }
+        XCTAssertEqual(during.0, "b"); XCTAssertTrue(during.1); XCTAssertNil(during.2); XCTAssertNil(during.3)
+        await model.configurePairedOnlineForTests(credentials: .init(clientId: "other", clientToken: "other"))
+        await gate.release("patient:2"); await current.value
+        let after = await MainActor.run { (model.selectedPatient, model.isWorking, model.errorMessage) }
+        XCTAssertNil(after.0); XCTAssertFalse(after.1); XCTAssertNil(after.2)
+    }
+
+    func testSamePatientLatestRequestTokenWins() async {
+        let gate = LifecycleLoadGate(["patient:1", "patient:2"])
+        let source = LifecycleMockDataSource(details: ["p": detail(id: "p", archived: false, version: 1)], loadGate: gate)
+        let model = await makeModel(source: source); await model.configurePairedOnlineForTests()
+        let first = Task { await model.loadPatient(summary(id: "p", archived: false, version: 1)) }
+        await gate.wait(for: "patient:1"); await source.setDetail(detail(id: "p", archived: false, version: 2))
+        let second = Task { await model.loadPatient(summary(id: "p", archived: false, version: 2)) }
+        await gate.wait(for: "patient:2"); await gate.release("patient:2"); await second.value
+        await gate.release("patient:1"); await first.value
+        let state = await MainActor.run { (model.selectedPatient?.version, model.isWorking) }
+        XCTAssertEqual(state.0, 2); XCTAssertFalse(state.1)
+    }
+
+    func testPatientWorkspacePublishesAtomicallyWithCapturedKeyAndClearsOnChildFailure() async throws {
+        let sealed = try XCTUnwrap(CryptoService.encryptField(CryptoService.jsonEncode("Nota B")!, masterKey: masterKey))
+        let entry = HomeBaseEntrySummary(id: "e", patientId: "b", type: "note", title: sealed, date: .distantPast, content: sealed, setting: nil, metadata: nil, attachments: nil, deletedAt: nil, deletionReason: nil, version: 1, createdAt: nil, updatedAt: nil)
+        let gate = LifecycleLoadGate(["prosthetic:b"])
+        let source = LifecycleMockDataSource(details: ["b": detail(id: "b", archived: false, version: 1), "c": detail(id: "c", archived: false, version: 1)], loadGate: gate, entriesByPatient: ["b": [entry]], entryErrorsByPatient: ["c": .httpStatus(500, "child failed")])
+        let model = await makeModel(source: source); await model.configurePairedOnlineForTests(masterKey: masterKey)
+        let load = Task { await model.loadPatient(summary(id: "b", archived: false, version: 1)) }
+        await gate.wait(for: "prosthetic:b")
+        let pending = await MainActor.run { (model.selectedPatientID, model.selectedPatient, model.entries, model.isWorking) }
+        XCTAssertEqual(pending.0, "b"); XCTAssertNil(pending.1); XCTAssertTrue(pending.2.isEmpty); XCTAssertTrue(pending.3)
+        await model.configurePairedOnlineForTests(masterKey: SymmetricKey(data: Data(repeating: 9, count: 32)))
+        await gate.release("prosthetic:b"); await load.value
+        let loaded = await MainActor.run { (model.selectedPatient?.id, model.entries.first?.title) }
+        XCTAssertEqual(loaded.0, "b"); XCTAssertEqual(loaded.1, "Nota B")
+        await model.loadPatient(summary(id: "c", archived: false, version: 1))
+        let failed = await MainActor.run { (model.selectedPatientID, model.selectedPatient, model.entries, model.errorMessage, model.isWorking) }
+        XCTAssertEqual(failed.0, "c"); XCTAssertNil(failed.1); XCTAssertTrue(failed.2.isEmpty)
+        XCTAssertTrue(failed.3?.contains("child failed") == true); XCTAssertFalse(failed.4)
+    }
+
     func testRestoreUsesTombstoneVersionAndReloadsTrash() async throws {
         let deleted = summary(id: "p1", archived: false, version: 5, deleted: true, reason: "web-delete")
         let source = LifecycleMockDataSource(summaries: [deleted])
@@ -453,6 +515,32 @@ private final class Counter {
     var value = 0
 }
 
+/* @Codex */
+private actor LifecycleLoadGate {
+    private let keys: Set<String>
+    private var reached: Set<String> = []
+    private var blocks: [String: CheckedContinuation<Void, Never>] = [:]
+    private var waiters: [String: [CheckedContinuation<Void, Never>]] = [:]
+
+    init(_ keys: Set<String>) { self.keys = keys }
+
+    func pause(_ key: String) async {
+        guard keys.contains(key) else { return }
+        await withCheckedContinuation { continuation in
+            blocks[key] = continuation
+            reached.insert(key)
+            waiters.removeValue(forKey: key)?.forEach { $0.resume() }
+        }
+    }
+
+    func wait(for key: String) async {
+        guard !reached.contains(key) else { return }
+        await withCheckedContinuation { waiters[key, default: []].append($0) }
+    }
+
+    func release(_ key: String) { blocks.removeValue(forKey: key)?.resume() }
+}
+
 private actor LifecycleMockDataSource: HomeBasePatientsDataSource {
     struct PinChangeCall {
         let currentPin: String
@@ -479,6 +567,10 @@ private actor LifecycleMockDataSource: HomeBasePatientsDataSource {
 
     private var summaries: [HomeBasePatientSummary]
     private var details: [String: HomeBasePatientDetail]
+    private let loadGate: LifecycleLoadGate?
+    private let entriesByPatient: [String: [HomeBaseEntrySummary]]
+    private let entryErrorsByPatient: [String: HomeBaseClientError]
+    private var patientFetchCount = 0
     private let loginResult: HomeBaseLoginResult
     private let pinChangeError: HomeBaseClientError?
     private let logoutError: HomeBaseClientError?
@@ -496,13 +588,19 @@ private actor LifecycleMockDataSource: HomeBasePatientsDataSource {
         loginResult: HomeBaseLoginResult = HomeBaseLoginResult(
             sessionCookie: "sid=test", encryptedMasterKey: nil, salt: nil),
         pinChangeError: HomeBaseClientError? = nil,
-        logoutError: HomeBaseClientError? = nil
+        logoutError: HomeBaseClientError? = nil,
+        loadGate: LifecycleLoadGate? = nil,
+        entriesByPatient: [String: [HomeBaseEntrySummary]] = [:],
+        entryErrorsByPatient: [String: HomeBaseClientError] = [:]
     ) {
         self.summaries = summaries
         self.details = details
         self.loginResult = loginResult
         self.pinChangeError = pinChangeError
         self.logoutError = logoutError
+        self.loadGate = loadGate
+        self.entriesByPatient = entriesByPatient
+        self.entryErrorsByPatient = entryErrorsByPatient
         if summaries.isEmpty {
             self.summaries = details.values.map {
                 HomeBasePatientSummary(
@@ -666,9 +764,14 @@ private actor LifecycleMockDataSource: HomeBasePatientsDataSource {
         sessionCookie: String,
         ambulatoryId: String?
     ) async throws -> HomeBasePatientDetail {
-        guard let detail = details[id] else { throw HomeBaseClientError.httpStatus(404, "Not found") }
+        patientFetchCount += 1
+        let detail = details[id]
+        await loadGate?.pause("patient:\(patientFetchCount)")
+        guard let detail else { throw HomeBaseClientError.httpStatus(404, "Not found") }
         return detail
     }
+
+    func setDetail(_ detail: HomeBasePatientDetail) { details[detail.id] = detail }
 
     func updatePatient(
         patientId: String,
@@ -801,7 +904,8 @@ private actor LifecycleMockDataSource: HomeBasePatientsDataSource {
         ambulatoryId: String?,
         limit: Int
     ) async throws -> [HomeBaseEntrySummary] {
-        []
+        if let error = entryErrorsByPatient[patientId] { throw error }
+        return entriesByPatient[patientId] ?? []
     }
 
     func createEntry(
@@ -1037,7 +1141,8 @@ private actor LifecycleMockDataSource: HomeBasePatientsDataSource {
         sessionCookie: String,
         ambulatoryId: String?
     ) async throws -> [HomeBaseProstheticPrescriptionSummary] {
-        []
+        await loadGate?.pause("prosthetic:\(patientId)")
+        return []
     }
 
     func createProstheticPrescription(


### PR DESCRIPTION
## Summary
- Cattura un contesto immutabile per ogni caricamento paziente, incluso request UUID, sessione, scope, client e master key.
- Recupera dettaglio e sette collezioni cliniche in memoria e le pubblica con un unico commit sincrono guardato.
- Applica latest-request-wins anche sullo stesso patient ID e impedisce alle richieste obsolete di cambiare dati, errori o stato busy.
- Aggiunge quattro regressioni deterministiche con actor continuation, senza sleep e con fixture sintetiche.

## Verification
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift test --package-path native/MediFlowMac --filter PairedPatientsWorkspaceModelLifecycleTests` — 18/18.
- `npm run test:native` — 365/365.
- `MEDIFLOW_DERIVED_DATA_DIR=/tmp/mediflow-76-xcode-derived npm run test:native:xcode` — 365/365, `TEST SUCCEEDED`.
- Build Release macOS no-signing universale — exit 0; binario `x86_64 arm64`.
- Due review Sol high indipendenti — PASS, nessun finding actionable.
- `git diff --check` pulito; hash binario base-to-head `5dba0e401a9fe9e1618a5a6ebac4a70149b038039868de49368e0f616f7e724d`.

## Risk / Notes
- Scope limitato al caricamento diretto A→B; revision refresh, reload dopo conflitto e invalidazione session/lifecycle restano nella foglia dipendente #81.
- #74 resta bloccata fino alla promozione sia di #76 sia di #81.
- Diff di 2 file / 306 gross LOC; nessun protocollo, view o dominio modificato.
- Nessuna PHI/PII e nessun dato paziente reale; solo fixture sintetiche.

## Ticket
Fixes #76
Refs #68
Blocks #81