### PR TITLE
fix(native): atomicizza refresh e reload del workspace

### DIFF
--- a/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/PairedPatientsWorkspaceModel.swift
+++ b/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/PairedPatientsWorkspaceModel.swift
@@ -304,7 +304,7 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
     /* @Codex */
     private struct PatientLoadContext {
         let requestID: UUID
-        let patientID: String
+        let patientID: String?
         let workspaceGeneration: UInt
         let sessionCookie: String
         let credentials: HomeBasePairedCredentials
@@ -841,28 +841,13 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
             return
         }
         #endif
-        guard let sessionCookie, let credentials = pairedCredentials else { return }
-        let context = PatientLoadContext(
-            requestID: UUID(), patientID: patient.id, workspaceGeneration: workspaceGeneration,
-            sessionCookie: sessionCookie, credentials: credentials,
-            ambulatoryID: ambulatoryId.trimmedOrNil, serverURL: serverURL, tlsPin: tlsPin,
-            connectionState: connectionState, client: makeClient(), masterKey: masterKey)
-        activePatientLoadRequestID = context.requestID
-        clearSelectedPatientWorkspace(preservingSelectionID: patient.id)
-        refreshWorkingState()
+        guard let context = beginPatientLoad(patientID: patient.id, clearingWorkspace: true) else { return }
         errorMessage = nil
         pendingConflict = nil
         do {
             let payload = try await fetchPatientWorkspace(context)
             guard canPublishPatientLoad(context) else { return }
-            setSelectedPatient(payload.detail, masterKey: context.masterKey)
-            entries = payload.entries
-            therapies = payload.therapies
-            checkups = payload.checkups
-            observations = payload.observations
-            servicePrescriptions = payload.services
-            servicePrescriptionItems = payload.serviceItems
-            prostheticPrescriptions = payload.prosthetics
+            publishPatientWorkspace(payload, context: context)
             statusMessage = "Dettaglio \(patient.lastName) aperto."
             finishCurrentPatientLoad()
         } catch {
@@ -883,41 +868,23 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
             return
         }
         #endif
-        guard let current = selectedPatient, let sessionCookie, let credentials = pairedCredentials else {
+        guard let current = selectedPatient else {
             pendingConflict = nil
             return
         }
-        let id = current.id
-        await runTask {
-            let fetchedDetail = try await self.makeClient().fetchPatient(
-                id: id, credentials: credentials, sessionCookie: sessionCookie,
-                ambulatoryId: self.ambulatoryId.trimmedOrNil)
-            self.setSelectedPatient(fetchedDetail) // @Codex
-            self.patientReportURL = nil
-            self.patientFHIRExportURL = nil
-            self.pendingFHIRWarningValidation = nil
-            self.entries = try await self.fetchDecryptedEntries(
-                patientId: id, credentials: credentials, sessionCookie: sessionCookie,
-                ambulatoryId: self.ambulatoryId.trimmedOrNil)
-            self.therapies = try await self.fetchDecryptedTherapies(
-                patientId: id, credentials: credentials, sessionCookie: sessionCookie,
-                ambulatoryId: self.ambulatoryId.trimmedOrNil)
-            self.checkups = try await self.fetchDecryptedCheckups(
-                patientId: id, credentials: credentials, sessionCookie: sessionCookie,
-                ambulatoryId: self.ambulatoryId.trimmedOrNil)
-            self.observations = try await self.fetchDecryptedObservations(
-                patientId: id, credentials: credentials, sessionCookie: sessionCookie,
-                ambulatoryId: self.ambulatoryId.trimmedOrNil)
-            self.servicePrescriptions = try await self.fetchServicePrescriptions(
-                patientId: id, credentials: credentials, sessionCookie: sessionCookie,
-                ambulatoryId: self.ambulatoryId.trimmedOrNil)
-            self.servicePrescriptionItems = try await self.fetchServicePrescriptionItems(
-                patientId: id, credentials: credentials, sessionCookie: sessionCookie,
-                ambulatoryId: self.ambulatoryId.trimmedOrNil)
-            self.prostheticPrescriptions = try await self.fetchProstheticPrescriptions(
-                patientId: id, credentials: credentials, sessionCookie: sessionCookie,
-                ambulatoryId: self.ambulatoryId.trimmedOrNil)
-            self.statusMessage = "Dati aggiornati dall'home-base. Riapplica la modifica."
+        guard let context = beginPatientLoad(patientID: current.id, clearingWorkspace: false) else { return }
+        do {
+            let payload = try await fetchPatientWorkspace(context)
+            guard canPublishPatientLoad(context) else { return }
+            publishPatientWorkspace(payload, context: context)
+            pendingConflict = nil
+            errorMessage = nil
+            statusMessage = "Dati aggiornati dall'home-base. Riapplica la modifica."
+            finishCurrentPatientLoad()
+        } catch {
+            guard canPublishPatientLoad(context) else { return }
+            finishCurrentPatientLoad()
+            applyPatientReloadFailure(error)
         }
     }
 
@@ -3600,12 +3567,30 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
     }
 
     /* @Codex */
