### PR TITLE
fix(native): stabilizza lifecycle del load paziente

### DIFF
--- a/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/PairedPatientsWorkspaceModel.swift
+++ b/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/PairedPatientsWorkspaceModel.swift
@@ -29,7 +29,11 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
     @Published var username = ""
     @Published var password = ""
     @Published var ambulatoryId = "" {
-        didSet { if oldValue.trimmedOrNil != ambulatoryId.trimmedOrNil { clearSelectedPatientWorkspace() } } // @Codex
+        didSet {
+            guard oldValue.trimmedOrNil != ambulatoryId.trimmedOrNil else { return }
+            invalidatePatientLoadContext()
+            clearSelectedPatientWorkspace()
+        } // @Codex
     }
     @Published private(set) var availableAmbulatories: [NetworkAmbulatorySummary] = []
     @Published private(set) var patients: [HomeBasePatientSummary] = []
@@ -265,6 +269,8 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
         pendingConflict.map(VersionConflictPresentation.init)
     }
     @Published private(set) var isWorking = false
+    /* @Codex */
+    @Published private(set) var canChangePatientSelection = true
 
     private let pairedStore: HomeBasePairedStore
     private let cacheStore: HomeBasePatientCacheStore
@@ -299,6 +305,7 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
     private struct PatientLoadContext {
         let requestID: UUID
         let patientID: String
+        let workspaceGeneration: UInt
         let sessionCookie: String
         let credentials: HomeBasePairedCredentials
         let ambulatoryID: String?
@@ -321,6 +328,10 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
     }
     /* @Codex */
     private var activePatientLoadRequestID: UUID?
+    /* @Codex */
+    private var workspaceGeneration: UInt = 0
+    /* @Codex */
+    private var exclusiveOperationIDs: Set<UUID> = []
     // S3 (D3, lane PRREG): injectable seam for the "Prescrittivo regionale"
     // handoff action (clipboard + external URL). Defaults to the real
     // implementation; tests inject a spy instead of touching the system
