### PR TITLE
fix(ui): consolida le ricette semantiche Lume

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -87,7 +87,7 @@ body {
 
 /* Ensure selected text is readable in dark mode */
 ::selection {
-  background: rgba(15, 23, 42, 0.14);
+  background: color-mix(in srgb, var(--lume-ink) 14%, transparent);
   color: inherit;
 }
 
@@ -96,16 +96,16 @@ body {
   --background: var(--lume-surface-canvas);
   --foreground: var(--lume-ink);
 
-  --card: #1a1f28;
-  --card-foreground: #f4f7fb;
-  --popover: #1a1f28;
-  --popover-foreground: #f4f7fb;
+  --card: var(--lume-surface-field);
+  --card-foreground: var(--lume-ink);
+  --popover: var(--lume-surface-focal);
+  --popover-foreground: var(--lume-ink);
 
-  --input: #222936;
-  --border: rgba(226, 232, 240, 0.1);
-  --muted: #a8b1c1;
-  --muted-foreground: #a8b1c1;
-  --primary: #cbd5e1;
+  --input: var(--lume-surface-focal);
+  --border: color-mix(in srgb, var(--lume-ink) 10%, transparent);
+  --muted: var(--lume-ink-muted);
+  --muted-foreground: var(--lume-ink-muted);
+  --primary: var(--lume-ink);
 }
 
 /* Ensure input/card backgrounds are readable in dark mode */
@@ -198,7 +198,7 @@ body {
 }
 
 :root[data-ui-style='redesign'] .patient-workbench-header {
-  border-color: rgba(112, 106, 100, 0.12);
+  border-color: color-mix(in srgb, var(--lume-ink) 12%, transparent);
 }
 
 :root[data-ui-style='redesign'] .patient-liquid-workbench,
@@ -291,7 +291,7 @@ body {
 
 :root[data-ui-style='redesign'] .patient-identity-lens-reader {
   border-radius: 16px;
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--lume-ink) 4%, transparent);
 }
 
 :root[data-ui-style='redesign'] .identity-lens-pane,
@@ -317,7 +317,7 @@ body {
 :root[data-ui-style='redesign'] .patient-detail-section,
 :root[data-ui-style='redesign'] .patient-detail-side-section {
   border-radius: 16px;
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--lume-ink) 4%, transparent);
 }
 
 /* Dark-mode aliases resolve to the grafite register without translucent overrides. */
