### PR TITLE
fix(ui): correggi la worklist compatta

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Le prove usano solo fixture sintetiche:
 - iPhone: XCUITest 2/2 sul simulatore iOS 27;
 - iPad: XCUITest 7/7 sul simulatore iPadOS 27;
 - macOS: build, resize, focus, tastiera, Cmd-R contestuale e VoiceOver manuale;
-- localhost: 78/78 test, viewport 320/390/768/1440 e zoom reale 200%/400%.
+- localhost: 82/82 test, viewport 320/390/768/1440 e zoom reale 200%/400%.
 
 Queste prove non dichiarano parity completa o conformità accessibilità. Gli
 audit automatici su iPhone e iPad sono verdi, ma VoiceOver reale mobile non è

--- a/components/kree8/kree8-clinical-cockpit-foundation.module.css
+++ b/components/kree8/kree8-clinical-cockpit-foundation.module.css
@@ -785,3 +785,27 @@
     justify-self: start;
   }
 }
+
+/* @Codex Compact localhost titles preserve hierarchy without consuming the action row. */
+@media (max-width: 480px) {
+  .areaShell { gap: 8px; }
+
+  .areaHeader { padding: 0 4px; }
+
+  .areaCaption { margin-bottom: 2px; }
+
+  .areaTitle { font-size: 20px; }
+
+  .areaTitle em,
+  .areaSubtitle {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+  }
+}

--- a/components/kree8/kree8-clinical-cockpit-patient-inbox.module.css
+++ b/components/kree8/kree8-clinical-cockpit-patient-inbox.module.css
@@ -418,17 +418,28 @@
 
   .patientSearchField { min-height: 44px; }
 
-  .worklistPanelHeader { row-gap: 6px; }
+  .worklistPanelHeader {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    column-gap: 8px;
+    row-gap: 6px;
+    align-items: center;
+  }
 
   .worklistPanelHeader > h2 {
+    min-width: 0;
     font-size: 17px;
     white-space: nowrap;
   }
 
-  .resultCount { margin-left: auto; }
+  .resultCount {
+    margin-left: 0;
+    white-space: nowrap;
+  }
 
   .worklistPanelHeader > span:last-child {
-    flex: 1 0 100%;
+    grid-column: 1 / -1;
+    width: 100%;
     margin-left: 0;
   }
 

--- a/components/kree8/kree8-clinical-cockpit-patient-inbox.module.css
+++ b/components/kree8/kree8-clinical-cockpit-patient-inbox.module.css
@@ -393,6 +393,83 @@
 
 }
 
+/* @Codex Compact localhost worklist preserves scan order and 44px touch targets. */
+@media (max-width: 480px) {
+  .worklistPanel { padding: 10px; }
+
+  .inboxScope { gap: 6px; }
+
+  .patientSearchRow { margin-top: 8px; }
+
+  .scopeChip {
+    min-height: 44px;
+    gap: 5px;
+    padding: 6px 8px;
+    font-size: 11px;
+  }
+
+  .patientScopeActions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    width: 100%;
+    margin-left: 0;
+    gap: 6px;
+  }
+
+  .patientSearchField { min-height: 44px; }
+
+  .worklistPanelHeader { row-gap: 6px; }
+
+  .worklistPanelHeader > h2 {
+    font-size: 17px;
+    white-space: nowrap;
+  }
+
+  .resultCount { margin-left: auto; }
+
+  .worklistPanelHeader > span:last-child {
+    flex: 1 0 100%;
+    margin-left: 0;
+  }
+
+  .worklistPanelHeader [data-lume-action='quiet'] {
+    display: inline-flex;
+    justify-content: center;
+    width: 100%;
+    min-height: 45px;
+    white-space: nowrap;
+  }
+
+  .patientRow {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 2px;
+    padding: 5px 8px;
+  }
+
+  .patientRowContent { gap: 2px; }
+
+  .patientSubline {
+    column-gap: 5px;
+    row-gap: 0;
+    font-size: 11px;
+    line-height: 1.35;
+  }
+
+  .patientCode { font-size: 11px; }
+
+  .patientSide {
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .patientWhen {
+    max-width: none;
+    text-align: left;
+    white-space: nowrap;
+  }
+}
+
 /* @Codex #98, #68: Quadro paziente, un solo fuoco e nessuna card elevata interna. */
 .quadroFocal {
   --lume-registro-family: "IBM Plex Mono", var(--font-registro), "SF Mono", monospace;

--- a/components/kree8/kree8-clinical-cockpit-shell.module.css
+++ b/components/kree8/kree8-clinical-cockpit-shell.module.css
@@ -266,24 +266,30 @@
   }
 }
 
