### PR TITLE
feat(ocr): aggiungi parser deterministico referti lab

### DIFF
--- a/lib/domain/documents/lab-report-parser.fixtures.ts
+++ b/lib/domain/documents/lab-report-parser.fixtures.ts
@@ -1,0 +1,25 @@
+/* @Codex */
+export const SYNTHETIC_LAB_REPORT_FIXTURES = [
+    {
+        id: 'columns-and-decimal-comma',
+        text: `REFERT0 SINTETICO - CHIMICA CLINICA
+Esame    Risultato    Unita    Valori di riferimento
+Creatinina    1,35 *    mg/dL    0,50 - 1,10    H
+Sodio         140       mmol/L   136 - 145`,
+        expectedAnalytes: ['Creatinina', 'Sodio'],
+    },
+    {
+        id: 'pipes-and-unilateral-bound',
+        text: `CAMPIONE SINTETICO
+Proteina C reattiva | 3,2 | mg/L | < 5
+Potassio | 3,1 | mmol/L | 3,5-5,1 | L`,
+        expectedAnalytes: ['Proteina C reattiva', 'Potassio'],
+    },
+    {
+        id: 'hematology-stars-and-ucum',
+        text: `EMATOLOGIA
+Emoglobina;** 10,8;g/dL;12,0 - 16,0;BASSO
+Globuli bianchi\t7,20\t10^3/uL\t4,00-10,00`,
+        expectedAnalytes: ['Emoglobina', 'Globuli bianchi'],
+    },
+] as const;

--- a/lib/domain/documents/lab-report-parser.test.ts
+++ b/lib/domain/documents/lab-report-parser.test.ts
@@ -1,0 +1,61 @@
+/* @Codex */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { SYNTHETIC_LAB_REPORT_FIXTURES } from './lab-report-parser.fixtures.ts';
+import { parseItalianLabReport } from './lab-report-parser.ts';
+
+for (const fixture of SYNTHETIC_LAB_REPORT_FIXTURES) {
+    test(`parses synthetic Italian lab fixture: ${fixture.id}`, () => {
+        const results = parseItalianLabReport(fixture.text);
+        assert.deepEqual(results.map((result) => result.analyte), [...fixture.expectedAnalytes]);
+    });
+}
+
+test('normalizes decimal commas, unilateral ranges, UCUM units and range flags', () => {
+    const results = SYNTHETIC_LAB_REPORT_FIXTURES.flatMap((fixture) => parseItalianLabReport(fixture.text));
+    const creatinine = results.find((result) => result.analyte === 'Creatinina');
+    const crp = results.find((result) => result.analyte === 'Proteina C reattiva');
+    const whiteCells = results.find((result) => result.analyte === 'Globuli bianchi');
+
+    assert.deepEqual(creatinine, {
+        analyte: 'Creatinina', value: '1.35', unit: 'mg/dL',
+        referenceRange: { text: '0,50 - 1,10', low: '0.50', high: '1.10' },
+        flag: 'alto', lineNumber: 3,
+        sourceLine: 'Creatinina    1,35 *    mg/dL    0,50 - 1,10    H',
+    });
+    assert.deepEqual(crp?.referenceRange, { text: '< 5', high: '5' });
+    assert.equal(crp?.flag, undefined);
+    assert.equal(whiteCells?.unit, '10*3/uL');
+});
+
+test('preserves strict and inclusive unilateral bounds at the threshold', () => {
+    const results = parseItalianLabReport(`Proteina C reattiva 5 mg/L < 5 H
+TSH 4 uUI/mL > 4 L
+Sodio 145 mmol/L <= 145`);
+
+    assert.deepEqual(results.map(({ analyte, flag }) => ({ analyte, flag })), [
+        { analyte: 'Proteina C reattiva', flag: 'alto' },
+        { analyte: 'TSH', flag: 'basso' },
+        { analyte: 'Sodio', flag: undefined },
+    ]);
+});
+
+test('canonicalizes supported unit casing and rejects ambiguous compact cell counts', () => {
+    const [sodium] = parseItalianLabReport('Sodio 140 MMOL/L 136-145');
+
+    assert.equal(sodium?.unit, 'mmol/L');
+    assert.deepEqual(parseItalianLabReport('Globuli bianchi 7,2 103/uL 4-10'), []);
+});
+
+test('discards incomplete, malformed and contradictory rows instead of guessing', () => {
+    const text = `Glicemia 104 mg/dL
+Creatinina 1,20 0,50-1,10
+Codice pratica 202607170001 mg/dL 0-10
+Potassio 6,2 mmol/L 3,5-5,1 L
+Sodio 140 mmol/L 136-145 H
+Proteina C reattiva > 5 mg/L < 5 H
+TSH < 4 uUI/mL > 4 L
+Calcio sette mg/dL 8,5-10,5`;
+
+    assert.deepEqual(parseItalianLabReport(text), []);
+});

