### PR TITLE
refactor(client): limita le invalidazioni live-query per tabella

### DIFF
--- a/app/analytics/page.tsx
+++ b/app/analytics/page.tsx
@@ -168,9 +168,10 @@ function SectionHeading({ label, title, description }: { label: string; title: s
 }
 
 export default function AnalyticsPage() {
+    /* @Codex */
     const patients = useLiveQuery(async () => db.patients
         .filter((patient) => !patient.isArchived)
-        .toArray());
+        .toArray(), [], undefined, ['patients', 'patients_to_ambulatories']);
     const [ageRange, setAgeRange] = useState<[number, number]>([0, 120]);
     const [auditDays, setAuditDays] = useState(30);
     const [auditSummary, setAuditSummary] = useState<AuditSummary | null>(null);

--- a/app/patients/[id]/edit/page.tsx
+++ b/app/patients/[id]/edit/page.tsx
@@ -30,6 +30,7 @@ export default function EditPatientPage() {
     const { showToast } = useToast();
     const confirm = useConfirm();
 
+    /* @Codex */
     const patient = useLiveQuery(async () => {
         const p = await db.patients.get(id);
         if (!p) return null;
@@ -37,7 +38,7 @@ export default function EditPatientPage() {
         // Fetch relations
         const checkups = await db.checkups.filter((c: any) => c.patientId === id).toArray();
         return { ...p, checkups };
-    }, [id]);
+    }, [id], undefined, ['patients', 'checkups']);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const onSubmit = async (data: any) => {

--- a/app/patients/[id]/modules/page.tsx
+++ b/app/patients/[id]/modules/page.tsx
@@ -213,6 +213,8 @@ export default function PatientDetailPage() {
     const { data: documentSynthesisKillSwitch, loading: documentSynthesisKillSwitchLoading } = useLiveQueryState(
         () => db.settings.get(AI_DOCUMENT_SYNTHESIS_KILL_SWITCH_KEY),
         [],
+        undefined,
+        ['settings'],
     );
     /* @Codex LUME-104/68: non derivare lo stato fail-closed del pannello mentre
        la preferenza e ancora in caricamento: aprirebbe la sezione per un falso
@@ -220,8 +222,15 @@ export default function PatientDetailPage() {
     const { data: patientInsightKillSwitch, loading: patientInsightKillSwitchLoading } = useLiveQueryState(
         () => db.settings.get(AI_PATIENT_INSIGHT_KILL_SWITCH_KEY),
         [],
+        undefined,
+        ['settings'],
     );
-    const smartImportKillSwitch = useLiveQuery(() => db.settings.get(AI_SMART_IMPORT_KILL_SWITCH_KEY), []);
+    const smartImportKillSwitch = useLiveQuery(
+        () => db.settings.get(AI_SMART_IMPORT_KILL_SWITCH_KEY),
+        [],
+        undefined,
+        ['settings'],
+    );
     /* @Codex */
     const exemptionCodes = Array.isArray(patient?.exemptions) ? patient.exemptions : [];
     /* @Codex */
@@ -254,6 +263,8 @@ export default function PatientDetailPage() {
             }));
         },
         [exemptionCodes.join('|')],
