### PR TITLE
feat(lume): riallinea analytics e impostazioni al canone

### DIFF
--- a/app/analytics/analytics.module.css
+++ b/app/analytics/analytics.module.css
@@ -1,0 +1,299 @@
+.loadingState {
+    margin: 0;
+    border: 1px solid color-mix(in srgb, var(--lume-ink) 12%, transparent);
+    border-radius: var(--lume-radius-card);
+    background: var(--lume-surface-field);
+    color: var(--lume-ink-muted);
+    padding: 1.25rem;
+    font-size: 0.875rem;
+}
+.focusSurface {
+    --lume-analytics-register-family: "IBM Plex Mono", var(--font-registro), "SF Mono", monospace;
+    display: grid;
+    grid-template-columns: minmax(0, 1.2fr) minmax(17rem, 0.8fr);
+    gap: 2rem;
+    scroll-margin-top: 8rem;
+    border: 1px solid color-mix(in srgb, var(--lume-ink) 14%, transparent);
+    border-radius: var(--lume-radius-panel);
+    background: var(--lume-surface-field);
+    box-shadow: none;
+    padding: clamp(1.25rem, 3vw, 2rem);
+}
+.focusSurface :global(.lume-registro),
+.layerSection :global(.lume-registro) {
+    font-family: var(--lume-analytics-register-family, "IBM Plex Mono", var(--font-registro), "SF Mono", monospace);
+}
+.answer {
+    min-width: 0;
+}
+.answer h2 {
+    max-width: 32ch;
+    margin: 0.5rem 0 0;
+    color: var(--lume-ink);
+    font-size: 1.3rem;
+    font-weight: 650;
+    line-height: 1.35;
+    text-wrap: balance;
+}
+.primaryValue {
+    margin: 1.25rem 0 0;
+    color: var(--lume-ink);
+    font-size: clamp(2.75rem, 6vw, 4.5rem);
+    font-variant-numeric: tabular-nums;
+    font-weight: 650;
+    letter-spacing: -0.035em;
+    line-height: 0.95;
+}
+.sectionLabel {
+    margin: 0;
+    color: var(--lume-ink-muted);
+    font-family: var(--lume-analytics-register-family, "IBM Plex Mono", var(--font-registro), "SF Mono", monospace);
+    font-size: 0.72rem;
+    font-variant-numeric: tabular-nums;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+}
+.mutedNote {
+    max-width: 70ch;
+    margin: 0.75rem 0 0;
+    color: var(--lume-ink-muted);
+    font-size: 0.82rem;
+    line-height: 1.55;
+}
+.filterField {
+    align-self: stretch;
+    display: grid;
+    gap: 1rem;
+    border-radius: var(--lume-radius-card);
+    background: var(--lume-surface-field);
+    padding: 1.1rem;
+}
+.filterField label {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    align-items: center;
+    gap: 0.4rem 0.75rem;
+    color: var(--lume-ink);
+    font-size: 0.82rem;
+    font-weight: 600;
+}
+.filterField strong {
+    color: var(--lume-ink-muted);
+    font-size: 0.75rem;
+    font-variant-numeric: tabular-nums;
+}
+.filterField input[type='range'] {
+    grid-column: 1 / -1;
+    width: 100%;
+    accent-color: var(--lume-accent);
+}
+.layerSection {
+    scroll-margin-top: 8rem;
+    border-top: 1px solid color-mix(in srgb, var(--lume-ink) 14%, transparent);
+    padding: clamp(1.25rem, 3vw, 1.75rem) 0;
+}
+.sectionHeading {
+    display: grid;
+    grid-template-columns: minmax(6rem, 0.28fr) minmax(0, 1fr);
+    gap: 1rem;
+    align-items: baseline;
+}
+.sectionHeading h2 {
+    margin: 0;
+    color: var(--lume-ink);
+    font-size: 1.05rem;
+    font-weight: 650;
+    text-wrap: balance;
+}
+.sectionHeading div > p {
+    max-width: 70ch;
+    margin: 0.35rem 0 0;
+    color: var(--lume-ink-muted);
+    font-size: 0.78rem;
+    line-height: 1.55;
+}
+.factList {
+    margin: 1.25rem 0 0;
+}
+.factRow {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(8rem, auto);
+    gap: 1rem;
+    align-items: baseline;
+    border-top: 1px solid color-mix(in srgb, var(--lume-ink) 10%, transparent);
+    padding: 0.8rem 0;
+}
+.factRow dt {
+    color: var(--lume-ink);
+    font-size: 0.84rem;
+    font-weight: 550;
+}
+.factRow dd {
+    margin: 0;
+    color: var(--lume-ink-muted);
+    font-size: 0.78rem;
+    text-align: right;
+}
+.chart {
+    display: grid;
+    gap: 1rem;
+    margin-top: 1.35rem;
+}
+.chartDatum {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 0.4rem;
+    color: var(--lume-ink-muted);
+    font-size: 0.78rem;
+}
+.chartDatum strong {
+    color: var(--lume-ink);
+    font-variant-numeric: tabular-nums;
+}
+.progressTrack {
+    height: 0.4rem;
+    overflow: hidden;
+    border-radius: var(--lume-radius-control);
+    background: color-mix(in srgb, var(--lume-ink) 10%, transparent);
+}
+.progressFill {
+    display: block;
+    height: 100%;
+    border-radius: inherit;
+    background: var(--lume-accent);
+    transition: width 180ms cubic-bezier(0.22, 0.61, 0.36, 1);
+}
+.tableScroller {
+    max-width: 100%;
+    margin-top: 1.25rem;
+    overflow-x: auto;
+    overscroll-behavior-inline: contain;
+    border: 1px solid color-mix(in srgb, var(--lume-ink) 12%, transparent);
+    border-radius: var(--lume-radius-card);
+    background: var(--lume-surface-field);
+}
+.tableScroller:focus-visible {
+    outline: 2px solid var(--lume-accent);
+    outline-offset: 2px;
+}
+.dataTable {
+    width: 100%;
+    min-width: 36rem;
+    border-collapse: collapse;
+    color: var(--lume-ink);
+    font-size: 0.8rem;
+}
+.dataTable th,
+.dataTable td {
+    border-bottom: 1px solid color-mix(in srgb, var(--lume-ink) 10%, transparent);
+    padding: 0.75rem 0.9rem;
+    text-align: left;
+    vertical-align: top;
+}
+.dataTable th {
+    color: var(--lume-ink-muted);
+    font-size: 0.72rem;
+    font-weight: 600;
+}
+.dataTable th:last-child,
+.dataTable td:last-child {
+    text-align: right;
+}
+.dataTable tbody tr:last-child td {
+    border-bottom: 0;
+}
+.emptyState {
+    margin: 1.25rem 0 0;
+    color: var(--lume-ink-muted);
+    font-size: 0.82rem;
+    line-height: 1.55;
+}
+.dataTable .emptyState {
+    padding-block: 1.5rem;
+    text-align: center;
+}
+.auditHeading {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(10rem, auto);
+    gap: 1.5rem;
+    align-items: start;
+}
+.compactField {
+    display: grid;
+    gap: 0.4rem;
+    color: var(--lume-ink-muted);
+    font-size: 0.72rem;
+    font-weight: 600;
+}
+.compactField select {
+    min-height: 2.5rem;
+    border: 1px solid color-mix(in srgb, var(--lume-ink) 14%, transparent);
+    border-radius: var(--lume-radius-control);
+    background: var(--lume-surface-field);
+    color: var(--lume-ink);
+    padding: 0 2rem 0 0.75rem;
+    font: inherit;
+}
+.auditResult {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 0.8rem;
+    margin-top: 1.25rem;
+}
+.auditResult > svg {
+    width: 1rem;
+    height: 1rem;
+    margin-top: 1rem;
+    color: var(--lume-signal-success);
+}
+.auditResult .factList {
+    margin-top: 0;
+}
+.warningState {
+    display: flex;
+    gap: 0.65rem;
+    align-items: flex-start;
+    margin: 1.25rem 0 0;
+    border-radius: var(--lume-radius-control);
+    background: color-mix(in srgb, var(--lume-signal-warning) 10%, var(--lume-surface-field));
+    color: color-mix(in srgb, var(--lume-signal-warning) 60%, var(--lume-ink));
+    padding: 0.85rem;
+    font-size: 0.82rem;
+}
+.warningState svg {
+    width: 1rem;
+    height: 1rem;
+    flex: 0 0 auto;
+}
+@media (max-width: 767px) {
+    .focusSurface,
+    .auditHeading,
+    .sectionHeading {
+        grid-template-columns: minmax(0, 1fr);
+    }
+    .focusSurface {
+        gap: 1.25rem;
+    }
+    .filterField {
+        padding: 1rem;
+    }
+    .factRow {
+        grid-template-columns: minmax(0, 1fr);
+        gap: 0.25rem;
+    }
+    .factRow dd {
+        text-align: left;
+    }
+    .auditResult {
+        grid-template-columns: minmax(0, 1fr);
+    }
+    .auditResult > svg {
+        margin-top: 0;
+    }
+}
+@media (prefers-reduced-motion: reduce) {
+    .progressFill {
+        transition-duration: 0.01ms;
+    }
+}

--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -1,13 +1,16 @@
 'use client';
 
+import { differenceInYears } from 'date-fns';
+import { AlertTriangle, ShieldCheck } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+
 import { Kree8WorkspaceShell } from '@/components/kree8/kree8-workspace-shell';
 import { db, type Diagnosis, type Patient } from '@/lib/db';
 import { useLiveQuery } from '@/lib/live-query';
-import { differenceInYears } from 'date-fns';
-import { Activity, AlertTriangle, ClipboardList, Clock, Filter, ShieldCheck, Stethoscope, Users } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
 