--- a/lib/domain/documents/lab-report-parser.ts
+++ b/lib/domain/documents/lab-report-parser.ts
@@ -1,0 +1,151 @@
+/* @Codex */
+import { classifyObservationRange, toNumericValue, type ObservationRangeFlag } from '../../observation-range';
+
+export interface ParsedLabResult {
+    analyte: string;
+    value: string;
+    unit: string;
+    referenceRange: {
+        text: string;
+        low?: string;
+        high?: string;
+    };
+    flag?: ObservationRangeFlag;
+    lineNumber: number;
+    sourceLine: string;
+}
+
+const NUMBER_SOURCE = String.raw`-?\d+(?:[.,]\d+)?`;
+const UNIT_SOURCE = String.raw`(?:mg\/dL|mg\/L|g\/dL|g\/L|mmol\/L|mEq\/L|U\/L|UI\/L|mUI\/L|uUI\/mL|[µμ]UI\/mL|ng\/mL|ng\/dL|pg\/mL|pg|fL|%|[µμu]g\/dL|[µμu]mol\/L|10(?:\^|\*)[36]\/[µμu]L)`;
+const RANGE_SOURCE = String.raw`(?:${NUMBER_SOURCE}\s*[-–]\s*${NUMBER_SOURCE}|[<>]=?\s*${NUMBER_SOURCE})`;
+const LAB_ROW = new RegExp(
+    String.raw`^(?<analyte>[\p{L}][\p{L}\p{N}()./' +%-]{1,79}?)\s+(?<leadingMark>\*{1,2}\s*)?(?<value>${NUMBER_SOURCE})(?<valueMark>\s*\*{1,2})?\s+(?<unit>${UNIT_SOURCE})\s+\(?(?<range>${RANGE_SOURCE})\)?(?:\s+(?<flag>H|L|ALTO|BASSO|HIGH|LOW|↑|↓|\*{1,2}))?$`,
+    'iu',
+);
+
+const HEADER_OR_NOISE = /^(?:esame|analita|parametro|risultato|valore|unita|unità|intervallo|range|valori? di riferimento|metodo|materiale|campione)\b/i;
+
+interface ParsedReferenceRange {
+    range: ParsedLabResult['referenceRange'];
+    lowerExclusive: boolean;
+    upperExclusive: boolean;
+}
+
+function normalizeDecimal(value: string): string {
+    return value.replace(/\s+/g, '').replace(',', '.');
+}
+
+function normalizeUnit(value: string): string {
+    const normalized = value.replace(/[µμ]/g, 'u');
+    const cellCount = normalized.match(/^10(?:\^|\*)([36])\/uL$/i);
+    if (cellCount) return `10*${cellCount[1]}/uL`;
+
+    const canonicalUnits: Record<string, string> = {
+        'mg/dl': 'mg/dL',
+        'mg/l': 'mg/L',
+        'g/dl': 'g/dL',
+        'g/l': 'g/L',
+        'mmol/l': 'mmol/L',
+        'meq/l': 'mEq/L',
+        'u/l': 'U/L',
+        'ui/l': 'U/L',
+        'mui/l': 'mUI/L',
+        'uui/ml': 'uUI/mL',
+        'ng/ml': 'ng/mL',
+        'ng/dl': 'ng/dL',
+        'pg/ml': 'pg/mL',
+        pg: 'pg',
+        fl: 'fL',
+        '%': '%',
+        'ug/dl': 'ug/dL',
+        'umol/l': 'umol/L',
+    };
+    return canonicalUnits[normalized.toLowerCase()] ?? normalized;
+}
+
+function parseReferenceRange(value: string): ParsedReferenceRange | undefined {
+    const text = value.replace(/\s+/g, ' ').trim();
+    const bilateral = text.match(new RegExp(String.raw`^(${NUMBER_SOURCE})\s*[-–]\s*(${NUMBER_SOURCE})$`));
+    if (bilateral) {
+        const low = normalizeDecimal(bilateral[1]);
+        const high = normalizeDecimal(bilateral[2]);
+        const lowNumber = toNumericValue(low);
+        const highNumber = toNumericValue(high);
+        if (lowNumber === null || highNumber === null || lowNumber > highNumber) return undefined;
+        return {
+            range: { text, low, high },
+            lowerExclusive: false,
+            upperExclusive: false,
+        };
+    }
+
+    const unilateral = text.match(new RegExp(String.raw`^([<>]=?)\s*(${NUMBER_SOURCE})$`));
+    if (!unilateral) return undefined;
+    const operator = unilateral[1];
+    const bound = normalizeDecimal(unilateral[2]);
+    if (toNumericValue(bound) === null) return undefined;
+    return operator.startsWith('<')
+        ? {
+            range: { text, high: bound },
+            lowerExclusive: false,
+            upperExclusive: operator === '<',
+        }
+        : {
+            range: { text, low: bound },
+            lowerExclusive: operator === '>',
+            upperExclusive: false,
+        };
+}
+
+function explicitFlag(value: string | undefined): ObservationRangeFlag | undefined {
+    if (!value || /^\*+$/.test(value)) return undefined;
+    return /^(?:H|ALTO|HIGH|↑)$/i.test(value) ? 'alto' : 'basso';
+}
+
+function parseLabRow(sourceLine: string, lineNumber: number): ParsedLabResult | undefined {
+    const normalizedLine = sourceLine
+        .replace(/\u00a0/g, ' ')
+        .replace(/[|;\t]+/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+    if (!normalizedLine || HEADER_OR_NOISE.test(normalizedLine)) return undefined;
+
+    const match = normalizedLine.match(LAB_ROW);
+    if (!match?.groups) return undefined;
+    const analyte = match.groups.analyte.trim();
+    if (analyte.length < 2 || /\d{4,}/.test(analyte)) return undefined;
+
+    const parsedReferenceRange = parseReferenceRange(match.groups.range);
+    if (!parsedReferenceRange) return undefined;
+    const referenceRange = parsedReferenceRange.range;
+    const value = normalizeDecimal(match.groups.value);
+    if ((value.match(/\d/g) ?? []).length > 8) return undefined;
+    const numericValue = toNumericValue(value);
+    const low = referenceRange.low === undefined ? null : toNumericValue(referenceRange.low);
+    const high = referenceRange.high === undefined ? null : toNumericValue(referenceRange.high);
+    const calculatedFlag = classifyObservationRange(value, referenceRange.low, referenceRange.high)
+        ?? (parsedReferenceRange.lowerExclusive && numericValue === low ? 'basso' : undefined)
+        ?? (parsedReferenceRange.upperExclusive && numericValue === high ? 'alto' : undefined);
+    const statedFlag = explicitFlag(match.groups.flag);
+    if (statedFlag && statedFlag !== calculatedFlag) return undefined;
+
+    return {
+        analyte,
+        value,
+        unit: normalizeUnit(match.groups.unit),
+        referenceRange,
+        flag: statedFlag ?? calculatedFlag,
+        lineNumber,
+        sourceLine: sourceLine.trim(),
+    };
+}
+
+/** Estrae solo righe complete e non ambigue. Nessun dato viene persistito. */
+export function parseItalianLabReport(text: string): ParsedLabResult[] {
+    const results: ParsedLabResult[] = [];
+    for (const [index, line] of text.replace(/\r/g, '').split('\n').entries()) {
+        const parsed = parseLabRow(line, index + 1);
+        if (parsed) results.push(parsed);
+    }
+    return results;
+}


### PR DESCRIPTION
## Summary

- aggiunge un parser deterministico per righe complete di referti di
  laboratorio italiani;
- normalizza decimali, unità e intervalli supportati;
- rifiuta righe incomplete e flag espliciti incoerenti, con fixture solo
  sintetiche.

## Verification

- test parser focalizzato: 7/7;
- `npm run test:unit`: 766/766;
- `npm run lint`;
- `npm run typecheck`;
- `npm run check:claims`: 466 file, 0 claim ad alto rischio;
- `npm run check:never-regress`;
- `npm run build`, incluso controllo standalone runtime bundle;
- `git diff --check`.

Tutti i gate sono stati eseguiti con Node 24.18.0.

## Risk / Notes

- il parser non è collegato alla UI e non persiste risultati;
- le unità supportate sono intenzionalmente limitate e i formati sconosciuti
  falliscono chiusi;
- le fixture sintetiche non provano tutti i formati di laboratorio italiani;
- la slice non dichiara conformità LOINC, UCUM generale o normativa;
- nessuna PHI/PII, dato paziente reale o contenuto email.

L'avvertenza Turbopack riguarda `next.config.ts` e Athena MLX, file non
modificati dalla PR.

## Ticket

Fixes WUL-510
