### PR TITLE
fix(api): versiona movimento bulk pazienti

### DIFF
--- a/app/api/patients/move/route.ts
+++ b/app/api/patients/move/route.ts
@@ -5,7 +5,11 @@ import { NextResponse } from 'next/server';
 /* @Codex */
 import { requireSession, unauthorizedResponse } from '@/lib/security/server-auth';
 /* @Codex */
-import { normalizeId, normalizeIdList } from '@/lib/patient-bulk-validation';
+import { patientMoveSchema } from '@/lib/api-schemas/patient-bulk';
+/* @Codex */
+import { parseApiBody } from '@/lib/api-schemas/parse';
+/* @Codex */
+import { buildPatientVersionConflictPayload } from '@/lib/patient-concurrency';
 // WUL-306 (ADR 0066): bulk reads treat soft-deleted patients as missing
 import { activePatients } from '@/lib/patient-lifecycle';
 
@@ -15,45 +19,50 @@ export async function POST(request: Request) {
     if (!session) return unauthorizedResponse();
 
     try {
-        const body = await request.json() as Record<string, unknown>;
-        const patientIds = normalizeIdList(body.patientIds);
-        const targetAmbulatoryId = normalizeId(body.targetAmbulatoryId);
-        const sourceAmbulatoryId = normalizeId(body.sourceAmbulatoryId);
-
-        if (patientIds.length === 0) {
-            return NextResponse.json({ error: "Invalid patient IDs" }, { status: 400 });
-        }
-
-        if (!targetAmbulatoryId) {
-            return NextResponse.json({ error: "Target ambulatory ID required" }, { status: 400 });
-        }
-
-        const target = await dbServer
-            .select({ id: ambulatories.id })
-            .from(ambulatories)
-            .where(eq(ambulatories.id, targetAmbulatoryId))
-            .get();
-        if (!target) {
-            return NextResponse.json({ error: 'Target ambulatory not found' }, { status: 404 });
-        }
-
-        const existingPatients = await dbServer
-            .select({ id: patients.id })
-            .from(patients)
-            .where(and(inArray(patients.id, patientIds), activePatients()));
-        const existingIds = new Set(existingPatients.map((item) => item.id));
-        const missingPatientIds = patientIds.filter((id) => !existingIds.has(id));
-        if (missingPatientIds.length > 0) {
-            return NextResponse.json(
-                { error: 'Some patients were not found', missingPatientIds },
-                { status: 404 }
-            );
-        }
+        const parsedBody = parseApiBody(patientMoveSchema, await request.json());
+        if (!parsedBody.ok) return parsedBody.response;
+        const { patientIds, patientVersions, targetAmbulatoryId, sourceAmbulatoryId } = parsedBody.data;
 
         // WUL-268 (STREAM A): membership delete + insert + primary-ownership update
         // must land atomically. better-sqlite3 transactions are synchronous, so no
         // awaits inside the callback (see app/api/system/backup-restore).
-        dbServer.transaction((tx) => {
+        /* @Codex */
+        const result = dbServer.transaction((tx): { status: 200 | 404 | 409; value: Record<string, unknown> } => {
+            const target = tx
+                .select({ id: ambulatories.id })
+                .from(ambulatories)
+                .where(eq(ambulatories.id, targetAmbulatoryId))
+                .get();
+            if (!target) {
+                return { status: 404, value: { error: 'Target ambulatory not found' } };
+            }
+
+            const existingPatients = tx
+                .select({
+                    id: patients.id,
+                    version: patients.version,
+                    updatedAt: patients.updatedAt,
+                    isArchived: patients.isArchived,
+                })
+                .from(patients)
+                .where(and(inArray(patients.id, patientIds), activePatients()))
+                .all();
+            const existingIds = new Set(existingPatients.map((patient) => patient.id));
+            const missingPatientIds = patientIds.filter((id) => !existingIds.has(id));
+            if (missingPatientIds.length > 0) {
+                return { status: 404, value: { error: 'Some patients were not found', missingPatientIds } };
+            }
+
+            for (const patient of existingPatients) {
+                const expectedVersion = patientVersions[patient.id];
+                if (patient.version !== expectedVersion) {
+                    return {
+                        status: 409,
+                        value: buildPatientVersionConflictPayload(expectedVersion, patient.id, patient),
+                    };
+                }
+            }
+
             /* @Codex */
             if (sourceAmbulatoryId) {
                 tx.delete(patientsToAmbulatories)
@@ -73,18 +82,32 @@ export async function POST(request: Request) {
                 .onConflictDoNothing()
                 .run();
 
-            tx.update(patients)
-                .set({ ambulatoryId: targetAmbulatoryId, updatedAt: new Date() })
-                .where(inArray(patients.id, patientIds))
-                .run();
-        });
+            const updatedVersions: Record<string, number> = {};
+            const updatedAt = new Date();
+            for (const patient of existingPatients) {
+                const nextVersion = patient.version + 1;
+                const updateResult = tx.update(patients)
+                    .set({ ambulatoryId: targetAmbulatoryId, version: nextVersion, updatedAt })
+                    .where(and(eq(patients.id, patient.id), eq(patients.version, patient.version), activePatients()))
+                    .run();
+                if (updateResult.changes !== 1) {
+                    throw new Error('Patient version changed during move');
+                }
+                updatedVersions[patient.id] = nextVersion;
+            }
 
-        return NextResponse.json({
-            success: true,
-            count: patientIds.length,
-            targetAmbulatoryId,
-            sourceAmbulatoryId: sourceAmbulatoryId ?? null
-        });
+            return {
+                status: 200,
+                value: {
+                    success: true,
+                    count: patientIds.length,
+                    targetAmbulatoryId,
+                    sourceAmbulatoryId: sourceAmbulatoryId ?? null,
+                    patientVersions: updatedVersions,
+                },
+            };
+        }, { behavior: 'immediate' });
+        return NextResponse.json(result.value, { status: result.status });
     } catch (error) {
         console.error("Move patients error:", error);
         return NextResponse.json({ error: "Failed to move patients" }, { status: 500 });

--- a/scripts/patient-concurrency-smoke.sh
+++ b/scripts/patient-concurrency-smoke.sh
@@ -12,79 +12,20 @@ BASE_URL="${E2E_BASE_URL:-http://127.0.0.1:3100}"
 REPORT_PATH="$DATA_DIR/reports/patient-concurrency-report.json"
 HOST="$(node -e "const u=new URL(process.env.E2E_BASE_URL || 'http://127.0.0.1:3100'); console.log(u.hostname)")"
 PORT="$(node -e "const u=new URL(process.env.E2E_BASE_URL || 'http://127.0.0.1:3100'); console.log(u.port || (u.protocol === 'https:' ? '443' : '80'))")"
-WORKSPACE_DIR="$DATA_DIR/next-workspace"
+DIST_DIR="$ROOT_DIR/.next-patient-concurrency"
 
 mkdir -p "$DATA_DIR" "$LOG_DIR"
+rm -f "$DATA_DIR/medical.db"
+rm -rf "$DIST_DIR"
 
 export MEDIFLOW_DATA_DIR="$DATA_DIR"
 export E2E_BASE_URL="$BASE_URL"
 export MEDIFLOW_LOCAL_API_TOKEN="${MEDIFLOW_LOCAL_API_TOKEN:-mediflow-e2e-local-token}"
+export MEDIFLOW_NEXT_DIST_DIR=".next-patient-concurrency"
+export E2E_PIN="${E2E_PIN:-1234}"
+export E2E_USERNAME="${E2E_USERNAME:-admin}"
 
-prepare_workspace() {
-  rm -rf "$WORKSPACE_DIR"
-  mkdir -p "$WORKSPACE_DIR"
-
-  for entry in app components lib public drizzle; do
-    if [[ -e "$ROOT_DIR/$entry" ]]; then
-      cp -R "$ROOT_DIR/$entry" "$WORKSPACE_DIR/$entry"
-    fi
-  done
-
-  for entry in package.json package-lock.json tsconfig.json next-env.d.ts postcss.config.mjs; do
-    if [[ -e "$ROOT_DIR/$entry" ]]; then
-      cp "$ROOT_DIR/$entry" "$WORKSPACE_DIR/$entry"
-    fi
-  done
-
-  cat >"$WORKSPACE_DIR/next.config.ts" <<'EOF'
-import type { NextConfig } from "next";
-
-const nextConfig: NextConfig = {
-  output: "standalone",
-  distDir: ".next-concurrency",
-  turbopack: {},
-  serverExternalPackages: ['pdfjs-dist', 'pm2'],
-  webpack: (config) => {
-    config.resolve.alias.canvas = false;
-    return config;
-  },
-};
-
-export default nextConfig;
-EOF
-
-  WORKSPACE_DIR_ENV="$WORKSPACE_DIR" node <<'NODE'
-const fs = require('fs');
-const path = require('path');
-
-for (const relativePath of ['app/api/patients/route.ts', 'app/api/patients/[id]/route.ts']) {
-  const filePath = path.join(process.env.WORKSPACE_DIR_ENV, relativePath);
-  let source = fs.readFileSync(filePath, 'utf8');
-  if (relativePath === 'app/api/patients/route.ts') {
-    source = source.replace(
-      'export async function GET() {',
-      'export async function GET(request: Request) {'
-    );
-  }
-  source = source.replace(
-    "import { requireSession, unauthorizedResponse } from '@/lib/security/server-auth';",
-    "import { requireSessionOrLocalToken, unauthorizedResponse } from '@/lib/security/server-auth';"
-  );
-  source = source.replaceAll(
-    "const session = await requireSession();",
-    "const session = await requireSessionOrLocalToken(request);"
-  );
-  fs.writeFileSync(filePath, source);
-}
-NODE
-}
-
-prepare_workspace
-
-(
-  cd "$WORKSPACE_DIR"
-  node "$ROOT_DIR/scripts/prepare-e2e-db.mjs"
-)
+node "$ROOT_DIR/scripts/prepare-e2e-db.mjs"
 
 DEV_PID=""
 
@@ -93,17 +34,24 @@ cleanup() {
     kill "$DEV_PID" >/dev/null 2>&1 || true
     wait "$DEV_PID" >/dev/null 2>&1 || true
   fi
-  rm -rf "$WORKSPACE_DIR"
+  rm -rf "$DIST_DIR"
 }
 
 trap cleanup EXIT
 
 echo "Starting Next.js dev server..."
-npx next dev "$WORKSPACE_DIR" --webpack --hostname "$HOST" --port "$PORT" >"$DEV_LOG" 2>&1 &
+npx next dev --webpack --hostname "$HOST" --port "$PORT" >"$DEV_LOG" 2>&1 &
 DEV_PID=$!
 
 echo "Waiting for $BASE_URL/api/v1/patients ..."
 for _ in {1..90}; do
+  if ! kill -0 "$DEV_PID" >/dev/null 2>&1; then
+    echo "Dev server exited before readiness."
+    echo "Check log: $DEV_LOG"
+    sed -n '1,120p' "$DEV_LOG"
+    exit 1
+  fi
+
   if curl -fsS -H "Authorization: Bearer $MEDIFLOW_LOCAL_API_TOKEN" "$BASE_URL/api/v1/patients" >/dev/null 2>&1; then
     echo "Server is ready."
     break

--- a/scripts/patient-concurrency-smoke.sh
+++ b/scripts/patient-concurrency-smoke.sh
@@ -5,7 +5,15 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-DATA_DIR="${MEDIFLOW_CONCURRENCY_DATA_DIR:-$ROOT_DIR/tmp-concurrency-data}"
+DATA_DIR="${MEDIFLOW_CONCURRENCY_DATA_DIR:-}"
+if [[ -z "$DATA_DIR" ]]; then
+  DATA_DIR="$(mktemp -d "${TMPDIR:-/tmp}/mediflow-patient-concurrency.XXXXXX")"
+elif [[ -e "$DATA_DIR" ]]; then
+  if [[ ! -d "$DATA_DIR" ]] || [[ -n "$(find "$DATA_DIR" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
+    echo "Refusing to use a non-empty concurrency data directory: $DATA_DIR"
+    exit 1
+  fi
+fi
 LOG_DIR="$DATA_DIR/logs"
 DEV_LOG="$LOG_DIR/next-dev.log"
 BASE_URL="${E2E_BASE_URL:-http://127.0.0.1:3100}"
@@ -15,7 +23,6 @@ PORT="$(node -e "const u=new URL(process.env.E2E_BASE_URL || 'http://127.0.0.1:3
 DIST_DIR="$ROOT_DIR/.next-patient-concurrency"
 
 mkdir -p "$DATA_DIR" "$LOG_DIR"
-rm -f "$DATA_DIR/medical.db"
 rm -rf "$DIST_DIR"
 
 export MEDIFLOW_DATA_DIR="$DATA_DIR"

--- a/scripts/patient-concurrency.test.mjs
+++ b/scripts/patient-concurrency.test.mjs
@@ -2,6 +2,7 @@
 /* @Codex */
 
 import assert from 'node:assert/strict';
+import Database from 'better-sqlite3';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -9,6 +10,8 @@ import { after, test } from 'node:test';
 
 const BASE_URL = process.env.E2E_BASE_URL || 'http://127.0.0.1:3100';
 const LOCAL_API_TOKEN = process.env.MEDIFLOW_LOCAL_API_TOKEN || 'mediflow-e2e-local-token';
+const USERNAME = process.env.E2E_USERNAME || 'admin';
+const PIN = process.env.E2E_PIN || '1234';
 const REPORT_PATH = resolveReportPath();
 
 const scenarioResults = [];
@@ -122,6 +125,130 @@ test('native update wins over web stale delete', async () => {
     });
 });
 
+test('bulk move waits for a concurrent writer and preserves unrelated memberships', async () => {
+    const context = await authContextPromise;
+    const dataDir = process.env.MEDIFLOW_DATA_DIR || process.env.MEDIFLOW_E2E_DATA_DIR;
+    assert.ok(dataDir, 'patient concurrency test requires a dedicated data directory');
+
+    const sourceAmbulatoryId = crypto.randomUUID();
+    const targetAmbulatoryId = crypto.randomUUID();
+    const preservedAmbulatoryId = crypto.randomUUID();
+    const ambulatoryIds = [sourceAmbulatoryId, targetAmbulatoryId, preservedAmbulatoryId];
+    const writer = new Database(path.join(dataDir, 'medical.db'));
+    writer.pragma('busy_timeout = 5000');
+    writer.pragma('foreign_keys = ON');
+
+    let patientId = null;
+    let transactionOpen = false;
+    let movePromise = null;
+    try {
+        const insertAmbulatory = writer.prepare(`
+            INSERT INTO ambulatories (id, name, type, is_default, version, created_at)
+            VALUES (?, ?, 'live', 0, 1, ?)
+        `);
+        const createdAt = Math.floor(Date.now() / 1000);
+        for (const [index, ambulatoryId] of ambulatoryIds.entries()) {
+            insertAmbulatory.run(ambulatoryId, `Bulk move ${index + 1}`, createdAt);
+        }
+
+        patientId = await context.web.createPatient({
+            ...buildPatientPayload('bulk move concurrency'),
+            ambulatoryId: sourceAmbulatoryId,
+        });
+        writer.prepare('UPDATE patients SET ambulatory_id = ? WHERE id = ?')
+            .run(sourceAmbulatoryId, patientId);
+        writer.prepare('DELETE FROM patients_to_ambulatories WHERE patient_id = ?')
+            .run(patientId);
+        const insertMembership = writer.prepare(`
+            INSERT INTO patients_to_ambulatories (patient_id, ambulatory_id, assigned_at)
+            VALUES (?, ?, ?)
+        `);
+        insertMembership.run(patientId, sourceAmbulatoryId, createdAt);
+        insertMembership.run(patientId, preservedAmbulatoryId, createdAt);
+
+        const invalid = await context.web.request('POST', '/move', {
+            patientIds: [patientId],
+            targetAmbulatoryId,
+        });
+        assert.equal(invalid.response.status, 400, 'move should require the exact version map');
+
+        writer.exec('BEGIN IMMEDIATE');
+        transactionOpen = true;
+        const competingWrite = writer.prepare(
+            'UPDATE patients SET version = version + 1 WHERE id = ?',
+        ).run(patientId);
+        assert.equal(competingWrite.changes, 1);
+
+        let requestSettled = false;
+        movePromise = context.web.request('POST', '/move', {
+            patientIds: [patientId],
+            patientVersions: { [patientId]: 1 },
+            targetAmbulatoryId,
+            sourceAmbulatoryId,
+        }).finally(() => {
+            requestSettled = true;
+        });
+
+        await delay(500);
+        assert.equal(requestSettled, false, 'move should wait before taking its read snapshot');
+
+        writer.exec('COMMIT');
+        transactionOpen = false;
+
+        const conflict = await movePromise;
+        assert.equal(conflict.response.status, 409);
+        assert.equal(conflict.json?.code, 'VERSION_CONFLICT');
+        assert.equal(conflict.json?.recordId, patientId);
+        assert.equal(conflict.json?.expectedVersion, 1);
+        assert.equal(conflict.json?.currentVersion, 2);
+
+        assert.deepEqual(readPatient(writer, patientId), {
+            ambulatoryId: sourceAmbulatoryId,
+            version: 2,
+        });
+        assert.deepEqual(
+            readMemberships(writer, patientId),
+            [preservedAmbulatoryId, sourceAmbulatoryId].sort(),
+        );
+
+        const retry = await context.web.request('POST', '/move', {
+            patientIds: [patientId],
+            patientVersions: { [patientId]: 2 },
+            targetAmbulatoryId,
+            sourceAmbulatoryId,
+        });
+        assert.equal(retry.response.status, 200);
+        assert.equal(retry.json?.patientVersions?.[patientId], 3);
+        assert.deepEqual(readPatient(writer, patientId), {
+            ambulatoryId: targetAmbulatoryId,
+            version: 3,
+        });
+        assert.deepEqual(
+            readMemberships(writer, patientId),
+            [preservedAmbulatoryId, targetAmbulatoryId].sort(),
+        );
+
+        scenarioResults.push({
+            name: 'bulk move waits for a concurrent writer',
+            winner: 'concurrent-writer',
+            loser: 'bulk-move',
+            loserOperation: 'move',
+            conflictStatus: conflict.response.status,
+            currentVersion: conflict.json?.currentVersion,
+        });
+    } finally {
+        if (transactionOpen) writer.exec('ROLLBACK');
+        if (movePromise) await movePromise.catch(() => undefined);
+        if (patientId) {
+            writer.prepare('DELETE FROM patients_to_ambulatories WHERE patient_id = ?').run(patientId);
+            writer.prepare('DELETE FROM patients WHERE id = ?').run(patientId);
+        }
+        const deleteAmbulatory = writer.prepare('DELETE FROM ambulatories WHERE id = ?');
+        for (const ambulatoryId of ambulatoryIds) deleteAmbulatory.run(ambulatoryId);
+        writer.close();
+    }
+});
+
 async function runConflictScenario({ name, winnerLane, loserLane, loserOperation }) {
     const context = await authContextPromise;
     const winner = context[winnerLane];
@@ -188,19 +315,37 @@ async function runConflictScenario({ name, winnerLane, loserLane, loserOperation
 
 async function createAuthContext() {
     await assertServerReady();
-    const authHeaders = {
+    const nativeAuthHeaders = {
         Authorization: `Bearer ${LOCAL_API_TOKEN}`
     };
+    const sessionCookie = await login();
 
     const nativeLane = new LaneClient('native-v1', '/api/v1/patients', {
-        ...authHeaders
+        ...nativeAuthHeaders
     });
 
     return {
-        web: new LaneClient('web', '/api/patients', authHeaders),
+        web: new LaneClient('web', '/api/patients', { Cookie: sessionCookie }),
         'native-v1': nativeLane,
         native: nativeLane
     };
+}
+
+async function login() {
+    const response = await fetch(new URL('/api/auth/login', BASE_URL), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username: USERNAME, password: PIN }),
+    });
+    assert.equal(response.status, 200, 'web concurrency lane should authenticate');
+
+    const setCookies = typeof response.headers.getSetCookie === 'function'
+        ? response.headers.getSetCookie()
+        : [];
+    const cookieSource = setCookies.find((cookie) => cookie.startsWith('mediflow_session='))
+        ?? response.headers.get('set-cookie');
+    assert.ok(cookieSource, 'login should return the mediflow_session cookie');
+    return cookieSource.split(';')[0];
 }
 
 async function cleanupPatient(nativeLane, patientId) {
@@ -209,6 +354,25 @@ async function cleanupPatient(nativeLane, patientId) {
 
     const result = await nativeLane.deletePatient(patientId, latest.version);
     assert.equal(result.response.status, 200, `Cleanup delete should succeed for ${patientId}`);
+}
+
+function readPatient(database, patientId) {
+    return database.prepare(
+        'SELECT ambulatory_id AS ambulatoryId, version FROM patients WHERE id = ?',
+    ).get(patientId);
+}
+
+function readMemberships(database, patientId) {
+    return database.prepare(`
+        SELECT ambulatory_id AS ambulatoryId
+        FROM patients_to_ambulatories
+        WHERE patient_id = ?
+        ORDER BY ambulatory_id
+    `).all(patientId).map((row) => row.ambulatoryId);
+}
+
+async function delay(milliseconds) {
+    await new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
 async function assertServerReady() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -50,7 +50,9 @@
     ".next-api-v1-put-negative/types/**/*.ts",
     ".next-api-v1-put-negative/dev/types/**/*.ts",
     ".next-legacy-clinical-writes/types/**/*.ts",
-    ".next-legacy-clinical-writes/dev/types/**/*.ts"
+    ".next-legacy-clinical-writes/dev/types/**/*.ts",
+    ".next-patient-concurrency/types/**/*.ts",
+    ".next-patient-concurrency/dev/types/**/*.ts"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Summary
- esegue snapshot, controllo versione e scritture del movimento bulk in una transazione `IMMEDIATE`
- restituisce il conflitto paziente canonico e incrementa ogni versione una sola volta
- rimuove soltanto la membership sorgente indicata e conserva le altre membership
- rende eseguibile lo smoke di concorrenza sul worktree reale con sessione web e dist dir isolato
- usa una directory temporanea per default e rifiuta directory esplicite non vuote

## Verification
- `npm run test:concurrency:patients` (5/5, incluso writer concorrente e membership terza)
- `npm run test:api-schemas` (6/6)
- `npm run test:db-transaction-rollback` (2/2)
- `npm run typecheck`
- ESLint mirato
- `bash -n scripts/patient-concurrency-smoke.sh`
- guard distruttivo: directory non vuota rifiutata, sentinella conservata
- `npm run check:claims` (466 file, 0 finding)
- `npm run check:never-regress`
- `git diff --check`
- review indipendente: APPROVE dopo chiusura del finding sulla directory dati

## Risk / Notes
- il movimento richiede una versione positiva ed esatta per ogni paziente
- il conflitto non modifica paziente o membership
- nessuna modifica a `/api/v1`, cifratura o modello membership
- la clipboard CUT resta nella slice successiva
- nessuna PHI/PII o fixture clinica reale

## Ticket
Refs WUL-312