### PR TITLE
fix(backup): completa il roundtrip clinico totale

### DIFF
--- a/app/api/system/backup-restore/route.ts
+++ b/app/api/system/backup-restore/route.ts
@@ -29,127 +29,20 @@ import {
 import { isWebAdminSession } from '@/lib/security/server-auth-policy';
 import {
     BACKUP_COLLECTIONS,
-    type BackupArtifact,
-    type BackupCollectionName,
     type BackupDataset,
     serializeBackupArtifact,
 } from '@/lib/backup-artifact';
-import { derivePatientAmbulatoryLinks } from '@/lib/backup-patient-ambulatory-links';
+import { restoreBackupArtifact } from '@/lib/backup-restore-executor';
 import { runBackupRestorePreflight } from '@/lib/backup-restore-preflight';
 
 /* @Codex */
 export const dynamic = 'force-dynamic';
-
-const CLEAR_ORDER: BackupCollectionName[] = [
-    'messages',
-    'attachments',
-    'observations',
-    'prostheticPrescriptions',
-    'servicePrescriptionItems',
-    'servicePrescriptions',
-    'serviceCatalogEntries',
-    'sissHandoffs',
-    'checkups',
-    'therapies',
-    'entries',
-    'patients',
-    'conversations',
-    'drugs',
-    'exemptions',
-    'ambulatories',
-];
-
-const INSERT_ORDER: BackupCollectionName[] = [
-    'ambulatories',
-    'drugs',
-    'exemptions',
-    'conversations',
-    'patients',
-    'entries',
-    'therapies',
-    'checkups',
-    'observations',
-    'prostheticPrescriptions',
-    'servicePrescriptions',
-    'servicePrescriptionItems',
-    'serviceCatalogEntries',
-    'sissHandoffs',
-    'attachments',
-    'messages',
-];
-
-const TABLES = {
-    ambulatories,
-    attachments,
-    checkups,
-    conversations,
-    drugs,
-    entries,
-    exemptions,
-    messages,
-    observations,
-    patients,
-    patientsToAmbulatories,
-    prostheticPrescriptions,
-    serviceCatalogEntries,
-    servicePrescriptionItems,
-    servicePrescriptions,
-    sissHandoffs: sissHandoffEvents,
-    therapies,
-} as const;
-
-const TABLE_LOOKUP = {
-    ambulatories,
-    attachments,
-    checkups,
-    conversations,
-    drugs,
-    entries,
-    exemptions,
-    messages,
-    observations,
-    patients,
-    prostheticPrescriptions,
-    serviceCatalogEntries,
-    servicePrescriptionItems,
-    servicePrescriptions,
-    sissHandoffs: sissHandoffEvents,
-    therapies,
-} as const;
-
-type InsertRunner = Pick<typeof dbServer, 'insert'>;
-type InsertableTable =
-    | typeof ambulatories
-    | typeof attachments
-    | typeof checkups
-    | typeof conversations
-    | typeof drugs
-    | typeof entries
-    | typeof exemptions
-    | typeof messages
-    | typeof observations
-    | typeof patients
-    | typeof patientsToAmbulatories
-    | typeof prostheticPrescriptions
-    | typeof serviceCatalogEntries
-    | typeof servicePrescriptionItems
-    | typeof servicePrescriptions
-    | typeof sissHandoffEvents
-    | typeof therapies;
 
 type PatientAmbulatoryLinkRow = {
     patientId: string;
     ambulatoryId: string;
     assignedAt: Date | null;
 };
-
-function chunk<T>(items: T[], size: number): T[][] {
-    const chunks: T[][] = [];
-    for (let index = 0; index < items.length; index += size) {
-        chunks.push(items.slice(index, index + size));
-    }
-    return chunks;
-}
 
 /* @Codex */
 function sortBackupRows<T extends Record<string, unknown>>(rows: T[]): T[] {
@@ -253,64 +146,6 @@ function buildBackupDataset(): BackupDataset {
 }
 
 /* @Codex */
-const DATE_FIELDS = new Set([
-    'assignedAt',
-    'birthDate',
-    'collaudoAt',
-    'createdAt',
-    'date',
-    'endDate',
-    'importedAt',
-    'observedAt',
-    'ocrQueueUpdatedAt',
-    'performedAt',
-    'prescribedAt',
-    'reportReceivedAt',
-    'scheduledAt',
-    'startDate',
-    'startedAt',
-    'completedAt',
-    'deletedAt',
-    'updatedAt',
-]);
-
-function normalizeDateValue(value: unknown): unknown {
-    if (value === null || value === undefined || value === '') return null;
-    if (value instanceof Date) return value;
-    if (typeof value === 'number') {
-        // Scheduled-runner artifacts predating WUL-319 carry raw SQLite unix-seconds
-        // integers; unix-milliseconds for any contemporary date are >= 10^12.
-        const milliseconds = Number.isInteger(value) && Math.abs(value) < 1_000_000_000_000
-            ? value * 1000
-            : value;
-        const parsed = new Date(milliseconds);
-        return Number.isNaN(parsed.getTime()) ? value : parsed;
-    }
-    if (typeof value === 'string') {
-        const parsed = new Date(value);
-        return Number.isNaN(parsed.getTime()) ? value : parsed;
-    }
-    return value;
-}
-
-function normalizeInsertRow<T extends Record<string, unknown>>(row: T): T {
-    const normalized: Record<string, unknown> = { ...row };
-    for (const field of DATE_FIELDS) {
-        if (Object.prototype.hasOwnProperty.call(normalized, field)) {
-            normalized[field] = normalizeDateValue(normalized[field]);
-        }
-    }
-    return normalized as T;
-}
-
-function insertRows<T extends Record<string, unknown>>(runner: InsertRunner, table: InsertableTable, rows: T[]): void {
-    if (rows.length === 0) return;
-    for (const group of chunk(rows, 250)) {
-        runner.insert(table).values(group.map(normalizeInsertRow)).run();
-    }
-}
-
-/* @Codex */
 export async function GET() {
     const session = await requireSession();
     if (!session) return unauthorizedResponse();
@@ -347,97 +182,7 @@ export async function POST(request: Request) {
             );
         }
 
-        // @Codex better-sqlite3 transactions are synchronous; promise callbacks break restore execution.
-        dbServer.transaction((tx) => {
-            for (const collection of CLEAR_ORDER) {
-                tx.delete(TABLE_LOOKUP[collection]).run();
-            }
-            tx.delete(TABLES.patientsToAmbulatories).run();
-
-            for (const collection of INSERT_ORDER) {
-                if (collection === 'patients') {
-                    insertRows(tx, TABLE_LOOKUP.patients, artifact.payload.patients);
-                    continue;
-                }
-
-                if (collection === 'ambulatories') {
-                    insertRows(tx, TABLE_LOOKUP.ambulatories, artifact.payload.ambulatories);
-                    continue;
-                }
-
-                if (collection === 'drugs') {
-                    insertRows(tx, TABLE_LOOKUP.drugs, artifact.payload.drugs);
-                    continue;
-                }
-
-                if (collection === 'exemptions') {
-                    insertRows(tx, TABLE_LOOKUP.exemptions, artifact.payload.exemptions);
-                    continue;
-                }
-
-                if (collection === 'conversations') {
-                    insertRows(tx, TABLE_LOOKUP.conversations, artifact.payload.conversations);
-                    continue;
-                }
-
-                if (collection === 'entries') {
-                    insertRows(tx, TABLE_LOOKUP.entries, artifact.payload.entries);
-                    continue;
-                }
-
-                if (collection === 'therapies') {
-                    insertRows(tx, TABLE_LOOKUP.therapies, artifact.payload.therapies);
-                    continue;
-                }
-
-                if (collection === 'checkups') {
-                    insertRows(tx, TABLE_LOOKUP.checkups, artifact.payload.checkups);
-                    continue;
-                }
-
-                if (collection === 'observations') {
-                    insertRows(tx, TABLE_LOOKUP.observations, artifact.payload.observations);
-                    continue;
-                }
-
-                if (collection === 'prostheticPrescriptions') {
-                    insertRows(tx, TABLE_LOOKUP.prostheticPrescriptions, artifact.payload.prostheticPrescriptions);
-                    continue;
-                }
-
-                if (collection === 'servicePrescriptions') {
-                    insertRows(tx, TABLE_LOOKUP.servicePrescriptions, artifact.payload.servicePrescriptions);
-                    continue;
-                }
-
-                if (collection === 'servicePrescriptionItems') {
-                    insertRows(tx, TABLE_LOOKUP.servicePrescriptionItems, artifact.payload.servicePrescriptionItems);
-                    continue;
-                }
-
-                if (collection === 'serviceCatalogEntries') {
-                    insertRows(tx, TABLE_LOOKUP.serviceCatalogEntries, artifact.payload.serviceCatalogEntries);
-                    continue;
-                }
-
-                if (collection === 'sissHandoffs') {
-                    insertRows(tx, TABLE_LOOKUP.sissHandoffs, artifact.payload.sissHandoffs);
-                    continue;
-                }
-
-                if (collection === 'attachments') {
-                    insertRows(tx, TABLE_LOOKUP.attachments, artifact.payload.attachments);
-                    continue;
-                }
-
-                if (collection === 'messages') {
-                    insertRows(tx, TABLE_LOOKUP.messages, artifact.payload.messages);
-                }
-            }
-
-            const patientLinks = derivePatientAmbulatoryLinks(artifact.payload.patients);
-            insertRows(tx, TABLES.patientsToAmbulatories, patientLinks);
-        });
+        restoreBackupArtifact(artifact);
 
         return NextResponse.json({
             success: true,

--- a/app/api/system/backup-restore/route.ts
+++ b/app/api/system/backup-restore/route.ts
@@ -74,6 +74,31 @@ function buildAssignedAmbulatoryIds(
 }
 
 /* @Codex */
+function buildAssignedAmbulatoryMemberships(
+    patient: Record<string, unknown>,
+    rows: PatientAmbulatoryLinkRow[],
+): Array<{ ambulatoryId: string; assignedAt: Date | null }> {
+    const memberships = new Map<string, Date | null>();
+    for (const row of rows) {
+        if (row.patientId === patient.id && row.ambulatoryId.trim().length > 0) {
+            memberships.set(row.ambulatoryId, row.assignedAt);
+        }
+    }
+
+    if (typeof patient.ambulatoryId === 'string' && patient.ambulatoryId.trim().length > 0 && !memberships.has(patient.ambulatoryId)) {
+        const fallback = patient.updatedAt instanceof Date
+            ? patient.updatedAt
+            : patient.createdAt instanceof Date
+                ? patient.createdAt
+                : null;
+        memberships.set(patient.ambulatoryId, fallback);
+    }
+
+    return Array.from(memberships, ([ambulatoryId, assignedAt]) => ({ ambulatoryId, assignedAt }))
+        .sort((left, right) => left.ambulatoryId.localeCompare(right.ambulatoryId));
+}
+
+/* @Codex */
 function filterRowsByReference<T extends Record<string, unknown>>(
     rows: T[],
     foreignKey: 'patientId' | 'conversationId',
@@ -109,8 +134,9 @@ function buildBackupDataset(): BackupDataset {
     const normalizedPatientAmbulatoryRows = sortBackupRows(patientAmbulatoryRows);
     const enrichedPatients = patientsRows.map((patient) => {
         const assignedAmbulatoryIds = buildAssignedAmbulatoryIds(patient, normalizedPatientAmbulatoryRows);
+        const assignedAmbulatoryMemberships = buildAssignedAmbulatoryMemberships(patient, normalizedPatientAmbulatoryRows);
         return assignedAmbulatoryIds.length > 0
-            ? { ...patient, assignedAmbulatoryIds }
+            ? { ...patient, assignedAmbulatoryIds, assignedAmbulatoryMemberships }
             : patient;
     });
     const patientIds = new Set(

--- a/docs/adr/0016-backup-artifact-v1-manifest-preflight.md
+++ b/docs/adr/0016-backup-artifact-v1-manifest-preflight.md
@@ -56,6 +56,10 @@ Adottiamo l'opzione 3.
   `assignedAmbulatoryIds` per preservare le assegnazioni secondarie
   many-to-many senza introdurre una collezione top-level separata nel formato
   v1.
+- I nuovi artifact possono includere anche `assignedAmbulatoryMemberships`,
+  metadato opzionale e retrocompatibile che conserva `ambulatoryId` e
+  `assignedAt` di ogni relazione. Il restore usa questo valore quando presente
+  e mantiene `assignedAmbulatoryIds` come fallback per gli artifact precedenti.
 - Il restore esegue un preflight server-side: format, versione, scope,
   checksum, counts e riferimenti interni devono essere coerenti prima di
   cancellare o reinserire i record.

--- a/lib/backup-artifact.ts
+++ b/lib/backup-artifact.ts
@@ -151,6 +151,17 @@ function parseAssignedAmbulatoryIds(value: unknown): string[] {
     ));
 }
 
+/* @Codex */
+function parseAssignedAmbulatoryMemberships(value: unknown): Array<{ ambulatoryId: string; assignedAt: unknown }> {
+    if (!Array.isArray(value)) return [];
+    return value.flatMap((item) => {
+        if (!item || typeof item !== 'object') return [];
+        const membership = item as Record<string, unknown>;
+        if (typeof membership.ambulatoryId !== 'string' || membership.ambulatoryId.trim().length === 0) return [];
+        return [{ ambulatoryId: membership.ambulatoryId, assignedAt: membership.assignedAt }];
+    });
+}
+
 function assertCollectionReferences(payload: BackupDataset): void {
     const ambulatoryIds = new Set(
         payload.ambulatories
@@ -182,6 +193,28 @@ function assertCollectionReferences(payload: BackupDataset): void {
                     'invalid-manifest',
                     `Patient ${patient.id ?? '<unknown>'} references an unknown assigned ambulatory.`,
                 );
+            }
+        }
+
+        for (const membership of parseAssignedAmbulatoryMemberships(patient.assignedAmbulatoryMemberships)) {
+            if (!ambulatoryIds.has(membership.ambulatoryId)) {
+                throw new BackupArtifactError(
+                    'invalid-manifest',
+                    `Patient ${patient.id ?? '<unknown>'} references an unknown ambulatory membership.`,
+                );
+            }
+            if (membership.assignedAt !== null && membership.assignedAt !== undefined) {
+                const assignedAt = membership.assignedAt instanceof Date
+                    ? membership.assignedAt
+                    : new Date(typeof membership.assignedAt === 'number' && Math.abs(membership.assignedAt) < 1_000_000_000_000
+                        ? membership.assignedAt * 1000
+                        : membership.assignedAt as string | number);
+                if (Number.isNaN(assignedAt.getTime())) {
+                    throw new BackupArtifactError(
+                        'invalid-manifest',
+                        `Patient ${patient.id ?? '<unknown>'} has an invalid ambulatory membership timestamp.`,
+                    );
+                }
             }
         }
     }

--- a/lib/backup-patient-ambulatory-links.ts
+++ b/lib/backup-patient-ambulatory-links.ts
@@ -14,6 +14,30 @@ function parseAssignedAmbulatoryIds(value: unknown): string[] {
     ));
 }
 
+function parseAssignedAmbulatoryMemberships(value: unknown): Array<{ ambulatoryId: string; assignedAt: unknown }> {
+    if (!Array.isArray(value)) return [];
+    return value.flatMap((item) => {
+        if (!item || typeof item !== 'object') return [];
+        const membership = item as Record<string, unknown>;
+        if (typeof membership.ambulatoryId !== 'string' || membership.ambulatoryId.trim().length === 0) return [];
+        return [{ ambulatoryId: membership.ambulatoryId, assignedAt: membership.assignedAt }];
+    });
+}
+
+function parseAssignedAt(value: unknown, fallback: Date): Date {
+    if (value instanceof Date) return Number.isNaN(value.getTime()) ? fallback : value;
+    if (typeof value === 'number') {
+        const milliseconds = Number.isInteger(value) && Math.abs(value) < 1_000_000_000_000 ? value * 1000 : value;
+        const parsed = new Date(milliseconds);
+        return Number.isNaN(parsed.getTime()) ? fallback : parsed;
+    }
+    if (typeof value === 'string') {
+        const parsed = new Date(value);
+        return Number.isNaN(parsed.getTime()) ? fallback : parsed;
+    }
+    return fallback;
+}
+
 export function derivePatientAmbulatoryLinks(
     patientsPayload: BackupArtifact['payload']['patients'],
 ): RestoredPatientAmbulatoryLink[] {
@@ -27,15 +51,21 @@ export function derivePatientAmbulatoryLinks(
                 ? new Date(patient.createdAt)
                 : new Date();
         const normalizedAssignedAt = Number.isNaN(assignedAt.getTime()) ? new Date() : assignedAt;
-        const ambulatoryIds = new Set(parseAssignedAmbulatoryIds(patient.assignedAmbulatoryIds));
+        const memberships = new Map<string, Date>();
+        for (const membership of parseAssignedAmbulatoryMemberships(patient.assignedAmbulatoryMemberships)) {
+            memberships.set(membership.ambulatoryId, parseAssignedAt(membership.assignedAt, normalizedAssignedAt));
+        }
+        for (const ambulatoryId of parseAssignedAmbulatoryIds(patient.assignedAmbulatoryIds)) {
+            if (!memberships.has(ambulatoryId)) memberships.set(ambulatoryId, normalizedAssignedAt);
+        }
         if (typeof patient.ambulatoryId === 'string' && patient.ambulatoryId.trim().length > 0) {
-            ambulatoryIds.add(patient.ambulatoryId);
+            if (!memberships.has(patient.ambulatoryId)) memberships.set(patient.ambulatoryId, normalizedAssignedAt);
         }
 
-        return Array.from(ambulatoryIds).map((ambulatoryId) => ({
+        return Array.from(memberships, ([ambulatoryId, assignedAt]) => ({
             patientId,
             ambulatoryId,
-            assignedAt: normalizedAssignedAt,
+            assignedAt,
         }));
     });
 }

--- a/lib/backup-restore-executor.ts
+++ b/lib/backup-restore-executor.ts
@@ -1,0 +1,167 @@
+/* @Codex */
+import { dbServer } from './db-server';
+import {
+    ambulatories,
+    attachments,
+    checkups,
+    conversations,
+    drugs,
+    entries,
+    exemptions,
+    messages,
+    observations,
+    patients,
+    patientsToAmbulatories,
+    prostheticPrescriptions,
+    serviceCatalogEntries,
+    servicePrescriptionItems,
+    servicePrescriptions,
+    sissHandoffEvents,
+    therapies,
+} from './schema';
+import type { BackupArtifact, BackupCollectionName } from './backup-artifact';
+import { derivePatientAmbulatoryLinks } from './backup-patient-ambulatory-links';
+
+const CLEAR_ORDER: BackupCollectionName[] = [
+    'messages',
+    'attachments',
+    'observations',
+    'prostheticPrescriptions',
+    'servicePrescriptionItems',
+    'servicePrescriptions',
+    'serviceCatalogEntries',
+    'sissHandoffs',
+    'checkups',
+    'therapies',
+    'entries',
+    'patients',
+    'conversations',
+    'drugs',
+    'exemptions',
+    'ambulatories',
+];
+
+const INSERT_ORDER: BackupCollectionName[] = [
+    'ambulatories',
+    'drugs',
+    'exemptions',
+    'conversations',
+    'patients',
+    'entries',
+    'therapies',
+    'checkups',
+    'prostheticPrescriptions',
+    'servicePrescriptions',
+    'servicePrescriptionItems',
+    'observations',
+    'serviceCatalogEntries',
+    'sissHandoffs',
+    'attachments',
+    'messages',
+];
+
+const TABLE_LOOKUP = {
+    ambulatories,
+    attachments,
+    checkups,
+    conversations,
+    drugs,
+    entries,
+    exemptions,
+    messages,
+    observations,
+    patients,
+    prostheticPrescriptions,
+    serviceCatalogEntries,
+    servicePrescriptionItems,
+    servicePrescriptions,
+    sissHandoffs: sissHandoffEvents,
+    therapies,
+} as const;
+
+type InsertRunner = Pick<typeof dbServer, 'insert'>;
+type InsertableTable = (typeof TABLE_LOOKUP)[BackupCollectionName] | typeof patientsToAmbulatories;
+
+function chunk<T>(items: T[], size: number): T[][] {
+    const chunks: T[][] = [];
+    for (let index = 0; index < items.length; index += size) {
+        chunks.push(items.slice(index, index + size));
+    }
+    return chunks;
+}
+
+export const DATE_FIELDS = new Set([
+    'assignedAt',
+    'birthDate',
+    'collaudoAt',
+    'createdAt',
+    'date',
+    'endDate',
+    'importedAt',
+    'observedAt',
+    'ocrQueueUpdatedAt',
+    'performedAt',
+    'prescribedAt',
+    'reportReceivedAt',
+    'scheduledAt',
+    'startDate',
+    'startedAt',
+    'completedAt',
+    'deletedAt',
+    'updatedAt',
+]);
+
+function normalizeDateValue(value: unknown): unknown {
+    if (value === null || value === undefined || value === '') return null;
+    if (value instanceof Date) return value;
+    if (typeof value === 'number') {
+        // Scheduled-runner artifacts predating WUL-319 carry raw SQLite unix-seconds
+        // integers; unix-milliseconds for any contemporary date are >= 10^12.
+        const milliseconds = Number.isInteger(value) && Math.abs(value) < 1_000_000_000_000
+            ? value * 1000
+            : value;
+        const parsed = new Date(milliseconds);
+        return Number.isNaN(parsed.getTime()) ? value : parsed;
+    }
+    if (typeof value === 'string') {
+        const parsed = new Date(value);
+        return Number.isNaN(parsed.getTime()) ? value : parsed;
+    }
+    return value;
+}
+
+function normalizeInsertRow<T extends Record<string, unknown>>(row: T): T {
+    const normalized: Record<string, unknown> = { ...row };
+    for (const field of DATE_FIELDS) {
+        if (Object.prototype.hasOwnProperty.call(normalized, field)) {
+            normalized[field] = normalizeDateValue(normalized[field]);
+        }
+    }
+    return normalized as T;
+}
+
+function insertRows<T extends Record<string, unknown>>(
+    runner: InsertRunner,
+    table: InsertableTable,
+    rows: T[],
+): void {
+    if (rows.length === 0) return;
+    for (const group of chunk(rows, 250)) {
+        runner.insert(table).values(group.map(normalizeInsertRow)).run();
+    }
+}
+
+export function restoreBackupArtifact(artifact: BackupArtifact): void {
+    dbServer.transaction((tx) => {
+        for (const collection of CLEAR_ORDER) {
+            tx.delete(TABLE_LOOKUP[collection]).run();
+        }
+        tx.delete(patientsToAmbulatories).run();
+
+        for (const collection of INSERT_ORDER) {
+            insertRows(tx, TABLE_LOOKUP[collection], artifact.payload[collection]);
+        }
+
+        insertRows(tx, patientsToAmbulatories, derivePatientAmbulatoryLinks(artifact.payload.patients));
+    });
+}

--- a/lib/backup-total-roundtrip.test.ts
+++ b/lib/backup-total-roundtrip.test.ts
@@ -101,8 +101,8 @@ async function populateSyntheticClinicalFixture(db: Database.Database): Promise<
         monitoring_profile: 'synthetic-monitoring', is_adi: 1, is_archived: 1, deleted_at: now - 10, version: 7,
         ambulatory_id: 'w7-amb-primary', created_at: now, updated_at: now + 2,
     });
-    insertRow(db, MEMBERSHIP_TABLE, { patient_id: 'w7-patient', ambulatory_id: 'w7-amb-primary', assigned_at: now + 2 });
-    insertRow(db, MEMBERSHIP_TABLE, { patient_id: 'w7-patient', ambulatory_id: 'w7-amb-secondary', assigned_at: now + 2 });
+    insertRow(db, MEMBERSHIP_TABLE, { patient_id: 'w7-patient', ambulatory_id: 'w7-amb-primary', assigned_at: now + 24 });
+    insertRow(db, MEMBERSHIP_TABLE, { patient_id: 'w7-patient', ambulatory_id: 'w7-amb-secondary', assigned_at: now + 25 });
     insertRow(db, 'entries', {
         id: 'w7-entry', patient_id: 'w7-patient', type: 'note', date: now + 3,
         ...(await sealed('entries', ['title', 'content', 'metadata', 'attachments', 'deletion_reason'])),

--- a/lib/backup-total-roundtrip.test.ts
+++ b/lib/backup-total-roundtrip.test.ts
@@ -2,14 +2,15 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import Database from 'better-sqlite3';
 import { BACKUP_COLLECTIONS, parseBackupArtifact } from './backup-artifact';
 import { decryptData, encryptData, generateMasterKey } from './security/security';
 
-const ROOT = process.cwd();
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const LOADER = path.join(ROOT, 'scripts/register-strip-types-loader.mjs');
 const MEMBERSHIP_TABLE = 'patients_to_ambulatories';
 const NON_BACKUP_TABLES = new Set(['audit_events', 'settings', 'users']);
@@ -42,7 +43,7 @@ function runNode(args: string[], env: Record<string, string> = {}): string {
 }
 
 function prepareDatabase(dataDir: string): void {
-    runNode(['scripts/prepare-e2e-db.mjs'], { MEDIFLOW_E2E_DATA_DIR: dataDir });
+    runNode(['scripts/prepare-e2e-db.mjs'], { MEDIFLOW_DATA_DIR: dataDir });
     const dbServerUrl = pathToFileURL(path.join(ROOT, 'lib/db-server.ts')).href;
     runNode(
         ['--experimental-strip-types', '--import', LOADER, '--input-type=module', '--eval', `await import(${JSON.stringify(dbServerUrl)});`],
@@ -196,7 +197,7 @@ function restoreArtifact(targetDataDir: string, artifactPath: string): void {
 }
 
 test('scheduled backup restores every clinical table and preserves ciphertext bytes', async () => {
-    const workDir = fs.mkdtempSync(path.join(ROOT, 'tmp-backup-roundtrip-'));
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mediflow-backup-roundtrip-'));
     const sourceDataDir = path.join(workDir, 'source');
     const targetDataDir = path.join(workDir, 'target');
     const backupDir = path.join(workDir, 'backups');

--- a/lib/backup-total-roundtrip.test.ts
+++ b/lib/backup-total-roundtrip.test.ts
@@ -1,0 +1,280 @@
+/* @Codex */
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { pathToFileURL } from 'node:url';
+import Database from 'better-sqlite3';
+import { BACKUP_COLLECTIONS, parseBackupArtifact } from './backup-artifact';
+import { decryptData, encryptData, generateMasterKey } from './security/security';
+
+const ROOT = process.cwd();
+const LOADER = path.join(ROOT, 'scripts/register-strip-types-loader.mjs');
+const MEMBERSHIP_TABLE = 'patients_to_ambulatories';
+const NON_BACKUP_TABLES = new Set(['audit_events', 'settings', 'users']);
+const BACKUP_TABLES = {
+    ambulatories: 'ambulatories',
+    attachments: 'attachments',
+    conversations: 'conversations',
+    drugs: 'drugs',
+    entries: 'entries',
+    exemptions: 'exemptions',
+    messages: 'messages',
+    observations: 'observations',
+    patients: 'patients',
+    prostheticPrescriptions: 'prosthetic_prescriptions',
+    serviceCatalogEntries: 'service_catalog_entries',
+    servicePrescriptionItems: 'service_prescription_items',
+    servicePrescriptions: 'service_prescriptions',
+    sissHandoffs: 'siss_handoff_events',
+    checkups: 'checkups',
+    therapies: 'therapies',
+} as const;
+
+function runNode(args: string[], env: Record<string, string> = {}): string {
+    return execFileSync(process.execPath, args, {
+        cwd: ROOT,
+        env: { ...process.env, ...env },
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+}
+
+function prepareDatabase(dataDir: string): void {
+    runNode(['scripts/prepare-e2e-db.mjs'], { MEDIFLOW_E2E_DATA_DIR: dataDir });
+    const dbServerUrl = pathToFileURL(path.join(ROOT, 'lib/db-server.ts')).href;
+    runNode(
+        ['--experimental-strip-types', '--import', LOADER, '--input-type=module', '--eval', `await import(${JSON.stringify(dbServerUrl)});`],
+        { MEDIFLOW_DATA_DIR: dataDir },
+    );
+}
+
+function schemaTables(db: Database.Database): string[] {
+    return (db.prepare(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name",
+    ).all() as Array<{ name: string }>).map((row) => row.name);
+}
+
+function quoteIdentifier(value: string): string {
+    return `"${value.replaceAll('"', '""')}"`;
+}
+
+function clearBackupTables(db: Database.Database, tables: string[]): void {
+    db.pragma('foreign_keys = OFF');
+    try {
+        db.transaction(() => {
+            for (const table of tables) {
+                db.prepare(`DELETE FROM ${quoteIdentifier(table)}`).run();
+            }
+        })();
+    } finally {
+        db.pragma('foreign_keys = ON');
+    }
+}
+
+function insertRow(db: Database.Database, table: string, row: Record<string, unknown>): void {
+    const columns = Object.keys(row);
+    const placeholders = columns.map(() => '?').join(', ');
+    db.prepare(
+        `INSERT INTO ${quoteIdentifier(table)} (${columns.map(quoteIdentifier).join(', ')}) VALUES (${placeholders})`,
+    ).run(...Object.values(row));
+}
+
+async function populateSyntheticClinicalFixture(db: Database.Database): Promise<void> {
+    const masterKey = await generateMasterKey();
+    const seal = async (label: string): Promise<string> => {
+        const encrypted = await encryptData(`synthetic:${label}`, masterKey);
+        assert.equal(await decryptData(encrypted.data, encrypted.iv, masterKey), `synthetic:${label}`);
+        return `ENC:${encrypted.iv}:${encrypted.data}`;
+    };
+    const sealed = async (table: string, columns: string[]): Promise<Record<string, string>> => Object.fromEntries(
+        await Promise.all(columns.map(async (column) => [column, await seal(`${table}.${column}`)])),
+    );
+    const now = 1_783_000_000;
+
+    insertRow(db, 'ambulatories', { id: 'w7-amb-primary', name: 'Ambulatorio sintetico W7', address: 'fixture locale', type: 'synthetic', is_default: 1, version: 3, created_at: now });
+    insertRow(db, 'ambulatories', { id: 'w7-amb-secondary', name: 'Ambulatorio sintetico secondario', type: 'synthetic', is_default: 0, version: 2, created_at: now + 1 });
+    insertRow(db, 'patients', {
+        id: 'w7-patient', first_name: 'Synthetic', last_name: 'Roundtrip', tax_code: 'SYNTHETIC-W7', birth_date: -631_152_000,
+        ...(await sealed('patients', ['address', 'phone', 'caregiver', 'exemptions', 'diagnoses', 'status_reason', 'notes', 'ai_summary', 'document_insights', 'archive_reason', 'archive_note', 'deletion_reason'])),
+        monitoring_profile: 'synthetic-monitoring', is_adi: 1, is_archived: 1, deleted_at: now - 10, version: 7,
+        ambulatory_id: 'w7-amb-primary', created_at: now, updated_at: now + 2,
+    });
+    insertRow(db, MEMBERSHIP_TABLE, { patient_id: 'w7-patient', ambulatory_id: 'w7-amb-primary', assigned_at: now + 2 });
+    insertRow(db, MEMBERSHIP_TABLE, { patient_id: 'w7-patient', ambulatory_id: 'w7-amb-secondary', assigned_at: now + 2 });
+    insertRow(db, 'entries', {
+        id: 'w7-entry', patient_id: 'w7-patient', type: 'note', date: now + 3,
+        ...(await sealed('entries', ['title', 'content', 'metadata', 'attachments', 'deletion_reason'])),
+        setting: 'ambulatorio', deleted_at: now + 4, version: 4, created_at: now + 3, updated_at: now + 4,
+    });
+    insertRow(db, 'therapies', {
+        id: 'w7-therapy', patient_id: 'w7-patient', drug_name: 'Farmaco sintetico', dosage: '1 unita', status: 'stopped',
+        start_date: now + 5, end_date: now + 6, motivation: await seal('therapies.motivation'), deletion_reason: await seal('therapies.deletion_reason'),
+        active_principle: 'Principio sintetico', diagnosis_code: 'SYN', diagnosis_name: 'Condizione sintetica', aic: 'W7AIC', atc: 'W7ATC',
+        version: 5, created_at: now + 5, updated_at: now + 6, deleted_at: now + 6,
+    });
+    insertRow(db, 'prosthetic_prescriptions', {
+        id: 'w7-prosthetic', patient_id: 'w7-patient', prescribed_at: now + 7, status: 'completed', category: 'standard', iso_code: 'SYN-ISO',
+        ...(await sealed('prosthetic_prescriptions', ['description', 'measures', 'clinical_reason', 'regional_prescription_id', 'supplier', 'collaudo_outcome', 'document_refs', 'notes'])),
+        collaudo_at: now + 8, source: 'manual', version: 2, created_at: now + 7, updated_at: now + 8,
+    });
+    insertRow(db, 'service_catalog_entries', {
+        id: 'w7-catalog', code_system: 'urn:synthetic', service_code: 'W7-SERVICE', display_name: 'Prestazione sintetica', category: 'laboratory',
+        branch_code: 'SYN', synonyms: '["fixture"]', source: 'manual', version: 'w7', active: 1, imported_at: now + 9, updated_at: now + 9,
+    });
+    insertRow(db, 'service_prescriptions', {
+        id: 'w7-service', patient_id: 'w7-patient', prescribed_at: now + 10, status: 'performed', category: 'laboratory', priority: 'routine',
+        code_system: 'urn:synthetic', service_code: 'W7-SERVICE',
+        ...(await sealed('service_prescriptions', ['service_name', 'clinical_question', 'provider', 'outcome_note', 'request_reference', 'document_refs', 'notes'])),
+        scheduled_at: now + 11, performed_at: now + 12, report_received_at: now + 13, source: 'manual', version: 6, created_at: now + 10, updated_at: now + 13,
+    });
+    insertRow(db, 'service_prescription_items', {
+        id: 'w7-service-item', patient_id: 'w7-patient', prescription_id: 'w7-service', ordinal: 0, status: 'performed', category: 'laboratory',
+        code_system: 'urn:synthetic', service_code: 'W7-SERVICE', catalog_entry_id: 'w7-catalog', match_status: 'manual', confidence: '1',
+        ...(await sealed('service_prescription_items', ['service_name', 'catalog_display_name', 'evidence', 'notes', 'outcome_note'])),
+        scheduled_at: now + 11, performed_at: now + 12, report_received_at: now + 13, version: 3, created_at: now + 10, updated_at: now + 13,
+    });
+    insertRow(db, 'observations', {
+        id: 'w7-observation', patient_id: 'w7-patient', code_system: 'http://loinc.org', code: 'W7', display: 'Osservazione sintetica',
+        unit_system: 'http://unitsofmeasure.org', unit_code: '1', value: '42', notes: await seal('observations.notes'), observed_at: now + 14,
+        source: 'manual', ref_low: '1', ref_high: '100', ref_text: 'fixture', service_prescription_item_id: 'w7-service-item',
+        deletion_reason: await seal('observations.deletion_reason'), version: 4, created_at: now + 14, updated_at: now + 15, deleted_at: now + 15,
+    });
+    insertRow(db, 'checkups', {
+        id: 'w7-checkup', patient_id: 'w7-patient', date: now + 16, title: 'Controllo sintetico', notes: await seal('checkups.notes'),
+        status: 'done', source: 'manual', deletion_reason: await seal('checkups.deletion_reason'), version: 2, created_at: now + 16, updated_at: now + 17, deleted_at: now + 17,
+    });
+    insertRow(db, 'siss_handoff_events', {
+        id: 'w7-siss', patient_id: 'w7-patient', action: 'open', module_label: 'Modulo sintetico',
+        ...(await sealed('siss_handoff_events', ['reason', 'next_action', 'notes', 'correlation_id'])),
+        started_at: now + 18, completed_at: now + 19, outcome: 'completed', created_at: now + 18, updated_at: now + 19,
+    });
+    insertRow(db, 'attachments', {
+        id: 'w7-attachment', patient_id: 'w7-patient', type: 'application/pdf', size: 128,
+        ...(await sealed('attachments', ['name', 'path', 'data', 'summary_snapshot', 'parse_evidence_artifact_snapshot', 'ocr_replay_artifact_snapshot'])),
+        ocr_queue_state: 'ocr_done', ocr_queue_reason: 'synthetic', ocr_queue_updated_at: now + 20, created_at: now + 20,
+    });
+    insertRow(db, 'conversations', { id: 'w7-conversation', title: await seal('conversations.title'), updated_at: now + 21, is_archived: 1, is_deleted: 1, created_at: now + 21 });
+    insertRow(db, 'messages', {
+        id: 'w7-message', conversation_id: 'w7-conversation', role: 'user', content: await seal('messages.content'), metadata: await seal('messages.metadata'),
+        attachment_type: 'application/octet-stream', attachment_base64: await seal('messages.attachment_base64'), created_at: now + 22,
+    });
+    insertRow(db, 'drugs', { aic: 'W7AIC', name: 'Farmaco sintetico', active_principle: 'Principio sintetico', company: 'Azienda sintetica', packaging: 'Fixture', class: 'A', price: 123, atc: 'W7ATC' });
+    insertRow(db, 'exemptions', { code: 'W7EX', description: 'Esenzione sintetica', type: 'synthetic', source: 'fixture', start_date: now, end_date: now + 30, is_pharma: 1, is_specialist: 1, is_national: 0, updated_at: now + 23 });
+}
+
+function primaryKeyColumns(db: Database.Database, table: string): string[] {
+    return (db.prepare(`PRAGMA table_info(${quoteIdentifier(table)})`).all() as Array<{ name: string; pk: number }>)
+        .filter((column) => column.pk > 0)
+        .sort((left, right) => left.pk - right.pk)
+        .map((column) => column.name);
+}
+
+function readOrderedRows(db: Database.Database, table: string): Array<Record<string, unknown>> {
+    const primaryKey = primaryKeyColumns(db, table);
+    assert.ok(primaryKey.length > 0, `${table} must expose a primary key for record-by-record comparison`);
+    return db.prepare(
+        `SELECT * FROM ${quoteIdentifier(table)} ORDER BY ${primaryKey.map(quoteIdentifier).join(', ')}`,
+    ).all() as Array<Record<string, unknown>>;
+}
+
+function restoreArtifact(targetDataDir: string, artifactPath: string): void {
+    const artifactUrl = pathToFileURL(path.join(ROOT, 'lib/backup-artifact.ts')).href;
+    const executorUrl = pathToFileURL(path.join(ROOT, 'lib/backup-restore-executor.ts')).href;
+    const source = `
+        import fs from 'node:fs';
+        import { parseBackupArtifact } from ${JSON.stringify(artifactUrl)};
+        import { restoreBackupArtifact } from ${JSON.stringify(executorUrl)};
+        const artifact = await parseBackupArtifact(JSON.parse(fs.readFileSync(process.env.W7_ARTIFACT_PATH, 'utf8')));
+        restoreBackupArtifact(artifact);
+    `;
+    runNode(
+        ['--experimental-strip-types', '--import', LOADER, '--input-type=module', '--eval', source],
+        { MEDIFLOW_DATA_DIR: targetDataDir, W7_ARTIFACT_PATH: artifactPath },
+    );
+}
+
+test('scheduled backup restores every clinical table and preserves ciphertext bytes', async () => {
+    const workDir = fs.mkdtempSync(path.join(ROOT, 'tmp-backup-roundtrip-'));
+    const sourceDataDir = path.join(workDir, 'source');
+    const targetDataDir = path.join(workDir, 'target');
+    const backupDir = path.join(workDir, 'backups');
+
+    try {
+        prepareDatabase(sourceDataDir);
+        prepareDatabase(targetDataDir);
+        fs.mkdirSync(backupDir, { recursive: true });
+
+        const sourceDb = new Database(path.join(sourceDataDir, 'medical.db'));
+        const targetDb = new Database(path.join(targetDataDir, 'medical.db'));
+        try {
+            const actualSchemaTables = schemaTables(sourceDb);
+            const expectedSchemaTables = [
+                ...NON_BACKUP_TABLES,
+                ...Object.values(BACKUP_TABLES),
+                MEMBERSHIP_TABLE,
+            ].sort();
+            assert.deepEqual(actualSchemaTables, expectedSchemaTables, 'new schema tables must be backed up or explicitly classified');
+            assert.deepEqual([...Object.keys(BACKUP_TABLES)].sort(), [...BACKUP_COLLECTIONS].sort());
+
+            const clinicalTables = actualSchemaTables.filter((table) => !NON_BACKUP_TABLES.has(table));
+            clearBackupTables(sourceDb, clinicalTables);
+            clearBackupTables(targetDb, clinicalTables);
+            await populateSyntheticClinicalFixture(sourceDb);
+
+            for (const table of clinicalTables) {
+                assert.equal(readOrderedRows(targetDb, table).length, 0, `target ${table} must be virgin before restore`);
+                assert.ok(readOrderedRows(sourceDb, table).length > 0, `source ${table} must contain a synthetic fixture`);
+            }
+
+            const runner = JSON.parse(runNode(['scripts/run-scheduled-backup.mjs'], {
+                MEDIFLOW_DATA_DIR: sourceDataDir,
+                MEDIFLOW_BACKUP_DEST_DIR: backupDir,
+                MEDIFLOW_BACKUP_FORCE: '1',
+            })) as { ok: boolean; artifactPath?: string; message?: string };
+            assert.equal(runner.ok, true, runner.message);
+            assert.ok(runner.artifactPath);
+
+            const schedulerRow = sourceDb.prepare("SELECT value FROM settings WHERE key = 'backupScheduler'").get() as { value: string };
+            const schedulerState = JSON.parse(schedulerRow.value);
+            assert.equal(schedulerState.run.lastRunStatus, 'success');
+            assert.equal(schedulerState.run.lastArtifactPath, runner.artifactPath);
+            assert.equal(typeof schedulerState.run.lastRunAt, 'string');
+            assert.equal(schedulerState.run.lastRetentionMode, 'auto');
+
+            const artifact = await parseBackupArtifact(JSON.parse(fs.readFileSync(runner.artifactPath, 'utf8')));
+            for (const [collection, table] of Object.entries(BACKUP_TABLES)) {
+                assert.equal(artifact.manifest.recordCounts[collection as keyof typeof BACKUP_TABLES], readOrderedRows(sourceDb, table).length);
+            }
+
+            restoreArtifact(targetDataDir, runner.artifactPath);
+
+            let encryptedFieldCount = 0;
+            for (const table of clinicalTables) {
+                const sourceRows = readOrderedRows(sourceDb, table);
+                const targetRows = readOrderedRows(targetDb, table);
+                assert.equal(targetRows.length, sourceRows.length, `${table} count must survive restore`);
+                assert.deepEqual(targetRows, sourceRows, `${table} rows must survive restore byte-for-byte`);
+
+                for (let rowIndex = 0; rowIndex < sourceRows.length; rowIndex += 1) {
+                    for (const [column, value] of Object.entries(sourceRows[rowIndex])) {
+                        if (typeof value !== 'string' || !value.startsWith('ENC:')) continue;
+                        encryptedFieldCount += 1;
+                        assert.equal(
+                            Buffer.from(String(targetRows[rowIndex][column])).compare(Buffer.from(value)),
+                            0,
+                            `${table}.${column} ciphertext must be byte-identical`,
+                        );
+                    }
+                }
+            }
+            assert.ok(encryptedFieldCount >= 50, 'fixture must exercise the complete encrypted clinical surface');
+        } finally {
+            sourceDb.close();
+            targetDb.close();
+        }
+    } finally {
+        fs.rmSync(workDir, { recursive: true, force: true });
+    }
+});

--- a/lib/scheduled-backup-membership-roundtrip.test.ts
+++ b/lib/scheduled-backup-membership-roundtrip.test.ts
@@ -36,9 +36,9 @@ test('scheduled backup roundtrip restores both ambulatory memberships for one pa
             sourceDb.prepare('INSERT INTO patients (id, first_name, last_name, tax_code, ambulatory_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)')
                 .run('roundtrip-patient', 'Synthetic', 'Membership', 'SYNTHETIC-ONLY', primaryAmbulatoryId, 1_700_000_000, 1_700_000_000);
             sourceDb.prepare('INSERT INTO patients_to_ambulatories (patient_id, ambulatory_id, assigned_at) VALUES (?, ?, ?)')
-                .run('roundtrip-patient', primaryAmbulatoryId, 1_700_000_000);
+                .run('roundtrip-patient', primaryAmbulatoryId, 1_700_000_100);
             sourceDb.prepare('INSERT INTO patients_to_ambulatories (patient_id, ambulatory_id, assigned_at) VALUES (?, ?, ?)')
-                .run('roundtrip-patient', 'roundtrip-amb-secondary', 1_700_000_000);
+                .run('roundtrip-patient', 'roundtrip-amb-secondary', 1_700_000_200);
         } finally {
             sourceDb.close();
         }
@@ -60,6 +60,10 @@ test('scheduled backup roundtrip restores both ambulatory memberships for one pa
         const artifact = await parseBackupArtifact(JSON.parse(fs.readFileSync(runnerResult.artifactPath, 'utf8')));
         const patient = artifact.payload.patients.find((row) => row.id === 'roundtrip-patient');
         assert.deepEqual(patient?.assignedAmbulatoryIds, [primaryAmbulatoryId, 'roundtrip-amb-secondary'].sort());
+        assert.deepEqual(patient?.assignedAmbulatoryMemberships, [
+            { ambulatoryId: primaryAmbulatoryId, assignedAt: '2023-11-14T22:15:00.000Z' },
+            { ambulatoryId: 'roundtrip-amb-secondary', assignedAt: '2023-11-14T22:16:40.000Z' },
+        ].sort((left, right) => left.ambulatoryId.localeCompare(right.ambulatoryId)));
 
         const targetDb = new Database(path.join(targetDataDir, 'medical.db'));
         try {
@@ -93,8 +97,11 @@ test('scheduled backup roundtrip restores both ambulatory memberships for one pa
                 }
             })();
 
-            const restored = targetDb.prepare('SELECT ambulatory_id FROM patients_to_ambulatories WHERE patient_id = ? ORDER BY ambulatory_id').all('roundtrip-patient') as Array<{ ambulatory_id: string }>;
-            assert.deepEqual(restored.map((row) => row.ambulatory_id), [primaryAmbulatoryId, 'roundtrip-amb-secondary'].sort());
+            const restored = targetDb.prepare('SELECT ambulatory_id, assigned_at FROM patients_to_ambulatories WHERE patient_id = ? ORDER BY ambulatory_id').all('roundtrip-patient') as Array<{ ambulatory_id: string; assigned_at: number }>;
+            assert.deepEqual(restored, [
+                { ambulatory_id: primaryAmbulatoryId, assigned_at: 1_700_000_100 },
+                { ambulatory_id: 'roundtrip-amb-secondary', assigned_at: 1_700_000_200 },
+            ].sort((left, right) => left.ambulatory_id.localeCompare(right.ambulatory_id)));
         } finally {
             targetDb.close();
         }

--- a/lib/scheduled-backup-membership-roundtrip.test.ts
+++ b/lib/scheduled-backup-membership-roundtrip.test.ts
@@ -5,12 +5,14 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
+import { fileURLToPath } from 'node:url';
 import Database from 'better-sqlite3';
 import { parseBackupArtifact } from './backup-artifact';
 import { derivePatientAmbulatoryLinks } from './backup-patient-ambulatory-links';
 
+const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
 test('scheduled backup roundtrip restores both ambulatory memberships for one patient', async () => {
-    const root = process.cwd();
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mediflow-scheduled-membership-'));
     const sourceDataDir = path.join(workDir, 'source');
     const targetDataDir = path.join(workDir, 'target');
@@ -19,8 +21,8 @@ test('scheduled backup roundtrip restores both ambulatory memberships for one pa
     try {
         for (const dataDir of [sourceDataDir, targetDataDir]) {
             execFileSync(process.execPath, ['scripts/prepare-e2e-db.mjs'], {
-                cwd: root,
-                env: { ...process.env, MEDIFLOW_E2E_DATA_DIR: dataDir },
+                cwd: ROOT_DIR,
+                env: { ...process.env, MEDIFLOW_DATA_DIR: dataDir },
                 stdio: 'pipe',
             });
         }
@@ -43,7 +45,7 @@ test('scheduled backup roundtrip restores both ambulatory memberships for one pa
 
         fs.mkdirSync(backupDir, { recursive: true });
         const runnerResult = JSON.parse(execFileSync(process.execPath, ['scripts/run-scheduled-backup.mjs'], {
-            cwd: root,
+            cwd: ROOT_DIR,
             env: {
                 ...process.env,
                 MEDIFLOW_DATA_DIR: sourceDataDir,

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "test:ocr-service:date": "node scripts/run-strip-types.mjs --test lib/domain/documents/ocr-service-date.test.ts",
     "test:ollama-pull-stream": "node scripts/run-strip-types.mjs --test lib/ollama-pull-stream.test.ts",
     "test:backup-restore:preflight": "node scripts/run-strip-types.mjs --test lib/backup-artifact.test.ts lib/backup-restore-preflight.test.ts lib/scheduled-backup-membership-roundtrip.test.ts",
+    "test:backup-restore:roundtrip": "node scripts/run-strip-types.mjs --test lib/backup-total-roundtrip.test.ts",
     "test:backup-restore:date-fields": "node --test scripts/backup-restore-date-fields.test.mjs",
     "test:backup-restore:drill": "node scripts/run-strip-types.mjs scripts/backup-restore-drill.mjs",
     "test:backup-scheduler": "bash scripts/backup-scheduler-test.sh",

--- a/scripts/backup-restore-date-fields.test.mjs
+++ b/scripts/backup-restore-date-fields.test.mjs
@@ -67,8 +67,8 @@ function loadRouteFunction(sourceFile, functionName) {
 }
 
 test('backup restore normalizes soft-delete tombstone timestamps', () => {
-  const routeSource = parseSource('app/api/system/backup-restore/route.ts', ts.ScriptKind.TS);
-  const dateFields = findDateFields(routeSource);
+  const executorSource = parseSource('lib/backup-restore-executor.ts', ts.ScriptKind.TS);
+  const dateFields = findDateFields(executorSource);
 
   assert.ok(
     dateFields.includes('deletedAt'),
@@ -77,8 +77,8 @@ test('backup restore normalizes soft-delete tombstone timestamps', () => {
 });
 
 test('scheduled runner date-field list matches the restore DATE_FIELDS', () => {
-  const routeSource = parseSource('app/api/system/backup-restore/route.ts', ts.ScriptKind.TS);
-  const routeDateFields = findDateFields(routeSource);
+  const executorSource = parseSource('lib/backup-restore-executor.ts', ts.ScriptKind.TS);
+  const routeDateFields = findDateFields(executorSource);
 
   assert.deepEqual([...RUNNER_DATE_FIELDS].sort(), [...routeDateFields].sort());
 });
@@ -104,8 +104,8 @@ test('scheduled runner converts unix-seconds date fields to ISO strings', () => 
 });
 
 test('backup restore coerces unix-seconds integers from legacy scheduled artifacts', () => {
-  const routeSource = parseSource('app/api/system/backup-restore/route.ts', ts.ScriptKind.TS);
-  const normalizeDateValue = loadRouteFunction(routeSource, 'normalizeDateValue');
+  const executorSource = parseSource('lib/backup-restore-executor.ts', ts.ScriptKind.TS);
+  const normalizeDateValue = loadRouteFunction(executorSource, 'normalizeDateValue');
 
   const fromSeconds = normalizeDateValue(1750000000);
   assert.ok(fromSeconds instanceof Date);

--- a/scripts/run-scheduled-backup.mjs
+++ b/scripts/run-scheduled-backup.mjs
@@ -362,6 +362,21 @@ function buildAssignedAmbulatoryIds(patient, rows) {
   return Array.from(ids).sort((left, right) => left.localeCompare(right));
 }
 
+/* @Codex */
+function buildAssignedAmbulatoryMemberships(patient, rows) {
+  const memberships = new Map();
+  for (const row of rows) {
+    if (row.patientId === patient.id && typeof row.ambulatoryId === 'string' && row.ambulatoryId.trim().length > 0) {
+      memberships.set(row.ambulatoryId, row.assignedAt ?? null);
+    }
+  }
+  if (typeof patient.ambulatoryId === 'string' && patient.ambulatoryId.trim().length > 0 && !memberships.has(patient.ambulatoryId)) {
+    memberships.set(patient.ambulatoryId, patient.updatedAt ?? patient.createdAt ?? null);
+  }
+  return Array.from(memberships, ([ambulatoryId, assignedAt]) => ({ ambulatoryId, assignedAt }))
+    .sort((left, right) => left.ambulatoryId.localeCompare(right.ambulatoryId));
+}
+
 function buildDataset(db, backupCollections) {
   return db.transaction(() => {
     const dataset = Object.fromEntries(
@@ -373,11 +388,14 @@ function buildDataset(db, backupCollections) {
       ]),
     );
     const patientAmbulatoryRows = hasTable(db, PATIENT_AMBULATORY_TABLE)
-      ? db.prepare(`SELECT * FROM ${PATIENT_AMBULATORY_TABLE}`).all().map((row) => normalizeRowKeys(row))
+      ? db.prepare(`SELECT * FROM ${PATIENT_AMBULATORY_TABLE}`).all().map((row) => normalizeRowDates(normalizeRowKeys(row)))
       : [];
     dataset.patients = dataset.patients.map((patient) => {
       const assignedAmbulatoryIds = buildAssignedAmbulatoryIds(patient, patientAmbulatoryRows);
-      return assignedAmbulatoryIds.length > 0 ? { ...patient, assignedAmbulatoryIds } : patient;
+      const assignedAmbulatoryMemberships = buildAssignedAmbulatoryMemberships(patient, patientAmbulatoryRows);
+      return assignedAmbulatoryIds.length > 0
+        ? { ...patient, assignedAmbulatoryIds, assignedAmbulatoryMemberships }
+        : patient;
     });
 
     const patientIds = new Set(dataset.patients.map((row) => row.id).filter((value) => typeof value === 'string' && value.length > 0));

--- a/scripts/scheduled-backup-date-fields.mjs
+++ b/scripts/scheduled-backup-date-fields.mjs
@@ -1,4 +1,4 @@
-// Keep in sync with DATE_FIELDS in app/api/system/backup-restore/route.ts
+// Keep in sync with DATE_FIELDS in lib/backup-restore-executor.ts
 // (enforced by scripts/backup-restore-date-fields.test.mjs).
 export const DATE_FIELDS = new Set([
   'assignedAt',


### PR DESCRIPTION
## Sintesi

- estrae l'esecutore di restore e ordina le collezioni secondo le dipendenze referenziali;
- conserva membership ambulatoriali, timestamp e campi data nei backup schedulati;
- aggiunge un roundtrip totale che confronta record e ciphertext byte per byte;
- rende i test backup indipendenti dalla cwd e dalle variabili dati ereditate.

## Mappa per la review

1. `lib/backup-restore-executor.ts` e `app/api/system/backup-restore/route.ts`: confine unico del restore.
2. `lib/backup-artifact.ts` e `lib/backup-patient-ambulatory-links.ts`: contratto artifact e membership.
3. `scripts/run-scheduled-backup.mjs`: esportazione schedulata e timestamp.
4. `lib/backup-total-roundtrip.test.ts` e `lib/scheduled-backup-membership-roundtrip.test.ts`: prove end-to-end locali su fixture sintetiche.

## Verifica

- Node 24, lint e typecheck: passati;
- `test:backup-restore:preflight`: 8/8;
- `test:backup-restore:roundtrip`: 1/1;
- `test:backup-restore:date-fields`: 5/5;
- confronto baseline/trattamento dell'isolamento membership: baseline `exit 1`, trattamento `exit 0`.

## Rischi e limiti

- la prova usa esclusivamente fixture sintetiche e non apre database clinici reali;
- il restore resta vincolato al formato artifact v1 e alle collezioni classificate dal test totale;
- nessun cambiamento allo schema o ai claim di cifratura.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
