### PR TITLE
fix(api): ripristina ricerca farmaci multi-token

### DIFF
--- a/drizzle/0023_aifa_packaging_search.sql
+++ b/drizzle/0023_aifa_packaging_search.sql
@@ -1,0 +1,2 @@
+/* @Codex */
+ALTER TABLE `drugs` ADD COLUMN `packaging_search` text;

--- a/lib/aifa-catalog-server.test.ts
+++ b/lib/aifa-catalog-server.test.ts
@@ -70,6 +70,14 @@ test('import persists the provenance manifest and enables bounded prefix search'
     assert.equal(search.rows.length, 1);
     assert.equal(search.rows[0].name, 'ACIDO SINTETICO');
 
+    const crossFieldSearch = await catalog.searchAifaCatalog('acido orale', 1);
+    assert.equal(crossFieldSearch.rows.length, 1);
+    assert.equal(crossFieldSearch.rows[0].aic, '000000101');
+
+    const accentFoldedSearch = await catalog.searchAifaCatalog('citta 500', 1);
+    assert.equal(accentFoldedSearch.rows.length, 1);
+    assert.equal(accentFoldedSearch.rows[0].aic, '000000102');
+
     catalog.clearAifaCatalog();
     assert.deepEqual(await catalog.getAifaCatalogStatus(), {
         count: 0,
@@ -124,4 +132,29 @@ test('legacy replacement removes AIFA rows without changing price scale or prefi
         price: 250,
         atc: 'A00AA00',
     }]);
+});
+
+test('runtime search applies cross-field tokens before the result cap', async () => {
+    const catalog = await loadCatalogModules();
+    catalog.replaceUnverifiedDrugCatalog([
+        ...Array.from({ length: 300 }, (_, index) => ({
+            aic: `DECOY-${index}`,
+            name: `ALFA ${String(index).padStart(3, '0')}`,
+            packaging: 'Compresse',
+            aicSearch: `decoy ${index}`,
+            nameSearch: `alfa ${String(index).padStart(3, '0')}`,
+            activePrincipleSearch: '',
+        })),
+        {
+            aic: 'TARGET',
+            name: 'ZETA ALFA',
+            packaging: 'Beta soluzione',
+            aicSearch: 'target',
+            nameSearch: 'zeta alfa',
+            activePrincipleSearch: '',
+        },
+    ]);
+
+    const search = await catalog.searchAifaCatalog('alfa beta', 1);
+    assert.deepEqual(search.rows.map((row) => row.aic), ['TARGET']);
 });

