### PR TITLE
docs(readme): aggiorna snapshot utilizzo token

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,11 +204,11 @@ controllare: test reali e guard automatici decidono se una modifica regge.
 
 | Snapshot | Token di sessione | Ripartizione | Cache letta |
 | :-- | --: | :-- | --: |
-| **16 luglio 2026** | **24.637.335.544** | Codex 18.203.669.984 · Claude Code 6.433.665.560 | 23.315.122.538 (94,6%) |
+| **17 luglio 2026** | **22.185.794.772** | Codex 15.546.136.608 · Claude Code 6.639.658.164 | 20.917.134.403 (94,3%) |
 
-<img src="./screenshots/token-models.svg" alt="Snapshot 16 luglio 2026: 24,64 mld token di sessione, 18,20 mld in Codex e 6,43 mld in Claude Code; 23,32 mld da cache letta." width="720" loading="lazy"/>
+<img src="./screenshots/token-models.svg" alt="Snapshot 17 luglio 2026: 22,19 mld token di sessione, 15,55 mld in Codex e 6,64 mld in Claude Code; 20,92 mld da cache letta." width="720" loading="lazy"/>
 
-**Effort Codex:** xhigh 7.066.995.820 · non registrato / Ultra 6.530.502.439 · medium 1.980.214.345 · high 1.524.704.732 · non registrato 1.080.929.187 · low 20.323.461. Le sessioni senza effort registrato restano separate; possono includere fan-out `Ultra`, che non è un livello di ragionamento. Nei transcript Claude Code l'effort non è esposto in modo uniforme.
+**Effort Codex:** xhigh 7.350.462.593 · non registrato / Ultra 4.395.761.468 · high 2.000.320.556 · medium 1.774.948.743 · low 24.643.248 · non registrato 0. Le sessioni senza effort registrato restano separate; possono includere fan-out `Ultra`, che non è un livello di ragionamento. Nei transcript Claude Code l'effort non è esposto in modo uniforme.
 
 Il conteggio usa i contatori di tutti i log locali dei due ambienti e non è filtrato per repository. Per Codex somma i delta dei totali cumulativi e conserva modello, effort e cache letta; per Claude Code deduplica le richieste e somma input diretto, cache creata, cache letta e output. Sono pubblicati soltanto aggregati: nessun prompt, contenuto di sessione o percorso locale entra nel README o nell'SVG.
 

