### PR TITLE
test(lume): rendi fail-closed il guard CSS sorgente

### DIFF
--- a/scripts/check-lume-tokens.mjs
+++ b/scripts/check-lume-tokens.mjs
@@ -13,6 +13,7 @@ import { fileURLToPath } from 'node:url';
 const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 export const DEFAULT_TOKENS_PATH = path.join(ROOT_DIR, 'docs/design/lume/tokens/lume.tokens.json');
 export const DEFAULT_CSS_MIRROR_PATH = path.join(ROOT_DIR, 'app/lume-tokens.css');
+export const DEFAULT_GLOBAL_CSS_PATH = path.join(ROOT_DIR, 'app/globals.css');
 
 // @Codex: fail-closed repository scan for literal colors outside Lume.
 const PALETTE_SOURCE_DIRS = ['app', 'components'];
@@ -438,6 +439,10 @@ export function loadCssMirror(cssPath = DEFAULT_CSS_MIRROR_PATH) {
   return readFileSync(cssPath, 'utf8');
 }
 
+export function loadGlobalStyles(cssPath = DEFAULT_GLOBAL_CSS_PATH) {
+  return readFileSync(cssPath, 'utf8');
+}
+
 // Active aliases resolve at runtime to a register-scoped variable.
 export const ACTIVE_ALIASES = [
   { alias: '--lume-surface-canvas', suffix: 'surface-canvas' },
@@ -484,6 +489,158 @@ export function parseCssBlocks(css) {
     blocks.push({ selector: rule[1].trim(), decls });
   }
   return blocks;
+}
+
+function cssWeight(weight) {
+  const percent = weight * 100;
+  if (!Number.isInteger(percent)) throw new Error(`CSS weight must be an integer percentage: ${weight}`);
+  return `${percent}%`;
+}
+
+// @Codex WUL-517: blocca le dichiarazioni sorgente per il sottoinsieme elencato.
+// evaluateContract misura testo e tinta; il bordo resta un peso sorgente
+// esplicito. Specificità, !important e override esterni non sono una prova della
+// cascade effettiva e restano contratti separati.
+export const GLOBAL_STYLE_RECIPES = [
+  ...['graphite-chip-tone', 'mf-alert'].flatMap((family) =>
+    ['success', 'warning', 'critical'].map((signal) => ({
+      selector: `.${family}-${signal}`,
+      declarations: {
+        'border-color': `color-mix(in srgb, var(--lume-signal-${signal}) 30%, transparent)`,
+        'background-color': `color-mix(in srgb, var(--lume-signal-${signal}) ${cssWeight(SIGNAL_TINT_WEIGHT)}, var(--lume-surface-field))`,
+        color: `color-mix(in srgb, var(--lume-signal-${signal}) ${cssWeight(SIGNAL_TEXT_WEIGHT)}, var(--lume-ink))`,
+      },
+      kind: 'semantic',
+    })),
+  ),
+  {
+    selector: '.siss-blocked-item-reason',
+    declarations: {
+      color: `color-mix(in srgb, var(--lume-signal-warning) ${cssWeight(SIGNAL_TEXT_WEIGHT)}, var(--lume-ink))`,
+    },
+    kind: 'semantic',
+  },
+  {
+    selector: '.mf-modal-backdrop',
+    declarations: { background: 'color-mix(in srgb, var(--lume-giorno-ink-primary) 62%, transparent)' },
+    kind: 'scrim',
+    target: '.mf-modal-backdrop',
+    allowedSelectors: ['.mf-modal-backdrop', ':root.dark .mf-modal-backdrop'],
+  },
+  {
+    selector: ':root.dark .mf-modal-backdrop',
+    declarations: { background: 'color-mix(in srgb, var(--lume-guardia-surface-chrome) 78%, transparent)' },
+    kind: 'scrim',
+    target: '.mf-modal-backdrop',
+    allowedSelectors: ['.mf-modal-backdrop', ':root.dark .mf-modal-backdrop'],
+  },
+  {
+    selector: '.mf-popover',
+    declarations: {
+      'box-shadow': '0 22px 44px color-mix(in srgb, var(--lume-giorno-ink-primary) 14%, transparent)',
+    },
+    kind: 'shadow',
+    target: '.mf-popover',
+    allowedSelectors: ['.mf-popover', ':root.dark .mf-popover'],
+  },
+  {
+    selector: ':root.dark .mf-popover',
+    declarations: {
+      'box-shadow': '0 26px 52px color-mix(in srgb, var(--lume-guardia-surface-chrome) 70%, transparent)',
+    },
+    kind: 'shadow',
+    target: '.mf-popover',
+    allowedSelectors: ['.mf-popover', ':root.dark .mf-popover'],
+  },
+];
+
+function braceDepthAt(css, end) {
+  let depth = 0;
+  for (let index = 0; index < end; index += 1) {
+    if (css[index] === '{') depth += 1;
+    if (css[index] === '}') depth -= 1;
+  }
+  return depth;
+}
+
+function parseStyleRules(css) {
+  const clean = css.replace(/\/\*[\s\S]*?\*\//g, '');
+  const rules = [];
+  const ruleRe = /([^{}]+)\{([^{}]*)\}/g;
+  for (let rule = ruleRe.exec(clean); rule; rule = ruleRe.exec(clean)) {
+    const declarations = new Map();
+    const duplicateDeclarations = new Set();
+    const declarationRe = /(?:^|;)\s*([a-zA-Z-]+)\s*:\s*([^;]+?)(?=;|$)/g;
+    for (let declaration = declarationRe.exec(rule[2]); declaration; declaration = declarationRe.exec(rule[2])) {
+      const rawProperty = declaration[1].trim();
+      const property = rawProperty.startsWith('--') ? rawProperty : rawProperty.toLowerCase();
+      if (declarations.has(property)) duplicateDeclarations.add(property);
+      declarations.set(property, declaration[2].replace(/\s+/g, ' ').trim());
+    }
+    rules.push({
+      selectors: rule[1].split(',').map((selector) => selector.replace(/\s+/g, ' ').trim()),
+      declarations,
+      duplicateDeclarations,
+      depth: braceDepthAt(clean, rule.index),
+    });
+  }
+  return rules;
+}
+
+function selectorTargetsRecipe(selector, recipeSelector) {
+  if (!recipeSelector.startsWith('.')) return false;
+  const className = recipeSelector.slice(1).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`(^|[^a-zA-Z0-9_-])\\.${className}(?![a-zA-Z0-9_-])`).test(selector);
+}
+
+export function verifyGlobalStyles(css) {
+  const rules = parseStyleRules(css);
+  for (const recipe of GLOBAL_STYLE_RECIPES) {
+    const target = recipe.target ?? recipe.selector;
+    const allowedSelectors = recipe.allowedSelectors ?? [recipe.selector];
+    const targetedRules = rules.filter((rule) =>
+      rule.selectors.some((selector) => selectorTargetsRecipe(selector, target)));
+    if (targetedRules.some((rule) => rule.depth > 0)) {
+      throw new Error(`global CSS ${recipe.selector} must not be conditional`);
+    }
+    if (targetedRules.some((rule) => rule.selectors.some((selector) =>
+      selectorTargetsRecipe(selector, target) && !allowedSelectors.includes(selector)))) {
+      throw new Error(`global CSS ${recipe.selector} has a non-canonical override selector`);
+    }
+    const matches = rules.filter((rule) => rule.depth === 0 && rule.selectors.includes(recipe.selector));
+    if (matches.length !== 1) throw new Error(`global CSS requires exactly one ${recipe.selector} rule`);
+    if (matches[0].duplicateDeclarations.size > 0) {
+      throw new Error(`global CSS ${recipe.selector} has duplicate declarations`);
+    }
+    for (const [property, expected] of Object.entries(recipe.declarations)) {
+      const got = matches[0].declarations.get(property);
+      if (got === undefined) throw new Error(`global CSS ${recipe.selector} missing ${property}`);
+      if (got !== expected) throw new Error(`global CSS ${recipe.selector} ${property} is ${got}, expected ${expected}`);
+    }
+    if (Object.hasOwn(recipe.declarations, 'background-color') && matches[0].declarations.has('background')) {
+      throw new Error(`global CSS ${recipe.selector} has an interfering background shorthand`);
+    }
+    if (Object.hasOwn(recipe.declarations, 'background') && matches[0].declarations.has('background-color')) {
+      throw new Error(`global CSS ${recipe.selector} has an interfering background-color declaration`);
+    }
+    const interferingBorder = [...matches[0].declarations.keys()].find((property) =>
+      property === 'border'
+      || /^(?:border-(?:top|right|bottom|left|block|inline)(?:-(?:start|end))?)(?:-(?:color|style|width))?$/.test(property)
+      || /^border-(?:style|width)$/.test(property));
+    if (Object.keys(recipe.declarations).some((property) => property.startsWith('border-'))
+      && interferingBorder !== undefined) {
+      throw new Error(`global CSS ${recipe.selector} has an interfering border shorthand`);
+    }
+    if (matches[0].declarations.has('all')) {
+      throw new Error(`global CSS ${recipe.selector} has an interfering all shorthand`);
+    }
+  }
+  return {
+    recipes: GLOBAL_STYLE_RECIPES.length,
+    semanticRecipes: GLOBAL_STYLE_RECIPES.filter((recipe) => recipe.kind === 'semantic').length,
+    scrimRecipes: GLOBAL_STYLE_RECIPES.filter((recipe) => recipe.kind === 'scrim').length,
+    shadowRecipes: GLOBAL_STYLE_RECIPES.filter((recipe) => recipe.kind === 'shadow').length,
+  };
 }
 
 function normalizeHex(value) {
@@ -540,11 +697,13 @@ function assertAlias(decls, alias, expectedValue, where) {
 function main() {
   let result;
   let mirror;
+  let globalStyles;
   let palette;
   try {
     const tokens = loadTokens();
     result = evaluateContract(tokens);
     mirror = verifyCssMirror(tokens, loadCssMirror());
+    globalStyles = verifyGlobalStyles(loadGlobalStyles());
     palette = scanPalette({ tokens });
   } catch (error) {
     console.error(`lume token check failed: ${error.message}`);
@@ -553,6 +712,10 @@ function main() {
   }
   console.log(formatReport(result));
   console.log(`CSS mirror app/lume-tokens.css: ${mirror.tokens} namespaced tokens matched, ${mirror.aliases} active aliases per theme OK`);
+  console.log(
+    `CSS source app/globals.css: ${globalStyles.semanticRecipes} semantic, `
+    + `${globalStyles.scrimRecipes} scrim and ${globalStyles.shadowRecipes} shadow recipes matched`,
+  );
   console.log(formatPaletteReport(palette));
   process.exitCode = result.pass && palette.violations.length === 0 && palette.allowlistIssues.length === 0 ? 0 : 1;
 }

--- a/scripts/check-lume-tokens.test.mjs
+++ b/scripts/check-lume-tokens.test.mjs
@@ -13,10 +13,13 @@ import {
   formatReport,
   loadTokens,
   loadCssMirror,
+  loadGlobalStyles,
   parseCssBlocks,
   expectedMirror,
   verifyCssMirror,
+  verifyGlobalStyles,
   ACTIVE_ALIASES,
+  PALETTE_ALLOWLIST,
   paletteFingerprint,
   scanPalette,
   scanPaletteSource,
@@ -150,6 +153,116 @@ test('a mirror missing the :root (giorno) active alias fails closed', () => {
 test('a mirror whose .dark alias points at the wrong register fails closed', () => {
   const css = loadCssMirror().replace('--lume-ink: var(--lume-grafite-ink-primary);', '--lume-ink: var(--lume-giorno-ink-primary);');
   assert.throws(() => verifyCssMirror(loadTokens(), css), /alias --lume-ink in \.dark\/grafite/);
+});
+
+// @Codex WUL-515
+test('committed global CSS pins the listed semantic, scrim and shadow source recipes', () => {
+  const summary = verifyGlobalStyles(loadGlobalStyles());
+  assert.deepEqual(summary, { recipes: 11, semanticRecipes: 7, scrimRecipes: 2, shadowRecipes: 2 });
+  assert.equal(PALETTE_ALLOWLIST.some((entry) => entry.path === 'app/globals.css'), false);
+  const palette = scanPaletteSource({
+    relativePath: 'app/globals.css',
+    source: loadGlobalStyles(),
+    tokens: loadTokens(),
+  });
+  assert.deepEqual(palette.violations, []);
+  assert.deepEqual(palette.allowlistIssues, []);
+});
+
+test('global CSS rejects raw warning text instead of the measured 60% recipe', () => {
+  const css = loadGlobalStyles().replace(
+    'color: color-mix(in srgb, var(--lume-signal-warning) 60%, var(--lume-ink));',
+    'color: var(--lume-signal-warning);',
+  );
+  assert.throws(() => verifyGlobalStyles(css), /global CSS \.graphite-chip-tone-warning color is var\(--lume-signal-warning\)/);
+});
+
+test('global CSS fails closed when a required selector or declaration is missing', () => {
+  const missingSelector = loadGlobalStyles().replace('.mf-alert-critical {', '.mf-alert-critical-missing {');
+  assert.throws(() => verifyGlobalStyles(missingSelector), /global CSS requires exactly one \.mf-alert-critical rule/);
+
+  const missingDeclaration = loadGlobalStyles().replace(
+    '.mf-alert-success {\n  border-color: color-mix(in srgb, var(--lume-signal-success) 30%, transparent);\n',
+    '.mf-alert-success {\n',
+  );
+  assert.throws(() => verifyGlobalStyles(missingDeclaration), /global CSS \.mf-alert-success missing border-color/);
+});
+
+test('global CSS rejects conditional recipes, override selectors and cascade shorthands', () => {
+  const conditional = loadGlobalStyles().replace(
+    /(\.mf-alert-critical \{[^}]+\})/,
+    '@media print { $1 }',
+  );
+  assert.throws(() => verifyGlobalStyles(conditional), /global CSS \.mf-alert-critical must not be conditional/);
+
+  const override = `${loadGlobalStyles()}\n.dark .mf-alert-warning { color: var(--lume-ink) !important; }\n`;
+  assert.throws(() => verifyGlobalStyles(override), /global CSS \.mf-alert-warning has a non-canonical override selector/);
+
+  const shorthand = loadGlobalStyles().replace(
+    '.mf-alert-success {',
+    '.mf-alert-success {\n  background: transparent;',
+  );
+  assert.throws(() => verifyGlobalStyles(shorthand), /global CSS \.mf-alert-success has an interfering background shorthand/);
+});
+
+test('global CSS protects scrim and shadow selectors from conditional or non-canonical overrides', () => {
+  const conditionalScrim = loadGlobalStyles().replace(
+    /(\.mf-modal-backdrop \{[^}]+\})/,
+    '@media print { $1 }',
+  );
+  assert.throws(() => verifyGlobalStyles(conditionalScrim), /global CSS \.mf-modal-backdrop must not be conditional/);
+
+  const shadowOverride = `${loadGlobalStyles()}\n.dark .mf-popover { box-shadow: none; }\n`;
+  assert.throws(() => verifyGlobalStyles(shadowOverride), /global CSS \.mf-popover has a non-canonical override selector/);
+});
+
+test('global CSS rejects destructive shorthands only on governed selectors', () => {
+  const borderShorthand = loadGlobalStyles().replace(
+    '.mf-alert-success {',
+    '.mf-alert-success {\n  border: none;',
+  );
+  assert.throws(() => verifyGlobalStyles(borderShorthand), /global CSS \.mf-alert-success has an interfering border shorthand/);
+
+  const sideBorderShorthand = loadGlobalStyles().replace(
+    '.mf-alert-success {',
+    '.mf-alert-success {\n  border-top: none;',
+  );
+  assert.throws(() => verifyGlobalStyles(sideBorderShorthand), /global CSS \.mf-alert-success has an interfering border shorthand/);
+
+  const uppercaseColor = loadGlobalStyles().replace(
+    '.mf-alert-success {',
+    '.mf-alert-success {\n  COLOR: var(--lume-signal-critical);',
+  );
+  assert.throws(() => verifyGlobalStyles(uppercaseColor), /global CSS \.mf-alert-success has duplicate declarations/);
+
+  const uppercaseBorder = loadGlobalStyles().replace(
+    '.mf-alert-success {',
+    '.mf-alert-success {\n  BORDER: none;',
+  );
+  assert.throws(() => verifyGlobalStyles(uppercaseBorder), /global CSS \.mf-alert-success has an interfering border shorthand/);
+
+  const allShorthand = loadGlobalStyles().replace(
+    '.mf-alert-success {',
+    '.mf-alert-success {\n  ALL: unset;',
+  );
+  assert.throws(() => verifyGlobalStyles(allShorthand), /global CSS \.mf-alert-success has an interfering all shorthand/);
+
+  const unrelatedFallback = `${loadGlobalStyles()}\n.unrelated { color: var(--lume-ink); color: inherit; }\n`;
+  assert.doesNotThrow(() => verifyGlobalStyles(unrelatedFallback));
+});
+
+test('global CSS rejects a light Grafite scrim or an unmeasured warning recipe', () => {
+  const lightScrim = loadGlobalStyles().replace(
+    'var(--lume-guardia-surface-chrome) 78%',
+    'var(--lume-giorno-ink-primary) 78%',
+  );
+  assert.throws(() => verifyGlobalStyles(lightScrim), /global CSS :root\.dark \.mf-modal-backdrop background/);
+
+  const unmeasuredWarning = loadGlobalStyles().replace(
+    'var(--lume-signal-warning) 60%, var(--lume-ink)',
+    'var(--lume-signal-warning) 70%, var(--lume-ink)',
+  );
+  assert.throws(() => verifyGlobalStyles(unmeasuredWarning), /global CSS \.graphite-chip-tone-warning color/);
 });
 
 test('palette guard catches an out-of-contract hex literal', () => {


### PR DESCRIPTION
## Summary
- Aggiunge un guard fail-closed per 11 ricette sorgente in `app/globals.css`.
- Rifiuta conditional, override non canonici, duplicati sui target e shorthand interferenti.
- Verifica direttamente la palette e aggiunge prove avverse per proprietà case-insensitive, scrim e shadow.

## Verification
- Node 24.18.0: `npm run test:lume-tokens` (30/30).
- `npm run check:lume-tokens` (42/42 coppie; 11 ricette; palette PASS).
- `npm run lint`, `npm run typecheck`, `npm run build`.
- `npm run check:never-regress`, `npm run check:claims`, `git diff --check`.
- Riesame indipendente Sol: PASS, nessun finding P1/P2.

## Risk / Notes
- Il guard verifica il sottoinsieme sorgente dichiarato; non prova la cascade effettiva o gli override esterni.
- Il parser non decodifica escape CSS intenzionalmente offuscati; il limite è accettato per questa sorgente mantenuta.
- Nessuna dipendenza, migrazione consumer o modifica motion.
- Il build conserva warning NFT preesistenti; compilazione e standalone bundle passano.
- Nessuna PHI/PII o fixture clinica reale.

## Ticket
Refs WUL-517