### PR TITLE
feat(performance): aggiunge baseline route list

### DIFF
--- a/docs/analysis/2026-07-17-baseline-performance.json
+++ b/docs/analysis/2026-07-17-baseline-performance.json
@@ -1,0 +1,540 @@
+{
+  "schemaVersion": "mediflow.list_route_performance_baseline.v1",
+  "measuredAt": "2026-07-17T13:28:50.625Z",
+  "git": {
+    "head": "7d9ce0f51e5851a3850d99fbb220c92b0be910f0",
+    "base": "d09c949a35b1326a7528bd6d24f4bc96bceaf845"
+  },
+  "environment": {
+    "node": "v24.18.0",
+    "platform": "darwin 27.0.0 arm64",
+    "hardwareModel": "Mac16,5",
+    "cpu": "Apple M4 Max",
+    "logicalCores": 14,
+    "memoryGiB": 36
+  },
+  "protocol": {
+    "server": "Next.js standalone production server",
+    "host": "127.0.0.1",
+    "port": 3113,
+    "measuredRuns": 7,
+    "warmupRunsExcludedPerRoute": 1,
+    "statistic": "median",
+    "seed": "mediflow-performance-2026-07-17",
+    "rowsPerPatient": {
+      "entries": 8,
+      "observations": 6,
+      "documents": 2
+    },
+    "documentRouteUsesMetadataOnly": true,
+    "clientCost": "JSON.parse + AES-256-GCM Node simulation for every ENC field"
+  },
+  "volumes": [
+    {
+      "patients": 200,
+      "routes": {
+        "patients": {
+          "path": "/api/patients",
+          "warmupRunsExcluded": 1,
+          "samples": [
+            {
+              "routeMs": 5.493,
+              "clientDecryptMs": 11.6,
+              "payloadBytes": 229581,
+              "records": 200,
+              "encryptedFields": 1200
+            },
+            {
+              "routeMs": 5.227,
+              "clientDecryptMs": 12.426,
+              "payloadBytes": 229581,
+              "records": 200,
+              "encryptedFields": 1200
+            },
+            {
+              "routeMs": 5.163,
+              "clientDecryptMs": 12.598,
+              "payloadBytes": 229581,
+              "records": 200,
+              "encryptedFields": 1200
+            },
+            {
+              "routeMs": 4.835,
+              "clientDecryptMs": 12.762,
+              "payloadBytes": 229581,
+              "records": 200,
+              "encryptedFields": 1200
+            },
+            {
+              "routeMs": 4.534,
+              "clientDecryptMs": 10.408,
+              "payloadBytes": 229581,
+              "records": 200,
+              "encryptedFields": 1200
+            },
+            {
+              "routeMs": 5.075,
+              "clientDecryptMs": 10.218,
+              "payloadBytes": 229581,
+              "records": 200,
+              "encryptedFields": 1200
+            },
+            {
+              "routeMs": 4.739,
+              "clientDecryptMs": 10.874,
+              "payloadBytes": 229581,
+              "records": 200,
+              "encryptedFields": 1200
+            }
+          ],
+          "median": {
+            "routeMs": 5.075,
+            "clientDecryptMs": 11.6,
+            "payloadBytes": 229581,
+            "records": 200,
+            "encryptedFields": 1200
+          }
+        },
+        "entries": {
+          "path": "/api/entries",
+          "warmupRunsExcluded": 1,
+          "samples": [
+            {
+              "routeMs": 10.529,
+              "clientDecryptMs": 41.596,
+              "payloadBytes": 1018401,
+              "records": 1600,
+              "encryptedFields": 4800
+            },
+            {
+              "routeMs": 9.057,
+              "clientDecryptMs": 47.98,
+              "payloadBytes": 1018401,
+              "records": 1600,
+              "encryptedFields": 4800
+            },
+            {
+              "routeMs": 9.284,
+              "clientDecryptMs": 48.3,
+              "payloadBytes": 1018401,
+              "records": 1600,
+              "encryptedFields": 4800
+            },
+            {
+              "routeMs": 8.039,
+              "clientDecryptMs": 44.404,
+              "payloadBytes": 1018401,
+              "records": 1600,
+              "encryptedFields": 4800
+            },
+            {
+              "routeMs": 9.44,
+              "clientDecryptMs": 49.535,
+              "payloadBytes": 1018401,
+              "records": 1600,
+              "encryptedFields": 4800
+            },
+            {
+              "routeMs": 9.333,
+              "clientDecryptMs": 48.083,
+              "payloadBytes": 1018401,
+              "records": 1600,
+              "encryptedFields": 4800
+            },
+            {
+              "routeMs": 8.942,
+              "clientDecryptMs": 47.495,
+              "payloadBytes": 1018401,
+              "records": 1600,
+              "encryptedFields": 4800
+            }
+          ],
+          "median": {
+            "routeMs": 9.284,
+            "clientDecryptMs": 47.98,
+            "payloadBytes": 1018401,
+            "records": 1600,
+            "encryptedFields": 4800
+          }
+        },
+        "observations": {
+          "path": "/api/observations",
+          "warmupRunsExcluded": 1,
+          "samples": [
+            {
+              "routeMs": 7.984,
+              "clientDecryptMs": 12.681,
+              "payloadBytes": 694941,
+              "records": 1200,
+              "encryptedFields": 1200
+            },
+            {
+              "routeMs": 7.397,
+              "clientDecryptMs": 13.103,
+              "payloadBytes": 694941,
+              "records": 1200,
+              "encryptedFields": 1200
+            },
+            {
+              "routeMs": 8.431,
+              "clientDecryptMs": 12.741,
+              "payloadBytes": 694941,
+              "records": 1200,
+              "encryptedFields": 1200
+            },
+            {
+              "routeMs": 8.349,
+              "clientDecryptMs": 12.364,
+              "payloadBytes": 694941,
+              "records": 1200,
+              "encryptedFields": 1200
+            },
+            {
+              "routeMs": 8.833,
+              "clientDecryptMs": 11.517,
+              "payloadBytes": 694941,
+              "records": 1200,
+              "encryptedFields": 1200
+            },
+            {
+              "routeMs": 8.205,
+              "clientDecryptMs": 13.086,
+              "payloadBytes": 694941,
+              "records": 1200,
+              "encryptedFields": 1200
+            },
+            {
+              "routeMs": 7.142,
+              "clientDecryptMs": 12.98,
+              "payloadBytes": 694941,
+              "records": 1200,
+              "encryptedFields": 1200
+            }
+          ],
+          "median": {
+            "routeMs": 8.205,
+            "clientDecryptMs": 12.741,
+            "payloadBytes": 694941,
+            "records": 1200,
+            "encryptedFields": 1200
+          }
+        },
+        "documents": {
+          "path": "/api/attachments?metadataOnly=true",
+          "warmupRunsExcluded": 1,
+          "samples": [
+            {
+              "routeMs": 4.756,
+              "clientDecryptMs": 13.133,
+              "payloadBytes": 350283,
+              "records": 400,
+              "encryptedFields": 1600
+            },
+            {
+              "routeMs": 4.46,
+              "clientDecryptMs": 14.69,
+              "payloadBytes": 350283,
+              "records": 400,
+              "encryptedFields": 1600
+            },
+            {
+              "routeMs": 4.701,
+              "clientDecryptMs": 16.024,
+              "payloadBytes": 350283,
+              "records": 400,
+              "encryptedFields": 1600
+            },
+            {
+              "routeMs": 4.765,
+              "clientDecryptMs": 16.231,
+              "payloadBytes": 350283,
+              "records": 400,
+              "encryptedFields": 1600
+            },
+            {
+              "routeMs": 3.47,
+              "clientDecryptMs": 16.19,
+              "payloadBytes": 350283,
+              "records": 400,
+              "encryptedFields": 1600
+            },
+            {
+              "routeMs": 4.737,
+              "clientDecryptMs": 16.095,
+              "payloadBytes": 350283,
+              "records": 400,
+              "encryptedFields": 1600
+            },
+            {
+              "routeMs": 4.794,
+              "clientDecryptMs": 16.267,
+              "payloadBytes": 350283,
+              "records": 400,
+              "encryptedFields": 1600
+            }
+          ],
+          "median": {
+            "routeMs": 4.737,
+            "clientDecryptMs": 16.095,
+            "payloadBytes": 350283,
+            "records": 400,
+            "encryptedFields": 1600
+          }
+        }
+      }
+    },
+    {
+      "patients": 2000,
+      "routes": {
+        "patients": {
+          "path": "/api/patients",
+          "warmupRunsExcluded": 1,
+          "samples": [
+            {
+              "routeMs": 20.958,
+              "clientDecryptMs": 108.833,
+              "payloadBytes": 2299401,
+              "records": 2000,
+              "encryptedFields": 12000
+            },
+            {
+              "routeMs": 17.356,
+              "clientDecryptMs": 123.876,
+              "payloadBytes": 2299401,
+              "records": 2000,
+              "encryptedFields": 12000
+            },
+            {
+              "routeMs": 17.591,
+              "clientDecryptMs": 118.78,
+              "payloadBytes": 2299401,
+              "records": 2000,
+              "encryptedFields": 12000
+            },
+            {
+              "routeMs": 16.169,
+              "clientDecryptMs": 118.689,
+              "payloadBytes": 2299401,
+              "records": 2000,
+              "encryptedFields": 12000
+            },
+            {
+              "routeMs": 16.435,
+              "clientDecryptMs": 118.548,
+              "payloadBytes": 2299401,
+              "records": 2000,
+              "encryptedFields": 12000
+            },
+            {
+              "routeMs": 15.823,
+              "clientDecryptMs": 119.273,
+              "payloadBytes": 2299401,
+              "records": 2000,
+              "encryptedFields": 12000
+            },
+            {
+              "routeMs": 15.626,
+              "clientDecryptMs": 118.996,
+              "payloadBytes": 2299401,
+              "records": 2000,
+              "encryptedFields": 12000
+            }
+          ],
+          "median": {
+            "routeMs": 16.435,
+            "clientDecryptMs": 118.78,
+            "payloadBytes": 2299401,
+            "records": 2000,
+            "encryptedFields": 12000
+          }
+        },
+        "entries": {
+          "path": "/api/entries",
+          "warmupRunsExcluded": 1,
+          "samples": [
+            {
+              "routeMs": 67.823,
+              "clientDecryptMs": 437.562,
+              "payloadBytes": 10184001,
+              "records": 16000,
+              "encryptedFields": 48000
+            },
+            {
+              "routeMs": 71.283,
+              "clientDecryptMs": 481.323,
+              "payloadBytes": 10184001,
+              "records": 16000,
+              "encryptedFields": 48000
+            },
+            {
+              "routeMs": 70.075,
+              "clientDecryptMs": 435.388,
+              "payloadBytes": 10184001,
+              "records": 16000,
+              "encryptedFields": 48000
+            },
+            {
+              "routeMs": 66.328,
+              "clientDecryptMs": 434.44,
+              "payloadBytes": 10184001,
+              "records": 16000,
+              "encryptedFields": 48000
+            },
+            {
+              "routeMs": 65.37,
+              "clientDecryptMs": 431.195,
+              "payloadBytes": 10184001,
+              "records": 16000,
+              "encryptedFields": 48000
+            },
+            {
+              "routeMs": 65.547,
+              "clientDecryptMs": 436.633,
+              "payloadBytes": 10184001,
+              "records": 16000,
+              "encryptedFields": 48000
+            },
+            {
+              "routeMs": 65.164,
+              "clientDecryptMs": 457.862,
+              "payloadBytes": 10184001,
+              "records": 16000,
+              "encryptedFields": 48000
+            }
+          ],
+          "median": {
+            "routeMs": 66.328,
+            "clientDecryptMs": 436.633,
+            "payloadBytes": 10184001,
+            "records": 16000,
+            "encryptedFields": 48000
+          }
+        },
+        "observations": {
+          "path": "/api/observations",
+          "warmupRunsExcluded": 1,
+          "samples": [
+            {
+              "routeMs": 58.84,
+              "clientDecryptMs": 139.454,
+              "payloadBytes": 6949941,
+              "records": 12000,
+              "encryptedFields": 12000
+            },
+            {
+              "routeMs": 57.014,
+              "clientDecryptMs": 128.773,
+              "payloadBytes": 6949941,
+              "records": 12000,
+              "encryptedFields": 12000
+            },
+            {
+              "routeMs": 56.714,
+              "clientDecryptMs": 118.424,
+              "payloadBytes": 6949941,
+              "records": 12000,
+              "encryptedFields": 12000
+            },
+            {
+              "routeMs": 55.907,
+              "clientDecryptMs": 135.707,
+              "payloadBytes": 6949941,
+              "records": 12000,
+              "encryptedFields": 12000
+            },
+            {
+              "routeMs": 57.204,
+              "clientDecryptMs": 135.597,
+              "payloadBytes": 6949941,
+              "records": 12000,
+              "encryptedFields": 12000
+            },
+            {
+              "routeMs": 56.423,
+              "clientDecryptMs": 131.246,
+              "payloadBytes": 6949941,
+              "records": 12000,
+              "encryptedFields": 12000
+            },
+            {
+              "routeMs": 61.421,
+              "clientDecryptMs": 138.344,
+              "payloadBytes": 6949941,
+              "records": 12000,
+              "encryptedFields": 12000
+            }
+          ],
+          "median": {
+            "routeMs": 57.014,
+            "clientDecryptMs": 135.597,
+            "payloadBytes": 6949941,
+            "records": 12000,
+            "encryptedFields": 12000
+          }
+        },
+        "documents": {
+          "path": "/api/attachments?metadataOnly=true",
+          "warmupRunsExcluded": 1,
+          "samples": [
+            {
+              "routeMs": 26.221,
+              "clientDecryptMs": 161.109,
+              "payloadBytes": 3497020,
+              "records": 4000,
+              "encryptedFields": 16000
+            },
+            {
+              "routeMs": 21.596,
+              "clientDecryptMs": 161.275,
+              "payloadBytes": 3497020,
+              "records": 4000,
+              "encryptedFields": 16000
+            },
+            {
+              "routeMs": 21.195,
+              "clientDecryptMs": 160.692,
+              "payloadBytes": 3497020,
+              "records": 4000,
+              "encryptedFields": 16000
+            },
+            {
+              "routeMs": 21.087,
+              "clientDecryptMs": 160.828,
+              "payloadBytes": 3497020,
+              "records": 4000,
+              "encryptedFields": 16000
+            },
+            {
+              "routeMs": 21.523,
+              "clientDecryptMs": 172.426,
+              "payloadBytes": 3497020,
+              "records": 4000,
+              "encryptedFields": 16000
+            },
+            {
+              "routeMs": 23.945,
+              "clientDecryptMs": 183.648,
+              "payloadBytes": 3497020,
+              "records": 4000,
+              "encryptedFields": 16000
+            },
+            {
+              "routeMs": 21.142,
+              "clientDecryptMs": 183.524,
+              "payloadBytes": 3497020,
+              "records": 4000,
+              "encryptedFields": 16000
+            }
+          ],
+          "median": {
+            "routeMs": 21.523,
+            "clientDecryptMs": 161.275,
+            "payloadBytes": 3497020,
+            "records": 4000,
+            "encryptedFields": 16000
+          }
+        }
+      }
+    }
+  ]
+}

