### PR TITLE
feat(fhir): stabilizza identità e riferimenti R4

### DIFF
--- a/lib/fhir/bundle-mapper.test.ts
+++ b/lib/fhir/bundle-mapper.test.ts
@@ -2,9 +2,11 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import { buildFhirBundleFromRecords } from './bundle-mapper';
+import type { FhirBundleInput } from './types';
 
+/* @Codex */
 test('buildFhirBundleFromRecords maps a minimal patient fixture deterministically', () => {
-    const bundle = buildFhirBundleFromRecords({
+    const input: FhirBundleInput = {
         generatedAt: '2026-07-08T09:00:00.000Z',
         patient: {
             id: 'patient-minimal',
@@ -29,62 +31,18 @@ test('buildFhirBundleFromRecords maps a minimal patient fixture deterministicall
         therapies: [],
         checkups: [],
         observations: [],
-    });
+    };
 
-    assert.deepEqual(bundle, {
-        resourceType: 'Bundle',
-        type: 'collection',
-        entry: [
-            {
-                resource: {
-                    resourceType: 'Patient',
-                    id: 'patient-minimal',
-                    active: true,
-                    identifier: [
-                        {
-                            use: 'official',
-                            system: 'http://hl7.it/sid/codice-fiscale',
-                            value: 'LVLDDA80A41F205X',
-                        },
-                    ],
-                    name: [
-                        {
-                            use: 'official',
-                            family: 'Lovelace',
-                            given: ['Ada'],
-                        },
-                    ],
-                    gender: 'unknown',
-                    birthDate: '1980-01-01',
-                    address: undefined,
-                    telecom: undefined,
-                    contact: undefined,
-                    meta: {
-                        lastUpdated: '2026-07-08T09:00:00.000Z',
-                    },
-                },
-            },
-            {
-                resource: {
-                    resourceType: 'Condition',
-                    id: 'condition-minimal-diabetes',
-                    subject: { reference: 'Patient/patient-minimal' },
-                    clinicalStatus: {
-                        coding: [{ system: 'http://terminology.hl7.org/CodeSystem/condition-clinical', code: 'active' }],
-                    },
-                    code: {
-                        coding: [{
-                            system: 'http://hl7.org/fhir/sid/icd-10',
-                            code: 'E11.9',
-                            display: 'Diabete mellito tipo 2 senza complicanze',
-                        }],
-                        text: 'Diabete mellito tipo 2 senza complicanze',
-                    },
-                    onsetDateTime: '2025-01-15T08:30:00.000Z',
-                },
-            },
-        ],
-    });
+    const bundle = buildFhirBundleFromRecords(input);
+    assert.deepEqual(bundle, buildFhirBundleFromRecords(input));
+    assert.equal(bundle.entry?.[0]?.fullUrl, 'urn:mediflow:fhir:Patient:patient-minimal');
+    assert.equal(bundle.entry?.[0]?.resource?.resourceType, 'Patient');
+    assert.equal('gender' in (bundle.entry?.[0]?.resource ?? {}), false);
+    assert.equal(bundle.entry?.[1]?.fullUrl, 'urn:mediflow:fhir:Condition:condition-minimal-diabetes');
+    assert.deepEqual(
+        (bundle.entry?.[1]?.resource as { subject?: unknown } | undefined)?.subject,
+        { reference: 'urn:mediflow:fhir:Patient:patient-minimal' },
+    );
 });
 
 test('buildFhirBundleFromRecords maps scale metadata to an Observation resource', () => {
@@ -124,4 +82,52 @@ test('buildFhirBundleFromRecords maps scale metadata to an Observation resource'
     assert.equal(observation?.resourceType, 'Observation');
     assert.equal(observation?.valueInteger, 6);
     assert.deepEqual(observation?.code, { text: 'ADL (Indice di Katz)' });
+});
+
+/* @Codex */
+test('diagnoses without persisted ids keep unique deterministic Condition ids', () => {
+    const input: FhirBundleInput = {
+        generatedAt: '2026-07-08T09:00:00.000Z',
+        patient: {
+            id: 'patient-diagnosis-without-ids',
+            firstName: 'Ada',
+            lastName: 'Lovelace',
+            taxCode: 'LVLDDA80A41F205X',
+            diagnoses: [
+                {
+                    code: 'E11.9',
+                    description: 'Diabete mellito tipo 2 senza complicanze',
+                    system: 'ICD-10',
+                    date: '2025-01-15T08:30:00.000Z',
+                },
+                {
+                    code: 'E11.9',
+                    description: 'Diabete mellito tipo 2 in controllo dietetico',
+                    system: 'ICD-10',
+                    date: '2025-01-15T08:30:00.000Z',
+                },
+                {
+                    code: 'E11.9',
+                    description: 'Diabete mellito tipo 2 senza complicanze',
+                    system: 'ICD-10',
+                    date: '2025-01-15T08:30:00.000Z',
+                },
+            ],
+        },
+        entries: [],
+        therapies: [],
+        checkups: [],
+        observations: [],
+    };
+
+    const firstBundle = buildFhirBundleFromRecords(input);
+    const secondBundle = buildFhirBundleFromRecords(input);
+    const conditions = firstBundle.entry?.filter((entry) => entry.resource?.resourceType === 'Condition') ?? [];
+    const ids = conditions.map((entry) => entry.resource?.id);
+    const fullUrls = conditions.map((entry) => entry.fullUrl);
+
+    assert.equal(conditions.length, 3);
+    assert.equal(new Set(ids).size, 3);
+    assert.equal(new Set(fullUrls).size, 3);
+    assert.deepEqual(firstBundle, secondBundle);
 });

--- a/lib/fhir/bundle-mapper.ts
+++ b/lib/fhir/bundle-mapper.ts
@@ -1,4 +1,5 @@
 import { Bundle } from 'fhir/r4';
+import { toFhirFullUrl } from './id';
 import { toFhirPatient } from './patient-adapter';
 import {
     toFhirCondition,
@@ -9,51 +10,48 @@ import {
 } from './clinical-adapter';
 import type { FhirBundleInput } from './types';
 
+type BundleResource = NonNullable<NonNullable<Bundle['entry']>[number]['resource']>;
+
+/* @Codex */
 export function buildFhirBundleFromRecords(input: FhirBundleInput): Bundle {
-    const patientId = input.patient.id;
+    const patientResource = toFhirPatient(input.patient, input.generatedAt);
+    const patientReference = toFhirFullUrl(patientResource.resourceType, patientResource.id!);
     const bundle: Bundle = {
         resourceType: "Bundle",
         type: "collection",
         entry: []
     };
 
-    bundle.entry?.push({
-        resource: toFhirPatient(input.patient, input.generatedAt)
+    const append = (resource: BundleResource) => bundle.entry?.push({
+        fullUrl: toFhirFullUrl(resource.resourceType, resource.id!),
+        resource,
     });
 
+    append(patientResource);
+
     if (input.patient.diagnoses) {
-        input.patient.diagnoses.forEach(diagnosis => {
-            bundle.entry?.push({
-                resource: toFhirCondition(diagnosis, patientId)
-            });
+        input.patient.diagnoses.forEach((diagnosis, index) => {
+            append(toFhirCondition(diagnosis, patientReference, index + 1));
         });
     }
 
     input.entries.forEach(entry => {
         if (entry.deletedAt) return;
 
-        bundle.entry?.push({
-            resource: toFhirEncounter(entry, patientId)
-        });
+        append(toFhirEncounter(entry, patientReference));
 
-        const observation = toFhirObservation(entry, patientId);
+        const observation = toFhirObservation(entry, patientReference);
         if (observation) {
-            bundle.entry?.push({
-                resource: observation
-            });
+            append(observation);
         }
     });
 
     input.therapies.forEach(therapy => {
-        bundle.entry?.push({
-            resource: toFhirMedicationStatement(therapy, patientId)
-        });
+        append(toFhirMedicationStatement(therapy, patientReference));
     });
 
     input.observations.forEach(observation => {
-        bundle.entry?.push({
-            resource: toFhirStructuredObservation(observation, patientId)
-        });
+        append(toFhirStructuredObservation(observation, patientReference));
     });
 
     return bundle;

--- a/lib/fhir/clinical-adapter.ts
+++ b/lib/fhir/clinical-adapter.ts
@@ -1,11 +1,25 @@
 import { Condition, Encounter, MedicationStatement, Observation } from 'fhir/r4';
+import { toFhirDerivedId, toFhirId } from './id';
 import type { FhirClinicalEntryInput, FhirDiagnosisInput, FhirObservationInput, FhirTherapyInput } from './types';
 
-export function toFhirCondition(diagnosis: FhirDiagnosisInput, patientId: string): Condition {
+/* @Codex */
+export function toFhirCondition(
+    diagnosis: FhirDiagnosisInput,
+    patientReference: string,
+    orderedPosition: number,
+): Condition {
+    const diagnosisDate = new Date(diagnosis.date).toISOString();
     return {
         resourceType: "Condition",
-        id: diagnosis.id ?? crypto.randomUUID(), // DB doesn't have IDs for diagnoses nested items, generating one or hash
-        subject: { reference: `Patient/${patientId}` },
+        id: diagnosis.id
+            ? toFhirId(diagnosis.id, 'condition')
+            : toFhirDerivedId('condition', [
+                diagnosis.system.trim(),
+                diagnosis.code.trim(),
+                diagnosisDate,
+                diagnosis.description.trim(),
+            ], orderedPosition),
+        subject: { reference: patientReference },
         clinicalStatus: {
             coding: [{ system: "http://terminology.hl7.org/CodeSystem/condition-clinical", code: "active" }]
         },
@@ -18,21 +32,22 @@ export function toFhirCondition(diagnosis: FhirDiagnosisInput, patientId: string
             }],
             text: diagnosis.description
         },
-        onsetDateTime: new Date(diagnosis.date).toISOString()
+        onsetDateTime: diagnosisDate
     };
 }
 
-export function toFhirEncounter(entry: FhirClinicalEntryInput, patientId: string): Encounter {
+/* @Codex */
+export function toFhirEncounter(entry: FhirClinicalEntryInput, patientReference: string): Encounter {
     return {
         resourceType: "Encounter",
-        id: entry.id,
+        id: toFhirId(entry.id, 'encounter'),
         status: "finished",
         class: {
             system: "http://terminology.hl7.org/CodeSystem/v3-ActCode",
             code: entry.setting === 'home' ? "HH" : "AMB",
             display: entry.setting === 'home' ? "home health" : "ambulatory"
         },
-        subject: { reference: `Patient/${patientId}` },
+        subject: { reference: patientReference },
         period: {
             start: new Date(entry.date).toISOString(),
             end: new Date(entry.date).toISOString()
@@ -45,17 +60,18 @@ export function toFhirEncounter(entry: FhirClinicalEntryInput, patientId: string
     };
 }
 
-export function toFhirObservation(entry: FhirClinicalEntryInput, patientId: string): Observation | null {
+/* @Codex */
+export function toFhirObservation(entry: FhirClinicalEntryInput, patientReference: string): Observation | null {
     if (entry.type !== 'scale' || !entry.metadata?.score) return null;
 
     return {
         resourceType: "Observation",
-        id: `obs-${entry.id}`,
+        id: toFhirId(`obs-${entry.id}`, 'observation'),
         status: "final",
         code: {
             text: entry.metadata.title as string
         },
-        subject: { reference: `Patient/${patientId}` },
+        subject: { reference: patientReference },
         effectiveDateTime: new Date(entry.date).toISOString(),
         valueInteger: Number(entry.metadata.score),
         interpretation: [{ text: entry.metadata.interpretation as string }],
@@ -63,15 +79,16 @@ export function toFhirObservation(entry: FhirClinicalEntryInput, patientId: stri
     };
 }
 
-export function toFhirMedicationStatement(therapy: FhirTherapyInput, patientId: string): MedicationStatement {
+/* @Codex */
+export function toFhirMedicationStatement(therapy: FhirTherapyInput, patientReference: string): MedicationStatement {
     return {
         resourceType: "MedicationStatement",
-        id: therapy.id,
+        id: toFhirId(therapy.id, 'medication-statement'),
         status: therapy.status === 'active' ? 'active' : (therapy.status === 'suspended' ? 'on-hold' : 'completed'),
         medicationCodeableConcept: {
             text: therapy.drugName
         },
-        subject: { reference: `Patient/${patientId}` },
+        subject: { reference: patientReference },
         effectivePeriod: {
             start: new Date(therapy.startDate).toISOString(),
             end: therapy.endDate ? new Date(therapy.endDate).toISOString() : undefined
@@ -84,13 +101,13 @@ export function toFhirMedicationStatement(therapy: FhirTherapyInput, patientId: 
 }
 
 /* @Codex */
-export function toFhirStructuredObservation(observation: FhirObservationInput, patientId: string): Observation {
+export function toFhirStructuredObservation(observation: FhirObservationInput, patientReference: string): Observation {
     const numericValue = Number(observation.value);
     const isNumeric = Number.isFinite(numericValue);
 
     return {
         resourceType: "Observation",
-        id: `obs-structured-${observation.id}`,
+        id: toFhirId(`obs-structured-${observation.id}`, 'observation'),
         status: "final",
         code: {
             coding: [
@@ -102,7 +119,7 @@ export function toFhirStructuredObservation(observation: FhirObservationInput, p
             ],
             text: observation.display,
         },
-        subject: { reference: `Patient/${patientId}` },
+        subject: { reference: patientReference },
         effectiveDateTime: new Date(observation.observedAt).toISOString(),
         valueQuantity: isNumeric
             ? {

--- a/lib/fhir/id.test.ts
+++ b/lib/fhir/id.test.ts
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { toFhirFullUrl, toFhirId } from './id';
+
+/* @Codex */
+test('toFhirId keeps normalized source identifiers distinct', () => {
+    const sanitizedId = toFhirId('entry/a', 'encounter');
+    const validId = toFhirId('entry-a', 'encounter');
+
+    assert.notEqual(sanitizedId, validId);
+    assert.notEqual(
+        toFhirFullUrl('Encounter', sanitizedId),
+        toFhirFullUrl('Encounter', validId),
+    );
+    assert.match(sanitizedId, /^[A-Za-z0-9-.]{1,64}$/);
+    assert.equal(toFhirId('entry-a', 'encounter'), 'entry-a');
+});

--- a/lib/fhir/id.ts
+++ b/lib/fhir/id.ts
@@ -1,0 +1,40 @@
+/* @Codex */
+function shortHash(value: string): string {
+    let hash = 0x811c9dc5;
+    for (let index = 0; index < value.length; index += 1) {
+        hash ^= value.charCodeAt(index);
+        hash = Math.imul(hash, 0x01000193);
+    }
+    return (hash >>> 0).toString(16).padStart(8, '0');
+}
+
+/* @Codex */
+export function toFhirDerivedId(
+    prefix: string,
+    parts: readonly string[],
+    orderedPosition: number,
+): string {
+    const canonicalValue = parts.map((part) => `${part.length}:${part}`).join('|');
+    return toFhirId(`${prefix}-${shortHash(canonicalValue)}-${orderedPosition}`, prefix);
+}
+
+/* @Codex */
+export function toFhirId(value: string, fallbackPrefix: string): string {
+    const normalized = value
+        .trim()
+        .replace(/[^A-Za-z0-9-.]/g, '-')
+        .replace(/-+/g, '-')
+        .replace(/^[.-]+|[.-]+$/g, '');
+    if (!normalized) return `${fallbackPrefix}-${shortHash(value)}`;
+
+    const needsHash = normalized !== value || normalized.length > 64;
+    if (!needsHash) return normalized;
+
+    const suffix = `-${shortHash(value)}`;
+    return `${normalized.slice(0, 64 - suffix.length)}${suffix}`;
+}
+
+/* @Codex */
+export function toFhirFullUrl(resourceType: string, id: string): string {
+    return `urn:mediflow:fhir:${resourceType}:${id}`;
+}

--- a/lib/fhir/patient-adapter.ts
+++ b/lib/fhir/patient-adapter.ts
@@ -1,12 +1,14 @@
 import { Patient as FhirPatient } from 'fhir/r4';
+import { toFhirId } from './id';
 import type { FhirPatientInput } from './types';
 
 export const CODICE_FISCALE_SYSTEM = "http://hl7.it/sid/codice-fiscale";
 
+/* @Codex */
 export function toFhirPatient(patient: FhirPatientInput, generatedAt: Date | string = new Date()): FhirPatient {
     return {
         resourceType: "Patient",
-        id: patient.id,
+        id: toFhirId(patient.id, 'patient'),
         active: !patient.isArchived,
         identifier: [
             {
@@ -22,7 +24,6 @@ export function toFhirPatient(patient: FhirPatientInput, generatedAt: Date | str
                 given: [patient.firstName]
             }
         ],
-        gender: "unknown", // Logic to extract from tax code could go here
         birthDate: patient.birthDate
             ? new Date(patient.birthDate).toISOString().split('T')[0]
             : undefined,


### PR DESCRIPTION
## Summary

- Aggiunge `fullUrl` assoluti al Bundle FHIR R4 e usa gli stessi URI nei riferimenti interni.
- Genera ID deterministici per le diagnosi che non hanno un ID persistito.
- Evita collisioni quando due ID sorgente diventano uguali dopo la normalizzazione.
- Omette `Patient.gender` quando il dato non è disponibile.

## Verification

- Test FHIR mirati: 4/4 passati.
- `npm run test:unit`: 740/740 passati.
- `npm run lint`: passato.
- `npm run typecheck`: passato.
- `npm run check:claims`: 466 file, 0 claim ad alto rischio.
- `npm run check:never-regress`: passato.
- `npm run check:openapi:drift`: passato.
- `npm run check:node-runtime`: Node 24.18.0 e ABI 137 passati.
- `npm run build`: passato.
- Revisione indipendente: nessun finding P0-P3 sul diff finale.

## Risk / Notes

- La modifica resta un export locale `collection`. Non prova conformità FSE o a un profilo HL7 Italia.
- Gli ID derivati delle diagnosi dipendono dall'ordine della lista sorgente.
- Checkup, testo narrativo, codifiche farmaco, validator e golden contract restano fuori da questa PR.
- I test usano solo dati sintetici. Nessuna PHI o PII è inclusa.
- Questa PR non chiude WUL-457.

## Ticket

Refs WUL-457