+    private func beginPatientLoad(
+        patientID: String?, clearingWorkspace: Bool
+    ) -> PatientLoadContext? {
+        guard canChangePatientSelection,
+              let sessionCookie,
+              let credentials = pairedCredentials else { return nil }
+        let context = PatientLoadContext(
+            requestID: UUID(), patientID: patientID, workspaceGeneration: workspaceGeneration,
+            sessionCookie: sessionCookie, credentials: credentials,
+            ambulatoryID: ambulatoryId.trimmedOrNil, serverURL: serverURL, tlsPin: tlsPin,
+            connectionState: connectionState, client: makeClient(), masterKey: masterKey)
+        activePatientLoadRequestID = context.requestID
+        if clearingWorkspace { clearSelectedPatientWorkspace(preservingSelectionID: patientID) }
+        refreshWorkingState()
+        return context
+    }
+
+    /* @Codex */
     private func fetchPatientWorkspace(_ context: PatientLoadContext) async throws -> PatientWorkspacePayload {
         let client = context.client
         let credentials = context.credentials
         let cookie = context.sessionCookie
         let scope = context.ambulatoryID
-        let patientID = context.patientID
+        guard let patientID = context.patientID else { throw HomeBaseClientError.contract }
         let detail = try await client.fetchPatient(
             id: patientID, credentials: credentials, sessionCookie: cookie, ambulatoryId: scope)
         let entries = try await client.fetchEntries(
@@ -3630,6 +3615,23 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
             detail: detail, entries: entries, therapies: therapies, checkups: checkups,
             observations: observations, services: services, serviceItems: serviceItems,
             prosthetics: prosthetics)
+    }
+
+    /* @Codex */
+    private func publishPatientWorkspace(
+        _ payload: PatientWorkspacePayload, context: PatientLoadContext
+    ) {
+        setSelectedPatient(payload.detail, masterKey: context.masterKey)
+        entries = payload.entries
+        therapies = payload.therapies
+        checkups = payload.checkups
+        observations = payload.observations
+        servicePrescriptions = payload.services
+        servicePrescriptionItems = payload.serviceItems
+        prostheticPrescriptions = payload.prosthetics
+        patientReportURL = nil
+        patientFHIRExportURL = nil
+        pendingFHIRWarningValidation = nil
     }
 
     /* @Codex */
