### PR TITLE
docs: prepara il closeout AI e la candidata 0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,28 +7,94 @@ e questo progetto aderisce al [Semantic Versioning](https://semver.org/spec/v2.0
 
 ## [Unreleased]
 
-### Sicurezza
+> Candidata `0.8.0`: contenuti in consolidamento. La versione del pacchetto
+> resta `0.7.3` finché contenuti, documentazione e verifica finale non sono
+> chiusi.
 
-- Aggiorna Next.js, Sharp e PostCSS alle versioni fissate dal lockfile. L'audit
-  di produzione non rileva vulnerabilita. L'audit globale conserva sei rilievi
-  limitati alle dipendenze di sviluppo.
+### Uso del prodotto
 
-### Migliorato
+#### Revisione degli output AI
 
-- **Contratti AI ed envelope**: Patient Insight, Smart Import e sintesi
-  documentale accettano solo envelope compatibili con la lane richiesta. Gli
-  envelope ambigui, multipli, incompleti o con chiavi riservate duplicate non
-  attivano il recupero legacy né una scrittura clinica.
-- **Housekeeping AI**: rimosso il parser file non usato dopo una verifica degli
-  importer. La route MLX mantiene il boundary di autenticazione esistente.
+- **Modifica**: Patient Insight, Smart Import e sintesi documentale accettano
+  solo contenitori JSON (`envelope`) compatibili con il contratto dell'attività
+  richiesta.
+  **Stato**: integrata in `main` con la PR #139.
+  **Limite**: il controllo del modello esterno resta
+  `BLOCKED_EXTERNAL_MODEL`; non è un risultato `PASS`.
+- **Modifica**: i contenitori ambigui, multipli, incompleti o con chiavi
+  riservate duplicate vengono rifiutati.
+  **Stato**: integrata e coperta da test deterministici e casi avversari.
+  **Limite**: la verifica non sostituisce la validazione di un modello in
+  esecuzione.
+- **Modifica**: le diagnosi estratte dai documenti restano materiale di
+  revisione.
+  **Stato**: la scrittura automatica nella scheda è rimossa.
+  **Limite**: una futura applicazione richiede un contratto e una conferma
+  espliciti.
 
-### Confini
+### Esecuzione e manutenzione
 
-- Le diagnosi estratte da documento restano materiale di revisione e non sono
-  aggiunte automaticamente alla scheda. Una futura applicazione richiede una
-  decisione contrattuale separata.
-- Codex Operator personale non entra in questa tranche. Richiede correzioni e
-  decisioni esplicite sui confini di egress, autenticazione e packaging.
+#### Dipendenze e pacchetto autonomo
+
+- **Modifica**: Next.js, Sharp e PostCSS usano le versioni fissate dal
+  file `package-lock.json`.
+  **Stato**: integrata in `main` con la PR #138.
+  **Limite**: `npm audit` rileva sei rilievi nelle dipendenze di sviluppo. Il
+  controllo delle sole dipendenze di produzione non rileva vulnerabilità.
+- **Modifica**: il controllo del pacchetto autonomo (`standalone`) convalida
+  gli artefatti nativi Sharp caricati. Rifiuta collegamenti simbolici o
+  ripieghi che si risolvono fuori dal pacchetto.
+  **Stato**: integrata e verificata su macOS, Linux e Windows.
+  **Limite**: il controllo copre i pacchetti dichiarati da
+  `package-lock.json`.
+
+#### Pulizia del codice AI
+
+- **Modifica**: il parser di file non usato è stato rimosso dopo la verifica
+  dei riferimenti di importazione.
+  **Stato**: integrata con la PR #139.
+  **Limite**: l'endpoint MLX mantiene il confine di autenticazione esistente.
+
+### Confini non consegnati
+
+- Codex Operator personale resta escluso. Richiede un nuovo piano di lavoro
+  senza invio di testo clinico, con autenticazione e pacchetto verificati.
+- Ollama resta l'unico fornitore AI operativo. I plug-in locali, LAN o cloud
+  non sono consegnati.
+- Il controllo dell'invio esterno resta chiuso. Una futura attivazione richiede
+  regole organizzative, scelta esplicita, minimizzazione, controlli verificati,
+  registrazione e ripiego locale.
+- Il cloud può offrire capacità o tempi di elaborazione diversi. Non è un
+  requisito e non implica una promessa clinica.
+
+### Sviluppo assistito
+
+Il perimetro comprende il lavoro che ha portato alle PR #138 e #139 e il
+relativo consolidamento. Non comprende la verifica UI, le prove di capacità o
+altri filoni senza modifiche promosse.
+
+| Fornitore (provider) e modello | Flusso (lane) | Ruolo o operazione | Token misurati | Fonte del conteggio |
+| --- | --- | --- | --- | --- |
+| OpenAI `gpt-5.6-terra/high` | Responsabile del programma | Inventario, controlli e consolidamento iniziale | 51.253.005 | `token_count`, record Codex del programma |
+| OpenAI `gpt-5.6-sol/max` | Responsabile del programma | Decisioni, integrazione, promozione e documentazione | 37.508.514 | `token_count`, record Codex del programma |
+| OpenAI `gpt-5.6-sol/max` | Verifiche indipendenti | Casi avversari, modifiche e controlli di confine | 112.514.880 | `token_count`, 11 sessioni figlie |
+| OpenAI `gpt-5.6-sol` (modalità Ultra; livello non registrato) | Revisione in sola lettura | Contratti AI, Codex Operator e selezione dei candidati | 19.106.786 | `token_count`, 3 sessioni figlie |
+| OpenAI `gpt-5.6-terra/high` | Verifica ordinaria | Controlli deterministici e supporto alla candidata | 3.340.670 | `token_count`, 1 sessione figlia |
+| Anthropic `claude-fable-5` | Coordinamento precedente | Strategia, impronta del candidato e acquisizione dei report A e B | 3.687.032 | Artefatto di provenienza del 22 luglio |
+| Anthropic `claude-opus-4-8` | Sintesi precedente | Sintesi dopo il ripiego automatico del fornitore | 319.743 | Artefatto di provenienza del 22 luglio |
+| OpenAI `gpt-5.6-terra/high` | Report A | Analisi dei flussi | 217.090 | Artefatto di provenienza del 22 luglio |
+| OpenAI `gpt-5.6-sol/high` | Report B | Analisi del nucleo contrattuale | 299.822 | Artefatto di provenienza del 22 luglio |
+| OpenAI `gpt-5.6-sol/high` | Report C | Analisi delle integrazioni e dell'esecuzione | 579.240 | Artefatto di provenienza del 22 luglio |
+| Anthropic `claude-opus-4-8/max` | Revisione a riga di comando | Critica avversaria dei contratti AI in sola lettura | 68.978 | Campo `usage` del risultato CLI |
+
+Il record Codex comprende 16 sessioni collegate. La fotografia è stata acquisita
+il 24 luglio 2026 alle 12:00 CEST e misura 223.723.855 token totali. Il contatore
+include ingresso e uscita; i token letti dalla memoria cache sono una parte
+dell'ingresso.
+
+L'artefatto del 22 luglio riporta i cinque valori indicati, ma non documenta la
+formula di somma o l'esclusività contabile. Per questo motivo tali valori non
+formano un totale aggregato.
 
 ## [0.7.3] - 2026-07-13
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,11 @@ clinici, terapie, note e documenti in una scheda che resti leggibile anche
 quando il percorso si allunga e le fonti si moltiplicano.
 
 Il principio è semplice: il dato resta vicino a chi lo produce e lo usa. Il Mac
-ospita la base autorevole; il cloud non è un requisito per lavorare. L'AI, quando
-c'è, gira in locale e propone materiale da rivedere. Non prende decisioni e non
-scrive dati clinici in autonomia.
+ospita la base autorevole; il cloud non è un requisito per lavorare. Le funzioni
+deterministiche restano locali. Il percorso AI locale usa Ollama quando è
+configurato. Se la funzione è abilitata, l'AI può aggiornare una sintesi locale.
+Non aggiunge diagnosi, terapie o altri dati clinici strutturati senza una
+conferma esplicita.
 
 Nel contesto territoriale italiano questo significa soprattutto togliere
 attrito: aprire la scheda, capire dove si è, ritrovare una fonte, distinguere una
@@ -110,24 +112,49 @@ modulare lo stack AI locale e rafforza backup, cifratura dei campi clinici,
 packaging e controlli sui claim pubblici.
 
 Restano aperti la parity dei client paired, gli snapshot di confronto completi,
-la verifica VoiceOver e il collaudo manuale P6 sul bundle macOS. Il gate verso
-provider AI esterni resta chiuso e non è consegnato alcun percorso di consenso
-o invio.
+la verifica VoiceOver e il collaudo manuale P6 sul bundle macOS. Il controllo
+per i fornitori AI esterni resta chiuso. Non è consegnato alcun percorso di
+consenso o invio.
 
-### Aggiornamenti in verifica
+### Aggiornamenti integrati
 
-La prossima tranche rafforza i contratti degli envelope AI. Un output AI deve
-rispettare la lane prevista prima di diventare materiale di revisione. Un
-envelope ambiguo, incompleto, multiplo o con chiavi riservate duplicate non può
-attivare il recupero legacy né una scrittura clinica.
+La tranche integrata rafforza i contratti dei contenitori JSON (`envelope`) AI.
+Un output AI deve rispettare il contratto dell'attività richiesta prima di
+diventare materiale di revisione. Un contenitore ambiguo, incompleto, multiplo o
+con chiavi riservate duplicate non può attivare il recupero legacy né essere
+usato.
 
 Le diagnosi estratte da documento restano materiale di revisione: la sintesi
 non le aggiunge automaticamente alla scheda. Codex Operator personale non è
-incluso: il relativo boundary richiede decisioni e correzioni separate.
+incluso: i relativi limiti di sicurezza richiedono decisioni e correzioni
+separate.
 
 Il dettaglio è nel [CHANGELOG](./CHANGELOG.md). La fotografia completa vive in
 [`docs/STATE_OF_THE_SYSTEM.md`](./docs/STATE_OF_THE_SYSTEM.md); la parity
 versionata in [`docs/parity-matrix.md`](./docs/parity-matrix.md).
+
+### Modelli e servizi opzionali
+
+Le funzioni deterministiche restano disponibili senza un modello. Il percorso
+AI locale usa Ollama ed è disponibile quando Ollama è configurato.
+L'architettura separa il servizio applicativo dal connettore del modello. Oggi
+è operativo soltanto il connettore Ollama.
+
+Una futura modifica può aggiungere plug-in opzionali per modelli locali, LAN o
+cloud. Le regole dell'organizzazione e la scelta esplicita dell'utente devono
+consentire ogni attivazione.
+
+Un fornitore esterno può offrire più capacità o ridurre alcuni tempi di
+elaborazione. Non è un requisito e non implica una promessa clinica.
+
+Prima di ogni invio servono minimizzazione, controlli verificati, registrazione
+locale e abilitazione esplicita. La redazione o pseudonimizzazione deve essere
+dimostrata per il flusso specifico. MediFlow non dichiara anonimizzazione
+garantita.
+
+Il controllo dell'invio esterno resta oggi chiuso. Nessun plug-in esterno accede
+direttamente al database. Il flusso separa proposta, chiarimento e scrittura
+autorizzata; la scrittura diretta tramite modello non è consegnata.
 
 ## Confini dichiarati
 
@@ -135,6 +162,8 @@ MediFlow non racconta più di quanto possa dimostrare.
 
 - **Il default è locale.** Nessun cloud obbligatorio, nessuna telemetria o
   uscita dati attiva per impostazione iniziale.
+- **I fornitori esterni non sono operativi.** L'estensione a plug-in richiede
+  attivazione esplicita, registrazione locale e controlli sull'invio esterno.
 - **iPhone e iPad non sono app complete.** Il perimetro operativo è
   `home-base + client paired`; cache offline e alcune superfici derivate dai
   documenti restano parziali o disponibili solo sull'host.

--- a/docs/repository-topology.md
+++ b/docs/repository-topology.md
@@ -7,7 +7,7 @@ read_when:
 
 # Repository Topology: MediFlow
 
-Ultimo aggiornamento: 2026-07-09 (`WUL-477`)
+Ultimo aggiornamento: 2026-07-24
 
 Mappa concisa delle aree top-level del repository, pensata per orientare agent e
 contributor: distingue il **runtime clinico** (codice che gira con dati paziente)
@@ -50,6 +50,30 @@ runtime artifact e fonti riservate restano fuori da Git secondo
 | `tmp/` | tooling effimero | Scratchpad locale. |
 | `Farmaci/` | dati di riferimento | Dataset farmaceutici di riferimento. |
 | `certs/` | dev tooling | Certificati TLS locali per dev. |
+
+## Confine AI e integrazioni opzionali
+
+La topologia AI implementata resta locale:
+
+- `lib/ai-service.ts` è la facciata usata dalle funzioni applicative;
+- `lib/ai-providers/` contiene il connettore operativo Ollama;
+- `lib/ai-egress-gate.ts` e `lib/ai-egress-audit.ts` applicano una chiusura
+  sicura in caso di errore (`fail-closed`) e scrivono un registro locale privo
+  di contenuto clinico.
+
+Non esistono fornitori cloud operativi, registri esterni o una superficie di
+consenso per l'invio esterno. Il controllo resta
+`closed_pending_redaction_lane`.
+
+Un futuro plug-in non può accedere direttamente al database. Può ricevere solo
+il contenuto minimo dopo regole, attivazione esplicita, controlli verificati e
+registrazione. La redazione o pseudonimizzazione deve essere dimostrata per il
+flusso specifico. MediFlow non dichiara anonimizzazione garantita.
+
+Le funzioni deterministiche restano disponibili senza plug-in. Il percorso AI
+locale richiede Ollama configurato. L'output esterno resta una proposta:
+chiarimento interattivo e scrittura autorizzata sono fasi separate. Questa
+regola descrive il confine, non una funzione cloud già consegnata.
 
 ## ⚠️ Regole operative
 


### PR DESCRIPTION
## Summary
- Chiarisce nel README la distinzione tra funzioni deterministiche locali, percorso AI con Ollama e fornitori esterni non consegnati.
- Limita la sezione Unreleased ai cambiamenti già promossi con le PR #138 e #139; la versione resta 0.7.3 e 0.8.0 resta una candidata.
- Aggiorna la topologia del confine AI implementato e aggiunge un recap misurato dello sviluppo assistito, con fonti e limiti.

## Verification
- Node 24.18.0.
- git diff --check.
- Inventario di 143 file Markdown con rg --files -g *.md.
- npm run check:claims: 466 file, 0 claim ad alto rischio.
- Verifier indipendente APPROVE sul fingerprint f73f8c1a744fd61f0f9c5e5d0ea96b3cab927ff9a9287bdd78b25b0aef942c1e.

## Risk / Notes
- Modifica solo documentazione. Nessun version bump, provider esterno, egress, funzione UI o scrittura diretta nel database.
- validate:ai-task-contracts resta BLOCKED_EXTERNAL_MODEL; non è registrato come PASS.
- WUL-361 e Codex Operator restano esclusi. Nessuna PHI/PII o dato paziente reale.
- La PR resta draft e non autorizza il merge.

## Ticket
Refs WUL-362
