### PR TITLE
fix(ui): usa movimento atomico per CUT pazienti

### DIFF
--- a/hooks/use-patient-clipboard.ts
+++ b/hooks/use-patient-clipboard.ts
@@ -1,83 +1,63 @@
 import { useState, useCallback } from 'react';
 import { notifyDbChange } from '@/lib/live-query';
+/* @Codex */
+import {
+    executePatientClipboardPaste,
+    type ClipboardOperation,
+    type PatientClipboardState,
+} from '@/lib/patient-clipboard';
 // import { toast } from '@/components/ui/use-toast'; // Assuming toast exists, or use console for now
 
-export type ClipboardOperation = 'copy' | 'cut';
-
-export interface ClipboardState {
-    patientIds: string[];
-    operation: ClipboardOperation | null;
-    sourceAmbulatoryId: string | null;
-}
+export type { ClipboardOperation };
+export type ClipboardState = PatientClipboardState;
 
 export function usePatientClipboard() {
     const [clipboard, setClipboard] = useState<ClipboardState>({
         patientIds: [],
+        patientVersions: {},
         operation: null,
         sourceAmbulatoryId: null
     });
 
     const copy = useCallback((patientIds: string[], sourceAmbulatoryId: string) => {
-        setClipboard({ patientIds, operation: 'copy', sourceAmbulatoryId });
+        setClipboard({ patientIds: [...patientIds], patientVersions: {}, operation: 'copy', sourceAmbulatoryId });
         console.log(`Copied ${patientIds.length} patients`);
     }, []);
 
-    const cut = useCallback((patientIds: string[], sourceAmbulatoryId: string) => {
-        setClipboard({ patientIds, operation: 'cut', sourceAmbulatoryId });
+    /* @Codex */
+    const cut = useCallback((
+        patientIds: string[],
+        sourceAmbulatoryId: string,
+        patientVersions: Record<string, number>,
+    ) => {
+        setClipboard({
+            patientIds: [...patientIds],
+            patientVersions: { ...patientVersions },
+            operation: 'cut',
+            sourceAmbulatoryId,
+        });
         console.log(`Cut ${patientIds.length} patients`);
     }, []);
 
     const clear = useCallback(() => {
-        setClipboard({ patientIds: [], operation: null, sourceAmbulatoryId: null });
+        setClipboard({ patientIds: [], patientVersions: {}, operation: null, sourceAmbulatoryId: null });
     }, []);
 
     const paste = useCallback(async (targetAmbulatoryId: string, isTestEnvironment: boolean) => {
-        if (!clipboard.patientIds.length || !clipboard.operation) return;
+        if (!clipboard.patientIds.length || !clipboard.operation) return false;
 
         try {
-            // Logic:
-            // 1. If Target is Test -> ALWAYS CLONE (Duplicate API)
-            // 2. If Target is Live:
-            //    a. If Operation is COPY -> LINK (Assign API)
-            //    b. If Operation is CUT -> LINK (Assign API) + UNLINK OLD (Unassign API)
-
-            let endpoint = '';
-            const body = { patientIds: clipboard.patientIds, targetAmbulatoryId };
-
-            if (isTestEnvironment) {
-                // CLONE
-                endpoint = '/api/patients/duplicate';
-            } else {
-                // LINK
-                endpoint = '/api/patients/assign';
-            }
-
-            // Execute Primary Action
-            const res = await fetch(endpoint, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(body)
-            });
-
-            if (!res.ok) throw new Error("Paste action failed");
-
-            // Execute Secondary Action (for CUT in Live environment)
-            if (!isTestEnvironment && clipboard.operation === 'cut' && clipboard.sourceAmbulatoryId) {
-                await fetch('/api/patients/unassign', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        patientIds: clipboard.patientIds,
-                        ambulatoryId: clipboard.sourceAmbulatoryId
-                    })
-                });
-            }
-
-            // Success
-            // toast({ title: "Incollato con successo", description: `${clipboard.patientIds.length} pazienti processati.` });
-            notifyDbChange(); // @Codex
-            clear();
-            return true;
+            return await executePatientClipboardPaste(
+                clipboard,
+                targetAmbulatoryId,
+                isTestEnvironment,
+                {
+                    onSuccess: () => {
+                        notifyDbChange();
+                        clear();
+                    },
+                },
+            );
         } catch (error) {
             console.error("Paste error", error);
             // toast({ title: "Errore", description: "Impossibile incollare i pazienti.", variant: "destructive" });

--- a/lib/patient-clipboard.test.ts
+++ b/lib/patient-clipboard.test.ts
@@ -1,0 +1,104 @@
+/* @Codex */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    executePatientClipboardPaste,
+    type PatientClipboardState,
+} from './patient-clipboard';
+
+function makeClipboard(overrides: Partial<PatientClipboardState> = {}): PatientClipboardState {
+    return {
+        patientIds: ['patient-1'],
+        patientVersions: {},
+        operation: 'copy',
+        sourceAmbulatoryId: 'ambulatory-source',
+        ...overrides,
+    };
+}
+
+function makeRecorder(ok: boolean) {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    return {
+        calls,
+        request: async (url: string, init: RequestInit) => {
+            calls.push({ url, init });
+            return { ok };
+        },
+    };
+}
+
+test('copy links live patients and test targets always duplicate', async () => {
+    const live = makeRecorder(true);
+    assert.equal(await executePatientClipboardPaste(
+        makeClipboard(),
+        'ambulatory-target',
+        false,
+        { request: live.request },
+    ), true);
+    assert.equal(live.calls[0]?.url, '/api/patients/assign');
+
+    const testTarget = makeRecorder(true);
+    assert.equal(await executePatientClipboardPaste(
+        makeClipboard({ operation: 'cut' }),
+        'ambulatory-test',
+        true,
+        { request: testTarget.request },
+    ), true);
+    assert.equal(testTarget.calls[0]?.url, '/api/patients/duplicate');
+});
+
+test('live cut uses one versioned move request', async () => {
+    const recorder = makeRecorder(true);
+    assert.equal(await executePatientClipboardPaste(
+        makeClipboard({
+            operation: 'cut',
+            patientVersions: { 'patient-1': 4 },
+        }),
+        'ambulatory-target',
+        false,
+        { request: recorder.request },
+    ), true);
+
+    assert.equal(recorder.calls.length, 1);
+    assert.equal(recorder.calls[0]?.url, '/api/patients/move');
+    assert.deepEqual(JSON.parse(String(recorder.calls[0]?.init.body)), {
+        patientIds: ['patient-1'],
+        patientVersions: { 'patient-1': 4 },
+        targetAmbulatoryId: 'ambulatory-target',
+        sourceAmbulatoryId: 'ambulatory-source',
+    });
+});
+
+test('failed or incomplete moves do not run the success effect', async () => {
+    let successCount = 0;
+    const failed = makeRecorder(false);
+    assert.equal(await executePatientClipboardPaste(
+        makeClipboard({ operation: 'cut', patientVersions: { 'patient-1': 4 } }),
+        'ambulatory-target',
+        false,
+        { request: failed.request, onSuccess: () => { successCount += 1; } },
+    ), false);
+    assert.equal(successCount, 0);
+
+    const incomplete = makeRecorder(true);
+    assert.equal(await executePatientClipboardPaste(
+        makeClipboard({ operation: 'cut' }),
+        'ambulatory-target',
+        false,
+        { request: incomplete.request, onSuccess: () => { successCount += 1; } },
+    ), false);
+    assert.equal(incomplete.calls.length, 0);
+    assert.equal(successCount, 0);
+});
+
+test('successful paste runs the clear effect once', async () => {
+    let successCount = 0;
+    const recorder = makeRecorder(true);
+    assert.equal(await executePatientClipboardPaste(
+        makeClipboard(),
+        'ambulatory-target',
+        false,
+        { request: recorder.request, onSuccess: () => { successCount += 1; } },
+    ), true);
+    assert.equal(successCount, 1);
+});

--- a/lib/patient-clipboard.ts
+++ b/lib/patient-clipboard.ts
@@ -1,0 +1,70 @@
+/* @Codex */
+export type ClipboardOperation = 'copy' | 'cut';
+
+export interface PatientClipboardState {
+    patientIds: string[];
+    patientVersions: Record<string, number>;
+    operation: ClipboardOperation | null;
+    sourceAmbulatoryId: string | null;
+}
+
+type PatientClipboardRequest = (
+    url: string,
+    init: RequestInit,
+) => Promise<{ ok: boolean }>;
+
+type PatientClipboardEffects = {
+    request?: PatientClipboardRequest;
+    onSuccess?: () => void;
+};
+
+export async function executePatientClipboardPaste(
+    clipboard: PatientClipboardState,
+    targetAmbulatoryId: string,
+    isTestEnvironment: boolean,
+    effects: PatientClipboardEffects = {},
+): Promise<boolean> {
+    if (clipboard.patientIds.length === 0 || !clipboard.operation || targetAmbulatoryId.trim().length === 0) {
+        return false;
+    }
+
+    let endpoint: string;
+    let body: Record<string, unknown>;
+    if (isTestEnvironment) {
+        endpoint = '/api/patients/duplicate';
+        body = { patientIds: clipboard.patientIds, targetAmbulatoryId };
+    } else if (clipboard.operation === 'copy') {
+        endpoint = '/api/patients/assign';
+        body = { patientIds: clipboard.patientIds, targetAmbulatoryId };
+    } else {
+        if (!clipboard.sourceAmbulatoryId || !hasExactPatientVersions(clipboard)) return false;
+        endpoint = '/api/patients/move';
+        body = {
+            patientIds: clipboard.patientIds,
+            patientVersions: clipboard.patientVersions,
+            targetAmbulatoryId,
+            sourceAmbulatoryId: clipboard.sourceAmbulatoryId,
+        };
+    }
+
+    const request = effects.request ?? ((url, init) => fetch(url, init));
+    const response = await request(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+    });
+    if (!response.ok) return false;
+
+    effects.onSuccess?.();
+    return true;
+}
+
+function hasExactPatientVersions(clipboard: PatientClipboardState): boolean {
+    const requestedIds = new Set(clipboard.patientIds);
+    if (Object.keys(clipboard.patientVersions).length !== requestedIds.size) return false;
+    return Array.from(requestedIds).every((patientId) => (
+        Object.hasOwn(clipboard.patientVersions, patientId)
+        && Number.isInteger(clipboard.patientVersions[patientId])
+        && clipboard.patientVersions[patientId] > 0
+    ));
+}

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "test:api-v1-put-negative-routes": "bash scripts/api-v1-put-negative-routes-test.sh",
     "test:legacy-clinical-writes": "bash scripts/legacy-clinical-writes-test.sh",
     "test:api-schemas": "node scripts/run-strip-types.mjs --test lib/api-schemas/api-schemas.test.ts",