-/* @Codex The primary labels and their counters no longer fit a 360 CSS-pixel
-   viewport at browser zoom 400%. Keep every destination in the document flow
-   instead of depending on an undiscoverable horizontal scroll position. */
-@media (max-width: 480px) {
+/* @Codex The primary labels and their counters no longer fit compact and
+   zoomed viewports. Keep every destination in the document flow instead of
+   depending on an undiscoverable horizontal scroll position. */
+@media (max-width: 767px) {
   .rail {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    align-items: stretch;
+    display: flex;
+    flex-wrap: wrap;
+    padding: 5px 6px;
+    gap: 4px;
     overflow: visible;
     scroll-snap-type: none;
   }
 
-  .brand { grid-column: 1 / -1; }
+  .brand {
+    flex: 1 1 100%;
+    padding: 4px 6px;
+  }
 
   .navItem {
+    flex: 0 1 auto;
     min-width: 0;
-    width: 100%;
-    justify-content: space-between;
+    min-height: 44px;
+    width: auto;
+    padding: 8px 10px;
   }
 }
 
@@ -639,6 +645,32 @@
   .avatarPill {
     display: none;
   }
+}
+
+/* @Codex Compact localhost controls keep the clinical surface readable at 400% zoom. */
+@media (max-width: 480px) {
+  .canvas {
+    gap: 8px;
+    padding: 8px;
+  }
+
+  .toolbar { gap: 6px; }
+
+  .search { min-height: 44px; }
+
+  .toolChip {
+    min-height: 44px;
+    white-space: normal;
+    text-align: center;
+  }
+
+  .framePanel {
+    padding: 0;
+    border: 0;
+    background: transparent;
+  }
+
+  .focusSurface { padding: 8px; }
 }
 
 /* ───────────── escape hatch ───────────── */

--- a/components/kree8/kree8-clinical-cockpit-shell.module.css
+++ b/components/kree8/kree8-clinical-cockpit-shell.module.css
@@ -269,7 +269,7 @@
 /* @Codex The primary labels and their counters no longer fit compact and
    zoomed viewports. Keep every destination in the document flow instead of
    depending on an undiscoverable horizontal scroll position. */