@@ -460,26 +460,29 @@ body {
 
   /* @Codex */
   .seeder-panel {
-    @apply rounded-[var(--lume-radius-panel)] border border-slate-200/70 dark:border-white/10 dark:bg-white/5;
+    @apply rounded-[var(--lume-radius-panel)] border;
     background: var(--lume-surface-field);
+    border-color: color-mix(in srgb, var(--lume-ink) 12%, transparent);
     box-shadow: var(--lume-shadow-resting);
   }
 
   /* @Codex */
   .seeder-subsection {
-    @apply rounded-[var(--lume-radius-card)] border border-white/70 dark:border-white/10 dark:bg-white/5;
+    @apply rounded-[var(--lume-radius-card)] border;
     background: var(--lume-surface-field);
+    border-color: color-mix(in srgb, var(--lume-ink) 12%, transparent);
     box-shadow: var(--lume-shadow-resting);
   }
 
   /* @Codex */
   .seeder-subsection-danger {
-    @apply border-red-200/70 dark:border-red-500/20 dark:bg-red-900/10;
+    border-color: color-mix(in srgb, var(--lume-signal-critical) 30%, transparent);
     background: color-mix(in srgb, var(--lume-signal-critical) 10%, var(--lume-surface-field));
   }
 
   .section-kicker {
-    @apply text-[10px] font-semibold uppercase tracking-[0.05em] text-slate-400 dark:text-slate-500;
+    @apply text-[10px] font-semibold uppercase tracking-[0.05em];
+    color: var(--lume-ink-muted);
   }
 
   .ui-btn-primary {
@@ -574,7 +577,7 @@ body {
 
   .clinical-rich-text blockquote,
   .clinical-rich-editor blockquote {
-    border-left: 2px solid rgba(15, 23, 42, 0.16);
+    border-left: 2px solid color-mix(in srgb, var(--lume-ink) 16%, transparent);
     padding-left: 0.875rem;
     color: var(--lume-ink-muted);
   }
@@ -649,70 +652,33 @@ body {
   line-height: 1.2;
 }
 
-/* @Codex WUL-UIUX: tinte semantiche allineate ai token Lume success/warning
-   (rgba dei token al 10-14%), cosi light e dark comunicano lo stesso stato. */
+/* @Codex WUL-515: ricette semantiche Lume condivise dai registri giorno e grafite. */
 .graphite-chip-tone-info {
-  border-color: rgba(75, 85, 101, 0.24);
-  background-color: rgba(75, 85, 101, 0.08);
+  border-color: color-mix(in srgb, var(--lume-accent) 24%, transparent);
+  background-color: color-mix(in srgb, var(--lume-accent) 8%, var(--lume-surface-field));
   color: var(--lume-accent);
 }
 
 .graphite-chip-tone-success {
-  border-color: rgba(75, 99, 84, 0.3);
-  background-color: rgba(75, 99, 84, 0.1);
-  color: var(--lume-signal-success);
+  border-color: color-mix(in srgb, var(--lume-signal-success) 30%, transparent);
+  background-color: color-mix(in srgb, var(--lume-signal-success) 10%, var(--lume-surface-field));
+  color: color-mix(in srgb, var(--lume-signal-success) 60%, var(--lume-ink));
 }
 
 .graphite-chip-tone-warning {
-  border-color: rgba(154, 106, 47, 0.32);
-  background-color: rgba(154, 106, 47, 0.12);
-  color: var(--lume-signal-warning);
+  border-color: color-mix(in srgb, var(--lume-signal-warning) 30%, transparent);
+  background-color: color-mix(in srgb, var(--lume-signal-warning) 10%, var(--lume-surface-field));
+  color: color-mix(in srgb, var(--lume-signal-warning) 60%, var(--lume-ink));
 }
 
 .graphite-chip-tone-critical {
-  border-color: rgba(163, 58, 47, 0.28);
-  background-color: rgba(163, 58, 47, 0.1);
-  color: var(--lume-signal-critical);
+  border-color: color-mix(in srgb, var(--lume-signal-critical) 30%, transparent);
+  background-color: color-mix(in srgb, var(--lume-signal-critical) 10%, var(--lume-surface-field));
+  color: color-mix(in srgb, var(--lume-signal-critical) 60%, var(--lume-ink));
 }
 
 .graphite-chip-tone-muted {
-  border-color: rgba(112, 106, 100, 0.18);
-  background-color: transparent;
-  color: var(--lume-ink-muted);
-}
-
-:root.dark .graphite-chip {
-  border-color: color-mix(in srgb, var(--lume-ink) 10%, transparent);
-  background-color: var(--lume-surface-field);
-  color: var(--lume-ink-muted);
-}
-
-:root.dark .graphite-chip-tone-info {
-  border-color: rgba(203, 213, 225, 0.22);
-  background-color: rgba(203, 213, 225, 0.08);
-  color: rgb(203, 213, 225);
-}
-
-:root.dark .graphite-chip-tone-success {
-  border-color: rgba(140, 210, 160, 0.32);
-  background-color: rgba(110, 190, 130, 0.12);
-  color: rgb(170, 220, 180);
-}
-
-:root.dark .graphite-chip-tone-warning {
-  border-color: rgba(232, 180, 96, 0.34);
-  background-color: rgba(232, 180, 96, 0.14);
-  color: rgb(240, 200, 130);
-}
-
-:root.dark .graphite-chip-tone-critical {
-  border-color: rgba(232, 130, 116, 0.36);
-  background-color: rgba(232, 110, 96, 0.14);
-  color: rgb(244, 170, 158);
-}
-
-:root.dark .graphite-chip-tone-muted {
-  border-color: rgba(255, 247, 240, 0.14);
+  border-color: color-mix(in srgb, var(--lume-ink) 18%, transparent);
   background-color: transparent;
   color: var(--lume-ink-muted);
 }
@@ -769,7 +735,7 @@ body {
 }
 
 .graphite-mini-btn:hover:not(:disabled) {
-  border-color: rgba(15, 23, 42, 0.24);
+  border-color: color-mix(in srgb, var(--lume-ink) 24%, transparent);
   color: var(--lume-ink);
 }
 
@@ -779,18 +745,13 @@ body {
 }
 
 .graphite-mini-btn:focus-visible {
-  outline: 2px solid rgba(15, 23, 42, 0.24);
+  outline: 2px solid color-mix(in srgb, var(--lume-accent) 65%, transparent);
   outline-offset: 2px;
 }
 
 :root.dark .graphite-mini-btn {
   border-color: var(--lume-border-color);
   background-color: var(--lume-surface-field);
-  color: var(--lume-ink);
-}
-
-:root.dark .graphite-mini-btn:hover:not(:disabled) {
-  border-color: rgba(203, 213, 225, 0.24);
   color: var(--lume-ink);
 }
 
@@ -812,12 +773,12 @@ body {
 }
 
 .siss-action-btn:hover:not(:disabled) {
-  border-color: rgba(15, 23, 42, 0.24);
+  border-color: color-mix(in srgb, var(--lume-ink) 24%, transparent);
   background-color: color-mix(in srgb, var(--lume-ink) 5%, var(--lume-surface-field));
 }
 
 .siss-action-btn:focus-visible {
-  outline: 2px solid rgba(15, 23, 42, 0.24);
+  outline: 2px solid color-mix(in srgb, var(--lume-accent) 65%, transparent);
   outline-offset: 2px;
 }
 
@@ -850,13 +811,8 @@ body {
   color: var(--lume-ink);
 }
 
-:root.dark .siss-action-btn:hover:not(:disabled) {
-  border-color: color-mix(in srgb, var(--lume-ink) 24%, transparent);
-  background-color: color-mix(in srgb, var(--lume-ink) 5%, var(--lume-surface-field));
-}
-
 :root.dark .siss-action-btn-head svg {
-  color: rgb(203, 213, 225);
+  color: var(--lume-ink);
 }
 
 .siss-feedback {
@@ -946,11 +902,7 @@ body {
 .siss-blocked-item-reason {
   font-size: 11.5px;
   line-height: 1.5;
-  color: var(--lume-signal-warning);
-}
-
-:root.dark .siss-blocked-item-reason {
-  color: rgb(240, 200, 130);
+  color: color-mix(in srgb, var(--lume-signal-warning) 60%, var(--lume-ink));
 }
 
 /* @Codex: Patient identity lens: code pills that work in dark too. */
@@ -967,27 +919,15 @@ body {
 }
 
 .patient-code-pill-plum {
-  border-color: rgba(15, 23, 42, 0.14);
-  background-color: rgba(15, 23, 42, 0.05);
+  border-color: color-mix(in srgb, var(--lume-signal-plum) 22%, transparent);
+  background-color: color-mix(in srgb, var(--lume-signal-plum) 8%, var(--lume-surface-field));
   color: var(--lume-ink);
 }
 
 .patient-code-pill-primary {
-  border-color: rgba(15, 23, 42, 0.14);
-  background-color: rgba(15, 23, 42, 0.05);
+  border-color: color-mix(in srgb, var(--lume-accent) 22%, transparent);
+  background-color: color-mix(in srgb, var(--lume-accent) 8%, var(--lume-surface-field));
   color: var(--lume-ink);
-}
-
-:root.dark .patient-code-pill-plum {
-  border-color: rgba(203, 213, 225, 0.22);
-  background-color: rgba(203, 213, 225, 0.08);
-  color: rgb(203, 213, 225);
-}
-
-:root.dark .patient-code-pill-primary {
-  border-color: rgba(203, 213, 225, 0.22);
-  background-color: rgba(203, 213, 225, 0.08);
-  color: rgb(203, 213, 225);
 }
 
 /* @Codex: superfici Lume opache per chrome, workspace e chip. */
@@ -1075,7 +1015,7 @@ body {
 
 /* @Codex WUL-229: Primitive Lume riusabili applicate a form,
    modals, dropdowns, secondary buttons and semantic alert blocks so individual
-   pages avoid hand-rolled bg-white/border-gray-* SaaS tokens. */
+   pages avoid hand-rolled palette utilities. */
 
 /* @Codex WUL-UIUX: .input-field era usata in form prestazioni/protesica/SISS
    ma non definita da nessuna parte (input nativi senza superficie ne focus ring).
@@ -1306,11 +1246,11 @@ textarea.input-field {
   display: grid;
   place-items: center;
   padding: 1.25rem;
-  background: rgba(24, 24, 28, 0.62);
+  background: color-mix(in srgb, var(--lume-giorno-ink-primary) 62%, transparent);
 }
 
 :root.dark .mf-modal-backdrop {
-  background: rgba(6, 5, 7, 0.78);
+  background: color-mix(in srgb, var(--lume-guardia-surface-chrome) 78%, transparent);
 }
 
 /* Popover Lume: opaco e in fuoco, senza filtro strutturale. */
@@ -1318,7 +1258,7 @@ textarea.input-field {
   border-radius: var(--lume-radius-card);
   border: 1px solid color-mix(in srgb, var(--lume-ink) 12%, transparent);
   background-color: var(--lume-surface-focal);
-  box-shadow: 0 22px 44px rgba(15, 23, 42, 0.14);
+  box-shadow: 0 22px 44px color-mix(in srgb, var(--lume-giorno-ink-primary) 14%, transparent);
   padding: 0.35rem;
   overflow: hidden;
 }
@@ -1326,7 +1266,7 @@ textarea.input-field {
 :root.dark .mf-popover {
   background-color: var(--lume-surface-focal);
   border-color: color-mix(in srgb, var(--lume-ink) 12%, transparent);
-  box-shadow: 0 26px 52px rgba(6, 5, 7, 0.5);
+  box-shadow: 0 26px 52px color-mix(in srgb, var(--lume-guardia-surface-chrome) 70%, transparent);
 }
 
 .mf-popover-row {
@@ -1377,54 +1317,29 @@ textarea.input-field {
   line-height: 1.5;
 }
 
-/* @Codex WUL-UIUX: stesse tinte semantiche dei chip graphite (rgba dei token
-   success/warning al 10-14%): light e dark comunicano lo stesso stato. */
+/* @Codex WUL-515: stessi pesi misurati per testo e tinta dei chip graphite. */
 .mf-alert-info {
-  border-color: rgba(75, 85, 101, 0.24);
-  background-color: rgba(75, 85, 101, 0.08);
+  border-color: color-mix(in srgb, var(--lume-accent) 24%, transparent);
+  background-color: color-mix(in srgb, var(--lume-accent) 8%, var(--lume-surface-field));
   color: var(--lume-ink);
 }
 
 .mf-alert-success {
-  border-color: rgba(75, 99, 84, 0.3);
-  background-color: rgba(75, 99, 84, 0.1);
-  color: var(--lume-signal-success);
+  border-color: color-mix(in srgb, var(--lume-signal-success) 30%, transparent);
+  background-color: color-mix(in srgb, var(--lume-signal-success) 10%, var(--lume-surface-field));
+  color: color-mix(in srgb, var(--lume-signal-success) 60%, var(--lume-ink));
 }
 
 .mf-alert-warning {
-  border-color: rgba(154, 106, 47, 0.32);
-  background-color: rgba(154, 106, 47, 0.12);
-  color: var(--lume-signal-warning);
+  border-color: color-mix(in srgb, var(--lume-signal-warning) 30%, transparent);
+  background-color: color-mix(in srgb, var(--lume-signal-warning) 10%, var(--lume-surface-field));
+  color: color-mix(in srgb, var(--lume-signal-warning) 60%, var(--lume-ink));
 }
 
 .mf-alert-critical {
-  border-color: rgba(163, 58, 47, 0.28);
-  background-color: rgba(163, 58, 47, 0.1);
-  color: var(--lume-signal-critical);
-}
-
-:root.dark .mf-alert-info {
-  border-color: rgba(203, 213, 225, 0.24);
-  background-color: rgba(203, 213, 225, 0.08);
-  color: rgb(203, 213, 225);
-}
-
-:root.dark .mf-alert-success {
-  border-color: rgba(140, 210, 160, 0.32);
-  background-color: rgba(110, 190, 130, 0.12);
-  color: rgb(170, 220, 180);
-}
-
-:root.dark .mf-alert-warning {
-  border-color: rgba(232, 180, 96, 0.34);
-  background-color: rgba(232, 180, 96, 0.14);
-  color: rgb(240, 200, 130);
-}
-
-:root.dark .mf-alert-critical {
-  border-color: rgba(232, 130, 116, 0.34);
-  background-color: rgba(232, 110, 96, 0.12);
-  color: rgb(244, 170, 158);
+  border-color: color-mix(in srgb, var(--lume-signal-critical) 30%, transparent);
+  background-color: color-mix(in srgb, var(--lume-signal-critical) 10%, var(--lume-surface-field));
+  color: color-mix(in srgb, var(--lume-signal-critical) 60%, var(--lume-ink));
 }
 
 /* Step indicator (used by onboarding wizard, multi-step flows). */
@@ -1801,7 +1716,7 @@ textarea.input-field {
 :root[data-ui-style='redesign'] [class*="border-indigo-"]:not(.mf-chroma-keep),
 :root[data-ui-style='redesign'] [class*="border-purple-"]:not(.mf-chroma-keep),
 :root[data-ui-style='redesign'] [class*="border-violet-"]:not(.mf-chroma-keep) {
-  border-color: rgba(15, 23, 42, 0.16) !important;
+  border-color: color-mix(in srgb, var(--lume-ink) 16%, transparent) !important;
 }
 
 :root[data-ui-style='redesign'] [class*="ring-blue-"]:not(.mf-chroma-keep),
@@ -1817,7 +1732,7 @@ textarea.input-field {
 :root[data-ui-style='redesign'] [class*="ring-indigo-"]:not(.mf-chroma-keep),
 :root[data-ui-style='redesign'] [class*="ring-purple-"]:not(.mf-chroma-keep),
 :root[data-ui-style='redesign'] [class*="ring-violet-"]:not(.mf-chroma-keep) {
-  --tw-ring-color: rgba(15, 23, 42, 0.18) !important;
+  --tw-ring-color: color-mix(in srgb, var(--lume-ink) 18%, transparent) !important;
 }
 
 :root[data-ui-style='redesign'] [class*="accent-blue-"]:not(.mf-chroma-keep),
@@ -1865,5 +1780,5 @@ textarea.input-field {
 :root.dark[data-ui-style='redesign'] [class*="text-indigo-"]:not(.mf-chroma-keep),
 :root.dark[data-ui-style='redesign'] [class*="text-purple-"]:not(.mf-chroma-keep),
 :root.dark[data-ui-style='redesign'] [class*="text-violet-"]:not(.mf-chroma-keep) {
-  color: rgb(226, 232, 240) !important;
+  color: var(--lume-ink) !important;
 }

--- a/scripts/check-lume-tokens.mjs
+++ b/scripts/check-lume-tokens.mjs
@@ -29,7 +29,6 @@ const FUNCTION_COLOR = /\b(?:rgba?|hsla?)\((?:[^()]*)\)/gi;
 // letterali legacy e le loro ripetizioni. La baseline deve combaciare
 // esattamente: una voce che copre meno letterali di quelli dichiarati fallisce.
 export const PALETTE_ALLOWLIST = [
-  {"path":"app/globals.css","reason":"Debito storico su superficie non clinica: migrazione Lume da completare.","occurrences":92,"fingerprint":"e34bda72190924e5384ab827ff61dde3f189c62b13c49278ba65ec7354bc27c0"},
   {"path":"app/mockups/scheda/page.tsx","reason":"Debito storico su superficie non clinica: migrazione Lume da completare.","occurrences":10,"fingerprint":"0b532d8493c010f98eba790c6cca032e0c871be43eccd5bb743d13b514892219"},
   {"path":"app/patients/[id]/edit/page.tsx","reason":"Debito storico su superficie clinica: migrazione Lume da completare.","occurrences":2,"fingerprint":"c465f2f78534069d2c5091795196bb3c49d4428b0c2aaa3a488617f7bc16d9a4"},
   {"path":"app/patients/[id]/scales/[scaleId]/page.tsx","reason":"Debito storico su superficie clinica: migrazione Lume da completare.","occurrences":8,"fingerprint":"2aa3c828cc9648c78578de11157a552e6a94dd15d7437c7e8b86d847a1024582"},


### PR DESCRIPTION
## Summary
- Sostituisce il debito palette di `app/globals.css` con alias e ricette Lume.
- Conserva i segnali success, warning e critical nei registri Giorno e Grafite.
- Corregge selezione, focus ring, scrim e shadow e rimuove la sola voce allowlist di `globals.css`.

## Verification
- Worktree isolato, Node 24.18.0: `npm run test:lume-tokens` (23/23).
- `npm run check:lume-tokens` (42/42 coppie; warning 6,532:1 Giorno e 6,090:1 Grafite).
- `npm run lint`, `npm run typecheck`, `npm run build`.
- `npm run check:never-regress`, `npm run check:claims`, `git diff --check`.
- Riesame indipendente Sol e autoreview: PASS.

## Risk / Notes
- Nessuna migrazione consumer, motion o modifica DTCG.
- Il guard sorgente è separato in WUL-517.
- Il build conserva warning NFT preesistenti; compilazione e standalone bundle passano.
- Nessuna PHI/PII o fixture clinica reale.

## Ticket
Refs WUL-515