--- a/screenshots/token-models.svg
+++ b/screenshots/token-models.svg
@@ -1,36 +1,38 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 560" width="920" height="560" role="img" aria-label="Dashboard token di sessione del 16 luglio 2026: totale 24.637.335.544, Codex 18.203.669.984, Claude Code 6.433.665.560.">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 560" width="920" height="560" role="img" aria-label="Dashboard token di sessione del 17 luglio 2026: totale 22.185.794.772, Codex 15.546.136.608, Claude Code 6.639.658.164.">
   <style>
     .frame{fill:#fbfaf7;stroke:#d9d7d1}.panel,.track{fill:#f0eee8}.rule{stroke:#e1ded8}.ink{fill:#181a1d}.muted{fill:#66707b}.body{fill:#31363d}.guide{stroke:#c9c6bf}
   </style>
   <defs><clipPath id="codex-bar"><rect x="48" y="168" width="824" height="38" rx="19"/></clipPath><clipPath id="claude-bar"><rect x="48" y="334" width="824" height="38" rx="19"/></clipPath></defs>
   <rect class="frame" x="6" y="6" width="908" height="548" rx="28" stroke-width="1.5"/>
   <circle cx="56" cy="54" r="8" fill="#d8673f"/><text class="ink" x="76" y="62" font-family="Inter,-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="25" font-weight="720">Il lavoro assistito, modello per modello</text>
-  <text class="muted" x="48" y="92" font-family="Inter,-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="13">Token di sessione dai log locali · snapshot 16 luglio 2026</text>
-  <rect class="panel" x="692" y="40" width="180" height="64" rx="16"/><text class="muted" x="712" y="62" font-family="Inter,sans-serif" font-size="10.5" font-weight="700" letter-spacing="0.8">TOTALE MISURATO</text><text class="ink" x="712" y="90" font-family="Inter,sans-serif" font-size="23" font-weight="760">24,64 mld</text>
+  <text class="muted" x="48" y="92" font-family="Inter,-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="13">Token di sessione dai log locali · snapshot 17 luglio 2026</text>
+  <rect class="panel" x="692" y="40" width="180" height="64" rx="16"/><text class="muted" x="712" y="62" font-family="Inter,sans-serif" font-size="10.5" font-weight="700" letter-spacing="0.8">TOTALE MISURATO</text><text class="ink" x="712" y="90" font-family="Inter,sans-serif" font-size="23" font-weight="760">22,19 mld</text>
   <line class="rule" x1="48" y1="126" x2="872" y2="126"/>
-  <text class="ink" x="48" y="153" font-family="Inter,sans-serif" font-size="15" font-weight="700">Codex · OpenAI</text><text x="872" y="153" text-anchor="end" font-family="IBM Plex Mono,ui-monospace,monospace" font-size="15" font-weight="650" fill="#7568c7">18,20 mld</text>
-  <rect class="track" x="48" y="168" width="824" height="38" rx="19"/><g clip-path="url(#codex-bar)"><rect x="48.00" y="168" width="378.05" height="38" fill="#5f50b7"/>
-    <rect x="426.05" y="168" width="204.22" height="38" fill="#312968"/>
-    <rect x="630.27" y="168" width="160.69" height="38" fill="#4b3f97"/>
-    <rect x="790.97" y="168" width="51.26" height="38" fill="#d6d1ed"/>
-    <rect x="842.23" y="168" width="15.14" height="38" fill="#a99fdd"/>
-    <rect x="857.37" y="168" width="14.63" height="38" fill="#887bcf"/></g>
-  <g font-family="Inter,-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="10.5"><rect x="48" y="228" width="10" height="10" rx="3" fill="#5f50b7"/><text class="body" x="65" y="237">GPT-5.6 Sol · 8,35 mld</text>
-    <rect x="323" y="228" width="10" height="10" rx="3" fill="#312968"/><text class="body" x="340" y="237">GPT-5.5 · 4,51 mld</text>
+  <text class="ink" x="48" y="153" font-family="Inter,sans-serif" font-size="15" font-weight="700">Codex · OpenAI</text><text x="872" y="153" text-anchor="end" font-family="IBM Plex Mono,ui-monospace,monospace" font-size="15" font-weight="650" fill="#7568c7">15,55 mld</text>
+  <rect class="track" x="48" y="168" width="824" height="38" rx="19"/><g clip-path="url(#codex-bar)"><rect x="48.00" y="168" width="366.69" height="38" fill="#5f50b7"/>
+    <rect x="414.69" y="168" width="228.88" height="38" fill="#312968"/>
+    <rect x="643.57" y="168" width="188.16" height="38" fill="#4b3f97"/>
+    <rect x="831.74" y="168" width="19.10" height="38" fill="#887bcf"/>
+    <rect x="850.83" y="168" width="17.72" height="38" fill="#a99fdd"/>
+    <rect x="868.55" y="168" width="3.45" height="38" fill="#d6d1ed"/></g>
+  <g font-family="Inter,-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="10.5"><rect x="48" y="228" width="10" height="10" rx="3" fill="#5f50b7"/><text class="body" x="65" y="237">GPT-5.6 Sol · 6,92 mld</text>
+    <rect x="323" y="228" width="10" height="10" rx="3" fill="#312968"/><text class="body" x="340" y="237">GPT-5.5 · 4,32 mld</text>
     <rect x="597" y="228" width="10" height="10" rx="3" fill="#4b3f97"/><text class="body" x="614" y="237">GPT-5.4 + mini · 3,55 mld</text>
-    <rect x="48" y="253" width="10" height="10" rx="3" fill="#d6d1ed"/><text class="body" x="65" y="262">Altri e non registrati · 1,13 mld</text>
+    <rect x="48" y="253" width="10" height="10" rx="3" fill="#887bcf"/><text class="body" x="65" y="262">GPT-5.6 Terra · 0,36 mld</text>
     <rect x="323" y="253" width="10" height="10" rx="3" fill="#a99fdd"/><text class="body" x="340" y="262">GPT-5.3 Codex + Spark · 0,33 mld</text>
-    <rect x="597" y="253" width="10" height="10" rx="3" fill="#887bcf"/><text class="body" x="614" y="262">GPT-5.6 Terra · 0,32 mld</text></g>
+    <rect x="597" y="253" width="10" height="10" rx="3" fill="#d6d1ed"/><text class="body" x="614" y="262">Altri e non registrati · 0,07 mld</text></g>
   <line class="rule" x1="48" y1="292" x2="872" y2="292"/>
-  <text class="ink" x="48" y="319" font-family="Inter,sans-serif" font-size="15" font-weight="700">Claude Code · Anthropic</text><text x="872" y="319" text-anchor="end" font-family="IBM Plex Mono,ui-monospace,monospace" font-size="15" font-weight="650" fill="#cf7450">6,43 mld</text>
-  <rect class="track" x="48" y="334" width="824" height="38" rx="19"/><g clip-path="url(#claude-bar)"><rect x="48.00" y="334" width="196.17" height="38" fill="#a64e32"/>
-    <rect x="244.17" y="334" width="67.96" height="38" fill="#cf7450"/>
-    <rect x="312.14" y="334" width="21.89" height="38" fill="#e5a17e"/>
-    <rect x="334.02" y="334" width="5.20" height="38" fill="#f2c7b3"/></g><line class="guide" x1="872" y1="164" x2="872" y2="376" stroke-dasharray="3 5"/>
-  <g font-family="Inter,-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="10.5"><rect x="48" y="394" width="10" height="10" rx="3" fill="#a64e32"/><text class="body" x="65" y="403">Opus 4.8 · 4,33 mld</text>
-    <rect x="254" y="394" width="10" height="10" rx="3" fill="#cf7450"/><text class="body" x="271" y="403">Fable 5 · 1,50 mld</text>
-    <rect x="460" y="394" width="10" height="10" rx="3" fill="#e5a17e"/><text class="body" x="477" y="403">Sonnet 5 · 0,48 mld</text>
-    <rect x="666" y="394" width="10" height="10" rx="3" fill="#f2c7b3"/><text class="body" x="683" y="403">Haiku 4.5 storico · 0,11 mld</text></g>
-  <rect class="panel" x="48" y="446" width="824" height="72" rx="18"/><text class="muted" x="68" y="470" font-family="Inter,sans-serif" font-size="11" font-weight="700" letter-spacing="0.45">COME LEGGERE IL DATO</text><text class="ink" x="68" y="493" font-family="IBM Plex Mono,ui-monospace,monospace" font-size="13" font-weight="600">23,32 mld cache letta · 1,22 mld input non cached · 0,10 mld output</text><text class="muted" x="68" y="510" font-family="Inter,sans-serif" font-size="10.5">Volume di contesto elaborato, non righe di codice, costo o qualità.</text>
+  <text class="ink" x="48" y="319" font-family="Inter,sans-serif" font-size="15" font-weight="700">Claude Code · Anthropic</text><text x="872" y="319" text-anchor="end" font-family="IBM Plex Mono,ui-monospace,monospace" font-size="15" font-weight="650" fill="#cf7450">6,64 mld</text>
+  <rect class="track" x="48" y="334" width="824" height="38" rx="19"/><g clip-path="url(#claude-bar)"><rect x="48.00" y="334" width="230.38" height="38" fill="#a64e32"/>
+    <rect x="278.38" y="334" width="88.45" height="38" fill="#cf7450"/>
+    <rect x="366.83" y="334" width="27.00" height="38" fill="#e5a17e"/>
+    <rect x="393.83" y="334" width="6.09" height="38" fill="#f2c7b3"/>
+    <rect x="399.92" y="334" width="0.00" height="38" fill="#f4d5c7"/></g><line class="guide" x1="872" y1="164" x2="872" y2="376" stroke-dasharray="3 5"/>
+  <g font-family="Inter,-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="10.5"><rect x="48" y="394" width="10" height="10" rx="3" fill="#a64e32"/><text class="body" x="65" y="403">Opus 4.8 · 4,35 mld</text>
+    <rect x="254" y="394" width="10" height="10" rx="3" fill="#cf7450"/><text class="body" x="271" y="403">Fable 5 · 1,67 mld</text>
+    <rect x="460" y="394" width="10" height="10" rx="3" fill="#e5a17e"/><text class="body" x="477" y="403">Sonnet 5 · 0,51 mld</text>
+    <rect x="666" y="394" width="10" height="10" rx="3" fill="#f2c7b3"/><text class="body" x="683" y="403">Haiku 4.5 storico · 0,11 mld</text>
+    <rect x="48" y="419" width="10" height="10" rx="3" fill="#f4d5c7"/><text class="body" x="65" y="428">Altri modelli Claude · 0,00 mld</text></g>
+  <rect class="panel" x="48" y="446" width="824" height="72" rx="18"/><text class="muted" x="68" y="470" font-family="Inter,sans-serif" font-size="11" font-weight="700" letter-spacing="0.45">COME LEGGERE IL DATO</text><text class="ink" x="68" y="493" font-family="IBM Plex Mono,ui-monospace,monospace" font-size="13" font-weight="600">20,92 mld cache letta · 1,18 mld input non cached · 0,09 mld output</text><text class="muted" x="68" y="510" font-family="Inter,sans-serif" font-size="10.5">Volume di contesto elaborato, non righe di codice, costo o qualità.</text>
   <text class="muted" x="872" y="540" text-anchor="end" font-family="Inter,sans-serif" font-size="10">Stessa scala per entrambe le barre · valori arrotondati</text>
 </svg>


### PR DESCRIPTION
## Summary
- aggiorna la snapshot aggregata al 17 luglio 2026
- rigenera il grafico SVG per modello, provider, cache ed effort
- mantiene fuori dagli artefatti prompt, contenuti di sessione e percorsi locali

## Verification
- Node.js 24.18.0
- node --check scripts/build-usage-dashboard.mjs
- USAGE_DASHBOARD_CUTOFF=2026-07-17T23:59:59+02:00 node scripts/build-usage-dashboard.mjs
- git diff --check
- xmllint --noout screenshots/token-models.svg
- review del diff limitata a README.md e screenshots/token-models.svg

## Risk / Notes
- la snapshot aggrega tutti i log locali disponibili e non è filtrata per repository
- il totale può diminuire rispetto a una snapshot precedente se i log locali disponibili cambiano
- nessun dato clinico, prompt o percorso locale è pubblicato

## Ticket
- Nessun ticket esplicito associato