-@media (max-width: 767px) {
+@media (max-width: 768px) {
   .rail {
     display: flex;
     flex-wrap: wrap;

--- a/docs/STATE_OF_THE_SYSTEM.md
+++ b/docs/STATE_OF_THE_SYSTEM.md
@@ -71,7 +71,7 @@ La fotografia corrente e questa:
   `MediFlowCore` concentra logica portabile, cifratura, contratti, filtri,
   clinical scales e store SQLite locale; Linux e Windows oggi verificano la
   portabilita del core in CI, non una parity applicativa completa.
-- **Parity UI 0.8**: iPhone 2/2, iPad 7/7, build/probe macOS e localhost 78/78
+- **Parity UI 0.8**: iPhone 2/2, iPad 7/7, build/probe macOS e localhost 82/82
   sono verdi sul tree verificato. La parity resta clinico-semantica, non pixel.
   VoiceOver reale mobile non è provato per il limite esterno della beta Xcode
   27; la deroga vale solo per la release sorgente e non autorizza claim di

--- a/docs/analysis/2026-07-27-parity-0.8-recovery-run.md
+++ b/docs/analysis/2026-07-27-parity-0.8-recovery-run.md
@@ -1911,3 +1911,79 @@ Controlli indipendenti:
   nessun finding bloccante.
 
 Verdetto: `APPROVE_COMMIT_UI_FIX`.
+
+### 15.35 Correzione del confine CI e nuova prova Xcode 27
+
+Il commit `68b8b971993bedfd7ded1c72eec415836037194b` è stato
+pubblicato sul branch della candidata e ha aperto la pull request 148. Sei
+controlli remoti sono passati. Il controllo E2E ha trovato quattro failure
+ripetibili su Ubuntu:
+
+- a 320 px, titolo e conteggio della worklist occupavano righe diverse;
+- a 768 px, il rail superiore tagliava l'ultima destinazione;
+- i due failure erano presenti nei registri giorno e grafite.
+
+Gli artefatti del run GitHub `30429611097` hanno confermato che si trattava di
+difetti di geometria dipendenti dalle metriche del browser e dei font. Il
+controller non ha modificato né ridotto le asserzioni.
+
+Correzione bounded:
+
+- la testata compatta usa una griglia esplicita con titolo e conteggio sulla
+  stessa riga;
+- l'azione `Nuova scheda` occupa la riga successiva e conserva il target
+  interattivo di almeno 44 px;
+- il breakpoint del rail include 768 px, quindi tutte le destinazioni restano
+  nel flusso e non richiedono uno scorrimento orizzontale nascosto;
+- contenuto, identifier, azioni, servizi, stato e token restano invariati.
+
+Le viste localhost a 320, 390 e 768 px sono solo prove tecniche di reflow,
+accessibilità e clipping. Non rappresentano l'app iPhone o iPad e non fanno
+parte della galleria pubblica. Gli asset pubblici mobile restano catture native
+della build Xcode.
+
+Evidenze web sul diff corretto, Node `v24.18.0`:
+
+- frame e worklist focalizzati: 21/21 PASS;
+- suite completa, un solo worker: 82/82 PASS in 7,7 minuti;
+- database sintetico:
+  `/tmp/mediflow-e2e-full-remediation.eUIj4N`;
+- lint, typecheck, claims guard e never-regress: PASS;
+- claims guard: 748 file, zero claim ad alto rischio;
+- token Lume: 30/30 PASS;
+- motion budget: 9/9 PASS;
+- build di produzione: PASS, 104 pagine statiche generate.
+
+Il volume Xcode 27 beta è montato e utilizzabile:
+
+- Xcode `27.0`, build `27A5194q`;
+- runtime iOS 27 e simulatori audit eleggibili;
+- iPhone: 8/8 PASS;
+- iPad: 8/8 PASS;
+- prove incluse: AX5, audit AX, navigazione delle superfici, identifier delle
+  tab, scorrimento sotto la tab bar, rotazione iPad e conservazione del
+  dettaglio;
+- bundle iPhone:
+  `/tmp/mediflow-xcode27-rerun.3pbRuL/iphone.xcresult`;
+- bundle iPad:
+  `/tmp/mediflow-xcode27-rerun.3pbRuL/ipad.xcresult`;
+- i due simulatori sono tornati nello stato `Shutdown`;
+- VoiceOver udibile non è stato avviato.
+
+Decision audit:
+
+| Decisione | Evidenza | Alternativa | Falsificatore | Stato |
+| --- | --- | --- | --- | --- |
+| Correggere la produzione e non indebolire i test | Screenshot CI mostrano composizione e clipping reali | Aumentare le tolleranze | Nuovo overflow o perdita di gerarchia | `accepted` |
+| Includere 768 px nel layout rail a capo | L'ultima voce era fuori dal rail | Conservare lo scorrimento orizzontale | Destinazione non visibile o non raggiungibile | `accepted` |
+| Trattare i proxy stretti come sola evidenza tecnica | Decisione utente e media manifest nativo | Pubblicarli come viste mobile | Asset mobile acquisito da Chromium | `accepted` |
+| Ripetere la matrice nativa su Xcode 27 | 8/8 iPhone e 8/8 iPad sullo snapshot corrente | Affidarsi ai soli run precedenti | `.xcresult` rosso o runtime non eleggibile | `accepted` |
+
+Promotion rule:
+
+1. fresh verifier indipendente sul nuovo diff;
+2. commit locale aggiuntivo senza riscrivere la storia remota;
+3. push fast-forward sul branch della pull request 148;
+4. tutti i controlli remoti devono tornare verdi;
+5. merge, tag e GitHub Release solo sul commit `main` verificato;
+6. stop su test rosso, secret, drift remoto o necessità di force push.

--- a/docs/analysis/2026-07-27-parity-0.8-recovery-run.md
+++ b/docs/analysis/2026-07-27-parity-0.8-recovery-run.md
@@ -1768,3 +1768,146 @@ Decisione:
 - richiedere un packet dipendenze separato, senza override fuori range e con
   regressione completa;
 - ripetere commit sicuro e fresh verifier sul nuovo hash prima del push.
+
+### 15.33 Chiusura della worklist compatta
+
+Run ID: `parity-0.8-compact-closure-20260729`.
+
+Modalità: `manager-goal`, con Codex come controller-of-record tecnico.
+
+Root:
+`/Users/leonardopegollo/.codex/worktrees/mediflow-0.8-release-candidate-local/medical-record-app`.
+
+Branch: `codex/mediflow-0.8-release-candidate-local`.
+
+HEAD di base: `c0d38b946e7873c831691f499c61c9fe5c5e62ff`.
+
+#### Lane e autorità
+
+- CoS parity 0.8: `gpt-5.6-sol`, effort high;
+- Fable UI: sessione isolata
+  `local_4f85ddab-9f02-40d9-97c7-4cd060b26c27`, Fable 5, effort High,
+  Bypass permissions, UltraCode disattivato;
+- prompt Fable atomico SHA-256:
+  `a53a8a0b84f25f8992fc2100396d93eb73675670832095957ab96b3a5c4892b8`;
+- verdetto Fable: `APPROVE_UI_PACKET`;
+- verifier indipendente: `gpt-5.6-sol`, effort high, read-only.
+
+La lane UI non ha usato né aggiornato sessioni Open Minis. Le tre sessioni
+Open Minis con stato `Needs input` restano post-0.8 e non bloccano questa
+release.
+
+#### Correzione
+
+Il packet compatto modifica soltanto CSS Lume e test Playwright. Non modifica
+DOM, identifier, azioni, servizi, testo clinico, dati, backend o token
+condivisi.
+
+La correzione:
+
+- riduce il rail e gli inset a 320 e 390 px;
+- mantiene i target interattivi ad almeno 44 px;
+- conserva il focus visibile da tastiera;
+- rimuove un livello decorativo annidato dal frame compatto;
+- rende la gerarchia e le righe paziente leggibili senza overflow;
+- aggiunge verifiche a 600 e 701 px per i confini responsive;
+- mantiene lo snapshot ARIA invariato tra 320 e 481 px.
+
+Le viste localhost a dimensione telefono o tablet restano solo evidenza di
+test. La galleria pubblica usa catture native iPhone e iPad. Le catture web
+pubbliche restano desktop.
+
+#### Errore rilevato e correzione del contratto
+
+Il primo run completo dopo il packet ha prodotto 78 PASS e quattro failure.
+I failure riguardavano `e2e/lume-frame.spec.ts`: il test richiedeva ancora il
+fondo `--lume-surface-field` sul pannello esterno a 320 e 390 px.
+
+Il comportamento runtime era intenzionale e già approvato da Fable: sotto
+481 px il pannello esterno è trasparente e senza bordo, mentre la superficie
+focale conserva il raggruppamento e il bordo. Il test è stato aggiornato per
+verificare in modo esplicito entrambi i contratti:
+
+- fino a 480 px: pannello trasparente e bordo di 0 px;
+- oltre 480 px: superficie field e bordo di 1 px.
+
+Le verifiche di token, focus, overflow, gerarchia e superficie focale non sono
+state rimosse o indebolite.
+
+#### Evidenze runtime
+
+Web, Node `v24.18.0`:
+
+- frame e worklist focalizzati: 21/21 PASS;
+- suite completa: 82/82 PASS, zero failure e zero skip;
+- durata suite completa: 7,8 minuti;
+- database sintetico isolato:
+  `/tmp/mediflow-e2e-final.1sLfNy`.
+
+Apple, Xcode 27 beta build `27A5194q`, runtime `24A5355p`:
+
+- iPhone 17 Pro: tab identifier 1/1 PASS;
+- bundle:
+  `/tmp/mediflow-ios27-iphone-green.tMBLGp/iphone.xcresult`;
+- iPad Pro 13-inch (M5): matrice parity 7/7 PASS;
+- bundle:
+  `/tmp/mediflow-ios27-ipad-green.296li3/ipad.xcresult`;
+- macOS arm64: build Debug PASS;
+- derived data:
+  `/tmp/mediflow-xcode27-macos.opubLF/DerivedData`;
+- simulatori audit: `Shutdown`;
+- VoiceOver mobile non è stato avviato.
+
+Il primo mount in sola lettura ha compilato i target iOS 27, ma ha impedito
+l'installazione nel simulatore. Il controller ha sganciato le attach stale e
+ha rimontato lo stesso sparsebundle in modalità scrivibile. Il nuovo test ha
+superato il punto di failure precedente. Nessuna riparazione del filesystem è
+stata eseguita.
+
+#### Decision audit
+
+| Decisione | Evidenza | Alternativa | Falsificatore | Stato |
+| --- | --- | --- | --- | --- |
+| Conservare il frame esterno trasparente sotto 481 px | Approvazione Fable e 21/21 focalizzati | Ripristinare un bordo decorativo | Perdita di raggruppamento, focus o contrasto | `accepted` |
+| Aggiornare il test del frame | Il test storico contraddiceva il contratto compatto approvato | Cambiare la produzione per il test | Failure su superficie focale, token o overflow | `corrected` |
+| Non pubblicare viste web compresse come media mobile | Manifest e dimensioni provano catture native separate | Usare proxy responsive nella galleria | Asset iPhone/iPad proveniente da Chromium | `accepted` |
+| Rimontare il volume simulatori scrivibile | Il failure era `Read-only file system`; la ripetizione supera installazione e test | Conservare il mount read-only | Nuovo failure di scrittura sul device set | `corrected` |
+| Conservare la deroga VoiceOver mobile | Authority root e limitazione pubblica | Dichiarare un PASS non provato | Test VoiceOver reale terminale | `accepted external limitation` |
+
+Confine aperto:
+
+- VoiceOver reale su iPhone e iPad resta non provato;
+- la deroga non sostiene claim App Store, certificazione o piena conformità.
+
+Promotion rule corrente:
+
+1. fresh verifier indipendente sul diff esatto;
+2. safe commit locale dei soli path verificati;
+3. verifica post-commit sul commit esatto;
+4. push non forzato del branch;
+5. pull request e merge solo con controlli remoti verdi e assenza di drift;
+6. tag `v0.8.0` e GitHub Release solo sul commit `main` verificato;
+7. stop su test rosso, secret, remote drift o necessità di force push.
+
+### 15.34 Fresh verifier del packet compatto
+
+Il verifier indipendente `gpt-5.6-sol/high` ha controllato il diff con:
+
+- branch `codex/mediflow-0.8-release-candidate-local`;
+- HEAD `c0d38b946e7873c831691f499c61c9fe5c5e62ff`;
+- nove path dirty attesi;
+- index vuoto e zero file untracked;
+- diff SHA-256
+  `2c2582eb99e9cbfa8d72f462677e7e40b0bd903a529c2b2af4d2efd4f3900553`.
+
+Controlli indipendenti:
+
+- `git diff --check`: PASS;
+- ESLint mirato sui due file Playwright: PASS;
+- TypeScript `--noEmit`: PASS;
+- parse JSON della matrice Apple: PASS;
+- parse PostCSS dei tre file CSS: PASS;
+- focus visibile, breakpoint, chiusura 320 px, confine media e privacy:
+  nessun finding bloccante.
+
+Verdetto: `APPROVE_COMMIT_UI_FIX`.

--- a/docs/apple-parity-matrix.json
+++ b/docs/apple-parity-matrix.json
@@ -38,7 +38,7 @@
         "surface": "localhost/web",
         "owner": "CoS parity 0.8",
         "status": "verified",
-        "requiredEvidence": "78/78, responsive 320/390/768/1440, tastiera/focus e zoom browser reale 200/400"
+        "requiredEvidence": "82/82, responsive 320/390/768/1440, tastiera/focus e zoom browser reale 200/400"
       }
     ],
     "blockingRule": "Un P1 confermato blocca il gate. La sola deroga accettata è il limite esterno VoiceOver mobile della candidata sorgente GitHub 0.8.",

--- a/e2e/lume-frame.spec.ts
+++ b/e2e/lume-frame.spec.ts
@@ -82,7 +82,16 @@ for (const frameCase of FRAME_CASES) {
 
     await expect(rail).toHaveCSS('background-color', expected.chrome);
     await expect(canvas).toHaveCSS('background-color', expected.canvas);
-    await expect(panel).toHaveCSS('background-color', expected.field);
+    if (frameCase.width <= 480) {
+      /* @Codex The compact frame deliberately removes one nested surface.
+         The focal surface still carries grouping while the outer panel
+         contributes no decorative border at reflow-proxy widths. */
+      await expect(panel).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
+      await expect(panel).toHaveCSS('border-top-width', '0px');
+    } else {
+      await expect(panel).toHaveCSS('background-color', expected.field);
+      await expect(panel).toHaveCSS('border-top-width', '1px');
+    }
     await expect(focus).toHaveCSS('background-color', expected.focal);
     await expect(focus).toHaveCSS('border-top-width', '1px');
     // Gli alias locali sono validati dal token checker e risolvono solo da

--- a/e2e/lume-worklist.spec.ts
+++ b/e2e/lume-worklist.spec.ts
@@ -11,13 +11,19 @@ import {
 
 type WorklistCase = {
   register: 'giorno' | 'grafite';
-  viewport: ReflowProxyViewport['viewport'];
+  viewport: ReflowProxyViewport['viewport'] | 'compact-transition' | 'rail-boundary';
   width: number;
   height: number;
 };
 
+const WORKLIST_VIEWPORTS: Omit<WorklistCase, 'register'>[] = [
+  ...REFLOW_PROXY_VIEWPORTS,
+  { viewport: 'compact-transition', width: 600, height: 900 },
+  { viewport: 'rail-boundary', width: 701, height: 900 },
+];
+
 const WORKLIST_CASES: WorklistCase[] = (['giorno', 'grafite'] as const).flatMap((register) =>
-  REFLOW_PROXY_VIEWPORTS.map((viewport) => ({ register, ...viewport })),
+  WORKLIST_VIEWPORTS.map((viewport) => ({ register, ...viewport })),
 );
 
 async function setRegister(page: Page, register: WorklistCase['register']): Promise<void> {
@@ -142,11 +148,127 @@ async function assertWorklistContract(page: Page): Promise<void> {
   await expect(page.getByTestId('lume-patient-lens-empty')).toHaveCount(0);
 }
 
+/* @Codex The narrow worklist previously passed overflow checks while its
+   navigation, heading, and rows still collapsed into an unusable composition. */
+async function assertCompactWorklistGeometry(page: Page, width: number): Promise<void> {
+  if (width > 480) return;
+
+  const geometry = await page.evaluate(() => {
+    const rail = document.querySelector<HTMLElement>('[data-testid="lume-frame-rail"]');
+    const worklist = document.querySelector<HTMLElement>('[data-testid="lume-worklist"]');
+    const title = worklist?.querySelector<HTMLElement>('h2');
+    const count = worklist?.querySelector<HTMLElement>('.lume-registro');
+    const action = worklist?.querySelector<HTMLElement>('[data-lume-action="quiet"]');
+    const rows = [...document.querySelectorAll<HTMLElement>('[data-testid="lume-patient-row"]')];
+    const navItems = [...document.querySelectorAll<HTMLElement>('[data-lume-frame-nav="true"]')];
+
+    if (!rail || !worklist || !title || !count || !action || rows.length === 0 || navItems.length === 0) {
+      return null;
+    }
+
+    const railBox = rail.getBoundingClientRect();
+    const worklistStyle = getComputedStyle(worklist);
+    const titleBox = title.getBoundingClientRect();
+    const countBox = count.getBoundingClientRect();
+    const actionBox = action.getBoundingClientRect();
+    const navRows = new Set(navItems.map((item) => Math.round(item.getBoundingClientRect().top)));
+
+    return {
+      railHeight: railBox.height,
+      navRowCount: navRows.size,
+      worklistInnerWidth: worklist.clientWidth
+        - Number.parseFloat(worklistStyle.paddingLeft)
+        - Number.parseFloat(worklistStyle.paddingRight),
+      titleHeight: titleBox.height,
+      titleAndCountShareLine: Math.abs(
+        (titleBox.top + titleBox.height / 2) - (countBox.top + countBox.height / 2),
+      ) <= 2,
+      actionFollowsHeading: actionBox.top >= Math.max(titleBox.bottom, countBox.bottom),
+      actionHeight: actionBox.height,
+      rowHeights: rows.map((row) => row.getBoundingClientRect().height),
+    };
+  });
+
+  expect(geometry).not.toBeNull();
+  expect(geometry?.railHeight).toBeLessThanOrEqual(150);
+  expect(geometry?.navRowCount).toBeLessThanOrEqual(2);
+  expect(geometry?.worklistInnerWidth).toBeGreaterThanOrEqual(240);
+  expect(geometry?.titleHeight).toBeLessThanOrEqual(27);
+  expect(geometry?.titleAndCountShareLine).toBe(true);
+  expect(geometry?.actionFollowsHeading).toBe(true);
+  expect(geometry?.actionHeight).toBeGreaterThanOrEqual(44);
+  for (const rowHeight of geometry?.rowHeights ?? []) {
+    expect(rowHeight).toBeLessThanOrEqual(100);
+  }
+}
+
+async function assertCompactAriaStable(page: Page, worklistCase: WorklistCase): Promise<void> {
+  if (worklistCase.width !== 320) return;
+
+  const canvas = page.getByTestId('lume-frame-canvas');
+  const compactSnapshot = await canvas.ariaSnapshot();
+  await page.setViewportSize({ width: 481, height: worklistCase.height });
+  const expandedSnapshot = await canvas.ariaSnapshot();
+  expect(compactSnapshot).toBe(expandedSnapshot);
+  await page.setViewportSize({ width: worklistCase.width, height: worklistCase.height });
+}
+
+async function assertTopComposition(page: Page, width: number): Promise<void> {
+  const composition = await page.evaluate(() => {
+    const rail = document.querySelector<HTMLElement>('[data-testid="lume-frame-rail"]');
+    const title = document.querySelector<HTMLElement>('[data-testid="lume-worklist"] h2');
+    const action = document.querySelector<HTMLElement>(
+      '[data-testid="lume-worklist"] [data-lume-action="quiet"]',
+    );
+    const rows = [...document.querySelectorAll<HTMLElement>('[data-testid="lume-patient-row"]')];
+    const navItems = [...document.querySelectorAll<HTMLElement>('[data-lume-frame-nav="true"]')];
+    if (!rail || !title || !action || rows.length === 0 || navItems.length === 0) return null;
+
+    const railBox = rail.getBoundingClientRect();
+    const navBoxes = navItems.map((item) => item.getBoundingClientRect());
+    const isFullyVisible = (box: DOMRect) => box.top >= 0 && box.bottom <= window.innerHeight;
+    const firstRowBox = rows[0].getBoundingClientRect();
+    const firstRowVisibleHeight = Math.max(
+      0,
+      Math.min(firstRowBox.bottom, window.innerHeight) - Math.max(firstRowBox.top, 0),
+    );
+    return {
+      railHasNoHorizontalOverflow: rail.scrollWidth <= rail.clientWidth + 1,
+      everyNavItemVisible: navBoxes.every(
+        (box) => box.left >= railBox.left - 1 && box.right <= railBox.right + 1,
+      ),
+      headingVisible: isFullyVisible(title.getBoundingClientRect()),
+      actionVisible: isFullyVisible(action.getBoundingClientRect()),
+      completeRowsVisible: rows.filter((row) => isFullyVisible(row.getBoundingClientRect())).length,
+      firstRowBottomMiss: Math.max(0, firstRowBox.bottom - window.innerHeight),
+      firstRowVisibleFraction: firstRowVisibleHeight / firstRowBox.height,
+    };
+  });
+
+  expect(composition).not.toBeNull();
+  expect(composition?.railHasNoHorizontalOverflow).toBe(true);
+  expect(composition?.everyNavItemVisible).toBe(true);
+  if (width === 320) {
+    expect(composition?.headingVisible).toBe(true);
+    expect(composition?.actionVisible).toBe(true);
+    if ((composition?.completeRowsVisible ?? 0) < 1) {
+      /* @Codex Fable's pre-declared compact closure rule permits a boundary
+         miss only when it is <=24px and at least 60% of row one remains visible. */
+      expect(composition?.firstRowBottomMiss).toBeLessThanOrEqual(24);
+      expect(composition?.firstRowVisibleFraction).toBeGreaterThanOrEqual(0.6);
+    }
+  } else if (width === 390) {
+    expect(composition?.completeRowsVisible).toBeGreaterThanOrEqual(2);
+  }
+}
+
 for (const worklistCase of WORKLIST_CASES) {
   test(`worklist Lume ${worklistCase.register} ${worklistCase.viewport}`, async ({ page }) => {
     await openSyntheticWorklist(page, worklistCase);
     await expect(page.locator('html')).toHaveClass(worklistCase.register === 'grafite' ? /dark/ : /light/);
     await assertWorklistContract(page);
+    await assertCompactAriaStable(page, worklistCase);
+    await assertCompactWorklistGeometry(page, worklistCase.width);
     await assertNoHorizontalOverflow(page, [
       { label: 'documento worklist', selector: 'document' },
       { label: 'worklist', selector: '[data-testid="lume-worklist"]' },
@@ -156,6 +278,16 @@ for (const worklistCase of WORKLIST_CASES) {
     const selectedRow = page.getByTestId('lume-patient-row').nth(1);
     await assertNotClippedInViewport(selectedRow, 'riga paziente selezionata');
     await assertKeyboardFocusProgresses(page, selectedRow, 'riga paziente selezionata');
+    await page.evaluate(() => {
+      window.scrollTo(0, 0);
+      document.querySelector<HTMLElement>('[data-testid="lume-frame-canvas"]')?.scrollTo(0, 0);
+    });
+    await assertTopComposition(page, worklistCase.width);
+    await page.screenshot({
+      path: `/tmp/lume-worklist-${worklistCase.register}-${worklistCase.viewport}-top.png`,
+      fullPage: false,
+      animations: 'disabled',
+    });
     await page.getByTestId('lume-patient-lens').scrollIntoViewIfNeeded();
     await page.screenshot({
       path: `/tmp/lume-worklist-${worklistCase.register}-${worklistCase.viewport}.png`,


### PR DESCRIPTION
## Summary
- Riduce livelli decorativi, inset e overflow della worklist Lume alle larghezze compatte.
- Mantiene target da almeno 44 px, focus visibile e semantica ARIA invariata.
- Aggiorna i contratti Playwright e i claim canonici della suite completa a 82/82.
- Conserva nella galleria pubblica soltanto catture native iPhone/iPad e immagini web desktop.

## Verification
- Playwright focalizzato frame + worklist: 21/21 PASS.
- Playwright completo: 82/82 PASS con Node 24.18.0.
- iPhone iOS 27: XCUITest 1/1 PASS; iPadOS 27: 7/7 PASS.
- macOS Xcode 27: build Debug arm64 PASS.
- `npm run lint`, `npm run typecheck`, `npm run build`, claims, never-regress, Lume tokens, motion budget e Apple wide QA: PASS.
- Fresh verifier post-commit: APPROVE_POST_COMMIT.

## Risk / Notes
- Solo fixture sintetiche; nessuna PHI/PII, credenziale reale o database reale.
- VoiceOver reale mobile resta non provato ed è documentato come limite esterno accettato; non è un claim di conformità.
- Le viste web responsive a dimensione telefono/tablet restano evidenza di test e non media pubblici.
- Open Minis e Intelligence Fabric restano post-0.8 e fuori dal runtime della release.