-/* @Codex */
+import styles from './analytics.module.css';
+
+/* @Codex LUME-110/68 */
 type AuditSummary = {
     days: number;
     totalEvents: number;
@@ -39,11 +42,11 @@ type AnalyticsStats = {
 };
 
 const ANALYTICS_NAV_ITEMS = [
-    { href: '#popolazione', label: 'Popolazione', meta: 'filtri' },
-    { href: '#indicatori', label: 'Indicatori', meta: 'schede' },
-    { href: '#audit', label: 'Audit', meta: 'tracciato' },
-    { href: '#eta', label: 'Età', meta: 'fasce' },
-    { href: '#diagnosi', label: 'Diagnosi', meta: 'top 10' },
+    { href: '#domanda', label: 'Domanda', meta: 'fuoco' },
+    { href: '#indicatori', label: 'Indicatori', meta: 'lettura' },
+    { href: '#eta', label: 'Età', meta: 'grafico' },
+    { href: '#diagnosi', label: 'Diagnosi', meta: 'tabella' },
+    { href: '#audit', label: 'Audit', meta: 'locale' },
 ];
 
 const EMPTY_AGE_DIST: Record<AgeBucket, number> = {
@@ -53,36 +56,11 @@ const EMPTY_AGE_DIST: Record<AgeBucket, number> = {
     '80+': 0,
 };
 
-type ToneKey = 'info' | 'success' | 'warning' | 'critical';
-
-const K8_TONES: Record<ToneKey, { accent: string; soft: string; line: string }> = {
-    info: {
-        accent: '#1d4ed8',
-        soft: '#dbeafe',
-        line: 'rgba(29, 78, 216, 0.24)',
-    },
-    success: {
-        accent: '#15803d',
-        soft: '#dcfce7',
-        line: 'rgba(21, 128, 61, 0.24)',
-    },
-    warning: {
-        accent: '#92400e',
-        soft: '#fef3c7',
-        line: 'rgba(146, 64, 14, 0.24)',
-    },
-    critical: {
-        accent: '#9a3412',
-        soft: '#ffe2dd',
-        line: 'rgba(154, 52, 18, 0.24)',
-    },
-};
-
-function normalizeAgeRange(range: [number, number]) {
+function normalizeAgeRange(range: [number, number]): [number, number] {
     return range[0] <= range[1] ? range : [range[1], range[0]];
 }
 
-function toDate(value: Patient['birthDate']) {
+function toDate(value: Patient['birthDate']): Date | null {
     if (!value) return null;
     const date = value instanceof Date ? value : new Date(value);
     return Number.isNaN(date.getTime()) ? null : date;
@@ -95,7 +73,7 @@ function getAgeBucket(age: number): AgeBucket {
     return '80+';
 }
 
-function diagnosisKey(diagnosis: Diagnosis) {
+function diagnosisKey(diagnosis: Diagnosis): string {
     const system = diagnosis.system?.trim() || 'ICD';
     const code = diagnosis.code?.trim() || 'senza-codice';
     const description = diagnosis.description?.trim() || code;
@@ -128,23 +106,22 @@ function buildAnalyticsStats(patients: Patient[], ageRange: [number, number]): A
         if (patient.isAdi) adiCount += 1;
         ageDist[getAgeBucket(age)] += 1;
 
-        if (patient.diagnoses?.length) {
-            withDiagnoses += 1;
-            for (const diagnosis of patient.diagnoses) {
-                const key = diagnosisKey(diagnosis);
-                const current = diagnosisCounts.get(key);
-                if (current) {
-                    current.count += 1;
-                } else {
-                    diagnosisCounts.set(key, {
-                        key,
-                        description: diagnosis.description?.trim() || diagnosis.code || 'Diagnosi senza descrizione',
-                        system: diagnosis.system?.trim() || 'ICD',
-                        code: diagnosis.code?.trim() || 'n/d',
-                        count: 1,
-                    });
-                }
+        if (!patient.diagnoses?.length) continue;
+        withDiagnoses += 1;
+        for (const diagnosis of patient.diagnoses) {
+            const key = diagnosisKey(diagnosis);
+            const current = diagnosisCounts.get(key);
+            if (current) {
+                current.count += 1;
+                continue;
             }
+            diagnosisCounts.set(key, {
+                key,
+                description: diagnosis.description?.trim() || diagnosis.code || 'Diagnosi senza descrizione',
+                system: diagnosis.system?.trim() || 'ICD',
+                code: diagnosis.code?.trim() || 'n/d',
+                count: 1,
+            });
         }
     }
 
@@ -156,34 +133,40 @@ function buildAnalyticsStats(patients: Patient[], ageRange: [number, number]): A
         withDiagnoses,
         ageDist,
         topDiagnoses: Array.from(diagnosisCounts.values())
-            .sort((a, b) => b.count - a.count)
+            .sort((left, right) => right.count - left.count)
             .slice(0, 10),
     };
 }
 
-function percent(part: number, total: number) {
-    if (!total) return 0;
-    return Math.round((part / total) * 100);
+function percent(part: number, total: number): number {
+    return total > 0 ? Math.round((part / total) * 100) : 0;
 }
 
-function ProgressLine({ value, total, tone }: { value: number; total: number; tone: ToneKey }) {
+function ProgressLine({ label, value, total }: { label: string; value: number; total: number }) {
+    const percentage = percent(value, total);
     return (
-        <div className="mt-4 h-2 w-full overflow-hidden rounded-full" style={{ background: 'color-mix(in srgb, var(--lume-ink) 12%, transparent)' }}>
-            <div
-                className="h-full rounded-full transition-[width] duration-700"
-                style={{ width: `${percent(value, total)}%`, background: K8_TONES[tone].accent }}
-            />
+        <div className={styles.progressTrack} role="img" aria-label={`${label}: ${value}, ${percentage}%`}>
+            <span className={styles.progressFill} style={{ width: `${percentage}%` }} />
+        </div>
+    );
+}
+
+function SectionHeading({ label, title, description }: { label: string; title: string; description: string }) {
+    return (
+        <div className={styles.sectionHeading}>
+            <p className={styles.sectionLabel}>{label}</p>
+            <div>
+                <h2>{title}</h2>
+                <p>{description}</p>
+            </div>
         </div>
     );
 }
 
 export default function AnalyticsPage() {
-    const patients = useLiveQuery(async () => {
-        return await db.patients
-            .filter((patient) => !patient.isArchived)
-            .toArray();
-    });
-
+    const patients = useLiveQuery(async () => db.patients
+        .filter((patient) => !patient.isArchived)
+        .toArray());
     const [ageRange, setAgeRange] = useState<[number, number]>([0, 120]);
     const [auditDays, setAuditDays] = useState(30);
     const [auditSummary, setAuditSummary] = useState<AuditSummary | null>(null);
@@ -197,7 +180,6 @@ export default function AnalyticsPage() {
         async function loadAuditSummary() {
             setAuditLoading(true);
             setAuditError(null);
-
             try {
                 const response = await fetch(`/api/system/audit?view=summary&days=${auditDays}&limit=500`, {
                     signal: controller.signal,
@@ -207,10 +189,8 @@ export default function AnalyticsPage() {
                         ? 'Serve un account admin per vedere l’audit locale.'
                         : 'Non riesco a leggere l’audit locale.');
                 }
-
                 const payload = await response.json() as AuditSummary;
-                if (!active) return;
-                setAuditSummary(payload);
+                if (active) setAuditSummary(payload);
             } catch (error) {
                 if (controller.signal.aborted || !active) return;
                 setAuditError(error instanceof Error ? error.message : 'Non riesco a leggere l’audit locale.');
@@ -221,7 +201,6 @@ export default function AnalyticsPage() {
         }
 
         void loadAuditSummary();
-
         return () => {
             active = false;
             controller.abort();
@@ -229,10 +208,10 @@ export default function AnalyticsPage() {
     }, [auditDays]);
 
     const normalizedAgeRange = normalizeAgeRange(ageRange);
-    const stats = useMemo(() => {
-        if (!patients) return null;
-        return buildAnalyticsStats(patients, ageRange);
-    }, [patients, ageRange]);
+    const stats = useMemo(
+        () => patients ? buildAnalyticsStats(patients, ageRange) : null,
+        [patients, ageRange],
+    );
 
     if (!patients || !stats) {
         return (
@@ -245,305 +224,215 @@ export default function AnalyticsPage() {
                 statusLabel="Sto leggendo dal Mac..."
                 navItems={ANALYTICS_NAV_ITEMS}
             >
-                <div className="mf-section p-6 text-sm" style={{ color: 'var(--lume-ink-muted)' }}>
-                    Sto preparando il cruscotto locale.
-                </div>
+                <p className={styles.loadingState} role="status">Sto preparando l’analisi locale.</p>
             </Kree8WorkspaceShell>
         );
     }
-
-    const topDiagnosis = stats.topDiagnoses[0];
 
     return (
         <Kree8WorkspaceShell
             eyebrow="Analisi"
             title="Cruscotto locale"
-            subtitle="Popolazione registrata e audit operativo, senza dati fuori dal dispositivo."
+            subtitle="Una domanda alla volta sui dati già registrati in questa postazione."
             backHref="/?area=incarico"
             backLabel="Torna ai pazienti"
-            statusLabel={`${stats.totalInRange} schede in ${normalizedAgeRange[0]}-${normalizedAgeRange[1]} anni · ${stats.withoutBirthDate} senza data nascita`}
+            statusLabel={`${stats.totalInRange} schede tra ${normalizedAgeRange[0]} e ${normalizedAgeRange[1]} anni`}
             navItems={ANALYTICS_NAV_ITEMS}
         >
-            <section id="popolazione" className="mf-section lume-focal space-y-5 p-5 scroll-mt-32">
-                <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
-                    <div className="min-w-0">
-                        <p className="section-kicker">Popolazione</p>
-                        <h2 className="mt-1 text-xl font-semibold" style={{ color: 'var(--lume-ink)' }}>Filtro età</h2>
-                        <p className="mt-1 text-sm" style={{ color: 'var(--lume-ink-muted)' }}>
-                            Il filtro considera le schede attive con data di nascita compilata.
-                        </p>
-                    </div>
-                    <div
-                        className="inline-flex w-fit items-center gap-2 rounded-full px-4 py-2 text-sm font-semibold"
-                        style={{
-                            background: K8_TONES.info.soft,
-                            color: K8_TONES.info.accent,
-                            border: `1px solid ${K8_TONES.info.line}`,
-                        }}
+            <section
+                id="domanda"
+                className={styles.focusSurface}
+                data-testid="analytics-focus-surface"
+                data-lume-analytics-focus="true"
+            >
+                <div className={styles.answer}>
+                    <p className={styles.sectionLabel}>Domanda operativa</p>
+                    <h2>Quante schede attive rientrano nella fascia d’età scelta?</h2>
+                    <p
+                        className={`${styles.primaryValue} lume-registro`}
+                        data-testid="analytics-primary-value"
+                        data-lume-register-value="true"
                     >
-                        <Filter className="h-4 w-4" />
-                        {normalizedAgeRange[0]}-{normalizedAgeRange[1]} anni
-                    </div>
+                        {stats.totalInRange}
+                    </p>
+                    <p className={styles.mutedNote}>
+                        {stats.totalInRange > 0
+                            ? `${percent(stats.totalInRange, stats.withBirthDate)}% delle schede con età nota.`
+                            : 'Nessuna scheda attiva con età nota rientra nel filtro corrente.'}
+                    </p>
                 </div>
 
-                <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_180px] lg:items-end">
-                    <div className="grid min-w-0 gap-4">
-                        <label className="min-w-0">
-                            <span className="mf-eyebrow mb-2 flex items-center justify-between gap-3">
-                                <span>Età minima</span>
-                                <strong className="lume-registro">{ageRange[0]} anni</strong>
-                            </span>
-                            <input
-                                type="range"
-                                min="0"
-                                max="120"
-                                aria-label="Età minima"
-                                value={ageRange[0]}
-                                onChange={(event) => setAgeRange([Number(event.target.value), ageRange[1]])}
-                                className="w-full"
-                                style={{ accentColor: K8_TONES.info.accent }}
-                            />
-                        </label>
-                        <label className="min-w-0">
-                            <span className="mf-eyebrow mb-2 flex items-center justify-between gap-3">
-                                <span>Età massima</span>
-                                <strong className="lume-registro">{ageRange[1]} anni</strong>
-                            </span>
-                            <input
-                                type="range"
-                                min="0"
-                                max="120"
-                                aria-label="Età massima"
-                                value={ageRange[1]}
-                                onChange={(event) => setAgeRange([ageRange[0], Number(event.target.value)])}
-                                className="w-full"
-                                style={{ accentColor: K8_TONES.info.accent }}
-                            />
-                        </label>
-                    </div>
+                <div className={styles.filterField} data-testid="analytics-filter-field">
+                    <p className={styles.sectionLabel}>Filtro quieto</p>
                     <label>
-                        <span className="mf-eyebrow mb-2 block">Finestra audit</span>
-                        <select
-                            aria-label="Finestra audit"
-                            value={auditDays}
-                            onChange={(event) => setAuditDays(Number(event.target.value))}
-                            className="mf-input mf-input-sm w-full cursor-pointer appearance-none"
-                        >
+                        <span>Età minima</span>
+                        <strong className="lume-registro">{ageRange[0]} anni</strong>
+                        <input
+                            type="range"
+                            min="0"
+                            max="120"
+                            aria-label="Età minima"
+                            value={ageRange[0]}
+                            onChange={(event) => setAgeRange([Number(event.target.value), ageRange[1]])}
+                        />
+                    </label>
+                    <label>
+                        <span>Età massima</span>
+                        <strong className="lume-registro">{ageRange[1]} anni</strong>
+                        <input
+                            type="range"
+                            min="0"
+                            max="120"
+                            aria-label="Età massima"
+                            value={ageRange[1]}
+                            onChange={(event) => setAgeRange([ageRange[0], Number(event.target.value)])}
+                        />
+                    </label>
+                </div>
+            </section>
+
+            <section id="indicatori" className={styles.layerSection} data-testid="analytics-layer-section">
+                <SectionHeading
+                    label="Indicatori"
+                    title="Lettura della popolazione filtrata"
+                    description="Valori di contesto, subordinati alla risposta principale."
+                />
+                <dl className={styles.factList}>
+                    <div className={styles.factRow}>
+                        <dt>Assistenza domiciliare integrata</dt>
+                        <dd><span className="lume-registro" data-lume-register-value="true">{stats.adiCount}</span> schede</dd>
+                    </div>
+                    <div className={styles.factRow}>
+                        <dt>Con almeno una diagnosi registrata</dt>
+                        <dd><span className="lume-registro" data-lume-register-value="true">{stats.withDiagnoses}</span> schede</dd>
+                    </div>
+                    <div className={styles.factRow}>
+                        <dt>Senza data di nascita, escluse dal filtro</dt>
+                        <dd><span className="lume-registro" data-lume-register-value="true">{stats.withoutBirthDate}</span> schede</dd>
+                    </div>
+                </dl>
+            </section>
+
+            <section id="eta" className={styles.layerSection}>
+                <SectionHeading
+                    label="Grafico"
+                    title="Distribuzione per fascia d’età"
+                    description="Ogni barra usa come base le schede comprese nel filtro."
+                />
+                <div className={styles.chart} aria-label="Distribuzione delle schede per fascia d’età">
+                    {Object.entries(stats.ageDist).map(([range, count]) => (
+                        <div className={styles.chartRow} key={range}>
+                            <div className={styles.chartDatum}>
+                                <span>{range} anni</span>
+                                <strong className="lume-registro" data-lume-register-value="true">{count}</strong>
+                            </div>
+                            <ProgressLine label={`${range} anni`} value={count} total={stats.totalInRange} />
+                        </div>
+                    ))}
+                </div>
+            </section>
+
+            <section id="diagnosi" className={styles.layerSection}>
+                <SectionHeading
+                    label="Tabella"
+                    title="Diagnosi più ricorrenti"
+                    description="Descrizione, sistema di codifica e numero di schede nel filtro corrente."
+                />
+                <div
+                    className={styles.tableScroller}
+                    data-testid="analytics-table-overflow"
+                    data-horizontal-overflow="declared"
+                    tabIndex={0}
+                    aria-label="Tabella diagnosi, scorrimento orizzontale disponibile se necessario"
+                >
+                    <table className={styles.dataTable}>
+                        <thead>
+                            <tr>
+                                <th scope="col">Diagnosi</th>
+                                <th scope="col">Codice</th>
+                                <th scope="col">Schede</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {stats.topDiagnoses.map((diagnosis) => (
+                                <tr key={diagnosis.key}>
+                                    <td>{diagnosis.description}</td>
+                                    <td className="lume-registro" data-lume-register-value="true">{diagnosis.system} {diagnosis.code}</td>
+                                    <td className="lume-registro" data-lume-register-value="true">{diagnosis.count}</td>
+                                </tr>
+                            ))}
+                            {stats.topDiagnoses.length === 0 ? (
+                                <tr>
+                                    <td colSpan={3} className={styles.emptyState}>
+                                        Nessuna diagnosi codificata nel filtro corrente.
+                                    </td>
+                                </tr>
+                            ) : null}
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+
+            <section id="audit" className={styles.layerSection}>
+                <div className={styles.auditHeading}>
+                    <SectionHeading
+                        label="Audit locale"
+                        title="Attività della postazione"
+                        description="Eventi tecnici senza contenuti clinici."
+                    />
+                    <label className={styles.compactField}>
+                        <span>Finestra audit</span>
+                        <select aria-label="Finestra audit" value={auditDays} onChange={(event) => setAuditDays(Number(event.target.value))}>
                             <option value={7}>Ultimi 7 giorni</option>
                             <option value={30}>Ultimi 30 giorni</option>
                             <option value={90}>Ultimi 90 giorni</option>
                         </select>
                     </label>
                 </div>
-            </section>
-
-            <section id="indicatori" className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4 scroll-mt-32">
-                <div className="mf-section p-5">
-                    <div className="flex items-start justify-between gap-3">
-                        <div>
-                            <p className="mf-eyebrow">Schede nel filtro</p>
-                            <p className="lume-registro mt-2 text-3xl font-semibold" style={{ color: 'var(--lume-ink)' }}>{stats.totalInRange}</p>
-                        </div>
-                        <Users className="h-7 w-7" style={{ color: K8_TONES.info.accent }} />
-                    </div>
-                    <ProgressLine value={stats.totalInRange} total={Math.max(stats.withBirthDate, 1)} tone="info" />
-                    <p className="mt-2 text-xs font-medium" style={{ color: K8_TONES.info.accent }}>
-                        {percent(stats.totalInRange, stats.withBirthDate)}% delle schede con età nota
-                    </p>
-                </div>
-
-                <div className="mf-section p-5">
-                    <div className="flex items-start justify-between gap-3">
-                        <div>
-                            <p className="mf-eyebrow">ADI attive</p>
-                            <p className="lume-registro mt-2 text-3xl font-semibold" style={{ color: 'var(--lume-ink)' }}>{stats.adiCount}</p>
-                        </div>
-                        <Stethoscope className="h-7 w-7" style={{ color: K8_TONES.warning.accent }} />
-                    </div>
-                    <ProgressLine value={stats.adiCount} total={stats.totalInRange} tone="warning" />
-                    <p className="mt-2 text-xs font-medium" style={{ color: K8_TONES.warning.accent }}>
-                        {percent(stats.adiCount, stats.totalInRange)}% delle schede filtrate
-                    </p>
-                </div>
-
-                <div className="mf-section p-5">
-                    <div className="flex items-start justify-between gap-3">
-                        <div>
-                            <p className="mf-eyebrow">Con diagnosi</p>
-                            <p className="lume-registro mt-2 text-3xl font-semibold" style={{ color: 'var(--lume-ink)' }}>{stats.withDiagnoses}</p>
-                        </div>
-                        <ClipboardList className="h-7 w-7" style={{ color: K8_TONES.success.accent }} />
-                    </div>
-                    <ProgressLine value={stats.withDiagnoses} total={stats.totalInRange} tone="success" />
-                    <p className="mt-2 text-xs font-medium" style={{ color: K8_TONES.success.accent }}>
-                        {percent(stats.withDiagnoses, stats.totalInRange)}% delle schede filtrate
-                    </p>
-                </div>
-
-                <div className="mf-section p-5">
-                    <div className="flex items-start justify-between gap-3">
-                        <div className="min-w-0">
-                            <p className="mf-eyebrow">Diagnosi più ricorrente</p>
-                            <p className="mt-2 truncate text-base font-semibold" title={topDiagnosis?.description} style={{ color: 'var(--lume-ink)' }}>
-                                {topDiagnosis?.description ?? 'Non disponibile'}
-                            </p>
-                        </div>
-                        <Activity className="h-7 w-7 shrink-0" style={{ color: K8_TONES.critical.accent }} />
-                    </div>
-                    <p className="mt-4 text-xs font-medium" style={{ color: K8_TONES.critical.accent }}>
-                        {topDiagnosis ? `${topDiagnosis.count} schede · ${topDiagnosis.system} ${topDiagnosis.code}` : 'Nessuna diagnosi codificata nel filtro'}
-                    </p>
-                </div>
-            </section>
-
-            <section id="audit" className="mf-section space-y-5 p-5 scroll-mt-32">
-                <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-                    <div>
-                        <p className="section-kicker">Audit</p>
-                        <h2 className="mt-1 flex items-center gap-2 text-xl font-semibold" style={{ color: 'var(--lume-ink)' }}>
-                            <ShieldCheck className="h-5 w-5" style={{ color: K8_TONES.success.accent }} />
-                            Attività locale
-                        </h2>
-                        <p className="mt-1 text-sm" style={{ color: 'var(--lume-ink-muted)' }}>
-                            Log operativo degli ultimi {auditDays} giorni, senza contenuti clinici.
-                        </p>
-                    </div>
-                </div>
 
                 {auditLoading ? (
-                    <div className="mf-section mf-section-tight p-4 text-sm" style={{ color: 'var(--lume-ink-muted)' }}>Sto leggendo il tracciato locale...</div>
+                    <p className={styles.emptyState} role="status">Sto leggendo il tracciato locale.</p>
                 ) : auditError ? (
-                    <div
-                        className="flex gap-2 rounded-[18px] border p-4 text-sm"
-                        style={{
-                            background: K8_TONES.warning.soft,
-                            borderColor: K8_TONES.warning.line,
-                            color: K8_TONES.warning.accent,
-                        }}
-                    >
-                        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
-                        <span>{auditError}</span>
-                    </div>
+                    <p className={styles.warningState} role="status">
+                        <AlertTriangle aria-hidden="true" />
+                        {auditError}
+                    </p>
                 ) : auditSummary ? (
-                    <>
-                        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
-                            <AuditCard label="Eventi" value={auditSummary.totalEvents} tone="info" />
-                            <AuditCard label="Completati" value={auditSummary.outcomes.success} tone="success" />
-                            <AuditCard label="Attori" value={auditSummary.distinctActors} tone="info" />
-                            <AuditCard
-                                label="Evento più frequente"
-                                value={auditSummary.topEventTypes[0]?.eventType ?? 'Nessuno'}
-                                note={`${auditSummary.topEventTypes[0]?.count ?? 0} occorrenze`}
-                                tone="critical"
-                            />
-                        </div>
-
-                        <div className="mf-section mf-section-tight p-4 text-sm" style={{ color: 'var(--lume-ink-muted)' }}>
-                            <p className="font-semibold" style={{ color: 'var(--lume-ink)' }}>Esiti e origine</p>
-                            <div className="mt-3 flex flex-wrap gap-4">
-                                <span>Completati: <strong className="lume-registro">{auditSummary.outcomes.success}</strong></span>
-                                <span>Errori: <strong className="lume-registro">{auditSummary.outcomes.failure}</strong></span>
-                                <span>Negati: <strong className="lume-registro">{auditSummary.outcomes.denied}</strong></span>
-                                <span>Web/API/Native: <strong className="lume-registro">{auditSummary.sourceSurfaces.web}/{auditSummary.sourceSurfaces.api}/{auditSummary.sourceSurfaces.native}</strong></span>
+                    <div className={styles.auditResult}>
+                        <ShieldCheck aria-hidden="true" />
+                        <dl className={styles.factList}>
+                            <div className={styles.factRow}>
+                                <dt>Eventi registrati</dt>
+                                <dd className="lume-registro" data-lume-register-value="true">{auditSummary.totalEvents}</dd>
                             </div>
-                            {auditSummary.isTruncated && (
-                                <p className="mt-3 text-xs" style={{ color: K8_TONES.warning.accent }}>
-                                    Riepilogo calcolato sui primi 500 eventi nel filtro.
-                                </p>
-                            )}
-                        </div>
-                    </>
-                ) : null}
+                            <div className={styles.factRow}>
+                                <dt>Completati, errori, negati</dt>
+                                <dd className="lume-registro" data-lume-register-value="true">
+                                    {auditSummary.outcomes.success} / {auditSummary.outcomes.failure} / {auditSummary.outcomes.denied}
+                                </dd>
+                            </div>
+                            <div className={styles.factRow}>
+                                <dt>Attori distinti</dt>
+                                <dd className="lume-registro" data-lume-register-value="true">{auditSummary.distinctActors}</dd>
+                            </div>
+                            <div className={styles.factRow}>
+                                <dt>Evento più frequente</dt>
+                                <dd>
+                                    <span className="lume-registro" data-lume-register-value="true">
+                                        {auditSummary.topEventTypes[0]?.eventType ?? 'Nessun evento'}
+                                    </span>
+                                    {auditSummary.topEventTypes[0] ? `, ${auditSummary.topEventTypes[0].count} occorrenze` : ''}
+                                </dd>
+                            </div>
+                        </dl>
+                        {auditSummary.isTruncated ? (
+                            <p className={styles.mutedNote}>Riepilogo calcolato sui primi 500 eventi nel filtro.</p>
+                        ) : null}
+                    </div>
+                ) : (
+                    <p className={styles.emptyState}>Nessun riepilogo audit disponibile.</p>
+                )}
             </section>
-
-            <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-                <section id="eta" className="mf-section p-5 scroll-mt-32">
-                    <h2 className="flex items-center gap-2 text-lg font-semibold" style={{ color: 'var(--lume-ink)' }}>
-                        <Clock className="h-5 w-5" style={{ color: 'var(--lume-ink-muted)' }} />
-                        Fasce d’età
-                    </h2>
-
-                    <div className="mt-5 space-y-4">
-                        {Object.entries(stats.ageDist).map(([range, count]) => (
-                            <div key={range}>
-                                <div className="mb-1 flex justify-between gap-4 text-sm">
-                                    <span className="font-medium" style={{ color: 'var(--lume-ink-muted)' }}>{range} anni</span>
-                                    <span className="lume-registro font-semibold" style={{ color: 'var(--lume-ink)' }}>{count}</span>
-                                </div>
-                                <ProgressLine value={count} total={stats.totalInRange} tone="info" />
-                            </div>
-                        ))}
-                    </div>
-                </section>
-
-                <section id="diagnosi" className="mf-section p-5 scroll-mt-32">
-                    <h2 className="flex items-center gap-2 text-lg font-semibold" style={{ color: 'var(--lume-ink)' }}>
-                        <Activity className="h-5 w-5" style={{ color: K8_TONES.critical.accent }} />
-                        Diagnosi registrate
-                    </h2>
-
-                    <div className="mt-5 max-h-72 space-y-2 overflow-y-auto pr-2">
-                        {stats.topDiagnoses.map((diagnosis, index) => (
-                            <div
-                                key={diagnosis.key}
-                                className="flex items-center gap-3 rounded-[14px] border p-3"
-                                style={{
-                                    background: 'var(--lume-surface-field)',
-                                    borderColor: 'color-mix(in srgb, var(--lume-ink) 12%, transparent)',
-                                }}
-                            >
-                                <div
-                                    className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-xs font-semibold"
-                                    style={{ background: K8_TONES.critical.soft, color: K8_TONES.critical.accent }}
-                                >
-                                    {index + 1}
-                                </div>
-                                <div className="min-w-0 flex-1">
-                                    <p className="truncate text-sm font-medium" style={{ color: 'var(--lume-ink)' }}>{diagnosis.description}</p>
-                                    <p className="lume-registro text-xs" style={{ color: 'var(--lume-ink-muted)' }}>{diagnosis.system} {diagnosis.code}</p>
-                                </div>
-                                <div className="lume-registro text-sm font-semibold" style={{ color: 'var(--lume-ink-muted)' }}>
-                                    {diagnosis.count} <span className="text-[10px] font-normal">schede</span>
-                                </div>
-                            </div>
-                        ))}
-                        {stats.topDiagnoses.length === 0 && (
-                            <p className="mt-10 text-center text-sm italic" style={{ color: 'var(--lume-ink-muted)' }}>
-                                Nessuna diagnosi codificata nel filtro corrente.
-                            </p>
-                        )}
-                    </div>
-                </section>
-            </div>
         </Kree8WorkspaceShell>
-    );
-}
-
-function AuditCard({
-    label,
-    value,
-    note,
-    tone,
-}: {
-    label: string;
-    value: number | string;
-    note?: string;
-    tone: ToneKey;
-}) {
-    const palette = K8_TONES[tone];
-
-    return (
-        <div
-            className="rounded-[var(--lume-radius-card)] p-4"
-            style={{
-                background: 'var(--lume-surface-field)',
-                border: '1px solid color-mix(in srgb, var(--lume-ink) 12%, transparent)',
-                boxShadow: 'none',
-            }}
-        >
-            <p className="mf-eyebrow" style={{ color: palette.accent }}>{label}</p>
-            <p className="lume-registro mt-2 truncate text-2xl font-semibold" title={String(value)} style={{ color: 'var(--lume-ink)' }}>{value}</p>
-            {note ? <p className="mt-1 text-xs" style={{ color: palette.accent }}>{note}</p> : null}
-        </div>
     );
 }

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,35 +1,19 @@
 'use client';
 
-// WUL-297: /settings is now a thin "Stato sistema" dashboard inside the
-// settings sidebar layout. Legacy #anchor deep-links redirect to the
-// dedicated sub-routes.
-
-import { useEffect } from 'react';
+import { ArrowUpRight } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import {
-    Activity,
-    ArrowUpRight,
-    Brain,
-    Building2,
-    Database,
-    Eye,
-    HardDrive,
-    KeyRound,
-    MonitorCog,
-    Settings2,
-    ShieldAlert,
-    UserRoundCog,
-    type LucideIcon,
-} from 'lucide-react';
-import { useSecurity } from '@/components/security-provider';
-/* @Codex */
-import NetworkOperatingModePanel from '@/components/settings/network-operating-mode-panel';
-import { ThemeToggle } from '@/components/theme-toggle';
-import { SETTINGS_NAV_GROUPS, type SettingsNavItem } from '@/lib/settings-navigation';
-import { SettingsSectionIntro } from '@/components/settings/settings-ui';
+import { useEffect, useMemo, useState } from 'react';
 
-// Old monolithic-page anchors → new sub-routes.
+import { ThemeToggle } from '@/components/theme-toggle';
+import {
+    deriveNetworkOperatingModeViewModel,
+    type NetworkOverviewPayload,
+} from '@/lib/network-operating-mode';
+import { SETTINGS_NAV_GROUPS } from '@/lib/settings-navigation';
+
+import styles from '@/components/settings/settings-lume.module.css';
+
 const LEGACY_ANCHOR_REDIRECTS: Record<string, string> = {
     '#account': '/settings/profilo',
     '#ai': '/settings/ai/modelli',
@@ -39,169 +23,220 @@ const LEGACY_ANCHOR_REDIRECTS: Record<string, string> = {
     '#appearance': '/settings/aspetto',
 };
 
-/* @Codex */
-const SETTINGS_ITEM_ICONS: Record<string, LucideIcon> = {
-    profilo: UserRoundCog,
-    aspetto: Eye,
-    ambulatori: Building2,
-    accesso: KeyRound,
-    backup: HardDrive,
-    repertori: Database,
-    'ai-modelli': Brain,
-    'ai-funzioni': Settings2,
-    diagnostica: Activity,
-    sviluppo: MonitorCog,
-    'zona-pericolo': ShieldAlert,
-};
-
-/* @Codex */
-const SETTINGS_ITEM_BADGES: Record<string, string> = {
-    profilo: 'operatore',
-    aspetto: 'preferenze',
-    ambulatori: 'contesti',
-    accesso: 'PIN',
-    backup: 'Mac',
-    repertori: 'manuale',
-    'ai-modelli': 'locale',
-    'ai-funzioni': 'governance',
-    diagnostica: 'servizi',
-    sviluppo: 'dev',
-    'zona-pericolo': 'admin',
-};
-
-/* @Codex */
-function SettingsCommandRow({ item }: { item: SettingsNavItem }) {
-    const Icon = SETTINGS_ITEM_ICONS[item.id] ?? Settings2;
-    const isDanger = item.tone === 'danger';
-
-    return (
-        <Link
-            href={item.href}
-            data-testid={`settings-overview-link-${item.id}`}
-            className="group grid min-h-[64px] grid-cols-[32px_minmax(0,1fr)_auto_18px] items-center gap-3 rounded-[var(--lume-radius-card)] border bg-[color:var(--lume-surface-field)] px-3.5 py-3 transition-colors hover:border-[color:var(--lume-accent)]"
-            style={{
-                borderColor: isDanger ? 'rgba(163, 58, 47, 0.26)' : 'color-mix(in srgb, var(--lume-ink) 12%, transparent)',
-                background: isDanger ? 'rgba(163, 58, 47, 0.06)' : 'var(--lume-surface-field)',
-            }}
-        >
-            <span
-                className="flex h-8 w-8 items-center justify-center rounded-[10px]"
-                style={{
-                    background: isDanger ? 'rgba(163, 58, 47, 0.08)' : 'var(--lume-surface-focal)',
-                    color: isDanger ? 'var(--lume-signal-critical)' : 'var(--lume-ink-muted)',
-                }}
-            >
-                <Icon className="h-4 w-4" aria-hidden="true" />
-            </span>
-            <span className="min-w-0">
-                <span
-                    className="block truncate text-[13px] font-semibold"
-                    style={{ color: isDanger ? 'var(--lume-signal-critical)' : 'var(--lume-ink)' }}
-                >
-                    {item.label}
-                </span>
-                <span className="mt-0.5 block truncate text-[11px]" style={{ color: 'var(--lume-ink-muted)' }}>
-                    {item.description}
-                </span>
-            </span>
-            <span
-                className="lume-registro hidden rounded-full px-2.5 py-1 text-[11px] font-semibold sm:inline-flex"
-                style={{
-                    background: isDanger ? 'rgba(163, 58, 47, 0.08)' : 'var(--lume-surface-focal)',
-                    color: isDanger ? 'var(--lume-signal-critical)' : 'var(--lume-ink-muted)',
-                }}
-            >
-                {SETTINGS_ITEM_BADGES[item.id] ?? 'apri'}
-            </span>
-            <ArrowUpRight
-                className="h-4 w-4 justify-self-end opacity-45 transition-opacity group-hover:opacity-100"
-                style={{ color: isDanger ? 'var(--lume-signal-critical)' : 'var(--lume-ink-muted)' }}
-                aria-hidden="true"
-            />
-        </Link>
-    );
+async function readNetworkOverview(): Promise<NetworkOverviewPayload> {
+    const response = await fetch('/api/system/network-overview', { cache: 'no-store' });
+    if (!response.ok) throw new Error('network overview failed');
+    return response.json() as Promise<NetworkOverviewPayload>;
 }
 
+/* @Codex LUME-110/68 */
 export default function SettingsPage() {
     const router = useRouter();
-    const { user } = useSecurity();
+    const [networkOverview, setNetworkOverview] = useState<NetworkOverviewPayload | null>(null);
+    const [confirmedNetworkMode, setConfirmedNetworkMode] = useState<
+        NetworkOverviewPayload['session']['operatingMode'] | null
+    >(null);
+    const [isNetworkLoading, setIsNetworkLoading] = useState(true);
+    const [isNetworkSaving, setIsNetworkSaving] = useState(false);
+    const [networkError, setNetworkError] = useState<string | null>(null);
+
+    const networkViewModel = useMemo(
+        () => (networkOverview ? deriveNetworkOperatingModeViewModel(networkOverview) : null),
+        [networkOverview],
+    );
 
     useEffect(() => {
         const target = LEGACY_ANCHOR_REDIRECTS[window.location.hash];
-        if (target) {
-            router.replace(target);
-        }
+        if (target) router.replace(target);
     }, [router]);
 
-    return (
-        <div className="space-y-6" data-testid="settings-overview-section">
-            <section className="mf-section lume-focal p-5 md:p-6">
-                <div className="grid gap-5 xl:grid-cols-[minmax(0,0.95fr)_minmax(360px,1.05fr)] xl:items-start">
-                    <div className="space-y-4">
-                        <div>
-                            <p className="section-kicker">Postazione locale</p>
-                            <h2 className="mt-1 text-xl font-semibold tracking-tight" style={{ color: 'var(--lume-ink)' }}>
-                                Stato operativo
-                            </h2>
-                            <p className="mt-2 max-w-2xl text-sm leading-relaxed" style={{ color: 'var(--lume-ink-muted)' }}>
-                                Controlli essenziali del Mac che ospita MediFlow, senza uscita dati di default.
-                            </p>
-                        </div>
-                        <div className="grid gap-3 sm:grid-cols-2">
-                            <div className="mf-section mf-section-tight min-w-0 p-4">
-                                <p className="section-kicker">Operatore</p>
-                                <p className="mt-2 truncate text-base font-semibold" style={{ color: 'var(--lume-ink)' }}>
-                                    {user?.displayName || 'Admin'}
-                                </p>
-                                <p className="mt-1 truncate text-xs" style={{ color: 'var(--lume-ink-muted)' }}>
-                                    {user?.ambulatoryName || 'Ambulatorio non impostato'}
-                                </p>
-                            </div>
-                            <div className="mf-section mf-section-tight min-w-0 p-4">
-                                <p className="section-kicker">Lettura</p>
-                                <div className="mt-2 flex flex-wrap items-center gap-3">
-                                    <div className="[&>div]:mx-0">
-                                        <ThemeToggle />
-                                    </div>
-                                </div>
-                                <p className="mt-2 text-xs leading-5" style={{ color: 'var(--lume-ink-muted)' }}>
-                                    Privacy Mode resta nell&apos;intestazione dell&apos;app.
-                                </p>
-                            </div>
-                        </div>
-                    </div>
+    useEffect(() => {
+        let cancelled = false;
+        void readNetworkOverview()
+            .then((overview) => {
+                if (!cancelled) {
+                    setNetworkOverview(overview);
+                    setConfirmedNetworkMode(overview.session.operatingMode);
+                }
+            })
+            .catch(() => {
+                if (!cancelled) setNetworkError('Stato rete non disponibile. Riprova dalla diagnostica.');
+            })
+            .finally(() => {
+                if (!cancelled) setIsNetworkLoading(false);
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, []);
 
-                    <div className="min-w-0">
-                        <NetworkOperatingModePanel />
-                    </div>
+    const updateNetworkMode = async () => {
+        const activeMode = networkOverview?.session.operatingMode ?? confirmedNetworkMode;
+        if (!activeMode || isNetworkSaving) return;
+        const nextMode = activeMode === 'network-home-base'
+            ? 'local-only'
+            : 'network-home-base';
+        setIsNetworkSaving(true);
+        setNetworkError(null);
+        try {
+            const response = await fetch('/api/settings/network.mode', {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ value: nextMode }),
+            });
+            if (!response.ok) throw new Error('network mode update failed');
+            setConfirmedNetworkMode(nextMode);
+            try {
+                const refreshedOverview = await readNetworkOverview();
+                setNetworkOverview(refreshedOverview);
+                setConfirmedNetworkMode(refreshedOverview.session.operatingMode);
+            } catch {
+                setNetworkOverview(null);
+                setNetworkError('Modalità aggiornata. I dettagli del nodo non sono ancora disponibili.');
+            }
+        } catch {
+            setNetworkError('La modalità non è cambiata. Riprova dalla diagnostica.');
+        } finally {
+            setIsNetworkSaving(false);
+        }
+    };
+
+    const currentNetworkMode = networkOverview?.session.operatingMode ?? confirmedNetworkMode;
+    const isHomeBase = currentNetworkMode === 'network-home-base';
+    const networkStatus = networkViewModel?.currentState.label
+        ?? (currentNetworkMode === 'network-home-base'
+            ? 'Home-base'
+            : currentNetworkMode === 'local-only'
+                ? 'Locale'
+                : networkError ? 'Non disponibile' : 'Lettura');
+    const networkEffect = !currentNetworkMode
+        ? networkError
+            ? 'La modalità operativa non è verificabile. Non viene fatta alcuna ipotesi sullo stato di home-base.'
+            : 'Lettura della modalità operativa in corso. Lo stato di home-base non è ancora determinato.'
+        : isHomeBase
+            ? networkOverview
+                ? 'Home-base abilitato. Il canale dati resta disponibile solo ai dispositivi associati con sessione operatore valida.'
+                : 'Home-base abilitato. Pairing e sessione non sono verificabili finché i dettagli del nodo non tornano disponibili.'
+            : 'Home-base disabilitato. Questa postazione non espone il canale dati ai dispositivi associati.';
+
+    return (
+        <div className={styles.overview} data-testid="settings-overview-section">
+            <section
+                className={styles.overviewFocus}
+                data-testid="settings-focus-section"
+                data-settings-section="system-status"
+                data-lume-elevation="focal"
+            >
+                <div>
+                    <p className={styles.sectionLabel}>Modalità operativa</p>
+                    <h2>
+                        {networkViewModel?.currentState.title
+                            ?? (currentNetworkMode
+                                ? 'Modalità salvata, dettagli del nodo non disponibili'
+                                : 'Lettura del nodo locale')}
+                    </h2>
+                    <p
+                        className={`${styles.overviewValue} lume-registro`}
+                        data-lume-register-value="true"
+                        data-testid="settings-network-mode-value"
+                        aria-live="polite"
+                    >
+                        {networkStatus}
+                    </p>
+                    <p className={styles.supportingCopy}>
+                        {networkEffect} Esportazione e backup restano percorsi separati ed espliciti.
+                    </p>
+                    {networkError ? <p className={styles.errorNote} role="status">{networkError}</p> : null}
+                </div>
+                <div className={styles.focusActions}>
+                    <button
+                        type="button"
+                        className={styles.primaryAction}
+                        data-settings-primary="true"
+                        data-testid="settings-network-mode-action"
+                        disabled={isNetworkLoading || isNetworkSaving || !currentNetworkMode}
+                        onClick={() => void updateNetworkMode()}
+                    >
+                        {isNetworkSaving
+                            ? 'Aggiornamento'
+                            : !currentNetworkMode
+                                ? isNetworkLoading ? 'Lettura stato' : 'Stato non disponibile'
+                                : isHomeBase
+                                    ? 'Disattiva home-base'
+                                    : 'Abilita home-base'}
+                    </button>
+                    <Link href="/settings/diagnostica" className={styles.secondaryAction}>
+                        Apri diagnostica
+                        <ArrowUpRight aria-hidden="true" />
+                    </Link>
                 </div>
             </section>
 
-            <section className="space-y-4">
-                <SettingsSectionIntro
-                    kicker="Sezioni"
-                    title="Tutte le impostazioni"
-                    description="Premi ⌘K per cercare un'impostazione e aprire subito la sezione corrispondente."
-                />
+            <section
+                className={styles.previewSection}
+                data-testid="settings-preview-section"
+                data-settings-section="appearance-preview"
+            >
+                <div className={styles.previewCopy}>
+                    <p className={styles.sectionLabel}>Anteprima immediata</p>
+                    <h2>Lettura della postazione</h2>
+                    <p className={styles.supportingCopy}>
+                        Il cambio di registro si vede subito su questa superficie ed è reversibile dallo stesso controllo.
+                    </p>
+                </div>
+                <div className={styles.previewField} aria-live="polite">
+                    <span>Valore verificabile</span>
+                    <strong className="lume-registro" data-lume-register-value="true">08:30</strong>
+                    <span>Testo operativo nella Voce</span>
+                </div>
+                <div className={styles.previewActions}>
+                    <ThemeToggle />
+                    <Link
+                        href="/settings/aspetto"
+                        className={styles.primaryAction}
+                        data-settings-primary="true"
+                    >
+                        Regola aspetto
+                        <ArrowUpRight aria-hidden="true" />
+                    </Link>
+                </div>
+            </section>
 
-                <div className="grid gap-4 xl:grid-cols-2">
+            <nav className={styles.settingsIndex} aria-labelledby="settings-index-title">
+                <div className={styles.indexHeading}>
+                    <p className={styles.sectionLabel}>Indice</p>
+                    <div>
+                        <h2 id="settings-index-title">Tutte le impostazioni</h2>
+                        <p>Apri una sezione oppure premi ⌘K. La configurazione resta separata dal lavoro clinico.</p>
+                    </div>
+                </div>
+
+                <div className={styles.indexGroups}>
                     {SETTINGS_NAV_GROUPS.map((group) => (
-                        <div key={group.id} className="mf-section mf-section-tight p-4 md:p-5">
-                            <div className="mb-3 flex items-baseline justify-between gap-3">
-                                <p className="section-kicker">{group.label}</p>
-                                <span className="lume-registro text-[11px]" style={{ color: 'var(--lume-ink-muted)' }}>
-                                    {group.items.length} sezioni
-                                </span>
-                            </div>
-                            <div className="grid gap-2">
+                        <div className={styles.indexGroup} key={group.id}>
+                            <p className={styles.indexGroupTitle}>{group.label}</p>
+                            <ul className={styles.indexList}>
                                 {group.items.map((item) => (
-                                    <SettingsCommandRow key={item.id} item={item} />
+                                    <li key={item.id}>
+                                        <Link
+                                            href={item.href}
+                                            className={styles.indexLink}
+                                            data-testid={`settings-overview-link-${item.id}`}
+                                            data-tone={item.tone ?? 'default'}
+                                        >
+                                            <span>
+                                                <strong>{item.label}</strong>
+                                                <small>{item.description}</small>
+                                            </span>
+                                            <ArrowUpRight aria-hidden="true" />
+                                        </Link>
+                                    </li>
                                 ))}
-                            </div>
+                            </ul>
                         </div>
                     ))}
                 </div>
-            </section>
+            </nav>
         </div>
     );
 }

--- a/components/settings/settings-lume.module.css
+++ b/components/settings/settings-lume.module.css
@@ -1,0 +1,468 @@
+.overview {
+    --lume-settings-register-family: "IBM Plex Mono", var(--font-registro), "SF Mono", monospace;
+    display: grid;
+    gap: 2rem;
+}
+.overview :global(.lume-registro),
+.navRoot :global(.lume-registro) {
+    font-family: var(--lume-settings-register-family, "IBM Plex Mono", var(--font-registro), "SF Mono", monospace);
+}
+.overviewFocus {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 2rem;
+    align-items: end;
+    border: 1px solid color-mix(in srgb, var(--lume-ink) 14%, transparent);
+    border-radius: var(--lume-radius-panel);
+    background: var(--lume-surface-focal);
+    box-shadow: 0 2px 8px color-mix(in srgb, var(--lume-ink) 10%, transparent);
+    padding: clamp(1.25rem, 3vw, 2rem);
+}
+.overviewFocus h2,
+.previewSection h2,
+.indexHeading h2,
+.sectionIntro h2 {
+    margin: 0.45rem 0 0;
+    color: var(--lume-ink);
+    font-size: 1.2rem;
+    font-weight: 650;
+    line-height: 1.35;
+    text-wrap: balance;
+}
+.overviewValue {
+    margin: 1rem 0 0;
+    color: var(--lume-ink);
+    font-size: clamp(2.1rem, 5vw, 3.25rem);
+    font-variant-numeric: tabular-nums;
+    font-weight: 650;
+    letter-spacing: -0.035em;
+    line-height: 1;
+}
+.sectionLabel,
+.navGroupLabel {
+    margin: 0;
+    color: var(--lume-ink-muted);
+    font-family: var(--lume-settings-register-family, "IBM Plex Mono", var(--font-registro), "SF Mono", monospace);
+    font-size: 0.7rem;
+    font-variant-numeric: tabular-nums;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+}
+.supportingCopy {
+    max-width: 70ch;
+    margin: 0.75rem 0 0;
+    color: var(--lume-ink-muted);
+    font-size: 0.82rem;
+    line-height: 1.55;
+}
+.focusActions {
+    display: grid;
+    min-width: 11rem;
+    gap: 0.65rem;
+}
+.errorNote {
+    margin: 0.65rem 0 0;
+    color: color-mix(in srgb, var(--lume-signal-critical) 24%, var(--lume-ink));
+    font-size: 0.75rem;
+    line-height: 1.45;
+}
+.primaryAction,
+.secondaryAction {
+    display: inline-flex;
+    min-height: 2.65rem;
+    align-items: center;
+    justify-content: center;
+    gap: 0.55rem;
+    border-radius: var(--lume-radius-control);
+    padding: 0.65rem 1rem;
+    font-size: 0.8rem;
+    font-weight: 650;
+    text-decoration: none;
+    transition: background-color 150ms cubic-bezier(0.22, 0.61, 0.36, 1), color 150ms cubic-bezier(0.22, 0.61, 0.36, 1);
+}
+.primaryAction {
+    border: 1px solid var(--lume-accent);
+    background: var(--lume-accent);
+    color: var(--lume-surface-focal);
+}
+.primaryAction:disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+}
+.primaryAction svg {
+    width: 0.95rem;
+    height: 0.95rem;
+}
+.secondaryAction {
+    border: 1px solid color-mix(in srgb, var(--lume-ink) 16%, transparent);
+    background: var(--lume-surface-field);
+    color: var(--lume-ink);
+}
+.primaryAction:hover,
+.primaryAction:focus-visible {
+    background: color-mix(in srgb, var(--lume-accent) 88%, var(--lume-ink));
+}
+.primaryAction:focus-visible,
+.secondaryAction:focus-visible,
+.indexLink:focus-visible,
+.navItem:focus-visible,
+.mobileToggle:focus-visible,
+.mobileSearch:focus-visible,
+.searchButton:focus-visible {
+    outline: 2px solid var(--lume-accent);
+    outline-offset: 2px;
+}
+.previewSection {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(12rem, 0.65fr) auto;
+    gap: 1.25rem;
+    align-items: center;
+    border-top: 1px solid color-mix(in srgb, var(--lume-ink) 14%, transparent);
+    border-bottom: 1px solid color-mix(in srgb, var(--lume-ink) 14%, transparent);
+    background: var(--lume-surface-field);
+    padding: 1.25rem;
+}
+.previewField {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.3rem 1rem;
+    border-radius: var(--lume-radius-card);
+    background: var(--lume-surface-focal);
+    padding: 0.9rem 1rem;
+    color: var(--lume-ink-muted);
+    font-size: 0.72rem;
+}
+.previewField strong {
+    grid-row: span 2;
+    align-self: center;
+    color: var(--lume-ink);
+    font-size: 1.1rem;
+    font-variant-numeric: tabular-nums;
+}
+.previewActions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    align-items: stretch;
+}
+.settingsIndex {
+    display: grid;
+    gap: 1.4rem;
+}
+.indexHeading {
+    display: grid;
+    grid-template-columns: minmax(5rem, 0.22fr) minmax(0, 1fr);
+    gap: 1rem;
+    align-items: baseline;
+}
+.indexHeading p:last-child {
+    max-width: 70ch;
+    margin: 0.35rem 0 0;
+    color: var(--lume-ink-muted);
+    font-size: 0.78rem;
+    line-height: 1.55;
+}
+.indexGroups {
+    border-top: 1px solid color-mix(in srgb, var(--lume-ink) 12%, transparent);
+}
+.indexGroup {
+    display: grid;
+    grid-template-columns: minmax(8rem, 0.25fr) minmax(0, 1fr);
+    gap: 1rem;
+    border-bottom: 1px solid color-mix(in srgb, var(--lume-ink) 12%, transparent);
+    padding: 1rem 0;
+}
+.indexGroupTitle {
+    margin: 0.75rem 0 0;
+    color: var(--lume-ink-muted);
+    font-size: 0.75rem;
+    font-weight: 650;
+}
+.indexList,
+.navItems {
+    display: grid;
+    gap: 0.25rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+.indexLink {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 1rem;
+    align-items: center;
+    border-radius: var(--lume-radius-control);
+    color: var(--lume-ink);
+    padding: 0.7rem 0.8rem;
+    text-decoration: none;
+    transition: background-color 120ms ease-out;
+}
+.indexLink:hover {
+    background: var(--lume-surface-focal);
+}
+.indexLink[data-tone='danger'] strong,
+.navItemDanger .navItemLabel {
+    color: var(--lume-signal-critical);
+}
+.indexLink strong,
+.indexLink small {
+    display: block;
+}
+.indexLink strong {
+    font-size: 0.8rem;
+    font-weight: 650;
+}
+.indexLink small {
+    margin-top: 0.2rem;
+    color: var(--lume-ink-muted);
+    font-size: 0.7rem;
+    line-height: 1.4;
+}
+.indexLink > svg {
+    width: 0.9rem;
+    height: 0.9rem;
+    color: var(--lume-ink-muted);
+}
+.sectionIntro {
+    display: grid;
+    gap: 0.25rem;
+}
+.sectionIntro p:last-child {
+    max-width: 70ch;
+    margin: 0.2rem 0 0;
+    color: var(--lume-ink-muted);
+    font-size: 0.82rem;
+    line-height: 1.55;
+}
+.settingSurface {
+    border: 1px solid color-mix(in srgb, var(--lume-ink) 14%, transparent);
+    border-radius: var(--lume-radius-panel);
+    background: var(--lume-surface-focal);
+    box-shadow: 0 2px 8px color-mix(in srgb, var(--lume-ink) 10%, transparent);
+}
+.settingLayer {
+    border-top: 1px solid color-mix(in srgb, var(--lume-ink) 12%, transparent);
+    border-bottom: 1px solid color-mix(in srgb, var(--lume-ink) 12%, transparent);
+    background: var(--lume-surface-field);
+}
+.settingInput {
+    width: 100%;
+    min-height: 2.75rem;
+    border: 1px solid color-mix(in srgb, var(--lume-ink) 16%, transparent);
+    border-radius: var(--lume-radius-control);
+    background: var(--lume-surface-field);
+    color: var(--lume-ink);
+    padding: 0.65rem 0.8rem;
+    font-size: 0.85rem;
+}
+.settingInput:focus {
+    border-color: var(--lume-accent);
+    outline: 2px solid var(--lume-accent);
+    outline-offset: 1px;
+}
+.settingLabel {
+    display: block;
+    margin-bottom: 0.4rem;
+    color: var(--lume-ink);
+    font-size: 0.78rem;
+    font-weight: 650;
+}
+.navRoot {
+    color: var(--lume-ink);
+}
+.mobileBar {
+    display: flex;
+    align-items: stretch;
+    gap: 0.5rem;
+}
+.mobileToggle,
+.mobileSearch,
+.searchButton {
+    border: 1px solid color-mix(in srgb, var(--lume-ink) 14%, transparent);
+    border-radius: var(--lume-radius-control);
+    background: var(--lume-surface-chrome);
+    color: var(--lume-ink);
+}
+.mobileToggle {
+    display: flex;
+    min-width: 0;
+    flex: 1;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.65rem 0.8rem;
+    text-align: left;
+}
+.mobileCurrent {
+    min-width: 0;
+}
+.mobileCurrent span,
+.mobileCurrent strong {
+    display: block;
+}
+.mobileCurrent span {
+    color: var(--lume-ink-muted);
+    font-size: 0.65rem;
+    font-weight: 600;
+}
+.mobileCurrent strong {
+    overflow: hidden;
+    margin-top: 0.15rem;
+    font-size: 0.8rem;
+    font-weight: 650;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.disclosureIcon {
+    width: 1rem;
+    height: 1rem;
+    flex: 0 0 auto;
+    color: var(--lume-ink-muted);
+    transition: transform 150ms cubic-bezier(0.22, 0.61, 0.36, 1);
+}
+.disclosureIconOpen {
+    transform: rotate(180deg);
+}
+.mobileSearch {
+    display: grid;
+    width: 2.75rem;
+    flex: 0 0 auto;
+    place-items: center;
+}
+.mobileSearch svg {
+    width: 1rem;
+    height: 1rem;
+}
+.mobileGroups {
+    margin-top: 0.5rem;
+    border: 1px solid color-mix(in srgb, var(--lume-ink) 14%, transparent);
+    border-radius: var(--lume-radius-card);
+    background: var(--lume-surface-chrome);
+    padding: 0.75rem;
+}
+.desktopSidebar {
+    display: none;
+}
+.navGroups {
+    display: grid;
+    gap: 1.25rem;
+}
+.navGroup {
+    display: grid;
+    gap: 0.45rem;
+}
+.navGroupLabel {
+    padding-inline: 0.35rem;
+}
+.navItem {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    border-radius: var(--lume-radius-control);
+    color: var(--lume-ink);
+    padding: 0.55rem 0.65rem;
+    text-decoration: none;
+    transition: background-color 120ms ease-out;
+}
+.navItem:hover {
+    background: color-mix(in srgb, var(--lume-surface-focal) 72%, transparent);
+}
+.navItemActive {
+    background: var(--lume-surface-focal);
+    box-shadow: 0 2px 8px color-mix(in srgb, var(--lume-ink) 9%, transparent);
+}
+.navItemCopy {
+    min-width: 0;
+}
+.navItemLabel,
+.navItemDescription {
+    display: block;
+}
+.navItemLabel {
+    color: var(--lume-ink);
+    font-size: 0.77rem;
+    font-weight: 620;
+}
+.navItemDescription {
+    margin-top: 0.15rem;
+    color: var(--lume-ink-muted);
+    font-size: 0.67rem;
+    line-height: 1.35;
+}
+.currentLabel {
+    flex: 0 0 auto;
+    color: var(--lume-ink-muted);
+    font-size: 0.62rem;
+    font-variant-numeric: tabular-nums;
+}
+.searchButton {
+    display: flex;
+    width: 100%;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.6rem 0.7rem;
+    color: var(--lume-ink-muted);
+    font-size: 0.7rem;
+    text-align: left;
+}
+.searchButton span {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+}
+.searchButton svg {
+    width: 0.85rem;
+    height: 0.85rem;
+}
+.searchButton kbd {
+    border: 1px solid color-mix(in srgb, var(--lume-ink) 14%, transparent);
+    border-radius: 0.35rem;
+    padding: 0.1rem 0.35rem;
+    font-size: 0.62rem;
+}
+@media (min-width: 1024px) {
+    .mobileBar,
+    .mobileGroups {
+        display: none;
+    }
+    .desktopSidebar {
+        display: grid;
+        gap: 1.25rem;
+    }
+}
+@media (max-width: 767px) {
+    .overviewFocus,
+    .previewSection,
+    .indexHeading,
+    .indexGroup {
+        grid-template-columns: minmax(0, 1fr);
+    }
+    .overviewFocus,
+    .previewSection {
+        align-items: stretch;
+        gap: 1.25rem;
+    }
+    .primaryAction {
+        width: 100%;
+    }
+    .focusActions {
+        width: 100%;
+    }
+    .previewActions {
+        align-items: stretch;
+    }
+    .indexGroupTitle {
+        margin-top: 0;
+    }
+}
+@media (prefers-reduced-motion: reduce) {
+    .primaryAction,
+    .secondaryAction,
+    .indexLink,
+    .navItem,
+    .disclosureIcon {
+        transition-duration: 0.01ms;
+    }
+}

--- a/components/settings/settings-nav-sidebar.tsx
+++ b/components/settings/settings-nav-sidebar.tsx
@@ -1,17 +1,15 @@
 'use client';
 
-// WUL-297: grouped sidebar for the settings information architecture.
-// Below lg the full nav collapses into a compact disclosure bar (current
-// section + accordion) so sub-route content stays above the fold.
-
-import { useEffect, useState } from 'react';
+import { ChevronDown, Search } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { ChevronDown, Search } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
 
 import { SETTINGS_NAV_GROUPS } from '@/lib/settings-navigation';
 import type { SettingsNavGroup, SettingsNavItem } from '@/lib/settings-navigation';
 import { cn } from '@/lib/utils';
+
+import styles from './settings-lume.module.css';
 
 function isItemActive(item: SettingsNavItem, pathname: string): boolean {
     return pathname === item.href || pathname.startsWith(`${item.href}/`);
@@ -26,41 +24,42 @@ function findActiveEntry(pathname: string): { group: SettingsNavGroup; item: Set
     return null;
 }
 
-function NavGroups({ pathname, testIdPrefix }: { pathname: string; testIdPrefix: string }) {
+function NavGroups({
+    pathname,
+    testIdPrefix,
+    onNavigate,
+}: {
+    pathname: string;
+    testIdPrefix: string;
+    onNavigate?: (isActive: boolean) => void;
+}) {
     return (
-        <>
+        <div className={styles.navGroups}>
             {SETTINGS_NAV_GROUPS.map((group) => (
-                <div key={group.id} className="space-y-1.5">
-                    <p className="section-kicker px-1">{group.label}</p>
-                    <ul className="space-y-1">
+                <div key={group.id} className={styles.navGroup}>
+                    <p className={styles.navGroupLabel}>{group.label}</p>
+                    <ul className={styles.navItems}>
                         {group.items.map((item) => {
                             const isActive = isItemActive(item, pathname);
-                            const isDanger = item.tone === 'danger';
                             return (
                                 <li key={item.id}>
                                     <Link
                                         href={item.href}
                                         aria-current={isActive ? 'page' : undefined}
+                                        data-state={isActive ? 'active' : 'idle'}
                                         data-testid={`${testIdPrefix}${item.id}`}
+                                        onClick={() => onNavigate?.(isActive)}
                                         className={cn(
-                                            'block rounded-[var(--lume-radius-card)] border px-3 py-2 transition-colors',
-                                            !isActive && 'border-transparent hover:border-[color:color-mix(in_srgb,var(--lume-ink)_18%,transparent)]',
+                                            styles.navItem,
+                                            isActive && styles.navItemActive,
+                                            item.tone === 'danger' && styles.navItemDanger,
                                         )}
-                                        style={isActive
-                                            ? isDanger
-                                                ? { borderColor: 'rgba(192, 57, 43, 0.3)', background: 'rgba(192, 57, 43, 0.08)' }
-                                                : { borderColor: 'color-mix(in srgb, var(--lume-ink) 14%, transparent)', background: 'var(--lume-surface-focal)', boxShadow: '0 2px 8px color-mix(in srgb, var(--lume-ink) 10%, transparent)' }
-                                            : undefined}
                                     >
-                                        <span
-                                            className="block text-[13px] font-semibold"
-                                            style={{ color: isDanger ? 'var(--lume-signal-critical)' : 'var(--lume-ink)' }}
-                                        >
-                                            {item.label}
+                                        <span className={styles.navItemCopy}>
+                                            <span className={styles.navItemLabel}>{item.label}</span>
+                                            <span className={styles.navItemDescription}>{item.description}</span>
                                         </span>
-                                        <span className="mt-0.5 block text-[11px] leading-4" style={{ color: 'var(--lume-ink-muted)' }}>
-                                            {item.description}
-                                        </span>
+                                        {isActive ? <span className={`${styles.currentLabel} lume-registro`}>Attiva</span> : null}
                                     </Link>
                                 </li>
                             );
@@ -68,53 +67,61 @@ function NavGroups({ pathname, testIdPrefix }: { pathname: string; testIdPrefix:
                     </ul>
                 </div>
             ))}
-        </>
+        </div>
     );
 }
 
+/* @Codex LUME-110/68 */
 export function SettingsNavSidebar({ onSearchRequest }: { onSearchRequest?: () => void }) {
     const pathname = usePathname();
     const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
+    const mobileToggleRef = useRef<HTMLButtonElement>(null);
+    const restoreFocusAfterNavigation = useRef(false);
+    const activeEntry = findActiveEntry(pathname);
 
-    // Collapse the mobile accordion as soon as navigation lands on a route.
     useEffect(() => {
         setIsMobileNavOpen(false);
+        if (!restoreFocusAfterNavigation.current) return;
+        restoreFocusAfterNavigation.current = false;
+        requestAnimationFrame(() => mobileToggleRef.current?.focus());
     }, [pathname]);
 
-    const activeEntry = findActiveEntry(pathname);
-    const isDangerActive = activeEntry?.item.tone === 'danger';
+    const closeMobileNavigation = (isActive: boolean) => {
+        if (isActive) {
+            restoreFocusAfterNavigation.current = false;
+            setIsMobileNavOpen(false);
+            requestAnimationFrame(() => mobileToggleRef.current?.focus());
+            return;
+        }
+        restoreFocusAfterNavigation.current = true;
+        setIsMobileNavOpen(false);
+    };
+
+    const closeMobileDisclosure = () => {
+        setIsMobileNavOpen(false);
+        requestAnimationFrame(() => mobileToggleRef.current?.focus());
+    };
 
     return (
-        <nav aria-label="Sezioni impostazioni" data-testid="settings-nav-sidebar">
-            {/* Compact treatment for narrow viewports (<lg): disclosure bar + accordion. */}
-            <div className="flex items-stretch gap-2 lg:hidden">
+        <nav aria-label="Sezioni impostazioni" data-testid="settings-nav-sidebar" className={styles.navRoot}>
+            <div className={styles.mobileBar}>
                 <button
+                    ref={mobileToggleRef}
                     type="button"
                     onClick={() => setIsMobileNavOpen((current) => !current)}
                     aria-expanded={isMobileNavOpen}
                     aria-controls="settings-nav-mobile-groups"
+                    aria-label={`${isMobileNavOpen ? 'Chiudi' : 'Apri'} navigazione impostazioni. Sezione attiva: ${activeEntry?.item.label ?? 'Panoramica'}`}
                     data-testid="settings-nav-mobile-toggle"
-                    className="flex min-w-0 flex-1 items-center justify-between gap-2 rounded-[var(--lume-radius-card)] border px-3 py-2 text-left transition-colors"
-                    style={{
-                        borderColor: isDangerActive ? 'rgba(163, 58, 47, 0.3)' : 'color-mix(in srgb, var(--lume-ink) 14%, transparent)',
-                        background: isDangerActive ? 'rgba(163, 58, 47, 0.08)' : 'var(--lume-surface-focal)',
-                    }}
+                    className={styles.mobileToggle}
                 >
-                    <span className="min-w-0">
-                        <span className="block text-[10px] font-semibold uppercase tracking-[0.12em]" style={{ color: 'var(--lume-ink-muted)' }}>
-                            {activeEntry ? activeEntry.group.label : 'Impostazioni'}
-                        </span>
-                        <span
-                            className="block truncate text-[13px] font-semibold"
-                            style={{ color: isDangerActive ? 'var(--lume-signal-critical)' : 'var(--lume-ink)' }}
-                        >
-                            {activeEntry ? activeEntry.item.label : 'Panoramica'}
-                        </span>
+                    <span className={styles.mobileCurrent}>
+                        <span>{activeEntry?.group.label ?? 'Impostazioni'}</span>
+                        <strong>{activeEntry?.item.label ?? 'Panoramica'}</strong>
                     </span>
                     <ChevronDown
                         aria-hidden="true"
-                        className={cn('h-4 w-4 shrink-0 transition-transform', isMobileNavOpen && 'rotate-180')}
-                        style={{ color: 'var(--lume-ink-muted)' }}
+                        className={cn(styles.disclosureIcon, isMobileNavOpen && styles.disclosureIconOpen)}
                     />
                 </button>
                 {onSearchRequest ? (
@@ -123,54 +130,38 @@ export function SettingsNavSidebar({ onSearchRequest }: { onSearchRequest?: () =
                         onClick={onSearchRequest}
                         aria-label="Cerca impostazione"
                         data-testid="settings-search-trigger-mobile"
-                        className="flex w-11 shrink-0 items-center justify-center rounded-[var(--lume-radius-card)] border transition-colors"
-                        style={{
-                            borderColor: 'color-mix(in srgb, var(--lume-ink) 14%, transparent)',
-                            background: 'var(--lume-surface-focal)',
-                            color: 'var(--lume-ink-muted)',
-                        }}
+                        className={styles.mobileSearch}
                     >
-                        <Search className="h-4 w-4" />
+                        <Search aria-hidden="true" />
                     </button>
                 ) : null}
             </div>
+
             <div
                 id="settings-nav-mobile-groups"
                 hidden={!isMobileNavOpen}
-                className="mt-2 space-y-5 rounded-[var(--lume-radius-panel)] border bg-[color:var(--lume-surface-field)] p-3 lg:hidden"
-                style={{
-                    borderColor: 'color-mix(in srgb, var(--lume-ink) 14%, transparent)',
+                className={styles.mobileGroups}
+                onKeyDown={(event) => {
+                    if (event.key !== 'Escape') return;
+                    event.preventDefault();
+                    closeMobileDisclosure();
                 }}
             >
-                <NavGroups pathname={pathname} testIdPrefix="settings-nav-mobile-" />
+                <NavGroups pathname={pathname} testIdPrefix="settings-nav-mobile-" onNavigate={closeMobileNavigation} />
             </div>
 
-            {/* Full sidebar from lg up. */}
-            <div className="hidden space-y-5 lg:block">
+            <div className={styles.desktopSidebar}>
                 {onSearchRequest ? (
                     <button
                         type="button"
                         onClick={onSearchRequest}
                         data-testid="settings-search-trigger"
-                        className="flex w-full items-center justify-between gap-2 rounded-[var(--lume-radius-card)] border bg-[color:var(--lume-surface-field)] px-3 py-2 text-left text-xs font-medium transition-colors"
-                        style={{
-                            borderColor: 'color-mix(in srgb, var(--lume-ink) 14%, transparent)',
-                            color: 'var(--lume-ink-muted)',
-                        }}
+                        className={styles.searchButton}
                     >
-                        <span className="inline-flex items-center gap-2">
-                            <Search className="h-3.5 w-3.5" />
-                            Cerca impostazione
-                        </span>
-                        <kbd
-                            className="lume-registro rounded-md border px-1.5 py-0.5 text-[10px]"
-                            style={{ borderColor: 'color-mix(in srgb, var(--lume-ink) 14%, transparent)', color: 'var(--lume-ink-muted)' }}
-                        >
-                            ⌘K
-                        </kbd>
+                        <span><Search aria-hidden="true" /> Cerca impostazione</span>
+                        <kbd className="lume-registro">⌘K</kbd>
                     </button>
                 ) : null}
-
                 <NavGroups pathname={pathname} testIdPrefix="settings-nav-" />
             </div>
         </nav>

--- a/components/settings/settings-ui.tsx
+++ b/components/settings/settings-ui.tsx
@@ -1,12 +1,13 @@
-/* @Codex Lume B3: opacità e gerarchia del modello focale per le impostazioni. */
-export const SETTINGS_CARD_CLASS = 'mf-section lume-focal p-6 md:p-7';
-export const SETTINGS_SECTION_CARD_CLASS = 'mf-section mf-section-tight p-5 md:p-6';
-export const SETTINGS_INPUT_CLASS = 'mf-input';
-export const SETTINGS_LABEL_CLASS = 'mf-field-label';
-export const SETTINGS_PRIMARY_BUTTON_CLASS = 'ui-btn-primary lume-press px-5 py-2.5 disabled:opacity-50';
-export const SETTINGS_SECONDARY_BUTTON_CLASS = 'mf-btn-secondary';
+import styles from './settings-lume.module.css';
 
-/* @Codex */
+/* @Codex LUME-110/68 */
+export const SETTINGS_CARD_CLASS = `${styles.settingSurface} p-6 md:p-7`;
+export const SETTINGS_SECTION_CARD_CLASS = `${styles.settingLayer} p-5 md:p-6`;
+export const SETTINGS_INPUT_CLASS = styles.settingInput;
+export const SETTINGS_LABEL_CLASS = styles.settingLabel;
+export const SETTINGS_PRIMARY_BUTTON_CLASS = `${styles.primaryAction} lume-press disabled:opacity-50`;
+export const SETTINGS_SECONDARY_BUTTON_CLASS = styles.secondaryAction;
+
 export function SettingsSectionIntro({
     kicker,
     title,
@@ -17,10 +18,10 @@ export function SettingsSectionIntro({
     description: string;
 }) {
     return (
-        <div className="space-y-1">
-            <p className="section-kicker">{kicker}</p>
-            <h2 className="text-2xl font-semibold tracking-tight" style={{ color: 'var(--lume-ink)' }}>{title}</h2>
-            <p className="max-w-3xl text-sm leading-6" style={{ color: 'var(--lume-ink-muted)' }}>{description}</p>
+        <div className={styles.sectionIntro}>
+            <p className={styles.sectionLabel}>{kicker}</p>
+            <h2>{title}</h2>
+            <p>{description}</p>
         </div>
     );
 }

--- a/e2e/lume-analytics-settings.spec.ts
+++ b/e2e/lume-analytics-settings.spec.ts
@@ -120,7 +120,7 @@ async function expectNarrowAnalytics(page: Page): Promise<void> {
       focusOverflow: focus.scrollWidth - focus.clientWidth,
       answerBeforeFilters: answer.top < filters.top,
       tableDeclared: scroller.dataset.horizontalOverflow,
-      tableOwnsOverflow: scroller.scrollWidth >= scroller.clientWidth,
+      tableOwnsOverflow: scroller.scrollWidth > scroller.clientWidth,
     };
   });
   expect(layout.documentOverflow).toBeLessThanOrEqual(1);
@@ -249,11 +249,16 @@ async function verifySettings(page: Page, viewCase: ViewCase): Promise<void> {
 }
 
 for (const viewCase of CASES) {
-  test(`analytics e settings Lume ${viewCase.register} ${viewCase.viewport}`, async ({ page }) => {
+  test(`analytics Lume ${viewCase.register} ${viewCase.viewport}`, async ({ page }) => {
     await page.setViewportSize({ width: viewCase.width, height: viewCase.height });
     await bootstrapUnlockedSession(page, process.env.E2E_PIN || '1234');
     await createAnalyticsFixture(page);
     await verifyAnalytics(page, viewCase);
+  });
+
+  test(`settings Lume fixture-free ${viewCase.register} ${viewCase.viewport}`, async ({ page }) => {
+    await page.setViewportSize({ width: viewCase.width, height: viewCase.height });
+    await bootstrapUnlockedSession(page, process.env.E2E_PIN || '1234');
     await verifySettings(page, viewCase);
   });
 }

--- a/e2e/lume-analytics-settings.spec.ts
+++ b/e2e/lume-analytics-settings.spec.ts
@@ -1,0 +1,259 @@
+/* @Codex LUME-110/68 */
+import { expect, test, type Locator, type Page } from '@playwright/test';
+
+import { bootstrapUnlockedSession } from './utils';
+
+type ViewCase = {
+  register: 'giorno' | 'grafite';
+  viewport: 'wide' | 'narrow';
+  width: number;
+  height: number;
+};
+
+const CASES: ViewCase[] = [
+  { register: 'giorno', viewport: 'wide', width: 1440, height: 960 },
+  { register: 'grafite', viewport: 'wide', width: 1440, height: 960 },
+  { register: 'giorno', viewport: 'narrow', width: 390, height: 844 },
+  { register: 'grafite', viewport: 'narrow', width: 390, height: 844 },
+];
+
+async function createAnalyticsFixture(page: Page): Promise<void> {
+  const suffix = `${Date.now()}`.slice(-8) + Math.random().toString(36).slice(2, 7).toUpperCase();
+  const response = await page.request.post('/api/patients', {
+    data: {
+      firstName: `Analisi${suffix.slice(0, 5)}`,
+      lastName: `Sintetica${suffix.slice(5)}`,
+      taxCode: `ANA${suffix}`,
+      birthDate: '1970-04-12T00:00:00.000Z',
+      address: 'Fixture sintetica analytics',
+      phone: '0000000110',
+      isAdi: true,
+      diagnoses: [{
+        system: 'ICD-11',
+        code: 'QA68',
+        description: 'Rilevazione sintetica analytics',
+        date: '2026-07-17T08:00:00.000Z',
+      }],
+    },
+  });
+  expect(response.ok(), `Fixture analytics: HTTP ${response.status()}`).toBe(true);
+}
+
+async function gotoWithRegister(
+  page: Page,
+  path: string,
+  register: ViewCase['register'],
+): Promise<void> {
+  await page.evaluate((value) => {
+    const theme = value === 'grafite' ? 'dark' : 'light';
+    localStorage.setItem('mediflow-theme', theme);
+  }, register);
+  await page.goto(path);
+  await expect(page.locator('html')).toHaveClass(register === 'grafite' ? /dark/ : /light/);
+}
+
+async function expectRegisterFont(locator: Locator, minimum: number): Promise<void> {
+  const specimens = await locator.evaluateAll(async (elements) => {
+    await document.fonts.ready;
+    return elements
+      .filter((element) => (element as HTMLElement).offsetParent !== null)
+      .map((element) => {
+        const style = getComputedStyle(element);
+        return {
+          available: document.fonts.check(`${style.fontWeight} ${style.fontSize} "IBM Plex Mono"`),
+          family: style.fontFamily,
+          numericVariant: style.fontVariantNumeric,
+        };
+      });
+  });
+  expect(specimens.length).toBeGreaterThanOrEqual(minimum);
+  for (const specimen of specimens) {
+    expect(specimen.family).toContain('IBM Plex Mono');
+    expect(specimen.available).toBe(true);
+    expect(specimen.numericVariant).toMatch(/tabular-nums|normal/);
+  }
+}
+
+async function expectNoSemanticSideBorders(page: Page, rootSelector: string): Promise<void> {
+  const offenders = await page.locator(rootSelector).locator('*').evaluateAll((elements) => {
+    const root = getComputedStyle(document.documentElement);
+    const semanticColors = [
+      '--lume-accent',
+      '--lume-signal-warning',
+      '--lume-signal-critical',
+      '--lume-signal-success',
+      '--lume-signal-plum',
+    ].map((token) => root.getPropertyValue(token).trim());
+
+    return elements.flatMap((element) => {
+      const style = getComputedStyle(element);
+      const leftWidth = Number.parseFloat(style.borderLeftWidth);
+      const rightWidth = Number.parseFloat(style.borderRightWidth);
+      const semantic = semanticColors.includes(style.borderLeftColor);
+      const asymmetric = leftWidth !== rightWidth || style.borderLeftColor !== style.borderRightColor;
+      return leftWidth > 1 || (leftWidth > 0 && semantic && asymmetric)
+        ? [element.getAttribute('data-testid') || element.tagName.toLowerCase()]
+        : [];
+    });
+  });
+  expect(offenders).toEqual([]);
+}
+
+async function setRange(page: Page, label: string, value: number): Promise<void> {
+  await page.getByLabel(label).evaluate((element, nextValue) => {
+    const input = element as HTMLInputElement;
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+    setter?.call(input, String(nextValue));
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+  }, value);
+}
+
+async function expectNarrowAnalytics(page: Page): Promise<void> {
+  const layout = await page.evaluate(() => {
+    const focus = document.querySelector<HTMLElement>('[data-testid="analytics-focus-surface"]')!;
+    const answer = focus.firstElementChild!.getBoundingClientRect();
+    const filters = document.querySelector<HTMLElement>('[data-testid="analytics-filter-field"]')!.getBoundingClientRect();
+    const scroller = document.querySelector<HTMLElement>('[data-testid="analytics-table-overflow"]')!;
+    return {
+      documentOverflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+      focusOverflow: focus.scrollWidth - focus.clientWidth,
+      answerBeforeFilters: answer.top < filters.top,
+      tableDeclared: scroller.dataset.horizontalOverflow,
+      tableOwnsOverflow: scroller.scrollWidth >= scroller.clientWidth,
+    };
+  });
+  expect(layout.documentOverflow).toBeLessThanOrEqual(1);
+  expect(layout.focusOverflow).toBeLessThanOrEqual(1);
+  expect(layout.answerBeforeFilters).toBe(true);
+  expect(layout.tableDeclared).toBe('declared');
+  expect(layout.tableOwnsOverflow).toBe(true);
+}
+
+async function verifyAnalytics(page: Page, viewCase: ViewCase): Promise<void> {
+  await gotoWithRegister(page, '/analytics', viewCase.register);
+
+  const focus = page.getByTestId('analytics-focus-surface');
+  await expect(focus).toBeVisible();
+  await expect(focus).toHaveAttribute('data-lume-focus', '');
+  await expect(page.locator('[data-lume-analytics-focus="true"]')).toHaveCount(1);
+  await expect(page.locator('#indicatori > dl')).toHaveCount(1);
+
+  const downstream = page.locator('#diagnosi');
+  await downstream.evaluate((element) => element.scrollIntoView({ behavior: 'auto', block: 'center' }));
+  await expect(focus).not.toHaveAttribute('data-lume-focus', '');
+  await expect(page.locator('[data-lume-focus]')).toHaveCount(1);
+  expect(await page.locator('[data-lume-focus]').getAttribute('id')).not.toBe('domanda');
+  await focus.evaluate((element) => element.scrollIntoView({ behavior: 'auto', block: 'center' }));
+  await expect(focus).toHaveAttribute('data-lume-focus', '');
+
+  const indicatorRows = await page.locator('#indicatori > dl > div').evaluateAll((elements) => elements.map((element) => {
+    const style = getComputedStyle(element);
+    return { shadow: style.boxShadow, radius: Number.parseFloat(style.borderRadius), background: style.backgroundColor };
+  }));
+  expect(indicatorRows.length).toBe(3);
+  for (const row of indicatorRows) {
+    expect(row.shadow).toBe('none');
+    expect(row.radius).toBe(0);
+    expect(row.background).toBe('rgba(0, 0, 0, 0)');
+  }
+
+  await expectRegisterFont(page.locator('[data-lume-register-value="true"]'), 8);
+  await expectNoSemanticSideBorders(page, '[data-testid="analytics-focus-surface"], #indicatori, #eta, #diagnosi, #audit');
+
+  await setRange(page, 'Età minima', 120);
+  await setRange(page, 'Età massima', 120);
+  await expect(page.getByTestId('analytics-primary-value')).toHaveText('0');
+  await expect(page.getByText('Nessuna scheda attiva con età nota rientra nel filtro corrente.')).toBeVisible();
+  await setRange(page, 'Età minima', 0);
+  await expect(page.getByTestId('analytics-primary-value')).not.toHaveText('0');
+
+  if (viewCase.viewport === 'narrow') await expectNarrowAnalytics(page);
+  await page.screenshot({
+    path: `/tmp/lume-analytics-${viewCase.register}-${viewCase.viewport}.png`,
+    animations: 'disabled',
+  });
+}
+
+async function verifySettings(page: Page, viewCase: ViewCase): Promise<void> {
+  await gotoWithRegister(page, '/settings/profilo', viewCase.register);
+
+  if (viewCase.viewport === 'narrow') {
+    const toggle = page.getByTestId('settings-nav-mobile-toggle');
+    await toggle.click();
+    const active = page.getByTestId('settings-nav-mobile-profilo');
+    await expect(active).toHaveAttribute('aria-current', 'page');
+    await expect(active.getByText('Attiva')).toBeVisible();
+    await active.click();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    await expect(toggle).toBeFocused();
+    await toggle.click();
+    await page.getByTestId('settings-nav-mobile-backup').click();
+    await expect(page).toHaveURL(/\/settings\/backup$/);
+    await expect(toggle).toBeFocused();
+    await expect(toggle).toHaveAccessibleName(/Sezione attiva: Backup/);
+  } else {
+    const active = page.getByTestId('settings-nav-profilo');
+    await expect(active).toHaveAttribute('aria-current', 'page');
+    await expect(active.getByText('Attiva')).toBeVisible();
+  }
+
+  await gotoWithRegister(page, '/settings', viewCase.register);
+
+  const settingsSections = page.locator('[data-settings-section]');
+  await expect(settingsSections).toHaveCount(2);
+  const primaryCounts = await settingsSections.evaluateAll((sections) => sections.map((section) => ({
+    section: section.getAttribute('data-settings-section'),
+    primary: section.querySelectorAll('[data-settings-primary="true"]').length,
+  })));
+  expect(primaryCounts).toEqual([
+    { section: 'system-status', primary: 1 },
+    { section: 'appearance-preview', primary: 1 },
+  ]);
+
+  const networkValue = page.getByTestId('settings-network-mode-value');
+  const networkAction = page.getByTestId('settings-network-mode-action');
+  await expect(networkValue).toHaveText('Locale');
+  await networkAction.click();
+  await expect(networkValue).toHaveText('Rete disponibile');
+  await expect(networkAction).toHaveText('Disattiva home-base');
+  await networkAction.click();
+  await expect(networkValue).toHaveText('Locale');
+
+  const preview = page.getByTestId('settings-preview-section');
+  const initialBackground = await preview.evaluate((element) => getComputedStyle(element).backgroundColor);
+  const oppositeTheme = viewCase.register === 'grafite' ? 'Chiaro' : 'Scuro';
+  await page.getByRole('button', { name: `Tema ${oppositeTheme}` }).click();
+  await expect(page.locator('html')).toHaveClass(viewCase.register === 'grafite' ? /light/ : /dark/);
+  const changedBackground = await preview.evaluate((element) => getComputedStyle(element).backgroundColor);
+  expect(changedBackground).not.toBe(initialBackground);
+  const originalTheme = viewCase.register === 'grafite' ? 'Scuro' : 'Chiaro';
+  await page.getByRole('button', { name: `Tema ${originalTheme}` }).click();
+  await expect(page.locator('html')).toHaveClass(viewCase.register === 'grafite' ? /dark/ : /light/);
+
+  await expectNoSemanticSideBorders(page, '[data-testid="settings-nav-sidebar"], [data-testid="settings-overview-section"]');
+  if (viewCase.viewport === 'narrow') {
+    const overflow = await page.evaluate(() => ({
+      document: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+      overview: document.querySelector<HTMLElement>('[data-testid="settings-overview-section"]')!.scrollWidth
+        - document.querySelector<HTMLElement>('[data-testid="settings-overview-section"]')!.clientWidth,
+    }));
+    expect(overflow.document).toBeLessThanOrEqual(1);
+    expect(overflow.overview).toBeLessThanOrEqual(1);
+  }
+
+  await page.screenshot({
+    path: `/tmp/lume-settings-${viewCase.register}-${viewCase.viewport}.png`,
+    animations: 'disabled',
+  });
+}
+
+for (const viewCase of CASES) {
+  test(`analytics e settings Lume ${viewCase.register} ${viewCase.viewport}`, async ({ page }) => {
+    await page.setViewportSize({ width: viewCase.width, height: viewCase.height });
+    await bootstrapUnlockedSession(page, process.env.E2E_PIN || '1234');
+    await createAnalyticsFixture(page);
+    await verifyAnalytics(page, viewCase);
+    await verifySettings(page, viewCase);
+  });
+}

--- a/scripts/check-lume-tokens.mjs
+++ b/scripts/check-lume-tokens.mjs
@@ -29,7 +29,6 @@ const FUNCTION_COLOR = /\b(?:rgba?|hsla?)\((?:[^()]*)\)/gi;
 // letterali legacy e le loro ripetizioni. La baseline deve combaciare
 // esattamente: una voce che copre meno letterali di quelli dichiarati fallisce.
 export const PALETTE_ALLOWLIST = [
-  {"path":"app/analytics/page.tsx","reason":"Debito storico su superficie non clinica: migrazione Lume da completare.","occurrences":12,"fingerprint":"ba3188e0b0a32411ade0d064e4450c195e7db3fdc9da223bd47b564e32a5d2c7"},
   {"path":"app/globals.css","reason":"Debito storico su superficie non clinica: migrazione Lume da completare.","occurrences":92,"fingerprint":"e34bda72190924e5384ab827ff61dde3f189c62b13c49278ba65ec7354bc27c0"},
   {"path":"app/mockups/scheda/page.tsx","reason":"Debito storico su superficie non clinica: migrazione Lume da completare.","occurrences":10,"fingerprint":"0b532d8493c010f98eba790c6cca032e0c871be43eccd5bb743d13b514892219"},
   {"path":"app/patients/[id]/edit/page.tsx","reason":"Debito storico su superficie clinica: migrazione Lume da completare.","occurrences":2,"fingerprint":"c465f2f78534069d2c5091795196bb3c49d4428b0c2aaa3a488617f7bc16d9a4"},
@@ -40,7 +39,6 @@ export const PALETTE_ALLOWLIST = [
   {"path":"app/settings/ai/funzioni/page.tsx","reason":"Debito storico su superficie non clinica: migrazione Lume da completare.","occurrences":68,"fingerprint":"ca52dc680f0af4a127bfa0277b6b6f9a72a6d476dfbd8f897f4f8d9a8591073e"},
   {"path":"app/settings/ai/modelli/page.tsx","reason":"Debito storico su superficie non clinica: migrazione Lume da completare.","occurrences":69,"fingerprint":"ed00586fa3d8c9858e20d6f1eb5e3d126b556977e243af3b0f2cda8a65507732"},
   {"path":"app/settings/ambulatories/page.tsx","reason":"Debito storico su superficie non clinica: migrazione Lume da completare.","occurrences":22,"fingerprint":"73aa6e8b77cfc4a94bc2e6036c314159d379c8d0903f4e8a25d6082413aa4981"},
-  {"path":"app/settings/page.tsx","reason":"Debito storico su superficie non clinica: migrazione Lume da completare.","occurrences":4,"fingerprint":"590af0d5ded8f9bcc8276244c5197ec75f05054c2f7c4da4dacd118a380183fc"},
   {"path":"app/settings/profilo/page.tsx","reason":"Debito storico su superficie non clinica: migrazione Lume da completare.","occurrences":1,"fingerprint":"ca27912f2918f354e5eb122bd8394691b50f6345542cca1a68402906cfa1408a"},
   {"path":"app/settings/repertori/page.tsx","reason":"Debito storico su superficie non clinica: migrazione Lume da completare.","occurrences":39,"fingerprint":"00346cb58c66877f3ea2784977640a34636c0a776c843221d36fb5af6626c123"},
   {"path":"app/settings/sviluppo/page.tsx","reason":"Debito storico su superficie non clinica: migrazione Lume da completare.","occurrences":1,"fingerprint":"ec8b1f7e92f6ad06696229de18e38a2fe2e006b9e87fef48103be7be871cadb9"},
@@ -67,7 +65,6 @@ export const PALETTE_ALLOWLIST = [
   {"path":"components/settings/drug-db-manager.tsx","reason":"Debito storico su superficie non clinica: migrazione Lume da completare.","occurrences":49,"fingerprint":"949082ec6de1587f0aed68b0ebbe25a952055f6aacb25e9274b0046e9b42956c"},
   {"path":"components/settings/exemption-db-manager.tsx","reason":"Debito storico su superficie non clinica: migrazione Lume da completare.","occurrences":43,"fingerprint":"abd7a2dd6152e443664f6882d5fe4cf1009a5509864ecff269c56e838807296e"},
   {"path":"components/settings/network-operating-mode-panel.tsx","reason":"Debito storico su superficie non clinica: migrazione Lume da completare.","occurrences":232,"fingerprint":"e7ad7ca7e5b04731b2e1024468b383c4d345082b21c3a8e01dc7c538e408d0d6"},
-  {"path":"components/settings/settings-nav-sidebar.tsx","reason":"Debito storico su superficie non clinica: migrazione Lume da completare.","occurrences":4,"fingerprint":"f265176cc32faa228150cb814a3a3a765850bb0615ba1d6d6d29761980478671"},
   {"path":"components/settings/settings-search.tsx","reason":"Debito storico su superficie non clinica: migrazione Lume da completare.","occurrences":1,"fingerprint":"30b66e71736711489accadafb52c1196a07501b44cbe3da7eac0cb30824ac0b6"},
   {"path":"components/settings/update-awareness-panel.tsx","reason":"Debito storico su superficie non clinica: migrazione Lume da completare.","occurrences":14,"fingerprint":"90bf901f29bf2adcbaa9e4642612d6af651bb684d5b8c0c70deee31f4f15b1fa"},
   {"path":"components/siss-patient-context-panel.tsx","reason":"Debito storico su superficie clinica: migrazione Lume da completare.","occurrences":4,"fingerprint":"dc1abc5bf03e92d3a95f90b3d3cea35b86b946c46faa6df73b3fa8e426f5db0b"},


### PR DESCRIPTION
Fixes #110
Refs #68

## Cosa contiene
Slice 6 dell'ordine di rifacimento: analytics e impostazioni alla grammatica del canone.

- Analytics: una domanda operativa in fuoco (scrollspy), filtri quieti su field, sezioni stratificate con section-label, tabella con overflow posseduto dal contenitore dichiarato (provato con `>` stretto e fixture che eccede), stati onesti; niente card-grid di metriche equivalenti.
- Impostazioni: `network.mode` reale e reversibile (PUT e ritorno), anteprima tema immediata, sidebar con `aria-current`/`aria-expanded` e ripristino del focus; nessun dato clinico nelle viste settings (test fixture-free strutturali, separati dai test analytics).
- Debito guardia: 1563 -> 1543 (clinico stabile); moduli CSS propri delle viste; workspace-shell non toccato.
- Nuovo e2e/lume-analytics-settings.spec.ts (8 test parametrizzati: 4 analytics con fixture, 4 settings fixture-free), giorno/grafite x wide/narrow.
- Matrice: Analytics e Impostazioni a `fedele` con riserva visuale manuale.

## Verifica eseguita
- Lane indipendente fresca: 2 P2 corretti (overflow tautologico, catture settings non fixture-free) + claim shard rimosso: la dipendenza d'ordine osservata era la race dei kill switch corretta in #108; conferma incrociata sul run unico completo: 53/53 senza retry.
- Gate su Node 24: guardia verde (189 sul rebase), typecheck, lint; analytics-settings x5 = 40/40 senza retry.
- Review estetica su 8 catture sintetiche.

🤖 Generated with [Claude Code](https://claude.com/claude-code)