--- a/lib/aifa-catalog-server.ts
+++ b/lib/aifa-catalog-server.ts
@@ -5,6 +5,7 @@ import { asc, eq, sql } from 'drizzle-orm';
 import {
     AIFA_CATALOG_MANIFEST_SETTING_KEY,
     buildAifaCatalogManifest,
+    normalizeAifaSearchText,
     parseAifaCsv,
     parseStoredAifaCatalogManifest,
     validateAifaManifestInput,
@@ -15,6 +16,7 @@ import { dbServer } from './db-server';
 import {
     buildDrugPrefixSearchOrder,
     buildDrugPrefixSearchPredicate,
+    buildDrugSearchPredicate,
     normalizeDrugSearchQuery,
 } from './drug-search-query';
 import { drugs, settings } from './schema';
@@ -102,10 +104,15 @@ export function clearAifaCatalog(): void {
 export function replaceUnverifiedDrugCatalog(items: readonly (typeof drugs.$inferInsert)[]): void {
     if (items.length === 0) throw new Error('Catalogo farmaci legacy vuoto');
 
+    const normalizedItems = items.map((item) => ({
+        ...item,
+        packagingSearch: item.packagingSearch ?? normalizeAifaSearchText(item.packaging || ''),
+    }));
+
     dbServer.transaction((transaction) => {
         transaction.delete(drugs).run();
-        for (let offset = 0; offset < items.length; offset += INSERT_BATCH_SIZE) {
-            transaction.insert(drugs).values(items.slice(offset, offset + INSERT_BATCH_SIZE)).run();
+        for (let offset = 0; offset < normalizedItems.length; offset += INSERT_BATCH_SIZE) {
+            transaction.insert(drugs).values(normalizedItems.slice(offset, offset + INSERT_BATCH_SIZE)).run();
         }
         transaction.delete(settings)
             .where(eq(settings.key, AIFA_CATALOG_MANIFEST_SETTING_KEY))
@@ -120,10 +127,18 @@ export async function searchAifaCatalog(
     const normalized = normalizeDrugSearchQuery(query);
     const status = await getAifaCatalogStatus();
     if (!normalized) return { rows: [], status };
+
+    const isMultiToken = normalized.includes(' ');
     const rows = await dbServer.select()
         .from(drugs)
-        .where(buildDrugPrefixSearchPredicate(normalized))
-        .orderBy(buildDrugPrefixSearchOrder(normalized), asc(drugs.name), asc(drugs.packaging))
+        .where(isMultiToken
+            ? buildDrugSearchPredicate(normalized)
+            : buildDrugPrefixSearchPredicate(normalized))
+        .orderBy(
+            ...(isMultiToken ? [] : [buildDrugPrefixSearchOrder(normalized)]),
+            asc(drugs.name),
+            asc(drugs.packaging),
+        )
         .limit(limit);
     return { rows, status };
 }

--- a/lib/aifa-catalog.test.ts
+++ b/lib/aifa-catalog.test.ts
@@ -35,6 +35,7 @@ test('parses the synthetic fixture with the real AIFA confezioni headers', () =>
         aicSearch: '000000101',
         nameSearch: 'acido sintetico',
         activePrincipleSearch: 'acido acetilsalicilico',
+        packagingSearch: '20 compresse da 100 mg uso orale',
     });
     assert.equal(parsed.drugs[1].nameSearch, 'farmaco citta');
     assert.equal(parsed.drugs[2].name, 'SOLUZIONE TEST');

--- a/lib/aifa-catalog.ts
+++ b/lib/aifa-catalog.ts
@@ -34,6 +34,7 @@ export type ParsedAifaDrug = {
     aicSearch: string;
     nameSearch: string;
     activePrincipleSearch: string;
+    packagingSearch: string;
 };
 
 export type AifaCsvParseResult = {
@@ -167,6 +168,7 @@ export function parseAifaCsv(text: string): AifaCsvParseResult {
             aicSearch: normalizeAifaSearchText(aic),
             nameSearch: normalizeAifaSearchText(name),
             activePrincipleSearch: normalizeAifaSearchText(activePrinciple || ''),
+            packagingSearch: normalizeAifaSearchText(readColumn(record, columns.packaging) || ''),
         });
     }
 

--- a/lib/db-server.ts
+++ b/lib/db-server.ts
@@ -3,6 +3,7 @@ import Database from 'better-sqlite3';
 /* @Codex */
 import fs from 'fs';
 import path from 'path';
+import { normalizeAifaSearchText } from '@/lib/aifa-catalog';
 import { ensureAuditSqliteSchema } from '@/lib/security/audit-db';
 import { resolveDataPath } from '@/lib/data-dir';
 import { copySqliteDatabaseSync, replaceSqliteDatabase } from '@/lib/sqlite-repair';
@@ -189,6 +190,26 @@ function applySchemaGuards() {
         ensureColumn('drugs', 'aic_search', 'aic_search TEXT');
         ensureColumn('drugs', 'name_search', 'name_search TEXT');
         ensureColumn('drugs', 'active_principle_search', 'active_principle_search TEXT');
+        ensureColumn('drugs', 'packaging_search', 'packaging_search TEXT');
+        const selectPendingPackagingSearchRows = sqlite.prepare(`
+            SELECT aic, packaging
+            FROM drugs
+            WHERE packaging_search IS NULL
+            LIMIT 1000
+        `);
+        const updatePackagingSearch = sqlite.prepare(`
+            UPDATE drugs SET packaging_search = ? WHERE aic = ?
+        `);
+        while (true) {
+            const rows = selectPendingPackagingSearchRows.all() as Array<{
+                aic: string;
+                packaging: string | null;
+            }>;
+            if (rows.length === 0) break;
+            for (const row of rows) {
+                updatePackagingSearch.run(normalizeAifaSearchText(row.packaging || ''), row.aic);
+            }
+        }
         sqlite.prepare('CREATE INDEX IF NOT EXISTS drugs_aic_search_idx ON drugs(aic_search)').run();
         sqlite.prepare('CREATE INDEX IF NOT EXISTS drugs_name_search_idx ON drugs(name_search)').run();
         sqlite.prepare('CREATE INDEX IF NOT EXISTS drugs_active_principle_search_idx ON drugs(active_principle_search)').run();

--- a/lib/drug-search-query.test.ts
+++ b/lib/drug-search-query.test.ts
@@ -35,15 +35,19 @@ function createSyntheticCatalog(rows: SyntheticDrug[]) {
             atc TEXT,
             aic_search TEXT,
             name_search TEXT,
-            active_principle_search TEXT
+            active_principle_search TEXT,
+            packaging_search TEXT
         );
         CREATE INDEX drugs_aic_search_idx ON drugs(aic_search);
         CREATE INDEX drugs_name_search_idx ON drugs(name_search);
         CREATE INDEX drugs_active_principle_search_idx ON drugs(active_principle_search);
     `);
     const insert = sqlite.prepare(`
-        INSERT INTO drugs (aic, name, active_principle, packaging, aic_search, name_search, active_principle_search)
-        VALUES (?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO drugs (
+            aic, name, active_principle, packaging,
+            aic_search, name_search, active_principle_search, packaging_search
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
     `);
     const insertAll = sqlite.transaction(() => {
         for (const row of rows) {
@@ -55,6 +59,7 @@ function createSyntheticCatalog(rows: SyntheticDrug[]) {
                 normalizeAifaSearchText(row.aic),
                 normalizeAifaSearchText(row.name),
                 normalizeAifaSearchText(row.activePrinciple || ''),
+                normalizeAifaSearchText(row.packaging || ''),
             );
         }
     });
@@ -137,6 +142,15 @@ test('production drug predicate handles nullable columns and literal LIKE metach
     ]);
 
     assert.deepEqual(catalog.search('100% Flacone_1\\speciale'), ['LITERAL']);
+    catalog.close();
+});
+
+test('production drug predicate folds accents in packaging tokens', () => {
+    const catalog = createSyntheticCatalog([
+        { aic: 'ACCENTED', name: 'Farmaco sintetico', packaging: 'Confezione unità orale' },
+    ]);
+
+    assert.deepEqual(catalog.search('unita orale'), ['ACCENTED']);
     catalog.close();
 });
 

--- a/lib/drug-search-query.ts
+++ b/lib/drug-search-query.ts
@@ -57,7 +57,11 @@ export function buildDrugSearchPredicate(value: string): SQL {
             SELECT 1
             FROM json_each(${escapedTokens}) AS search_token
             WHERE NOT (
-                coalesce(${drugs.name}, '') LIKE '%' || search_token.value || '%' ESCAPE ${'\\'}
+                coalesce(${drugs.nameSearch}, '') LIKE '%' || search_token.value || '%' ESCAPE ${'\\'}
+                OR coalesce(${drugs.activePrincipleSearch}, '') LIKE '%' || search_token.value || '%' ESCAPE ${'\\'}
+                OR coalesce(${drugs.packagingSearch}, '') LIKE '%' || search_token.value || '%' ESCAPE ${'\\'}
+                OR coalesce(${drugs.aicSearch}, '') LIKE '%' || search_token.value || '%' ESCAPE ${'\\'}
+                OR coalesce(${drugs.name}, '') LIKE '%' || search_token.value || '%' ESCAPE ${'\\'}
                 OR coalesce(${drugs.activePrinciple}, '') LIKE '%' || search_token.value || '%' ESCAPE ${'\\'}
                 OR coalesce(${drugs.packaging}, '') LIKE '%' || search_token.value || '%' ESCAPE ${'\\'}
                 OR coalesce(${drugs.aic}, '') LIKE '%' || search_token.value || '%' ESCAPE ${'\\'}

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -419,6 +419,8 @@ export const drugs = sqliteTable('drugs', {
     nameSearch: text('name_search'),
     /* @Codex */
     activePrincipleSearch: text('active_principle_search'),
+    /* @Codex */
+    packagingSearch: text('packaging_search'),
 }, (t) => ({
     /* @Codex: aic is already indexed by the primary key; these cover accent-folded prefix search. */
     aicSearchIdx: index('drugs_aic_search_idx').on(t.aicSearch),


### PR DESCRIPTION
## Summary
- Ripristina il matching multi-token tra nome, principio attivo, confezione e AIC prima del limite dei risultati.
- Mantiene il percorso indicizzato e il ranking per le query a token singolo.
- Aggiunge packaging_search con popolamento sui nuovi import e backfill a blocchi per i database esistenti.
- Aggiunge regressioni sintetiche per cap, campi incrociati e accenti.

## Verification
- Node 24.18.0: test focalizzati AIFA/search, 12/12 passati.
- Node 24.18.0: unit test completi, 742/742 passati.
- npm run check:schema-drift: passato, 20 tabelle e 19 indici coerenti.
- ESLint mirato, npm run typecheck, npm run check:claims, npm run check:never-regress e git diff --check: passati.
- npm run build: passato; restano due warning Turbopack preesistenti sul tracciamento NFT.
- Benchmark sintetico su 158.001 righe: backfill circa 674 ms in memoria; query multi-token circa 94 ms; risultato oltre il cap trovato.
- Revisione indipendente finale: approvata senza finding P0-P3.

## Risk / Notes
- Le query multi-token eseguono una scansione del catalogo; il percorso a token singolo resta indicizzato.
- Il backfill del campo derivato avviene una sola volta e usa blocchi da 1.000 righe.
- Nessuna PHI/PII, nessun database reale e nessun contenuto clinico reale.

## Ticket
Fixes WUL-494