+        undefined,
+        ['exemptions'],
     );
 
     /* @Codex WUL-UIUX Fase 7: stessa pipeline del Quadro (lib/patient-workspace).

--- a/app/patients/[id]/scales/[scaleId]/page.tsx
+++ b/app/patients/[id]/scales/[scaleId]/page.tsx
@@ -22,7 +22,8 @@ export default function ScaleRunnerPage() {
     const scaleId = params.scaleId as string;
     const [setting, setSetting] = useState<'ambulatory' | 'home'>('ambulatory');
 
-    const patient = useLiveQuery(() => db.patients.get(patientId), [patientId]);
+    /* @Codex */
+    const patient = useLiveQuery(() => db.patients.get(patientId), [patientId], undefined, ['patients']);
     const scaleDef = SCALES[scaleId];
 
     const handleComplete = async (result: { score: number; answers: Record<string, string | number>; interpretation: string }) => {

--- a/app/patients/[id]/scales/page.tsx
+++ b/app/patients/[id]/scales/page.tsx
@@ -30,7 +30,8 @@ function getScaleIcon(scaleId: string) {
 export default function ScalesPage() {
     const params = useParams();
     const id = params.id as string;
-    const patient = useLiveQuery(() => db.patients.get(id), [id]);
+    /* @Codex */
+    const patient = useLiveQuery(() => db.patients.get(id), [id], undefined, ['patients']);
     const scales = Object.values(SCALES);
 
     const workspaceNavItems: Kree8WorkspaceNavItem[] = [

--- a/app/scales/page.tsx
+++ b/app/scales/page.tsx
@@ -59,6 +59,7 @@ export default function ScalesLibraryPage() {
         ? [...SCALE_NAV_BASE, { href: '#paziente', label: 'Paziente', meta: 'avvio scala' }]
         : SCALE_NAV_BASE;
 
+    /* @Codex */
     const patients = useLiveQuery(
         () => {
             if (!selectedScaleDefinition) return Promise.resolve([]);
@@ -71,7 +72,9 @@ export default function ScalesLibraryPage() {
                 .limit(8)
                 .toArray();
         },
-        [normalizedSearchTerm, selectedScaleDefinition]
+        [normalizedSearchTerm, selectedScaleDefinition],
+        undefined,
+        ['patients', 'patients_to_ambulatories'],
     );
 
     useEffect(() => {

--- a/components/ai-patient-insight.tsx
+++ b/components/ai-patient-insight.tsx
@@ -32,7 +32,12 @@ export default function AIPatientInsight({ patient, stale = false }: AIPatientIn
     const [modelLabel, setModelLabel] = useState<string>("");
     const aiModelLabels = useAiModelLabels();
     /* @Codex */
-    const patientInsightKillSwitch = useLiveQuery(() => db.settings.get(AI_PATIENT_INSIGHT_KILL_SWITCH_KEY), []);
+    const patientInsightKillSwitch = useLiveQuery(
+        () => db.settings.get(AI_PATIENT_INSIGHT_KILL_SWITCH_KEY),
+        [],
+        undefined,
+        ['settings'],
+    );
 
     const abortControllerRef = useRef<AbortController | null>(null);
     /* @Codex */

--- a/components/document-upload.tsx
+++ b/components/document-upload.tsx
@@ -61,9 +61,16 @@ export default function DocumentUpload({ patientId }: DocumentUploadProps) {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             return items.sort((a: any, b: any) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
         },
-        [patientId]
+        [patientId],
+        undefined,
+        ['attachments'],
     );
-    const documentSynthesisKillSwitch = useLiveQuery(() => db.settings.get(AI_DOCUMENT_SYNTHESIS_KILL_SWITCH_KEY), []);
+    const documentSynthesisKillSwitch = useLiveQuery(
+        () => db.settings.get(AI_DOCUMENT_SYNTHESIS_KILL_SWITCH_KEY),
+        [],
+        undefined,
+        ['settings'],
+    );
     const documentSynthesisEnabled = isAiDocumentSynthesisEnabledValue(documentSynthesisKillSwitch?.value);
 
 
@@ -293,7 +300,7 @@ export default function DocumentUpload({ patientId }: DocumentUploadProps) {
             await db.attachments.update(file.id, { ocrQueueState: 'ocr_failed' }).catch(() => undefined);
         } finally {
             setReplayingId(null);
-            notifyDbChange();
+            notifyDbChange('attachments');
         }
     };
 

--- a/components/kree8/areas/repertori-area.tsx
+++ b/components/kree8/areas/repertori-area.tsx
@@ -142,6 +142,7 @@ function buildLiveCatalogState(drugCount: number, exemptionCount: number): Kree8
 
 function RepertoriArea({ isReview }: { isReview: boolean }) {
   const [selectedCatalogId, setSelectedCatalogId] = useState(REVIEW_CATALOGS[0]?.id ?? '');
+  /* @Codex */
   const catalogState = useLiveQuery<Kree8CatalogClientState, Kree8CatalogClientState>(
     async () => {
       if (isReview) return REVIEW_CATALOG_STATE;
@@ -166,6 +167,7 @@ function RepertoriArea({ isReview }: { isReview: boolean }) {
       rows: [],
       indexedCount: 0,
     },
+    ['drugs', 'exemptions'],
   );
 
   const catalogs = catalogState?.rows ?? [];

--- a/components/kree8/kree8-clinical-cockpit.tsx
+++ b/components/kree8/kree8-clinical-cockpit.tsx
@@ -230,7 +230,7 @@ export function Kree8ClinicalCockpit({
     async () => (isReview ? [] : db.patients.toArray()),
     [isReview],
     undefined,
-    ['patients'],
+    ['patients', 'patients_to_ambulatories'],
   );
 
   /* @Codex */
@@ -287,7 +287,7 @@ export function Kree8ClinicalCockpit({
     },
     [isReview, selectedPatient?.id],
     undefined,
-    ['entries', 'therapies', 'checkups', 'observations', 'attachments'],
+    ['patients', 'entries', 'therapies', 'checkups', 'observations', 'attachments'],
   );
 
   useEffect(() => {

--- a/components/observation-manager.tsx
+++ b/components/observation-manager.tsx
@@ -147,12 +147,15 @@ export default function ObservationManager({
     const italianLoincLabel = (analyteCode: string, fallback: string) =>
         loincOptions.find((item) => item.code === analyteCode)?.displayIt ?? fallback;
 
+    /* @Codex */
     const observations = useLiveQuery(
         async () => {
             const items = await db.observations.filter((o) => o.patientId === patientId).toArray();
             return items.sort((a, b) => new Date(b.observedAt).getTime() - new Date(a.observedAt).getTime());
         },
         [patientId],
+        undefined,
+        ['observations'],
     );
 
     type Observation = NonNullable<typeof observations>[number];

--- a/components/patient-smart-import-panel.tsx
+++ b/components/patient-smart-import-panel.tsx
@@ -294,7 +294,12 @@ export default function PatientSmartImportPanel({ patient, entries = [], onRevie
         undefined,
         ['attachments'],
     );
-    const smartImportKillSwitch = useLiveQuery(() => db.settings.get(AI_SMART_IMPORT_KILL_SWITCH_KEY), []);
+    const smartImportKillSwitch = useLiveQuery(
+        () => db.settings.get(AI_SMART_IMPORT_KILL_SWITCH_KEY),
+        [],
+        undefined,
+        ['settings'],
+    );
 
     const sourceCount = countUsableSources(patient, entries, attachments?.length || 0);
     const smartImportEnabled = isAiSmartImportEnabledValue(smartImportKillSwitch?.value);

--- a/components/pdf-importer.tsx
+++ b/components/pdf-importer.tsx
@@ -38,7 +38,12 @@ export default function PdfImporter({ onDataExtracted, patientId }: PdfImporterP
     const [aiStage, setAiStage] = useState<string>("");
     /* @Codex */
     const aiModels = useAiModelLabels();
-    const documentSynthesisKillSwitch = useLiveQuery(() => db.settings.get(AI_DOCUMENT_SYNTHESIS_KILL_SWITCH_KEY), []);
+    const documentSynthesisKillSwitch = useLiveQuery(
+        () => db.settings.get(AI_DOCUMENT_SYNTHESIS_KILL_SWITCH_KEY),
+        [],
+        undefined,
+        ['settings'],
+    );
     const documentSynthesisEnabled = isAiDocumentSynthesisEnabledValue(documentSynthesisKillSwitch?.value);
 
     const onDrop = async (acceptedFiles: File[]) => {

--- a/components/prosthetic-prescription-manager.tsx
+++ b/components/prosthetic-prescription-manager.tsx
@@ -115,6 +115,7 @@ export default function ProstheticPrescriptionManager({ patientId, embedded = fa
     const [error, setError] = useState<string | null>(null);
     const [form, setForm] = useState<FormState>(() => emptyForm());
 
+    /* @Codex */
     const prescriptions = useLiveQuery(
         async () => {
             const items = await db.prostheticPrescriptions
@@ -123,6 +124,8 @@ export default function ProstheticPrescriptionManager({ patientId, embedded = fa
             return items.sort((left, right) => new Date(right.prescribedAt).getTime() - new Date(left.prescribedAt).getTime());
         },
         [patientId],
+        undefined,
+        ['prosthetic_prescriptions'],
     );
 
     const testedCount = useMemo(

--- a/components/service-prescription-manager.tsx
+++ b/components/service-prescription-manager.tsx
@@ -194,6 +194,7 @@ export default function ServicePrescriptionManager({ patientId, embedded = false
     const [error, setError] = useState<string | null>(null);
     const [form, setForm] = useState<FormState>(() => emptyForm());
 
+    /* @Codex */
     const prescriptions = useLiveQuery(
         async () => {
             const items = await db.servicePrescriptions
@@ -204,6 +205,8 @@ export default function ServicePrescriptionManager({ patientId, embedded = false
             );
         },
         [patientId],
+        undefined,
+        ['service_prescriptions'],
     );
 
     const prescriptionItems = useLiveQuery(
@@ -214,6 +217,8 @@ export default function ServicePrescriptionManager({ patientId, embedded = false
             return items.sort((left, right) => left.ordinal - right.ordinal);
         },
         [patientId],
+        undefined,
+        ['service_prescription_items'],
     );
 
     const itemsByPrescription = useMemo(() => {

--- a/components/service-prescription-manager.tsx
+++ b/components/service-prescription-manager.tsx
@@ -22,7 +22,7 @@ import {
     type ServicePrescriptionPriority,
     type ServicePrescriptionStatus,
 } from '@/lib/db';
-import { useLiveQuery } from '@/lib/live-query';
+import { notifyDbChange, useLiveQuery } from '@/lib/live-query';
 import { useConfirm } from '@/components/ui/confirm-dialog';
 import { DocumentReferenceChip } from '@/components/document-reference-chip';
 import { Badge } from '@/components/ui/badge';
@@ -391,9 +391,15 @@ export default function ServicePrescriptionManager({ patientId, embedded = false
             tone: 'danger'
         });
         if (!confirmed) return;
-        const children = itemsByPrescription.get(item.id) ?? [];
-        await Promise.all(children.map((child) => db.servicePrescriptionItems.delete(child.id, { suppressNotify: true, version: child.version })));
-        await db.servicePrescriptions.delete(item.id, { version: item.version });
+        try {
+            await db.servicePrescriptions.delete(item.id, { version: item.version });
+        } catch (error) {
+            notifyDbChange('service_prescriptions');
+            throw error;
+        } finally {
+            // @Codex: il delete atomico del parent rimuove anche i figli lato server.
+            notifyDbChange('service_prescription_items');
+        }
     };
 
     const headerActions = (

--- a/components/siss-handoff-diary.tsx
+++ b/components/siss-handoff-diary.tsx
@@ -78,6 +78,7 @@ export default function SissHandoffDiary({ patientId, embedded = false }: Props)
     const [closureNextAction, setClosureNextAction] = useState('');
     const [closureOutcome, setClosureOutcome] = useState<SissHandoffOutcome>('completed');
 
+    /* @Codex */
     const handoffs = useLiveQuery(
         async () => {
             const items = await db.sissHandoffs
@@ -86,6 +87,8 @@ export default function SissHandoffDiary({ patientId, embedded = false }: Props)
             return items.sort((left, right) => new Date(right.startedAt).getTime() - new Date(left.startedAt).getTime());
         },
         [patientId],
+        undefined,
+        ['siss_handoff_events'],
     );
 
     const pendingHandoff = useMemo(

--- a/components/siss-patient-context-panel.tsx
+++ b/components/siss-patient-context-panel.tsx
@@ -276,6 +276,8 @@ export default function SissPatientContextPanel({ patientId, patientTaxCode, emb
             return new Map(payload.map((item) => [item.code.trim().toUpperCase(), item.description || '']));
         },
         [prescriptiveExemptionCodes.join('|')],
+        undefined,
+        ['exemptions'],
     );
 
     const handleCopyField = async (field: PrescriptiveCopyField) => {

--- a/components/timeline-entry-card.tsx
+++ b/components/timeline-entry-card.tsx
@@ -62,12 +62,15 @@ function presentEntry(entry: TimelineEntryData): EntryPresentation {
 }
 
 function EntryAttachments({ attachmentIds, onView }: { attachmentIds: string[], onView: (file: Attachment) => void }) {
+    /* @Codex */
     const attachments = useLiveQuery(
         async () => {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             return await db.attachments.filter((a: any) => attachmentIds.includes(a.id)).toArray();
         },
-        [attachmentIds]
+        [attachmentIds],
+        undefined,
+        ['attachments'],
     );
 
     if (!attachments?.length) return null;

--- a/components/treatment-reasoning-panel.tsx
+++ b/components/treatment-reasoning-panel.tsx
@@ -93,6 +93,8 @@ export default function TreatmentReasoningPanel({
     const treatmentReasoningKillSwitch = useLiveQuery(
         () => db.settings.get(AI_TREATMENT_REASONING_KILL_SWITCH_KEY),
         [],
+        undefined,
+        ['settings'],
     );
     const treatmentReasoningEnabled = isAiTreatmentReasoningEnabledValue(treatmentReasoningKillSwitch?.value);
     const sourceSummary = useMemo(

--- a/lib/hooks/use-clinical-alerts.ts
+++ b/lib/hooks/use-clinical-alerts.ts
@@ -11,6 +11,7 @@ export interface ClinicalAlert {
 }
 
 export function useClinicalAlerts() {
+    /* @Codex */
     return useLiveQuery(async () => {
         // Only consider active patients
         const patients = await db.patients
@@ -90,5 +91,5 @@ export function useClinicalAlerts() {
 
         // Return top 5 most urgent
         return alerts.sort((a, _b) => (a.severity === 'high' ? -1 : 1)).slice(0, 5);
-    }, []);
+    }, [], undefined, ['patients', 'patients_to_ambulatories', 'entries']);
 }

--- a/lib/live-query-scope.ts
+++ b/lib/live-query-scope.ts
@@ -1,17 +1,48 @@
-// STREAM B: pure scoped-invalidation predicate for the live-query layer.
-//
-// Kept in its own module (no React import) so it can be unit-tested under the
-// strip-types test runner without pulling the client-only React hooks in
-// live-query.ts.
-//
-// A scoped listener re-runs when: the notification is unscoped (changedTable
-// undefined), or the subscriber is unscoped (tables empty/undefined), or the
-// changed table is in the subscriber's set.
+/* @Codex */
+export type DbChangeTable = string;
+export type DbChangeScope = readonly DbChangeTable[] | undefined;
+
+// An unscoped notification or subscription preserves the original broadcast
+// behaviour. Otherwise only listeners interested in the changed table run.
 export function shouldReactToChange(
-    tables: readonly string[] | undefined,
-    changedTable: string | undefined,
+    tables: DbChangeScope,
+    changedTable: DbChangeTable | undefined,
 ): boolean {
     if (changedTable === undefined) return true;
     if (!tables || tables.length === 0) return true;
     return tables.includes(changedTable);
+}
+
+type DbChangeListener = () => void;
+type DbChangeSubscription = {
+    listener: DbChangeListener;
+    resolveScope: () => DbChangeScope;
+};
+
+/* @Codex */
+export function createDbChangeBus() {
+    const subscriptions = new Set<DbChangeSubscription>();
+
+    const subscribeWithScopeResolver = (
+        listener: DbChangeListener,
+        resolveScope: () => DbChangeScope,
+    ) => {
+        const subscription = { listener, resolveScope };
+        subscriptions.add(subscription);
+        return () => {
+            subscriptions.delete(subscription);
+        };
+    };
+
+    return {
+        subscribe(listener: DbChangeListener, scope?: DbChangeScope) {
+            return subscribeWithScopeResolver(listener, () => scope);
+        },
+        subscribeWithScopeResolver,
+        notify(changedTable?: DbChangeTable) {
+            subscriptions.forEach(({ listener, resolveScope }) => {
+                if (shouldReactToChange(resolveScope(), changedTable)) listener();
+            });
+        },
+    };
 }

--- a/lib/live-query-scoped-invalidation.test.ts
+++ b/lib/live-query-scoped-invalidation.test.ts
@@ -1,26 +1,38 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { shouldReactToChange } from './live-query-scope';
+import { createDbChangeBus } from './live-query-scope';
 
-test('unscoped notification wakes every subscriber (backward compatible)', () => {
-    // notifyDbChange() with no table === undefined changedTable.
-    assert.equal(shouldReactToChange(undefined, undefined), true);
-    assert.equal(shouldReactToChange([], undefined), true);
-    assert.equal(shouldReactToChange(['entries'], undefined), true);
+/* @Codex */
+test('a table notification wakes only matching and unscoped subscribers', () => {
+    const bus = createDbChangeBus();
+    let patientInvalidations = 0;
+    let observationInvalidations = 0;
+    let globalInvalidations = 0;
+
+    bus.subscribe(() => { patientInvalidations += 1; }, ['patients']);
+    bus.subscribe(() => { observationInvalidations += 1; }, ['observations']);
+    bus.subscribe(() => { globalInvalidations += 1; });
+
+    bus.notify('observations');
+
+    assert.equal(patientInvalidations, 0);
+    assert.equal(observationInvalidations, 1);
+    assert.equal(globalInvalidations, 1);
 });
 
-test('unscoped subscriber wakes on any table change', () => {
-    assert.equal(shouldReactToChange(undefined, 'entries'), true);
-    assert.equal(shouldReactToChange([], 'attachments'), true);
-});
+test('an unscoped notification wakes every subscriber', () => {
+    const bus = createDbChangeBus();
+    let patientInvalidations = 0;
+    let observationInvalidations = 0;
+    let globalInvalidations = 0;
 
-test('scoped subscriber wakes only on a matching table', () => {
-    assert.equal(shouldReactToChange(['entries'], 'entries'), true);
-    assert.equal(shouldReactToChange(['entries', 'therapies'], 'therapies'), true);
-});
+    bus.subscribe(() => { patientInvalidations += 1; }, ['patients']);
+    bus.subscribe(() => { observationInvalidations += 1; }, ['observations']);
+    bus.subscribe(() => { globalInvalidations += 1; });
 
-test('scoped subscriber ignores unrelated table changes', () => {
-    assert.equal(shouldReactToChange(['entries'], 'attachments'), false);
-    assert.equal(shouldReactToChange(['patients'], 'checkups'), false);
-    assert.equal(shouldReactToChange(['entries', 'therapies'], 'observations'), false);
+    bus.notify();
+
+    assert.equal(patientInvalidations, 1);
+    assert.equal(observationInvalidations, 1);
+    assert.equal(globalInvalidations, 1);
 });

--- a/lib/live-query-scoped-invalidation.test.ts
+++ b/lib/live-query-scoped-invalidation.test.ts
@@ -1,6 +1,14 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import { createDbChangeBus } from './live-query-scope';
+
+function sourceBetween(source: string, startMarker: string, endMarker: string): string {
+    const start = source.indexOf(startMarker);
+    const end = source.indexOf(endMarker, start + startMarker.length);
+    assert.ok(start >= 0 && end > start, `invalid source markers: ${startMarker} -> ${endMarker}`);
+    return source.slice(start, end);
+}
 
 /* @Codex */
 test('a table notification wakes only matching and unscoped subscribers', () => {
@@ -35,4 +43,50 @@ test('an unscoped notification wakes every subscriber', () => {
     assert.equal(patientInvalidations, 1);
     assert.equal(observationInvalidations, 1);
     assert.equal(globalInvalidations, 1);
+});
+
+test('subscriptions observe their latest scope and can unsubscribe', () => {
+    const bus = createDbChangeBus();
+    let scope: readonly string[] = ['patients'];
+    let scopedInvalidations = 0;
+    let globalInvalidations = 0;
+    bus.subscribeWithScopeResolver(() => { scopedInvalidations += 1; }, () => scope);
+    const unsubscribeGlobal = bus.subscribe(() => { globalInvalidations += 1; }, []);
+
+    bus.notify('patients');
+    scope = ['observations'];
+    bus.notify('patients');
+    bus.notify('observations');
+    unsubscribeGlobal();
+    bus.notify();
+
+    assert.equal(scopedInvalidations, 3);
+    assert.equal(globalInvalidations, 3);
+});
+
+test('composite mutations retain every required invalidation', () => {
+    const serviceSource = readFileSync('components/service-prescription-manager.tsx', 'utf8');
+    const deleteBlock = sourceBetween(serviceSource, 'const deleteItem', 'const headerActions');
+    assert.doesNotMatch(deleteBlock, /servicePrescriptionItems\.delete/);
+    assert.match(deleteBlock, /try\s*\{[\s\S]*servicePrescriptions\.delete[\s\S]*\}\s*catch \(error\) \{[^}]*notifyDbChange\('service_prescriptions'\);[^}]*throw error;\s*\}\s*finally\s*\{[^}]*notifyDbChange\('service_prescription_items'\);\s*\}/);
+    const clipboardSource = readFileSync('hooks/use-patient-clipboard.ts', 'utf8');
+    assert.match(clipboardSource, /return await executePatientClipboardPaste\(\s*clipboard,\s*targetAmbulatoryId,\s*isTestEnvironment,/);
+    assert.match(clipboardSource, /notifyDbChange\(\)/);
+    assert.doesNotMatch(clipboardSource, /fetch\(/);
+    const helperSource = readFileSync('lib/patient-clipboard.ts', 'utf8');
+    assert.match(helperSource, /endpoint = '\/api\/patients\/move'/);
+    assert.match(helperSource, /hasExactPatientVersions/);
+    assert.doesNotMatch(helperSource, /api\/patients\/unassign/);
+});
+
+test('both React hooks retain dynamic scope resolver wiring', () => {
+    const source = readFileSync('lib/live-query.ts', 'utf8');
+    const hookBlocks = [
+        sourceBetween(source, 'export function useLiveQuery<', 'export type LiveQueryState'),
+        sourceBetween(source, 'export function useLiveQueryState<', '    return { data, error, loading };'),
+    ];
+    for (const hookBlock of hookBlocks) {
+        assert.match(hookBlock, /const tablesRef = useRef\(tables\);\s*tablesRef\.current = tables;/);
+        assert.match(hookBlock, /dbChangeBus\.subscribeWithScopeResolver\(\(\) => \{[\s\S]*?\}, \(\) => tablesRef\.current\), \[\]\)/);
+    }
 });

--- a/lib/live-query.ts
+++ b/lib/live-query.ts
@@ -1,46 +1,29 @@
 'use client';
 
 import { DependencyList, useEffect, useRef, useState } from 'react';
-/* STREAM B: pure predicate lives in its own React-free module for unit testing. */
-import { shouldReactToChange } from './live-query-scope';
+import { createDbChangeBus } from './live-query-scope';
+import type { DbChangeScope } from './live-query-scope';
 
 /* @Codex */
-// STREAM B: scoped invalidation. A listener may declare the tables it cares about;
-// a notification carries the table that changed. Unscoped on either side means
-// "match everything" so the pre-existing broadcast behaviour is preserved.
-type DbChangeListener = (table?: string) => void;
+const dbChangeBus = createDbChangeBus();
 
 /* @Codex */
-const dbChangeListeners = new Set<DbChangeListener>();
+export const subscribeDbChanges = dbChangeBus.subscribe;
 
 /* @Codex */
-function subscribeDbChanges(listener: DbChangeListener) {
-    dbChangeListeners.add(listener);
-    return () => {
-        dbChangeListeners.delete(listener);
-    };
-}
-
-/* @Codex */
-// notifyDbChange() with no arg keeps the original semantics (notify everyone).
-// notifyDbChange('entries') only wakes listeners scoped to 'entries' (or unscoped).
-export function notifyDbChange(table?: string) {
-    dbChangeListeners.forEach((listener) => listener(table));
-}
-
+export const notifyDbChange = dbChangeBus.notify;
 
 /* @Codex */
 export function useLiveQuery<T, TDefault = undefined>(
     querier: () => Promise<T> | T,
     deps?: DependencyList,
     defaultResult?: TDefault,
-    /* STREAM B: optional table scope; when set, only matching notifications re-run. */
-    tables?: readonly string[],
+    tables?: DbChangeScope,
 ): T | TDefault | undefined {
     const querierRef = useRef(querier);
     const [result, setResult] = useState<T | TDefault | undefined>(defaultResult);
     const [revision, setRevision] = useState(0);
-    /* @Codex STREAM B: keep latest scope without re-subscribing on every render. */
+    /* @Codex */
     const tablesRef = useRef(tables);
     tablesRef.current = tables;
 
@@ -48,10 +31,9 @@ export function useLiveQuery<T, TDefault = undefined>(
         querierRef.current = querier;
     }, [querier]);
 
-    useEffect(() => subscribeDbChanges((changedTable) => {
-        if (!shouldReactToChange(tablesRef.current, changedTable)) return;
+    useEffect(() => dbChangeBus.subscribeWithScopeResolver(() => {
         setRevision((previous) => previous + 1);
-    }), []);
+    }, () => tablesRef.current), []);
 
     useEffect(() => {
         let cancelled = false;
@@ -90,15 +72,14 @@ export function useLiveQueryState<T, TDefault = undefined>(
     querier: () => Promise<T> | T,
     deps?: DependencyList,
     defaultResult?: TDefault,
-    /* STREAM B: optional table scope; when set, only matching notifications re-run. */
-    tables?: readonly string[],
+    tables?: DbChangeScope,
 ): LiveQueryState<T, TDefault> {
     const querierRef = useRef(querier);
     const [data, setData] = useState<T | TDefault | undefined>(defaultResult);
     const [error, setError] = useState<unknown>(null);
     const [loading, setLoading] = useState(true);
     const [revision, setRevision] = useState(0);
-    /* @Codex STREAM B: keep latest scope without re-subscribing on every render. */
+    /* @Codex */
     const tablesRef = useRef(tables);
     tablesRef.current = tables;
 
@@ -106,10 +87,9 @@ export function useLiveQueryState<T, TDefault = undefined>(
         querierRef.current = querier;
     }, [querier]);
 
-    useEffect(() => subscribeDbChanges((changedTable) => {
-        if (!shouldReactToChange(tablesRef.current, changedTable)) return;
+    useEffect(() => dbChangeBus.subscribeWithScopeResolver(() => {
         setRevision((previous) => previous + 1);
-    }), []);
+    }, () => tablesRef.current), []);
 
     useEffect(() => {
         let cancelled = false;

--- a/lib/live-query.ts
+++ b/lib/live-query.ts
@@ -8,9 +8,6 @@ import type { DbChangeScope } from './live-query-scope';
 const dbChangeBus = createDbChangeBus();
 
 /* @Codex */
-export const subscribeDbChanges = dbChangeBus.subscribe;
-
-/* @Codex */
 export const notifyDbChange = dbChangeBus.notify;
 
 /* @Codex */


### PR DESCRIPTION
## Summary

- Introduce un bus live-query con invalidazioni per tabella e conserva il broadcast globale compatibile.
- Dichiara le tabelle lette dai consumer client rimasti senza scope.
- Conserva la clipboard atomica multi-tabella e usa il delete atomico della prestazione con refresh di parent e figli.
- Aggiunge guardie per scope dinamico, unsubscribe, wiring degli hook e mutazioni composte.

## Verification

- Node 24.18.0 runtime contract: pass.
- `npm run test:list-query-data-plane`: 25/25.
- `npm run test:patient-clipboard`: 4/4.
- `prescription-delete-concurrency.test.ts`: 4/4.
- `npm run test:unit`: 759/759.
- `npm run lint`: pass.
- `npm run typecheck`: pass.
- `npm run check:claims`: 466 file, 0 claim ad alto rischio.
- `npm run check:never-regress`: pass.
- `npm run build`: pass, incluso il bundle standalone.
- `git diff --check`: pass.
- Review indipendente Claude e Sol: SHIP sul diff finale.

## Risk / Notes

- `DbChangeTable` resta una stringa; i mapping correnti sono stati confrontati con il registro `ApiTable`.
- Il build conserva due warning Turbopack preesistenti su Athena MLX e `next.config.ts`, fuori dal diff.
- Nessuna migrazione, dipendenza, PHI/PII o modifica dei confini server e sicurezza.

## Ticket

Fixes WUL-507
