### PR TITLE
fix(ai): ripara JSON troncato senza perdere campi validi

### DIFF
--- a/lib/ai-task-contracts.test.ts
+++ b/lib/ai-task-contracts.test.ts
@@ -6,6 +6,7 @@ import {
     buildDocumentSynthesisExtractionPrompt,
     buildPatientInsightExtractionPrompt,
     buildSmartImportExtractionPrompt,
+    extractJsonObject,
     parseDocumentSynthesisExtractionResponse,
     parsePatientInsightExtractionResponse,
     parseSmartImportExtractionResponse,
@@ -722,4 +723,130 @@ test('document synthesis extraction repairs truncated envelope when only closing
     assert.equal(parsed.value.data.medications[0], 'Humalog 4 U ai pasti principali');
     assert.equal(parsed.value.data.problemStatements[0].label, 'Diabete mellito tipo 2');
     assert.equal(parsed.value.data.therapyCandidates[0].drugMention, 'Humalog');
+});
+
+test('extractJsonObject repairs truncation inside JSON strings', () => {
+    const cases = [
+        '{"a":"cut',
+        '{"a":"cut}',
+        '{"a":"cut\\',
+        '```json\n{"a":"cut\n```',
+    ];
+
+    for (const truncated of cases) {
+        const extraction = extractJsonObject(truncated);
+
+        assert.ok(extraction);
+        assert.equal(extraction.repairedTruncation, true);
+        assert.doesNotThrow(() => JSON.parse(extraction.rawJson));
+    }
+});
+
+test('extractJsonObject preserves punctuation inside a truncated string', () => {
+    const extraction = extractJsonObject('{"note":"febbre, ');
+
+    assert.ok(extraction);
+    assert.equal(extraction.repairedTruncation, true);
+    assert.equal(JSON.parse(extraction.rawJson).note, 'febbre,');
+});
+
+test('extractJsonObject falls back to the last complete member', () => {
+    const cases = [
+        '{"a":1,"b":',
+        '{"a":1,"partialKey',
+        '{"a":1,"b":{"c":',
+        '{"a":1,"b":"caf\\u00e',
+        '{"a":1,"b":tru',
+    ];
+
+    for (const truncated of cases) {
+        const extraction = extractJsonObject(truncated);
+
+        assert.ok(extraction);
+        assert.equal(extraction.repairedTruncation, true);
+        assert.deepEqual(JSON.parse(extraction.rawJson), { a: 1 });
+    }
+});
+
+test('extractJsonObject rejects an unrepairable first member', () => {
+    const extraction = extractJsonObject('{"only":');
+
+    assert.equal(extraction, null);
+});
+
+test('extractJsonObject does not reduce an array root to its first object', () => {
+    const extraction = extractJsonObject('```json\n[{"a":1},{"b":2}]\n```\nTesto finale');
+
+    assert.ok(extraction);
+    assert.equal(extraction.repairedTruncation, false);
+    assert.deepEqual(JSON.parse(extraction.rawJson), [{ a: 1 }, { b: 2 }]);
+});
+
+test('extractJsonObject ignores bracketed prose before an object', () => {
+    const cases = [
+        'Ecco l\'analisi [S1]:\n{"a":1,"b":',
+        '[S1]:\n{"a":1,"b":',
+    ];
+
+    for (const response of cases) {
+        const extraction = extractJsonObject(response);
+
+        assert.ok(extraction);
+        assert.equal(extraction.repairedTruncation, true);
+        assert.deepEqual(JSON.parse(extraction.rawJson), { a: 1 });
+    }
+});
+
+test('extractJsonObject preserves or rejects an array after bracketed prose', () => {
+    const complete = extractJsonObject('[S1]: [{"a":1},{"b":2}]');
+    const truncated = extractJsonObject('[S1]: [{"a":1},{"b":');
+
+    assert.ok(complete);
+    assert.equal(complete.repairedTruncation, false);
+    assert.deepEqual(JSON.parse(complete.rawJson), [{ a: 1 }, { b: 2 }]);
+    assert.equal(truncated, null);
+});
+
+test('document synthesis keeps a bare object opener invalid', () => {
+    const parsed = parseDocumentSynthesisExtractionResponse('{', 'testo OCR');
+
+    assert.equal(parsed.validJson, false);
+    assert.equal(parsed.validTask, false);
+    assert.equal(parsed.repairedTruncation, false);
+    assert.equal(parsed.value.data.qualityReason, 'JSON del modello non valido');
+});
+
+test('extractJsonObject keeps malformed balanced JSON distinct from truncation', () => {
+    const extraction = extractJsonObject('{"a": }');
+
+    assert.ok(extraction);
+    assert.equal(extraction.repairedTruncation, false);
+    assert.throws(() => JSON.parse(extraction.rawJson));
+});
+
+test('document synthesis preserves earlier fields after truncation inside a string', () => {
+    const truncated = `{
+  "schemaVersion": "mediflow.ai.extract.v1",
+  "task": "document_synthesis",
+  "summary": "Referto con terapia esplicita",
+  "data": {
+    "qualityLevel": "green",
+    "medications": ["Farmaco A"],
+    "diagnoses": [
+      {
+        "code": "J44.9",
+        "description": "Broncopneumopatia cronica ostruttiva",
+        "system": "ICD-10"
+      }
+    ],
+    "problemStatements": [{"label": "Diagnosi interrotta`;
+
+    const parsed = parseDocumentSynthesisExtractionResponse(truncated, 'testo OCR');
+
+    assert.equal(parsed.validJson, true);
+    assert.equal(parsed.validTask, true);
+    assert.equal(parsed.repairedTruncation, true);
+    assert.deepEqual(parsed.value.data.medications, ['Farmaco A']);
+    assert.equal(parsed.value.data.diagnoses[0].code, 'J44.9');
+    assert.equal(parsed.value.data.problemStatements.length, 0);
 });