+    "test:patient-clipboard": "node scripts/run-strip-types.mjs --test lib/patient-clipboard.test.ts",
     "test:document-input-normalization": "node scripts/run-strip-types.mjs --test lib/domain/documents/document-input-normalization.test.ts",
     "test:ocr-service:date": "node scripts/run-strip-types.mjs --test lib/domain/documents/ocr-service-date.test.ts",
     "test:ollama-pull-stream": "node scripts/run-strip-types.mjs --test lib/ollama-pull-stream.test.ts",


### PR DESCRIPTION
## Summary
- Sposta il contratto del clipboard pazienti in un helper testabile.
- Usa una sola richiesta versionata `/api/patients/move` per CUT verso un ambulatorio live.
- Conserva COPY live e duplicazione verso target test.
- Mantiene il clipboard quando la richiesta non riesce o mancano versioni esatte.

## Verification
- `npm run test:patient-clipboard` (4/4)
- ESLint mirato sui tre file TypeScript
- `npm run typecheck`
- `npm run check:claims` (466 file, 0 claim ad alto rischio)
- `npm run check:never-regress`
- `git diff --check main...HEAD`
- parsing di `package.json`
- revisione indipendente: APPROVE dopo correzione dello snapshot difensivo

## Risk / Notes
- Il hook non ha consumatori attivi nel repository: questa PR definisce e verifica il contratto, ma non aggiunge una nuova superficie UI.
- Nessuna PHI/PII, nessun dato paziente reale, nessun contenuto email.

## Ticket
Fixes WUL-312