### PR TITLE
refactor(api): unifica payload bulk pazienti

### DIFF
--- a/app/api/patients/assign/route.ts
+++ b/app/api/patients/assign/route.ts
@@ -5,7 +5,9 @@ import { NextResponse } from 'next/server';
 /* @Codex */
 import { requireSession, unauthorizedResponse } from '@/lib/security/server-auth';
 /* @Codex */
-import { normalizeId, normalizeIdList } from '@/lib/patient-bulk-validation';
+import { patientAssignSchema } from '@/lib/api-schemas/patient-bulk';
+/* @Codex */
+import { parseApiBody } from '@/lib/api-schemas/parse';
 // WUL-306 (ADR 0066): bulk reads treat soft-deleted patients as missing
 import { activePatients } from '@/lib/patient-lifecycle';
 
@@ -15,13 +17,9 @@ export async function POST(request: Request) {
     if (!session) return unauthorizedResponse();
 
     try {
-        const body = await request.json() as Record<string, unknown>;
-        const patientIds = normalizeIdList(body.patientIds);
-        const targetAmbulatoryId = normalizeId(body.targetAmbulatoryId);
-
-        if (patientIds.length === 0 || !targetAmbulatoryId) {
-            return NextResponse.json({ error: "Invalid parameters" }, { status: 400 });
-        }
+        const parsedBody = parseApiBody(patientAssignSchema, await request.json());
+        if (!parsedBody.ok) return parsedBody.response;
+        const { patientIds, targetAmbulatoryId } = parsedBody.data;
 
         const target = await dbServer
             .select({ id: ambulatories.id })

--- a/app/api/patients/duplicate/route.ts
+++ b/app/api/patients/duplicate/route.ts
@@ -6,7 +6,9 @@ import { v4 as uuidv4 } from 'uuid';
 /* @Codex */
 import { requireSession, unauthorizedResponse } from '@/lib/security/server-auth';
 /* @Codex */
-import { normalizeId, normalizeIdList } from '@/lib/patient-bulk-validation';
+import { patientDuplicateSchema } from '@/lib/api-schemas/patient-bulk';
+/* @Codex */
+import { parseApiBody } from '@/lib/api-schemas/parse';
 // WUL-306 (ADR 0066): bulk reads treat soft-deleted patients as missing
 import { activePatients } from '@/lib/patient-lifecycle';
 
@@ -16,13 +18,9 @@ export async function POST(request: Request) {
     if (!session) return unauthorizedResponse();
 
     try {
-        const body = await request.json() as Record<string, unknown>;
-        const patientIds = normalizeIdList(body.patientIds);
-        const targetAmbulatoryId = normalizeId(body.targetAmbulatoryId);
-
-        if (patientIds.length === 0 || !targetAmbulatoryId) {
-            return NextResponse.json({ error: "Invalid parameters" }, { status: 400 });
-        }
+        const parsedBody = parseApiBody(patientDuplicateSchema, await request.json());
+        if (!parsedBody.ok) return parsedBody.response;
+        const { patientIds, targetAmbulatoryId } = parsedBody.data;
 
         const target = await dbServer
             .select({ id: ambulatories.id })

--- a/app/api/patients/unassign/route.ts
+++ b/app/api/patients/unassign/route.ts
@@ -5,7 +5,9 @@ import { NextResponse } from 'next/server';
 /* @Codex */
 import { requireSession, unauthorizedResponse } from '@/lib/security/server-auth';
 /* @Codex */
-import { normalizeId, normalizeIdList } from '@/lib/patient-bulk-validation';
+import { patientUnassignSchema } from '@/lib/api-schemas/patient-bulk';
+/* @Codex */
+import { parseApiBody } from '@/lib/api-schemas/parse';
 // WUL-306 (ADR 0066): bulk reads treat soft-deleted patients as missing
 import { activePatients } from '@/lib/patient-lifecycle';
 
@@ -15,13 +17,9 @@ export async function POST(request: Request) {
     if (!session) return unauthorizedResponse();
 
     try {
-        const body = await request.json() as Record<string, unknown>;
-        const patientIds = normalizeIdList(body.patientIds);
-        const ambulatoryId = normalizeId(body.ambulatoryId);
-
-        if (patientIds.length === 0 || !ambulatoryId) {
-            return NextResponse.json({ error: "Invalid parameters" }, { status: 400 });
-        }
+        const parsedBody = parseApiBody(patientUnassignSchema, await request.json());
+        if (!parsedBody.ok) return parsedBody.response;
+        const { patientIds, ambulatoryId } = parsedBody.data;
 
         const target = await dbServer
             .select({ id: ambulatories.id })

--- a/lib/api-schemas/api-schemas.test.ts
+++ b/lib/api-schemas/api-schemas.test.ts
@@ -7,6 +7,12 @@ import { authSetupSchema } from './auth';
 import { checkupCreateSchema, therapyUpdateSchema } from './clinical-writes';
 import { conversationCreateSchema } from './conversations';
 import { INVALID_API_PAYLOAD_ERROR, parseApiBody } from './parse';
+import {
+    patientAssignSchema,
+    patientDuplicateSchema,
+    patientMoveSchema,
+    patientUnassignSchema,
+} from './patient-bulk';
 import { servicePrescriptionCreateSchema } from './prescriptions';
 import { sissHandoffCreateSchema } from './siss-handoffs';
 
@@ -138,3 +144,64 @@ test('service prescription and SISS schemas validate enum/date boundaries with 4
     });
 });
 
+/* @Codex */
+test('patient bulk schemas normalize IDs and reject malformed payloads', async () => {
+    assert.deepEqual(await expectValid(patientAssignSchema, {
+        patientIds: [' patient-1 ', 'patient-1', 'patient-2'],
+        targetAmbulatoryId: ' ambulatory-1 ',
+    }), {
+        patientIds: ['patient-1', 'patient-2'],
+        targetAmbulatoryId: 'ambulatory-1',
+    });
+    await expectValid(patientDuplicateSchema, {
+        patientIds: ['patient-1'],
+        targetAmbulatoryId: 'ambulatory-2',
+    });
+    await expectValid(patientUnassignSchema, {
+        patientIds: ['patient-1'],
+        ambulatoryId: 'ambulatory-1',
+    });
+    await expectInvalid400(patientAssignSchema, {
+        patientIds: [],
+        targetAmbulatoryId: 'ambulatory-1',
+    });
+    await expectInvalid400(patientUnassignSchema, {
+        patientIds: ['patient-1'],
+        ambulatoryId: 42,
+    });
+});
+
+/* @Codex */
+test('patient move requires one positive expected version per requested patient', async () => {
+    assert.deepEqual(await expectValid(patientMoveSchema, {
+        patientIds: [' patient-1 ', 'patient-2'],
+        targetAmbulatoryId: ' ambulatory-2 ',
+        sourceAmbulatoryId: null,
+        patientVersions: { 'patient-1': 3, 'patient-2': 7 },
+    }), {
+        patientIds: ['patient-1', 'patient-2'],
+        targetAmbulatoryId: 'ambulatory-2',
+        sourceAmbulatoryId: undefined,
+        patientVersions: { 'patient-1': 3, 'patient-2': 7 },
+    });
+    await expectInvalid400(patientMoveSchema, {
+        patientIds: ['patient-1', 'patient-2'],
+        targetAmbulatoryId: 'ambulatory-2',
+        patientVersions: { 'patient-1': 3 },
+    });
+    await expectInvalid400(patientMoveSchema, {
+        patientIds: ['patient-1'],
+        targetAmbulatoryId: 'ambulatory-2',
+        patientVersions: { 'patient-1': 0 },
+    });
+    await expectInvalid400(patientMoveSchema, {
+        patientIds: ['patient-1'],
+        targetAmbulatoryId: 'ambulatory-2',
+        patientVersions: { 'patient-1': 3, 'patient-2': 7 },
+    });
+    await expectInvalid400(patientMoveSchema, {
+        patientIds: ['constructor'],
+        targetAmbulatoryId: 'ambulatory-2',
+        patientVersions: {},
+    });
+});

--- a/lib/api-schemas/patient-bulk.ts
+++ b/lib/api-schemas/patient-bulk.ts
@@ -1,0 +1,44 @@
+/* @Codex */
+import { z } from 'zod';
+
+const idSchema = z.string().trim().min(1);
+const patientIdsSchema = z.array(idSchema).min(1).transform((ids) => Array.from(new Set(ids)));
+const patientVersionsSchema = z.record(z.string(), z.number().int().positive());
+
+const targetAmbulatorySchema = z.object({
+    patientIds: patientIdsSchema,
+    targetAmbulatoryId: idSchema,
+});
+
+export const patientAssignSchema = targetAmbulatorySchema;
+export const patientDuplicateSchema = targetAmbulatorySchema;
+
+export const patientUnassignSchema = z.object({
+    patientIds: patientIdsSchema,
+    ambulatoryId: idSchema,
+});
+
+export const patientMoveSchema = targetAmbulatorySchema.extend({
+    sourceAmbulatoryId: idSchema.nullish().transform((value) => value ?? undefined),
+    patientVersions: patientVersionsSchema,
+}).superRefine((value, context) => {
+    const requestedIds = new Set(value.patientIds);
+    for (const patientId of requestedIds) {
+        if (!Object.hasOwn(value.patientVersions, patientId)) {
+            context.addIssue({
+                code: 'custom',
+                path: ['patientVersions', patientId],
+                message: 'Missing patient version',
+            });
+        }
+    }
+    for (const patientId of Object.keys(value.patientVersions)) {
+        if (!requestedIds.has(patientId)) {
+            context.addIssue({
+                code: 'custom',
+                path: ['patientVersions', patientId],
+                message: 'Unexpected patient version',
+            });
+        }
+    }
+});


### PR DESCRIPTION
## Summary
- aggiunge schemi Zod condivisi per assegnazione, rimozione, duplicazione e movimento bulk
- normalizza e deduplica gli ID; richiede una versione positiva ed esatta per ogni paziente nel payload di movimento
- applica gli schemi condivisi alle route assign, unassign e duplicate
- mantiene la route move sul validatore esistente fino alla slice CAS transazionale

## Verification
- `npm run test:api-schemas` (6/6)
- ESLint mirato sui cinque file della slice
- `npm run typecheck`
- `npm run check:claims` (466 file, 0 finding)
- `npm run check:never-regress`
- `git diff --check`
- review indipendente: APPROVE dopo correzione del controllo sulle proprietà ereditate

## Risk / Notes
- i payload con elementi non validi sono rifiutati interamente
- nessuna modifica a `/api/v1`, cifratura, membership o persistenza
- la concorrenza e il CAS del movimento restano nella slice successiva
- nessuna PHI/PII o fixture clinica reale

## Ticket
Refs WUL-312