@@ -697,10 +708,10 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
     }
 
     func lockSessionNow() async {
-        isWorking = true
+        let operationID = beginExclusiveOperation()
         errorMessage = nil
         pendingConflict = nil
-        defer { isWorking = false }
+        defer { finishExclusiveOperation(operationID) }
 
         var remoteLogoutConfirmed = false
         if let sessionCookie, let credentials = pairedCredentials {
@@ -808,6 +819,7 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
     }
 
     func loadPatient(_ patient: HomeBasePatientSummary) async {
+        guard canChangePatientSelection else { return }
         if selectedPatient?.id != patient.id {
             invalidateAttachmentPatientState()
         }
@@ -831,13 +843,13 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
         #endif
         guard let sessionCookie, let credentials = pairedCredentials else { return }
         let context = PatientLoadContext(
-            requestID: UUID(), patientID: patient.id, sessionCookie: sessionCookie,
-            credentials: credentials, ambulatoryID: ambulatoryId.trimmedOrNil,
-            serverURL: serverURL, tlsPin: tlsPin, connectionState: connectionState,
-            client: makeClient(), masterKey: masterKey)
+            requestID: UUID(), patientID: patient.id, workspaceGeneration: workspaceGeneration,
+            sessionCookie: sessionCookie, credentials: credentials,
+            ambulatoryID: ambulatoryId.trimmedOrNil, serverURL: serverURL, tlsPin: tlsPin,
+            connectionState: connectionState, client: makeClient(), masterKey: masterKey)
         activePatientLoadRequestID = context.requestID
         clearSelectedPatientWorkspace(preservingSelectionID: patient.id)
-        isWorking = true
+        refreshWorkingState()
         errorMessage = nil
         pendingConflict = nil
         do {
@@ -3115,6 +3127,8 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
     }
 
     func clearPairing() async {
+        let operationID = beginExclusiveOperation()
+        defer { finishExclusiveOperation(operationID) }
         errorMessage = nil
         do {
             try pairedStore.clear()
@@ -3622,6 +3636,7 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
     private func canPublishPatientLoad(_ context: PatientLoadContext) -> Bool {
         guard activePatientLoadRequestID == context.requestID else { return false }
         let contextIsCurrent = selectedPatientID == context.patientID
+            && workspaceGeneration == context.workspaceGeneration
             && sessionCookie == context.sessionCookie && pairedCredentials == context.credentials
             && ambulatoryId.trimmedOrNil == context.ambulatoryID
             && serverURL == context.serverURL && tlsPin == context.tlsPin
@@ -3636,12 +3651,40 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
     /* @Codex */
     private func finishCurrentPatientLoad() {
         activePatientLoadRequestID = nil
-        isWorking = false
+        refreshWorkingState()
+    }
+
+    /* @Codex */
+    private func invalidatePatientLoadContext() {
+        workspaceGeneration &+= 1
+        activePatientLoadRequestID = nil
+        refreshWorkingState()
+    }
+
+    /* @Codex */
+    private func beginExclusiveOperation() -> UUID {
+        let operationID = UUID()
+        exclusiveOperationIDs.insert(operationID)
+        invalidatePatientLoadContext()
+        return operationID
+    }
+
+    /* @Codex */
+    private func finishExclusiveOperation(_ operationID: UUID) {
+        exclusiveOperationIDs.remove(operationID)
+        refreshWorkingState()
+    }
+
+    /* @Codex */
+    private func refreshWorkingState() {
+        canChangePatientSelection = exclusiveOperationIDs.isEmpty
+        isWorking = activePatientLoadRequestID != nil || !exclusiveOperationIDs.isEmpty
     }
 
     /* @Codex */
     private func applyPatientLoadFailure(_ error: Error) {
         if case HomeBaseClientError.httpStatus(let status, _) = error, status == 401 {
+            invalidatePatientLoadContext()
             connectionState = .sessionExpired
             sessionCookie = nil
             masterKey = nil
@@ -3955,15 +3998,16 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
     }
 
     private func runTask(_ operation: @escaping () async throws -> Void) async {
-        isWorking = true
+        let operationID = beginExclusiveOperation()
         errorMessage = nil
         pendingConflict = nil
-        defer { isWorking = false }
+        defer { finishExclusiveOperation(operationID) }
         do {
             try await operation()
         } catch {
             if case HomeBaseClientError.httpStatus(let status, _) = error,
                status == 401 {
+                invalidatePatientLoadContext()
                 connectionState = .sessionExpired
                 sessionCookie = nil
                 masterKey = nil

--- a/native/MediFlowMac/Tests/MediFlowAppleSharedTests/PairedPatientsWorkspaceModelLifecycleTests.swift
+++ b/native/MediFlowMac/Tests/MediFlowAppleSharedTests/PairedPatientsWorkspaceModelLifecycleTests.swift
@@ -219,6 +219,72 @@ final class PairedPatientsWorkspaceModelLifecycleTests: XCTestCase {
         XCTAssertTrue(failed.3?.contains("child failed") == true); XCTAssertFalse(failed.4)
     }
 
+    func testLockInvalidatesPatientLoadBeforeRemoteLogoutCompletes() async {
+        let gate = LifecycleLoadGate(["patient:1", "logout"])
+        let source = LifecycleMockDataSource(
+            details: ["a": detail(id: "a", archived: false, version: 1)], loadGate: gate)
+        let model = await makeModel(source: source); await model.configurePairedOnlineForTests()
+        let load = Task { await model.loadPatient(summary(id: "a", archived: false, version: 1)) }
+        await gate.wait(for: "patient:1")
+        let lock = Task { await model.lockSessionNow() }
+        await gate.wait(for: "logout")
+        await gate.release("patient:1"); await load.value
+        let duringLock = await MainActor.run {
+            (model.selectedPatient, model.isWorking, model.canChangePatientSelection)
+        }
+        XCTAssertNil(duringLock.0); XCTAssertTrue(duringLock.1); XCTAssertFalse(duringLock.2)
+        await gate.release("logout"); await lock.value
+        let locked = await MainActor.run {
+            (model.selectedPatient, model.connectionState, model.isWorking, model.canChangePatientSelection)
+        }
+        XCTAssertNil(locked.0); XCTAssertEqual(locked.1, .sessionExpired)
+        XCTAssertFalse(locked.2); XCTAssertTrue(locked.3)
+    }
+
+    func testScopeRoundTripInvalidatesCapturedPatientLoad() async {
+        let gate = LifecycleLoadGate(["patient:1"])
+        let source = LifecycleMockDataSource(
+            details: ["a": detail(id: "a", archived: false, version: 1)], loadGate: gate)
+        let model = await makeModel(source: source); await model.configurePairedOnlineForTests()
+        await MainActor.run { model.ambulatoryId = "AMB-A" }
+        let load = Task { await model.loadPatient(summary(id: "a", archived: false, version: 1)) }
+        await gate.wait(for: "patient:1")
+        await MainActor.run { model.ambulatoryId = "AMB-B"; model.ambulatoryId = "AMB-A" }
+        let invalidated = await MainActor.run {
+            (model.selectedPatientID, model.selectedPatient, model.isWorking, model.canChangePatientSelection)
+        }
+        XCTAssertNil(invalidated.0); XCTAssertNil(invalidated.1)
+        XCTAssertFalse(invalidated.2); XCTAssertTrue(invalidated.3)
+        await gate.release("patient:1"); await load.value
+        let state = await MainActor.run {
+            (model.selectedPatientID, model.selectedPatient, model.isWorking, model.canChangePatientSelection)
+        }
+        XCTAssertNil(state.0); XCTAssertNil(state.1); XCTAssertFalse(state.2); XCTAssertTrue(state.3)
+    }
+
+    func testOverlappingExclusiveTasksKeepSelectionDisabledUntilLastOwnerFinishes() async {
+        let gate = LifecycleLoadGate(["pin:1", "pin:2"])
+        let initial = detail(id: "a", archived: false, version: 1)
+        let source = LifecycleMockDataSource(details: ["a": initial, "b": detail(id: "b", archived: false, version: 1)], loadGate: gate)
+        let model = await makeModel(source: source)
+        await model.configurePairedOnlineForTests(masterKey: masterKey, selectedPatient: initial)
+        let first = Task { await model.changePin(currentPin: "1357", newPin: "2468") }
+        await gate.wait(for: "pin:1")
+        let second = Task { await model.changePin(currentPin: "1357", newPin: "8642") }
+        await gate.wait(for: "pin:2")
+        await model.loadPatient(summary(id: "b", archived: false, version: 1))
+        let overlapping = await MainActor.run {
+            (model.selectedPatientID, model.isWorking, model.canChangePatientSelection)
+        }
+        XCTAssertEqual(overlapping.0, "a"); XCTAssertTrue(overlapping.1); XCTAssertFalse(overlapping.2)
+        await gate.release("pin:1"); await first.value
+        let oneOwner = await MainActor.run { (model.isWorking, model.canChangePatientSelection) }
+        XCTAssertTrue(oneOwner.0); XCTAssertFalse(oneOwner.1)
+        await gate.release("pin:2"); await second.value
+        let finished = await MainActor.run { (model.isWorking, model.canChangePatientSelection) }
+        XCTAssertFalse(finished.0); XCTAssertTrue(finished.1)
+    }
+
     func testRestoreUsesTombstoneVersionAndReloadsTrash() async throws {
         let deleted = summary(id: "p1", archived: false, version: 5, deleted: true, reason: "web-delete")
         let source = LifecycleMockDataSource(summaries: [deleted])
@@ -634,6 +700,7 @@ private actor LifecycleMockDataSource: HomeBasePatientsDataSource {
             encryptedMasterKey: encryptedMasterKey,
             salt: salt
         ))
+        await loadGate?.pause("pin:\(pinChangeCalls.count)")
         if let pinChangeError { throw pinChangeError }
         return HomeBaseMutationAcknowledgement(success: true)
     }
@@ -642,6 +709,7 @@ private actor LifecycleMockDataSource: HomeBasePatientsDataSource {
         credentials: HomeBasePairedCredentials, sessionCookie: String
     ) async throws -> HomeBaseMutationAcknowledgement {
         logoutCalls += 1
+        await loadGate?.pause("logout")
         if let logoutError { throw logoutError }
         return HomeBaseMutationAcknowledgement(success: true)
     }


### PR DESCRIPTION
## Summary
- Invalida in modo sincrono i load paziente quando cambiano sessione, scope o pairing.
- Deriva busy e disponibilità della selezione dagli owner attivi, mantenendo request-safe due operazioni concorrenti.
- Mantiene il load diretto A → B latest-request-wins; revision refresh e reload conflitto restano nella foglia #83.

## Verification
- Lifecycle mirati: 21/21.
- SwiftPM completo: 368/368.
- Xcode completo: 368/368, TEST SUCCEEDED.
- MediFlowMacApp Release: BUILD SUCCEEDED, binario universale x86_64 + arm64.
- MediFlowMobileApp iOS Simulator: BUILD SUCCEEDED.
- Due review indipendenti sul bundle pubblicato: PASS, zero finding azionabili.

## Risk / Notes
- Perimetro: 2 file, 134 gross LOC; hash binario del diff af245bdabad994a1ad69b47f82d6244e38cbdde3e00d883295c84a6d98bc87ee.
- Nessun protocollo, view o percorso revision/reload modificato.
- Fixture esclusivamente sintetiche; nessuna PHI/PII.
- Merge non automatico: attendere tutti i check sullo SHA pubblicato.

## Ticket
Fixes #81
Refs #68
Blocks #83