--- a/docs/analysis/2026-07-17-baseline-performance.md
+++ b/docs/analysis/2026-07-17-baseline-performance.md
@@ -1,0 +1,112 @@
+---
+summary: "Baseline riproducibile delle route list principali su 200 e 2000 pazienti sintetici."
+read_when:
+  - "Confrontando una modifica alle query list, agli allegati o alla decifratura client con numeri misurati."
+  - "Ripetendo il benchmark di patients, entries, observations e documents su una macchina locale."
+---
+
+# Baseline performance delle route list
+
+Data misura: 17 luglio 2026, 15:28 CEST  
+Base runtime: `origin/main` a `d09c949a35b1326a7528bd6d24f4bc96bceaf845`  
+Tooling benchmark: `7d9ce0f51e5851a3850d99fbb220c92b0be910f0`
+
+Questa baseline misura le route list reali su un database SQLite interamente
+sintetico. Non contiene dati derivati da pazienti reali. Il seed usa
+identificativi, timestamp, volumi e ciphertext deterministici; due rigenerazioni
+con la stessa configurazione hanno prodotto lo stesso hash del file SQLite.
+
+I campioni grezzi sono in
+[`2026-07-17-baseline-performance.json`](./2026-07-17-baseline-performance.json).
+
+## Ambiente
+
+| Voce | Valore |
+| --- | --- |
+| Hardware | Mac16,5, Apple M4 Max, 14 core logici |
+| Memoria | 36 GiB |
+| Sistema | Darwin 27.0.0, arm64 |
+| Node.js | v24.18.0 |
+| Server | build Next.js 16.2.6, server production standalone |
+| Trasporto | HTTP locale su `127.0.0.1:3113` |
+
+La build ha completato con i warning NFT gia presenti sul trace dinamico di
+`athena-mlx-runtime.ts`. Il benchmark non modifica quel codice e non usa la
+route MLX.
+
+## Protocollo
+
+- Volumi: 200 e 2000 pazienti.
+- Per paziente: 8 voci di diario, 6 osservazioni e 2 documenti.
+- Seed fisso: `mediflow-performance-2026-07-17`.
+- Route: `/api/patients`, `/api/entries`, `/api/observations` e
+  `/api/attachments?metadataOnly=true`.
+- La route documenti usa il nome runtime `attachments` e la modalita metadata:
+  il payload base64 del file non viene trasferito.
+- Per ogni route: 1 warmup escluso e 7 campioni misurati.
+- Statistica di confronto: mediana.
+- Tempo route: da prima della `fetch` al completamento della lettura del body.
+- Costo client simulato: `JSON.parse` del body e AES-256-GCM in Node per ogni
+  campo `ENC:`. Non include rendering React o lavoro del browser oltre questi
+  due passaggi.
+- Ogni volume usa un database rigenerato e un processo server nuovo.
+- La porta dedicata viene controllata prima di creare dati o avviare la build;
+  se e occupata, lo script fallisce chiuso.
+
+## Risultati
+
+| Pazienti | Route | Record | Payload | Route mediana | Parse e decifratura mediana |
+| ---: | --- | ---: | ---: | ---: | ---: |
+| 200 | patients | 200 | 229.581 B (0,219 MiB) | 5,075 ms | 11,600 ms |
+| 200 | entries | 1.600 | 1.018.401 B (0,971 MiB) | 9,284 ms | 47,980 ms |
+| 200 | observations | 1.200 | 694.941 B (0,663 MiB) | 8,205 ms | 12,741 ms |
+| 200 | documents | 400 | 350.283 B (0,334 MiB) | 4,737 ms | 16,095 ms |
+| 2.000 | patients | 2.000 | 2.299.401 B (2,193 MiB) | 16,435 ms | 118,780 ms |
+| 2.000 | entries | 16.000 | 10.184.001 B (9,712 MiB) | 66,328 ms | 436,633 ms |
+| 2.000 | observations | 12.000 | 6.949.941 B (6,628 MiB) | 57,014 ms | 135,597 ms |
+| 2.000 | documents | 4.000 | 3.497.020 B (3,335 MiB) | 21,523 ms | 161,275 ms |
+
+## Lettura dei numeri
+
+Il problema macroscopico osservato e il trasferimento delle liste globali non
+paginate. A 2000 pazienti, `entries` restituisce 16.000 record e 9,712 MiB in
+una singola risposta. Il tempo server e trasporto resta sotto 70 ms sulla
+macchina di prova, ma parsing e decifratura simulata raggiungono una mediana di
+436,633 ms. Anche `observations` e `documents` trasferiscono rispettivamente
+6,628 MiB e 3,335 MiB.
+
+La baseline non dimostra da sola quale ottimizzazione adottare. Fornisce il
+numero di confronto per future modifiche a paginazione, query pushdown,
+metadata degli allegati o strategia di decifratura. Questa lane non modifica
+codice di produzione.
+
+## Replica esatta
+
+Da un checkout pulito del commit del tooling indicato sopra:
+
+```bash
+export PATH="$HOME/.nvm/versions/node/v24.18.0/bin:$PATH"
+npm ci
+npm run benchmark:list-routes
+```
+
+Il comando:
+
+1. rigenera `tmp-perf/p200/medical.db` e `tmp-perf/p2000/medical.db`;
+2. crea una build production isolata in `.next-performance-baseline`;
+3. misura le quattro route su `127.0.0.1:3113`;
+4. sovrascrive il JSON grezzo accanto a questo documento;
+5. ripristina `tsconfig.json` e rimuove l'output build isolato.
+
+Per verificare soltanto il seed con un volume diverso:
+
+```bash
+npm run seed:performance-baseline -- \
+  --data-dir "$PWD/tmp-perf/manual-p500" \
+  --patients 500 \
+  --force
+```
+
+I tempi assoluti dipendono da hardware, carico macchina, versione del sistema e
+cache del filesystem. I confronti futuri devono usare lo stesso protocollo e
+riportare ambiente, commit e campioni grezzi.

