### PR TITLE
docs: documenta il workflow monitor

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,6 +120,28 @@ codifica ICD obbligatoria), ancorati all'ADR 0065:
 npm run check:claims
 ```
 
+### Monitor del workflow
+
+Il monitor valuta i metadati Git e le verifiche dichiarate per la branch corrente.
+
+```bash
+npm run workflow-monitor -- --check=focused=pass --persist-checks
+npm run workflow-monitor
+npm run workflow-monitor -- clear-checks
+```
+
+Il primo comando salva le verifiche per la branch e lo SHA esatti. Il sidecar resta fuori da Git in `~/.codex/state/mediflow-workflow-monitor/checks.json`.
+
+Il monitor riusa il sidecar solo con worktree pulito, branch invariata e SHA invariato. Usa `--no-persisted-checks` per ignorare il sidecar.
+
+Il monitor registra gli esiti dichiarati, ma non esegue i check. Conserva gli output dei check come prova separata.
+
+Il monitor non stampa il diff o i percorsi modificati. Restituisce `blocked` quando il diff contiene un percorso protetto.
+
+Il monitor non esegue `git fetch`. Aggiorna `origin/main` prima di usare il conteggio `behind` come evidenza corrente.
+
+La CI e il controller restano le autorita per il merge.
+
 ### Test concorrenza pazienti
 
 Per verificare i conflitti cross-client su `patients.version`:


### PR DESCRIPTION
## Summary
- Documenta persistenza, riuso e cancellazione del sidecar locale del workflow monitor.
- Chiarisce che il monitor registra esiti dichiarati ma non esegue i check.
- Mantiene CI e controller come autorita per freschezza della base e merge.

## Verification
- `git diff --check` — passato.
- `rg --files -g "*.md" | sort` — passato.
- `npm run check:claims` — 466 file, 0 claim ad alto rischio.

## Risk / Notes
- Modifica solo `CONTRIBUTING.md`; nessun comportamento runtime o contratto API cambia.
- Nessuna PHI/PII, database clinico, credenziale o contenuto email.

## Ticket
Refs WUL-481