@@ -3823,64 +3825,63 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
 
     /* @Codex */
     private func checkNetworkRevision(refreshOnChange: Bool) async {
-        guard connectionState == .pairedOnline,
-              let sessionCookie,
-              let credentials = pairedCredentials else { return }
+        guard activePatientLoadRequestID == nil,
+              connectionState == .pairedOnline,
+              let context = beginPatientLoad(
+                patientID: selectedPatientID, clearingWorkspace: false
+              ) else { return }
         do {
-            let revision = try await makeClient().fetchNetworkRevision(
-                credentials: credentials,
-                sessionCookie: sessionCookie,
-                ambulatoryId: ambulatoryId.trimmedOrNil
+            let revision = try await context.client.fetchNetworkRevision(
+                credentials: context.credentials,
+                sessionCookie: context.sessionCookie,
+                ambulatoryId: context.ambulatoryID
             )
-            guard self.lastSeenNetworkFingerprint != nil else {
+            guard let previousFingerprint = lastSeenNetworkFingerprint else {
+                guard canPublishPatientLoad(context) else { return }
                 lastSeenNetworkFingerprint = revision.fingerprint
+                finishCurrentPatientLoad()
                 return
             }
-            guard refreshOnChange, lastSeenNetworkFingerprint != revision.fingerprint else { return }
+            guard refreshOnChange, previousFingerprint != revision.fingerprint else {
+                guard canPublishPatientLoad(context) else { return }
+                finishCurrentPatientLoad()
+                return
+            }
+            let refreshed = try await fetchRevisionWorkspace(context)
+            guard canPublishPatientLoad(context) else { return }
+            patients = refreshed.patients
+            if let workspace = refreshed.workspace {
+                publishPatientWorkspace(workspace, context: context)
+            } else {
+                clearSelectedPatientWorkspace()
+            }
             lastSeenNetworkFingerprint = revision.fingerprint
-            try await refreshCurrentWorkspaceAfterRevision(
-                credentials: credentials,
-                sessionCookie: sessionCookie
-            )
             statusMessage = "Home-base aggiornato, dati ricaricati."
+            finishCurrentPatientLoad()
         } catch {
-            // Revision polling must not interrupt manual work when the Mac is offline.
+            guard canPublishPatientLoad(context) else { return }
+            finishCurrentPatientLoad()
+            if case HomeBaseClientError.httpStatus(let status, _) = error, status == 401 {
+                applyPatientLoadFailure(error)
+            }
         }
     }
 
     /* @Codex */
-    private func refreshCurrentWorkspaceAfterRevision(
-        credentials: HomeBasePairedCredentials,
-        sessionCookie: String
-    ) async throws {
-        let selectionBeforeRefresh = selectedPatientID
-        patients = try await makeClient().fetchPatients(
-            credentials: credentials,
-            sessionCookie: sessionCookie,
-            ambulatoryId: ambulatoryId.trimmedOrNil,
+    private func fetchRevisionWorkspace(
+        _ context: PatientLoadContext
+    ) async throws -> (patients: [HomeBasePatientSummary], workspace: PatientWorkspacePayload?) {
+        let refreshedPatients = try await context.client.fetchPatients(
+            credentials: context.credentials,
+            sessionCookie: context.sessionCookie,
+            ambulatoryId: context.ambulatoryID,
             includeDeleted: false
         )
-        .map { PatientFieldCrypto.decryptSummary($0, masterKey: masterKey) }
-        if let patientId = reconcilePatientSelection(
-            selectionBeforeRefresh, in: patients, invalidatingWorkspace: false
-        ) {
-            let fetchedDetail = try await makeClient().fetchPatient(
-                id: patientId,
-                credentials: credentials,
-                sessionCookie: sessionCookie,
-                ambulatoryId: ambulatoryId.trimmedOrNil
-            )
-            setSelectedPatient(fetchedDetail) // @Codex
-            entries = try await fetchDecryptedEntries(patientId: patientId, credentials: credentials, sessionCookie: sessionCookie, ambulatoryId: ambulatoryId.trimmedOrNil)
-            therapies = try await fetchDecryptedTherapies(patientId: patientId, credentials: credentials, sessionCookie: sessionCookie, ambulatoryId: ambulatoryId.trimmedOrNil)
-            checkups = try await fetchDecryptedCheckups(patientId: patientId, credentials: credentials, sessionCookie: sessionCookie, ambulatoryId: ambulatoryId.trimmedOrNil)
-            observations = try await fetchDecryptedObservations(patientId: patientId, credentials: credentials, sessionCookie: sessionCookie, ambulatoryId: ambulatoryId.trimmedOrNil)
-            servicePrescriptions = try await fetchServicePrescriptions(patientId: patientId, credentials: credentials, sessionCookie: sessionCookie, ambulatoryId: ambulatoryId.trimmedOrNil)
-            servicePrescriptionItems = try await fetchServicePrescriptionItems(patientId: patientId, credentials: credentials, sessionCookie: sessionCookie, ambulatoryId: ambulatoryId.trimmedOrNil)
-            prostheticPrescriptions = try await fetchProstheticPrescriptions(patientId: patientId, credentials: credentials, sessionCookie: sessionCookie, ambulatoryId: ambulatoryId.trimmedOrNil)
-            patientReportURL = nil
-            patientFHIRExportURL = nil
+        .map { PatientFieldCrypto.decryptSummary($0, masterKey: context.masterKey) }
+        guard Self.reconciledPatientSelectionID(context.patientID, in: refreshedPatients) != nil else {
+            return (refreshedPatients, nil)
         }
+        return (refreshedPatients, try await fetchPatientWorkspace(context))
     }
 
     private func applyLaunchOverrides(_ launchOverrides: AppleFoundationLaunchOverrides) {
@@ -4034,6 +4035,23 @@ final class PairedPatientsWorkspaceModel: ObservableObject {
                 return
             }
             errorMessage = error.localizedDescription
+        }
+    }
+
+    /* @Codex */
+    private func applyPatientReloadFailure(_ error: Error) {
+        if case HomeBaseClientError.versionConflict(let payload) = error {
+            pendingConflict = payload
+            statusMessage = error.localizedDescription
+            errorMessage = nil
+        } else if case HomeBaseClientError.pinChangeConflict = error {
+            statusMessage = error.localizedDescription
+            errorMessage = nil
+        } else if case HomeBaseClientError.httpStatus(let status, _) = error, status == 409 {
+            statusMessage = "Conflitto versione: ricarica il modulo e confronta la voce prima di salvare."
+            errorMessage = nil
+        } else {
+            applyPatientLoadFailure(error)
         }
     }
 

--- a/native/MediFlowMac/Tests/MediFlowAppleSharedTests/PairedPatientsWorkspaceModelLifecycleTests.swift
+++ b/native/MediFlowMac/Tests/MediFlowAppleSharedTests/PairedPatientsWorkspaceModelLifecycleTests.swift
@@ -285,6 +285,87 @@ final class PairedPatientsWorkspaceModelLifecycleTests: XCTestCase {
         XCTAssertFalse(finished.0); XCTAssertTrue(finished.1)
     }
 
+    func testRevisionSupersededBySelectionLeavesFingerprintRetryable() async {
+        let oldA = detail(id: "a", archived: false, version: 1)
+        let newA = detail(id: "a", archived: false, version: 2)
+        let b = detail(id: "b", archived: false, version: 1)
+        let gate = LifecycleLoadGate(["revision:2"])
+        let source = LifecycleMockDataSource(
+            summaries: [summary(id: "a", archived: false, version: 2), summary(id: "b", archived: false, version: 1)],
+            details: ["a": newA, "b": b], loadGate: gate,
+            revisions: [revision("stable"), revision("changed"), revision("changed")])
+        let model = await makeModel(source: source)
+        await model.configurePairedOnlineForTests(
+            patients: [summary(id: "a", archived: false, version: 1), summary(id: "b", archived: false, version: 1)],
+            selectedPatient: oldA)
+        await model.checkNetworkRevisionOnForeground()
+        let stale = Task { await model.checkNetworkRevisionOnForeground() }
+        await gate.wait(for: "revision:2"); await model.loadPatient(summary(id: "b", archived: false, version: 1))
+        await gate.release("revision:2"); await stale.value
+        var state = await MainActor.run { (model.patients.first?.version, model.selectedPatient?.id, model.statusMessage) }
+        XCTAssertEqual(state.0, 1); XCTAssertEqual(state.1, "b"); XCTAssertEqual(state.2, "Dettaglio Rossi aperto.")
+        await model.checkNetworkRevisionOnForeground()
+        state = await MainActor.run { (model.patients.first?.version, model.selectedPatient?.id, model.statusMessage) }
+        XCTAssertEqual(state.0, 2); XCTAssertEqual(state.1, "b"); XCTAssertEqual(state.2, "Home-base aggiornato, dati ricaricati.")
+    }
+
+    /* @Codex */
+    func testForegroundRevisionDoesNotSupersedeActivePatientLoad() async {
+        let b = detail(id: "b", archived: false, version: 1)
+        let gate = LifecycleLoadGate(["patient:1"])
+        let source = LifecycleMockDataSource(details: ["b": b], loadGate: gate)
+        let model = await makeModel(source: source); await model.configurePairedOnlineForTests()
+        let load = Task { await model.loadPatient(summary(id: "b", archived: false, version: 1)) }
+        await gate.wait(for: "patient:1"); await model.checkNetworkRevisionOnForeground()
+        var state = await MainActor.run { (model.selectedPatientID, model.selectedPatient?.id, model.isWorking) }
+        XCTAssertEqual(state.0, "b"); XCTAssertNil(state.1); XCTAssertTrue(state.2)
+        await gate.release("patient:1"); await load.value
+        state = await MainActor.run { (model.selectedPatientID, model.selectedPatient?.id, model.isWorking) }
+        XCTAssertEqual(state.0, "b"); XCTAssertEqual(state.1, "b"); XCTAssertFalse(state.2)
+    }
+
+    func testRevisionPublishesListWorkspaceAndStatusAtomically() async {
+        let oldA = detail(id: "a", archived: false, version: 1)
+        let gate = LifecycleLoadGate(["prosthetic:a"])
+        let source = LifecycleMockDataSource(
+            summaries: [summary(id: "a", archived: false, version: 2)],
+            details: ["a": detail(id: "a", archived: false, version: 2)], loadGate: gate,
+            revisions: [revision("stable"), revision("changed")])
+        let model = await makeModel(source: source)
+        await model.configurePairedOnlineForTests(
+            patients: [summary(id: "a", archived: false, version: 1)], selectedPatient: oldA)
+        await model.checkNetworkRevisionOnForeground()
+        let refresh = Task { await model.checkNetworkRevisionOnForeground() }
+        await gate.wait(for: "prosthetic:a")
+        var state = await MainActor.run { (model.patients.first?.version, model.selectedPatient?.version, model.statusMessage, model.isWorking) }
+        XCTAssertEqual(state.0, 1); XCTAssertEqual(state.1, 1); XCTAssertNil(state.2); XCTAssertTrue(state.3)
+        await gate.release("prosthetic:a"); await refresh.value
+        state = await MainActor.run { (model.patients.first?.version, model.selectedPatient?.version, model.statusMessage, model.isWorking) }
+        XCTAssertEqual(state.0, 2); XCTAssertEqual(state.1, 2)
+        XCTAssertEqual(state.2, "Home-base aggiornato, dati ricaricati."); XCTAssertFalse(state.3)
+    }
+
+    func testReloadSupersededBySelectionCannotOverwriteNewerConflictState() async {
+        let conflict = await PairedPatientsWorkspaceModel.uiTestSeededConflict()
+        let a = detail(id: "a", archived: false, version: 1)
+        let b = detail(id: "b", archived: false, version: 1)
+        let gate = LifecycleLoadGate(["patient:1"])
+        let source = LifecycleMockDataSource(
+            details: ["a": a, "b": b], pinChangeError: .versionConflict(conflict), loadGate: gate)
+        let model = await makeModel(source: source)
+        await model.configurePairedOnlineForTests(masterKey: masterKey, selectedPatient: a)
+        let reload = Task { await model.reloadAfterConflict() }
+        await gate.wait(for: "patient:1"); await model.loadPatient(summary(id: "b", archived: false, version: 1))
+        await model.changePin(currentPin: "1357", newPin: "2468")
+        await gate.release("patient:1"); await reload.value
+        let state = await MainActor.run {
+            (model.selectedPatient?.id, model.pendingConflict, model.statusMessage, model.errorMessage, model.isWorking)
+        }
+        XCTAssertEqual(state.0, "b"); XCTAssertEqual(state.1, conflict)
+        XCTAssertEqual(state.2, HomeBaseClientError.versionConflict(conflict).localizedDescription)
+        XCTAssertNil(state.3); XCTAssertFalse(state.4)
+    }
+
     func testRestoreUsesTombstoneVersionAndReloadsTrash() async throws {
         let deleted = summary(id: "p1", archived: false, version: 5, deleted: true, reason: "web-delete")
         let source = LifecycleMockDataSource(summaries: [deleted])
@@ -575,6 +656,10 @@ final class PairedPatientsWorkspaceModelLifecycleTests: XCTestCase {
             deletionReason: deleted ? "web-delete" : nil
         )
     }
+
+    private func revision(_ fingerprint: String) -> NetworkRevisionSummary {
+        NetworkRevisionSummary(revision: fingerprint, sourceFingerprint: "src", fingerprint: fingerprint)
+    }
 }
 
 private final class Counter {
@@ -636,7 +721,9 @@ private actor LifecycleMockDataSource: HomeBasePatientsDataSource {
     private let loadGate: LifecycleLoadGate?
     private let entriesByPatient: [String: [HomeBaseEntrySummary]]
     private let entryErrorsByPatient: [String: HomeBaseClientError]
+    private let revisions: [NetworkRevisionSummary]
     private var patientFetchCount = 0
+    private var revisionFetchCount = 0
     private let loginResult: HomeBaseLoginResult
     private let pinChangeError: HomeBaseClientError?
     private let logoutError: HomeBaseClientError?
@@ -657,7 +744,10 @@ private actor LifecycleMockDataSource: HomeBasePatientsDataSource {
         logoutError: HomeBaseClientError? = nil,
         loadGate: LifecycleLoadGate? = nil,
         entriesByPatient: [String: [HomeBaseEntrySummary]] = [:],
-        entryErrorsByPatient: [String: HomeBaseClientError] = [:]
+        entryErrorsByPatient: [String: HomeBaseClientError] = [:],
+        revisions: [NetworkRevisionSummary] = [
+            NetworkRevisionSummary(revision: "1", sourceFingerprint: "src", fingerprint: "stable")
+        ]
     ) {
         self.summaries = summaries
         self.details = details
@@ -667,6 +757,7 @@ private actor LifecycleMockDataSource: HomeBasePatientsDataSource {
         self.loadGate = loadGate
         self.entriesByPatient = entriesByPatient
         self.entryErrorsByPatient = entryErrorsByPatient
+        self.revisions = revisions
         if summaries.isEmpty {
             self.summaries = details.values.map {
                 HomeBasePatientSummary(
@@ -1268,7 +1359,10 @@ private actor LifecycleMockDataSource: HomeBasePatientsDataSource {
         sessionCookie: String,
         ambulatoryId: String?
     ) async throws -> NetworkRevisionSummary {
-        NetworkRevisionSummary(revision: "1", sourceFingerprint: "src", fingerprint: "stable")
+        revisionFetchCount += 1
+        await loadGate?.pause("revision:\(revisionFetchCount)")
+        guard !revisions.isEmpty else { throw HomeBaseClientError.contract }
+        return revisions[min(revisionFetchCount - 1, revisions.count - 1)]
     }
 
     func fetchFseValidatePatient(


### PR DESCRIPTION
## Summary
- Cattura UUID, selezione, generazione, sessione, scope, client e chiave prima del primo await.
- Riusa il payload workspace condiviso per pubblicare lista, dettaglio, moduli, fingerprint e stato solo dal request owner.
- Impedisce al refresh in foreground di sottrarre ownership a un load attivo, mantenendo la selezione diretta capace di superare refresh e reload.
- Mantiene il mapping dei conflitti 409 confinato al reload, senza modifiche a protocolli, view o dominio.

## Verification
- Lifecycle mirato: 25/25 PASS, incluse quattro race deterministiche senza sleep.
- SwiftPM completo: MediFlowCore 150/150 e MediFlowAppleShared 372/372.
- Xcode runner: 372/372, TEST SUCCEEDED.
- MediFlowMacApp Release: BUILD SUCCEEDED; binario universale x86_64 + arm64.
- MediFlowMobileApp Release per iOS Simulator: BUILD SUCCEEDED.
- Due review indipendenti PASS sul diff SHA-256 871a3e9484a43d1aead19ddd695b8813d7bf7b28a9ec525ee5031a241010d39f.

## Risk / Notes
- Due soli file, 304 gross LOC; nessun terzo file o fetch duplicato.
- #74 resta bloccata fino all'integrazione e ai workflow post-main di questa PR.
- Fixture esclusivamente sintetiche; nessuna PHI/PII.
- Nessun merge automatico: la promozione richiede tutti i check GitHub verdi sullo SHA pubblicato.

## Ticket
Fixes #83
Refs #68