--- a/docs/analysis/2026-07-17-baseline-performance.md
+++ b/docs/analysis/2026-07-17-baseline-performance.md
@@ -7,8 +7,10 @@ read_when:
 
 # Baseline performance delle route list
 
-Data misura: 17 luglio 2026, 15:28 CEST  
-Base runtime: `origin/main` a `d09c949a35b1326a7528bd6d24f4bc96bceaf845`  
+Data misura: 17 luglio 2026, 15:28 CEST
+
+Base runtime: `origin/main` a `d09c949a35b1326a7528bd6d24f4bc96bceaf845`
+
 Tooling benchmark: `7d9ce0f51e5851a3850d99fbb220c92b0be910f0`
 
 Questa baseline misura le route list reali su un database SQLite interamente

--- a/docs/markdown-index.md
+++ b/docs/markdown-index.md
@@ -11,7 +11,7 @@ read_when:
 > GitHub mostra in alto solo alcuni file speciali (`README`, `CONTRIBUTING`, `SECURITY`, ecc.).
 > Questo file elenca invece **tutti** i `.md` tracciati nella repository con una sintesi rapida d'uso.
 
-Ultimo aggiornamento: 2026-07-15
+Ultimo aggiornamento: 2026-07-17
 
 ## 📚 Come usare questo indice
 