--- a/lib/ai-task-contracts.ts
+++ b/lib/ai-task-contracts.ts
@@ -577,25 +577,115 @@ export interface ExtractedJsonObject {
     repairedTruncation: boolean;
 }
 
-export function extractJsonObject(response: string): ExtractedJsonObject | null {
-    const clean = stripModelArtifacts(response);
-    const fenced = clean.match(/```(?:json)?\s*([\s\S]*?)```/i);
-    if (fenced?.[1]) {
-        return { rawJson: fenced[1].trim(), repairedTruncation: false };
-    }
+interface JsonContainer {
+    opener: '{' | '[';
+    parent: JsonContainer | null;
+}
 
-    const firstBrace = clean.indexOf('{');
-    const lastBrace = clean.lastIndexOf('}');
-    if (firstBrace === -1 || lastBrace === -1 || lastBrace <= firstBrace) {
-        return null;
+// @Codex: chiude solo i contenitori osservati nello stesso prefisso JSON.
+function closeJsonContainers(fragment: string, container: JsonContainer | null): string {
+    let closed = fragment;
+    for (let current = container; current; current = current.parent) {
+        closed += current.opener === '{' ? '}' : ']';
     }
+    return closed;
+}
 
-    const fragment = clean.slice(firstBrace, lastBrace + 1).trim();
-    const stack: string[] = [];
+// @Codex: delimita una radice completa senza interpretarne ancora il contenuto.
+function extractBalancedJsonValue(candidate: string, rootStart: number): string | null {
+    let container: JsonContainer | null = null;
     let inString = false;
     let escaping = false;
 
-    for (const char of fragment) {
+    for (let index = rootStart; index < candidate.length; index += 1) {
+        const char = candidate[index];
+        if (inString) {
+            if (escaping) {
+                escaping = false;
+                continue;
+            }
+            if (char === '\\') {
+                escaping = true;
+                continue;
+            }
+            if (char === '"') inString = false;
+            continue;
+        }
+
+        if (char === '"') {
+            inString = true;
+            continue;
+        }
+        if (char === '{' || char === '[') {
+            container = { opener: char, parent: container };
+            continue;
+        }
+        if (char === '}' || char === ']') {
+            const expected = char === '}' ? '{' : '[';
+            if (container?.opener !== expected) return null;
+            container = container.parent;
+            if (!container) return candidate.slice(rootStart, index + 1);
+        }
+    }
+
+    return null;
+}
+
+// @Codex: una riparazione dichiarata deve essere un oggetto JSON parsabile.
+function isParsableJsonObject(value: string, requireMember = false): boolean {
+    try {
+        const parsed = JSON.parse(value) as unknown;
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return false;
+        return !requireMember || Object.keys(parsed).length > 0;
+    } catch {
+        return false;
+    }
+}
+
+export function extractJsonObject(response: string): ExtractedJsonObject | null {
+    const clean = stripModelArtifacts(response);
+    const fenced = clean.match(/```(?:json)?\s*([\s\S]*?)```/i);
+    // @Codex: usa lo stesso scanner per risposte libere e blocchi JSON recintati.
+    const fencedCandidate = fenced?.[1]?.trim();
+    const candidate = fencedCandidate && /[\[{]/.test(fencedCandidate)
+        ? fencedCandidate
+        : clean;
+    let rootStart = -1;
+    let searchStart = 0;
+
+    while (searchStart < candidate.length) {
+        const nextBrace = candidate.indexOf('{', searchStart);
+        const nextBracket = candidate.indexOf('[', searchStart);
+        if (nextBrace === -1 && nextBracket === -1) return null;
+
+        if (nextBrace !== -1 && (nextBracket === -1 || nextBrace < nextBracket)) {
+            rootStart = nextBrace;
+            break;
+        }
+
+        const arrayCandidate = extractBalancedJsonValue(candidate, nextBracket);
+        if (!arrayCandidate) return null;
+        try {
+            if (Array.isArray(JSON.parse(arrayCandidate))) {
+                return { rawJson: arrayCandidate, repairedTruncation: false };
+            }
+        } catch {
+            // Un blocco bilanciato ma non JSON puo essere un marcatore come [S1].
+        }
+        searchStart = nextBracket + arrayCandidate.length;
+    }
+
+    if (rootStart === -1) return null;
+
+    const fragment = candidate.slice(rootStart).trim();
+    let container: JsonContainer | null = null;
+    let lastCommaCheckpoint: { endIndex: number; container: JsonContainer } | null = null;
+    let inString = false;
+    let escaping = false;
+    let mismatchedClosing = false;
+
+    for (let index = 0; index < fragment.length; index += 1) {
+        const char = fragment[index];
         if (inString) {
             if (escaping) {
                 escaping = false;
@@ -616,31 +706,61 @@ export function extractJsonObject(response: string): ExtractedJsonObject | null 
             continue;
         }
         if (char === '{' || char === '[') {
-            stack.push(char);
+            container = { opener: char, parent: container };
             continue;
         }
         if (char === '}' || char === ']') {
             const expected = char === '}' ? '{' : '[';
-            if (stack[stack.length - 1] === expected) {
-                stack.pop();
+            if (container?.opener === expected) {
+                container = container.parent;
+                if (!container) {
+                    return {
+                        rawJson: fragment.slice(0, index + 1),
+                        repairedTruncation: false,
+                    };
+                }
+            } else {
+                mismatchedClosing = true;
             }
+            continue;
+        }
+        if (char === ',' && container) {
+            lastCommaCheckpoint = { endIndex: index, container };
         }
     }
 
+    if (mismatchedClosing || !container) return null;
+
+    let repairablePrefix = inString
+        ? fragment
+        : fragment.replace(/,\s*$/g, '');
     if (inString) {
-        return { rawJson: fragment, repairedTruncation: false };
+        if (escaping) repairablePrefix = repairablePrefix.slice(0, -1);
+        repairablePrefix += '"';
     }
 
-    let repaired = fragment.replace(/,\s*$/g, '');
-    while (stack.length > 0) {
-        const opener = stack.pop();
-        repaired += opener === '{' ? '}' : ']';
+    const repaired = closeJsonContainers(repairablePrefix, container);
+    if (isParsableJsonObject(repaired, true)) {
+        return {
+            rawJson: repaired,
+            repairedTruncation: true,
+        };
     }
 
-    return {
-        rawJson: repaired,
-        repairedTruncation: repaired !== fragment,
-    };
+    if (lastCommaCheckpoint) {
+        const completePrefix = fragment
+            .slice(0, lastCommaCheckpoint.endIndex)
+            .trimEnd();
+        const fallback = closeJsonContainers(completePrefix, lastCommaCheckpoint.container);
+        if (isParsableJsonObject(fallback, true)) {
+            return {
+                rawJson: fallback,
+                repairedTruncation: true,
+            };
+        }
+    }
+
+    return null;
 }
 
 export function parsePatientInsightExtractionResponse(response: string): AITaskParseResult<PatientInsightExtraction> {


### PR DESCRIPTION
## Summary
- Ripara gli oggetti JSON del modello troncati dentro stringhe o membri finali incompleti.
- Promuove una riparazione solo dopo la validazione come oggetto JSON non vuoto e conserva i membri completi precedenti.
- Mantiene distinti JSON malformati, marker come `[S1]` e radici array, senza ridurre un array al primo elemento.

## Verification
- `npm run test:ai-task-contracts` su Node 24.18.0: 33/33 pass.
- `npm run lint`.
- `npm run typecheck`.
- `npm run check:claims`: 466 file, 0 claim ad alto rischio.
- `npm run check:never-regress`.
- `npm run build` e controllo standalone runtime bundle.
- `git diff --check`.
- Probe sintetico su 846 prefissi: tutti i 795 risultati dichiarati riparati sono oggetti JSON parsabili.
- Revisione indipendente finale sul diff reale: nessun rilievo residuo.

## Risk / Notes
- Scope limitato al parser dei contratti AI e ai relativi test; nessun cambio a schema, API, persistenza o interfaccia.
- Un token numerico troncato che resta sintatticamente valido è indistinguibile dal numero completo; i contratti consumer correnti usano campi testuali.
- Nessuna PHI/PII, nessun dato paziente reale, nessun contenuto email.

## Ticket
Refs WUL-362 (solo AIH-14 e AIH-62; gli altri finding restano aperti).