@@ -85,6 +85,7 @@ Ultimo aggiornamento: 2026-07-15
 
 | File | Scopo | Quando consultarlo |
 | --- | --- | --- |
+| [docs/analysis/2026-07-17-baseline-performance.md](./analysis/2026-07-17-baseline-performance.md) | Baseline riproducibile delle route list principali su 200 e 2000 pazienti sintetici, con payload, tempi HTTP, costo di decifratura simulato e campioni grezzi JSON. | Quando si misura o confronta una modifica a query list, paginazione, allegati o decifratura client. |
 | [docs/analysis/2026-07-05-audit-esterno-v2-triage.md](./analysis/2026-07-05-audit-esterno-v2-triage.md) | Triage secondario dell'audit esterno V2, collegato a `WUL-470` e figlie `WUL-471`..`WUL-475`, con separazione tra obiezioni misframed e residui azionabili su PIN, FHIR, MDR, sync futuro e drift ADR. | Quando si rivedono le issue nate dall'audit esterno V2 o serve recuperare il razionale completo dietro il tracker Linear. |
 | [docs/analysis/2026-07-12-evoluzione-stack-intelligente-euristiche-scaffold-roadmap.md](./analysis/2026-07-12-evoluzione-stack-intelligente-euristiche-scaffold-roadmap.md) | Closeout secondario di provider scaffold, control-flow, attese locali e roadmap dello stack intelligente, riallineato alla verita di `main`. | Quando si pianifica una nuova slice AI/euristica o si verifica cosa resta oltre le PR #39, #41, #42 e #43. |
 | [docs/markdown-index.md](./markdown-index.md) | Indice completo markdown con sintesi. | Per navigazione completa e controllo copertura doc. |

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "test:db-bootstrap-concurrency": "node scripts/run-strip-types.mjs --test lib/db-server-bootstrap-concurrency.test.ts",
     "test:db-transaction-rollback": "node scripts/run-strip-types.mjs --test lib/db-transaction-rollback.test.ts",
     "test:schema-drift": "node scripts/run-strip-types.mjs --test scripts/check-schema-drift.test.ts",
+    "seed:performance-baseline": "node scripts/run-strip-types.mjs scripts/seed-performance-baseline.mjs",
     "benchmark:clinical-facts:observations": "node scripts/run-strip-types.mjs scripts/benchmark-observation-facts.mjs",
     "benchmark:icd-resolver": "node scripts/run-strip-types.mjs scripts/benchmark-icd-resolver.ts",
     "benchmark:aifa-resolver": "node scripts/run-strip-types.mjs scripts/benchmark-aifa-resolver.ts",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "test:db-transaction-rollback": "node scripts/run-strip-types.mjs --test lib/db-transaction-rollback.test.ts",
     "test:schema-drift": "node scripts/run-strip-types.mjs --test scripts/check-schema-drift.test.ts",
     "seed:performance-baseline": "node scripts/run-strip-types.mjs scripts/seed-performance-baseline.mjs",
+    "benchmark:list-routes": "node scripts/benchmark-list-routes.mjs",
     "benchmark:clinical-facts:observations": "node scripts/run-strip-types.mjs scripts/benchmark-observation-facts.mjs",
     "benchmark:icd-resolver": "node scripts/run-strip-types.mjs scripts/benchmark-icd-resolver.ts",
     "benchmark:aifa-resolver": "node scripts/run-strip-types.mjs scripts/benchmark-aifa-resolver.ts",

--- a/scripts/benchmark-list-routes.mjs
+++ b/scripts/benchmark-list-routes.mjs
@@ -1,0 +1,321 @@
+#!/usr/bin/env node
+/* @Codex */
+
+import { spawn } from 'node:child_process';
+import { createDecipheriv } from 'node:crypto';
+import fs from 'node:fs';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const RUN_STRIP_TYPES = path.join(ROOT_DIR, 'scripts/run-strip-types.mjs');
+const SEED_SCRIPT = path.join(ROOT_DIR, 'scripts/seed-performance-baseline.mjs');
+const FIXTURE_KEY = Buffer.from('83c4f061bfd9c7d14fe63f7566fc0aa980b16019d8d8ab4a8ef971b52508b6db', 'hex');
+const LOGIN = { username: 'performance-baseline', password: '314159' };
+const ROUTES = [
+  { id: 'patients', path: '/api/patients' },
+  { id: 'entries', path: '/api/entries' },
+  { id: 'observations', path: '/api/observations' },
+  { id: 'documents', path: '/api/attachments?metadataOnly=true' },
+];
+
+function parseArgs(argv) {
+  const args = {
+    volumes: [200, 2000],
+    runs: 7,
+    port: 3113,
+    out: path.join(ROOT_DIR, 'docs/analysis/2026-07-17-baseline-performance.json'),
+    dataRoot: path.join(ROOT_DIR, 'tmp-performance-baseline-data'),
+    distDir: '.next-performance-baseline',
+    skipBuild: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (flag === '--skip-build') args.skipBuild = true;
+    else if (flag === '--volumes') {
+      args.volumes = (value ?? '').split(',').map((item) => Number.parseInt(item, 10));
+      index += 1;
+    } else if (flag === '--runs') { args.runs = Number.parseInt(value ?? '', 10); index += 1; }
+    else if (flag === '--port') { args.port = Number.parseInt(value ?? '', 10); index += 1; }
+    else if (flag === '--out') { args.out = path.resolve(value ?? ''); index += 1; }
+    else if (flag === '--data-root') { args.dataRoot = path.resolve(value ?? ''); index += 1; }
+    else if (flag === '--dist-dir') { args.distDir = value ?? ''; index += 1; }
+    else throw new Error(`Argomento non riconosciuto: ${flag}`);
+  }
+  if (args.runs < 5 || !Number.isSafeInteger(args.runs)) throw new Error('--runs deve essere un intero >= 5');
+  if (args.port < 1024 || args.port > 65535) throw new Error('--port deve essere compresa tra 1024 e 65535');
+  if (!args.volumes.length || args.volumes.some((value) => !Number.isSafeInteger(value) || value < 1)) {
+    throw new Error('--volumes richiede interi positivi separati da virgola');
+  }
+  if (!args.distDir || path.isAbsolute(args.distDir) || args.distDir.includes('..')) {
+    throw new Error('--dist-dir deve essere un path relativo interno al repository');
+  }
+  return args;
+}
+
+function run(command, commandArgs, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, commandArgs, { cwd: ROOT_DIR, stdio: 'inherit', ...options });
+    child.once('error', reject);
+    child.once('exit', (code, signal) => code === 0
+      ? resolve()
+      : reject(new Error(`${path.basename(command)} ${commandArgs.join(' ')} terminato con ${signal ?? code}`)));
+  });
+}
+
+function isPortOccupied(port) {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection({ host: '127.0.0.1', port });
+    socket.setTimeout(1000);
+    socket.once('connect', () => { socket.destroy(); resolve(true); });
+    socket.once('timeout', () => { socket.destroy(); resolve(false); });
+    socket.once('error', (error) => {
+      socket.destroy();
+      if (error.code === 'ECONNREFUSED') resolve(false);
+      else reject(error);
+    });
+  });
+}
+
+async function seedVolume(dataDir, patients) {
+  await run(process.execPath, [
+    RUN_STRIP_TYPES,
+    SEED_SCRIPT,
+    '--data-dir', dataDir,
+    '--patients', String(patients),
+    '--entries-per-patient', '8',
+    '--observations-per-patient', '6',
+    '--documents-per-patient', '2',
+    '--force',
+  ]);
+}
+
+function startServer(args, dataDir) {
+  const standaloneRoot = path.join(ROOT_DIR, args.distDir, 'standalone');
+  return spawn(process.execPath, [path.join(standaloneRoot, 'server.js')], {
+    cwd: standaloneRoot,
+    env: {
+      ...process.env,
+      HOSTNAME: '127.0.0.1',
+      PORT: String(args.port),
+      MEDIFLOW_DATA_DIR: dataDir,
+      MEDIFLOW_NEXT_DIST_DIR: args.distDir,
+    },
+    stdio: ['ignore', 'inherit', 'inherit'],
+  });
+}
+
+async function waitForServer(server, baseUrl) {
+  const deadline = Date.now() + 60_000;
+  while (Date.now() < deadline) {
+    if (server.exitCode !== null) throw new Error(`Il server benchmark e terminato con ${server.exitCode}`);
+    try {
+      const response = await fetch(`${baseUrl}/api/auth/check`, { cache: 'no-store' });
+      if (response.ok) return;
+    } catch {
+      // Avvio non ancora completato.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+  throw new Error(`Timeout in attesa del server benchmark su ${baseUrl}`);
+}
+
+async function stopServer(server) {
+  if (!server || server.exitCode !== null) return;
+  server.kill('SIGTERM');
+  await Promise.race([
+    new Promise((resolve) => server.once('exit', resolve)),
+    new Promise((resolve) => setTimeout(resolve, 10_000)),
+  ]);
+  if (server.exitCode === null) server.kill('SIGKILL');
+}
+
+async function login(baseUrl) {
+  const response = await fetch(`${baseUrl}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(LOGIN),
+  });
+  if (!response.ok) throw new Error(`Login benchmark fallito: ${response.status} ${await response.text()}`);
+  const setCookie = response.headers.get('set-cookie');
+  if (!setCookie) throw new Error('Il login benchmark non ha restituito il cookie di sessione');
+  return setCookie.split(';', 1)[0];
+}
+
+function decryptFixture(value) {
+  const [, ivBase64, encryptedBase64] = value.split(':', 3);
+  const encrypted = Buffer.from(encryptedBase64, 'base64');
+  const decipher = createDecipheriv('aes-256-gcm', FIXTURE_KEY, Buffer.from(ivBase64, 'base64'));
+  decipher.setAuthTag(encrypted.subarray(-16));
+  return JSON.parse(Buffer.concat([decipher.update(encrypted.subarray(0, -16)), decipher.final()]).toString('utf8'));
+}
+
+function simulateClientDecryption(payload) {
+  let encryptedFields = 0;
+  const visit = (value) => {
+    if (typeof value === 'string' && value.startsWith('ENC:')) {
+      decryptFixture(value);
+      encryptedFields += 1;
+      return;
+    }
+    if (Array.isArray(value)) value.forEach(visit);
+    else if (value && typeof value === 'object') Object.values(value).forEach(visit);
+  };
+  visit(payload);
+  return encryptedFields;
+}
+
+async function measureRequest(baseUrl, route, cookie) {
+  const requestStartedAt = performance.now();
+  const response = await fetch(`${baseUrl}${route.path}`, {
+    headers: { Cookie: cookie, 'Cache-Control': 'no-cache' },
+    cache: 'no-store',
+  });
+  const body = Buffer.from(await response.arrayBuffer());
+  const routeMs = performance.now() - requestStartedAt;
+  if (!response.ok) throw new Error(`${route.path} ha risposto ${response.status}: ${body.toString('utf8')}`);
+
+  const decryptStartedAt = performance.now();
+  const payload = JSON.parse(body.toString('utf8'));
+  const encryptedFields = simulateClientDecryption(payload);
+  const clientDecryptMs = performance.now() - decryptStartedAt;
+  return {
+    routeMs: Number(routeMs.toFixed(3)),
+    clientDecryptMs: Number(clientDecryptMs.toFixed(3)),
+    payloadBytes: body.byteLength,
+    records: Array.isArray(payload) ? payload.length : 1,
+    encryptedFields,
+  };
+}
+
+function median(values) {
+  const sorted = [...values].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 ? sorted[middle] : (sorted[middle - 1] + sorted[middle]) / 2;
+}
+
+async function measureRoutes(baseUrl, cookie, runs) {
+  const routeResults = {};
+  for (const route of ROUTES) {
+    await measureRequest(baseUrl, route, cookie);
+    const samples = [];
+    for (let index = 0; index < runs; index += 1) samples.push(await measureRequest(baseUrl, route, cookie));
+    routeResults[route.id] = {
+      path: route.path,
+      warmupRunsExcluded: 1,
+      samples,
+      median: {
+        routeMs: Number(median(samples.map((sample) => sample.routeMs)).toFixed(3)),
+        clientDecryptMs: Number(median(samples.map((sample) => sample.clientDecryptMs)).toFixed(3)),
+        payloadBytes: median(samples.map((sample) => sample.payloadBytes)),
+        records: median(samples.map((sample) => sample.records)),
+        encryptedFields: median(samples.map((sample) => sample.encryptedFields)),
+      },
+    };
+  }
+  return routeResults;
+}
+
+function sysctl(name) {
+  try { return execFileSync('sysctl', ['-n', name], { encoding: 'utf8' }).trim(); }
+  catch { return null; }
+}
+
+function gitValue(args) {
+  return execFileSync('git', args, { cwd: ROOT_DIR, encoding: 'utf8' }).trim();
+}
+
+function printTable(volumes) {
+  console.log('\nVolume | Route | Record | Payload | Route mediana | Decifratura mediana');
+  console.log('--- | --- | ---: | ---: | ---: | ---:');
+  for (const volume of volumes) {
+    for (const [route, result] of Object.entries(volume.routes)) {
+      console.log(`${volume.patients} | ${route} | ${result.median.records} | ${result.median.payloadBytes} B | ${result.median.routeMs} ms | ${result.median.clientDecryptMs} ms`);
+    }
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (await isPortOccupied(args.port)) {
+    throw new Error(`porta dedicata ${args.port} gia occupata: nessun benchmark e stato avviato`);
+  }
+  const tsconfigPath = path.join(ROOT_DIR, 'tsconfig.json');
+  const originalTsconfig = fs.readFileSync(tsconfigPath, 'utf8');
+  try {
+  fs.mkdirSync(args.dataRoot, { recursive: true });
+  const seeded = [];
+  for (const patients of args.volumes) {
+    const dataDir = path.join(args.dataRoot, `patients-${patients}`);
+    await seedVolume(dataDir, patients);
+    seeded.push({ patients, dataDir });
+  }
+
+  if (!args.skipBuild) {
+    fs.rmSync(path.join(ROOT_DIR, args.distDir), { recursive: true, force: true });
+    await run(process.execPath, [path.join(ROOT_DIR, 'node_modules/next/dist/bin/next'), 'build'], {
+      env: { ...process.env, MEDIFLOW_DATA_DIR: seeded[0].dataDir, MEDIFLOW_NEXT_DIST_DIR: args.distDir },
+    });
+  }
+
+  const baseUrl = `http://127.0.0.1:${args.port}`;
+  const volumes = [];
+  for (const volume of seeded) {
+    let server;
+    try {
+      server = startServer(args, volume.dataDir);
+      await waitForServer(server, baseUrl);
+      const cookie = await login(baseUrl);
+      volumes.push({ patients: volume.patients, routes: await measureRoutes(baseUrl, cookie, args.runs) });
+    } finally {
+      await stopServer(server);
+    }
+  }
+
+  const report = {
+    schemaVersion: 'mediflow.list_route_performance_baseline.v1',
+    measuredAt: new Date().toISOString(),
+    git: { head: gitValue(['rev-parse', 'HEAD']), base: gitValue(['merge-base', 'HEAD', 'origin/main']) },
+    environment: {
+      node: process.version,
+      platform: `${os.platform()} ${os.release()} ${os.arch()}`,
+      hardwareModel: sysctl('hw.model'),
+      cpu: os.cpus()[0]?.model ?? null,
+      logicalCores: os.cpus().length,
+      memoryGiB: Number((os.totalmem() / 1024 ** 3).toFixed(1)),
+    },
+    protocol: {
+      server: 'Next.js standalone production server',
+      host: '127.0.0.1',
+      port: args.port,
+      measuredRuns: args.runs,
+      warmupRunsExcludedPerRoute: 1,
+      statistic: 'median',
+      seed: 'mediflow-performance-2026-07-17',
+      rowsPerPatient: { entries: 8, observations: 6, documents: 2 },
+      documentRouteUsesMetadataOnly: true,
+      clientCost: 'JSON.parse + AES-256-GCM Node simulation for every ENC field',
+    },
+    volumes,
+  };
+  fs.mkdirSync(path.dirname(args.out), { recursive: true });
+  fs.writeFileSync(args.out, `${JSON.stringify(report, null, 2)}\n`);
+  printTable(volumes);
+  console.log(`\nBaseline JSON scritta in ${args.out}`);
+  } finally {
+    if (fs.readFileSync(tsconfigPath, 'utf8') !== originalTsconfig) {
+      fs.writeFileSync(tsconfigPath, originalTsconfig);
+    }
+    if (!args.skipBuild) fs.rmSync(path.join(ROOT_DIR, args.distDir), { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(`[performance-baseline] ${error instanceof Error ? error.stack : String(error)}`);
+  process.exitCode = 1;
+});

--- a/scripts/benchmark-list-routes.mjs
+++ b/scripts/benchmark-list-routes.mjs
@@ -29,7 +29,8 @@ function parseArgs(argv) {
     runs: 7,
     port: 3113,
     out: path.join(ROOT_DIR, 'docs/analysis/2026-07-17-baseline-performance.json'),
-    dataRoot: path.join(ROOT_DIR, 'tmp-performance-baseline-data'),
+    // Keep the absolute path below the macOS Unix-socket limit used by PM2.
+    dataRoot: path.join(ROOT_DIR, 'tmp-perf'),
     distDir: '.next-performance-baseline',
     skipBuild: false,
   };
@@ -251,7 +252,7 @@ async function main() {
   fs.mkdirSync(args.dataRoot, { recursive: true });
   const seeded = [];
   for (const patients of args.volumes) {
-    const dataDir = path.join(args.dataRoot, `patients-${patients}`);
+    const dataDir = path.join(args.dataRoot, `p${patients}`);
     await seedVolume(dataDir, patients);
     seeded.push({ patients, dataDir });
   }

--- a/scripts/seed-performance-baseline.mjs
+++ b/scripts/seed-performance-baseline.mjs
@@ -1,0 +1,252 @@
+#!/usr/bin/env node
+/* @Codex */
+
+import { createCipheriv, createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Database from 'better-sqlite3';
+
+const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const FIXED_NOW_SECONDS = Date.parse('2026-07-17T08:00:00.000Z') / 1000;
+const FIXTURE_KEY = Buffer.from('83c4f061bfd9c7d14fe63f7566fc0aa980b16019d8d8ab4a8ef971b52508b6db', 'hex');
+const FIXTURE_USER = {
+  id: 'performance-baseline-admin',
+  username: 'performance-baseline',
+  pin: '314159',
+  passwordHash: '$2b$10$abcdefghijklmnopqrstuu/wvEjv3nXWHtp7iCXrVnXx9GxkRO/iG',
+};
+const DEFAULT_COUNTS = { entries: 8, observations: 6, documents: 2 };
+
+function parsePositiveInteger(value, flag) {
+  const parsed = Number.parseInt(value ?? '', 10);
+  if (!Number.isSafeInteger(parsed) || parsed < 0 || (flag === '--patients' && parsed < 1)) {
+    throw new Error(`${flag} richiede un intero ${flag === '--patients' ? 'positivo' : 'non negativo'}`);
+  }
+  return parsed;
+}
+
+function parseArgs(argv) {
+  const args = {
+    dataDir: null,
+    patients: 200,
+    entries: DEFAULT_COUNTS.entries,
+    observations: DEFAULT_COUNTS.observations,
+    documents: DEFAULT_COUNTS.documents,
+    force: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    if (flag === '--force') args.force = true;
+    else if (flag === '--data-dir') args.dataDir = path.resolve(argv[++index] ?? '');
+    else if (flag === '--patients') args.patients = parsePositiveInteger(argv[++index], flag);
+    else if (flag === '--entries-per-patient') args.entries = parsePositiveInteger(argv[++index], flag);
+    else if (flag === '--observations-per-patient') args.observations = parsePositiveInteger(argv[++index], flag);
+    else if (flag === '--documents-per-patient') args.documents = parsePositiveInteger(argv[++index], flag);
+    else throw new Error(`Argomento non riconosciuto: ${flag}`);
+  }
+  if (!args.dataDir) throw new Error('--data-dir e obbligatorio');
+  return args;
+}
+
+function applyMigrations(db) {
+  const migrationsDir = path.join(ROOT_DIR, 'drizzle');
+  const migrationFiles = fs.readdirSync(migrationsDir)
+    .filter((file) => file.endsWith('.sql'))
+    .sort((left, right) => left.localeCompare(right));
+  db.pragma('foreign_keys = OFF');
+  try {
+    for (const fileName of migrationFiles) {
+      const sql = fs.readFileSync(path.join(migrationsDir, fileName), 'utf8')
+        .replace(/^-->\s+statement-breakpoint\s*$/gm, '');
+      if (sql.trim()) db.exec(sql);
+    }
+  } finally {
+    db.pragma('foreign_keys = ON');
+  }
+}
+
+function encryptedFixture(value, identity) {
+  const iv = createHash('sha256').update(`mediflow-performance:${identity}`).digest().subarray(0, 12);
+  const cipher = createCipheriv('aes-256-gcm', FIXTURE_KEY, iv);
+  const encrypted = Buffer.concat([cipher.update(JSON.stringify(value), 'utf8'), cipher.final(), cipher.getAuthTag()]);
+  return `ENC:${iv.toString('base64')}:${encrypted.toString('base64')}`;
+}
+
+function patientId(index) {
+  return `perf-patient-${String(index).padStart(6, '0')}`;
+}
+
+function seedRows(db, counts) {
+  const insertPatient = db.prepare(`
+    INSERT INTO patients (
+      id, first_name, last_name, tax_code, birth_date, address, phone, caregiver,
+      diagnoses, notes, document_insights, is_adi, is_archived, version,
+      ambulatory_id, created_at, updated_at
+    ) VALUES (
+      @id, @firstName, @lastName, @taxCode, @birthDate, @address, @phone, @caregiver,
+      @diagnoses, @notes, @documentInsights, @isAdi, 0, 1,
+      'performance-baseline-ambulatory', @createdAt, @updatedAt
+    )
+  `);
+  const insertMembership = db.prepare(`
+    INSERT INTO patients_to_ambulatories (patient_id, ambulatory_id, assigned_at)
+    VALUES (?, 'performance-baseline-ambulatory', ?)
+  `);
+  const insertEntry = db.prepare(`
+    INSERT INTO entries (id, patient_id, type, title, date, content, metadata, version, created_at, updated_at)
+    VALUES (@id, @patientId, @type, @title, @date, @content, @metadata, 1, @createdAt, @updatedAt)
+  `);
+  const insertObservation = db.prepare(`
+    INSERT INTO observations (
+      id, patient_id, code_system, code, display, unit_system, unit_code, value,
+      notes, observed_at, source, version, created_at, updated_at
+    ) VALUES (
+      @id, @patientId, 'LOINC', @code, @display, 'UCUM', @unitCode, @value,
+      @notes, @observedAt, 'manual', 1, @createdAt, @updatedAt
+    )
+  `);
+  const insertDocument = db.prepare(`
+    INSERT INTO attachments (
+      id, patient_id, name, type, size, path, data, summary_snapshot,
+      parse_evidence_artifact_snapshot, ocr_queue_state, ocr_queue_updated_at, created_at
+    ) VALUES (
+      @id, @patientId, @name, 'application/pdf', 4096, @path, @data, @summary,
+      @evidence, 'ocr_done', @createdAt, @createdAt
+    )
+  `);
+
+  db.transaction(() => {
+    db.prepare(`
+      INSERT INTO users (
+        id, username, display_name, ambulatory_name, role, password_hash,
+        encrypted_master_key, salt, failed_login_attempts, created_at
+      ) VALUES (?, ?, 'Benchmark sintetico', 'Ambulatorio benchmark', 'admin', ?,
+        'fixture-wrapped-master-key-not-for-runtime', 'AAECAwQFBgcICQoLDA0ODw==', 0, ?)
+    `).run(FIXTURE_USER.id, FIXTURE_USER.username, FIXTURE_USER.passwordHash, FIXED_NOW_SECONDS);
+    db.prepare(`
+      INSERT INTO ambulatories (id, name, type, is_default, version, created_at)
+      VALUES ('performance-baseline-ambulatory', 'Ambulatorio benchmark sintetico', 'test', 1, 1, ?)
+    `).run(FIXED_NOW_SECONDS);
+
+    for (let patientIndex = 0; patientIndex < counts.patients; patientIndex += 1) {
+      const id = patientId(patientIndex);
+      const createdAt = FIXED_NOW_SECONDS - (counts.patients - patientIndex) * 3600;
+      const identity = `patient:${patientIndex}`;
+      insertPatient.run({
+        id,
+        firstName: `Persona${String(patientIndex).padStart(6, '0')}`,
+        lastName: `Sintetica${String(patientIndex % 97).padStart(2, '0')}`,
+        taxCode: `PERF${String(patientIndex).padStart(12, '0')}`,
+        birthDate: FIXED_NOW_SECONDS - (40 + (patientIndex % 55)) * 365 * 86400,
+        address: encryptedFixture(`Via sintetica ${patientIndex % 200}, Comune test`, `${identity}:address`),
+        phone: encryptedFixture(`+3902${String(patientIndex).padStart(8, '0')}`, `${identity}:phone`),
+        caregiver: encryptedFixture(`Contatto sintetico ${patientIndex}`, `${identity}:caregiver`),
+        diagnoses: encryptedFixture([{ code: 'TEST-01', description: 'Condizione cronica sintetica' }], `${identity}:diagnoses`),
+        notes: encryptedFixture('Nota clinica sintetica ripetibile per il benchmark locale.', `${identity}:notes`),
+        documentInsights: encryptedFixture([], `${identity}:document-insights`),
+        isAdi: patientIndex % 10 === 0 ? 1 : 0,
+        createdAt,
+        updatedAt: createdAt + 1800,
+      });
+      insertMembership.run(id, createdAt);
+
+      for (let index = 0; index < counts.entries; index += 1) {
+        const rowIdentity = `${identity}:entry:${index}`;
+        insertEntry.run({
+          id: `${id}-entry-${String(index).padStart(2, '0')}`,
+          patientId: id,
+          type: ['visit', 'phone', 'exam', 'note'][index % 4],
+          title: encryptedFixture(`Voce clinica sintetica ${index + 1}`, `${rowIdentity}:title`),
+          date: createdAt - index * 14 * 86400,
+          content: encryptedFixture('Contenuto clinico sintetico con lunghezza stabile per la baseline.', `${rowIdentity}:content`),
+          metadata: encryptedFixture({ source: 'performance-baseline', ordinal: index }, `${rowIdentity}:metadata`),
+          createdAt,
+          updatedAt: createdAt,
+        });
+      }
+
+      for (let index = 0; index < counts.observations; index += 1) {
+        const rowIdentity = `${identity}:observation:${index}`;
+        insertObservation.run({
+          id: `${id}-observation-${String(index).padStart(2, '0')}`,
+          patientId: id,
+          code: ['85354-9', '8867-4', '8310-5'][index % 3],
+          display: ['Pressione arteriosa', 'Frequenza cardiaca', 'Temperatura corporea'][index % 3],
+          unitCode: ['mm[Hg]', '/min', 'Cel'][index % 3],
+          value: String(70 + ((patientIndex + index) % 60)),
+          notes: encryptedFixture('Osservazione sintetica per misura ripetibile.', `${rowIdentity}:notes`),
+          observedAt: createdAt - index * 30 * 86400,
+          createdAt,
+          updatedAt: createdAt,
+        });
+      }
+
+      for (let index = 0; index < counts.documents; index += 1) {
+        const rowIdentity = `${identity}:document:${index}`;
+        insertDocument.run({
+          id: `${id}-document-${String(index).padStart(2, '0')}`,
+          patientId: id,
+          name: encryptedFixture(`referto-sintetico-${index + 1}.pdf`, `${rowIdentity}:name`),
+          path: encryptedFixture(`fixture/referto-sintetico-${index + 1}.pdf`, `${rowIdentity}:path`),
+          data: encryptedFixture('JVBERi0xLjQKJSBmaXh0dXJlIHNpbnRldGljYQo=', `${rowIdentity}:data`),
+          summary: encryptedFixture('Sintesi documentale sintetica, sempre soggetta a revisione.', `${rowIdentity}:summary`),
+          evidence: encryptedFixture({ schemaVersion: 1, facts: [], source: 'synthetic' }, `${rowIdentity}:evidence`),
+          createdAt: createdAt - index * 7 * 86400,
+        });
+      }
+    }
+  })();
+}
+
+export async function seedPerformanceDatabase(options) {
+  fs.mkdirSync(options.dataDir, { recursive: true });
+  const dbPath = path.join(options.dataDir, 'medical.db');
+  if (fs.existsSync(dbPath) && !options.force) {
+    throw new Error(`${dbPath} esiste gia: usa --force solo per sostituire questa fixture sintetica`);
+  }
+  fs.rmSync(dbPath, { force: true });
+  fs.rmSync(`${dbPath}-shm`, { force: true });
+  fs.rmSync(`${dbPath}-wal`, { force: true });
+
+  const bootstrapDb = new Database(dbPath);
+  try {
+    applyMigrations(bootstrapDb);
+  } finally {
+    bootstrapDb.close();
+  }
+
+  process.env.MEDIFLOW_DATA_DIR = options.dataDir;
+  await import('@/lib/db-server');
+
+  const db = new Database(dbPath);
+  try {
+    db.pragma('journal_mode = WAL');
+    db.pragma('synchronous = NORMAL');
+    seedRows(db, options);
+    db.exec('ANALYZE');
+    db.pragma('wal_checkpoint(TRUNCATE)');
+    return {
+      schemaVersion: 'mediflow.performance_seed.v1',
+      seed: 'mediflow-performance-2026-07-17',
+      dataDir: options.dataDir,
+      dbPath,
+      patients: options.patients,
+      entries: options.patients * options.entries,
+      observations: options.patients * options.observations,
+      documents: options.patients * options.documents,
+      login: { username: FIXTURE_USER.username, pin: FIXTURE_USER.pin },
+    };
+  } finally {
+    db.close();
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    console.log(JSON.stringify(await seedPerformanceDatabase(parseArgs(process.argv.slice(2))), null, 2));
+  } catch (error) {
+    console.error(`[performance-seed] ${error instanceof Error ? error.message : String(error)}`);
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Summary
- aggiunge seed sintetico deterministico per 200 e 2.000 pazienti
- misura route list, payload e costo di decifratura client con protocollo riproducibile
- registra baseline JSON e relazione Markdown, indicizzando la nuova documentazione

## Verification
- Node.js 24.18.0, ABI 137
- npm run typecheck
- npm run lint
- npm run test:unit
- npm run check:never-regress
- npm run check:claims
- npm run check:lume-tokens
- node scripts/benchmark-list-routes.mjs con output temporaneo controller
- git diff --check origin/main...HEAD

## Risk / Notes
- usa esclusivamente fixture sintetiche e una porta loopback dedicata
- i tempi sono una baseline hardware-specifica, non una soglia universale
- il benchmark controller ha verificato schema, volumi e HEAD del report senza modificare il worktree

## Ticket
- Nessun ticket esplicito associato