### PR TITLE
fix(fhir): preserva i punteggi scala pari a zero

### DIFF
--- a/lib/fhir/clinical-adapter.test.ts
+++ b/lib/fhir/clinical-adapter.test.ts
@@ -1,0 +1,51 @@
+/* @Codex WUL-327 */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { toFhirObservation } from './clinical-adapter';
+import type { FhirClinicalEntryInput } from './types';
+
+function scaleEntry(score: unknown): FhirClinicalEntryInput {
+    return {
+        id: 'entry-scale-1',
+        patientId: 'patient-1',
+        date: '2025-03-11T00:00:00Z',
+        type: 'scale',
+        content: 'Valutazione di prova',
+        metadata: { title: 'PPS', score, interpretation: 'Stabile' },
+    };
+}
+
+test('toFhirObservation accetta zero e i punteggi numerici validi', () => {
+    const cases: Array<[unknown, number]> = [[0, 0], ['0', 0], [27, 27], ['27', 27]];
+    for (const [score, expected] of cases) {
+        const resource = toFhirObservation(scaleEntry(score), 'Patient/patient-1');
+        assert.ok(resource, `score ${JSON.stringify(score)} deve produrre una Observation`);
+        assert.equal(resource.valueInteger, expected);
+    }
+});
+
+test('toFhirObservation tratta come assenti i punteggi vuoti o non numerici senza inventare zero', () => {
+    const missing: unknown[] = [null, undefined, '', '   ', Number.NaN, 'abc', Number.POSITIVE_INFINITY];
+    for (const score of missing) {
+        const resource = toFhirObservation(scaleEntry(score), 'Patient/patient-1');
+        assert.equal(resource, null, `score ${JSON.stringify(score)} deve restare assente`);
+    }
+});
+
+test('toFhirObservation ignora le voci non-scala e i metadata assenti', () => {
+    assert.equal(toFhirObservation({ ...scaleEntry(5), type: 'note' }, 'Patient/patient-1'), null);
+    assert.equal(toFhirObservation({ ...scaleEntry(0), metadata: undefined }, 'Patient/patient-1'), null);
+});
+
+test('toFhirObservation conserva la forma della risorsa per un punteggio valido', () => {
+    const resource = toFhirObservation(scaleEntry(27), 'Patient/patient-1');
+    assert.ok(resource);
+    assert.equal(resource.resourceType, 'Observation');
+    assert.equal(resource.status, 'final');
+    assert.equal(resource.code?.text, 'PPS');
+    assert.deepEqual(resource.subject, { reference: 'Patient/patient-1' });
+    assert.equal(resource.effectiveDateTime, new Date('2025-03-11T00:00:00Z').toISOString());
+    assert.equal(resource.valueInteger, 27);
+    assert.deepEqual(resource.interpretation, [{ text: 'Stabile' }]);
+    assert.deepEqual(resource.note, [{ text: 'Valutazione di prova' }]);
+});

--- a/lib/fhir/clinical-adapter.ts
+++ b/lib/fhir/clinical-adapter.ts
@@ -60,21 +60,37 @@ export function toFhirEncounter(entry: FhirClinicalEntryInput, patientReference:
     };
 }
 
+/* @Codex WUL-327: un punteggio scala è presente solo se è un numero finito
+   (o una stringa non vuota che ne rappresenta uno). Lo zero è un valore
+   clinico valido; il vecchio guard per verità lo scartava, mentre una stringa
+   di soli spazi diventava silenziosamente `valueInteger: 0`. */
+function toFiniteScaleScore(score: unknown): number | null {
+    if (typeof score === 'number') {
+        return Number.isFinite(score) ? score : null;
+    }
+    if (typeof score === 'string' && score.trim() !== '') {
+        const parsed = Number(score);
+        return Number.isFinite(parsed) ? parsed : null;
+    }
+    return null;
+}
+
 /* @Codex */
 export function toFhirObservation(entry: FhirClinicalEntryInput, patientReference: string): Observation | null {
-    if (entry.type !== 'scale' || !entry.metadata?.score) return null;
+    const score = toFiniteScaleScore(entry.metadata?.score);
+    if (entry.type !== 'scale' || score === null) return null;
 
     return {
         resourceType: "Observation",
         id: toFhirId(`obs-${entry.id}`, 'observation'),
         status: "final",
         code: {
-            text: entry.metadata.title as string
+            text: entry.metadata?.title as string
         },
         subject: { reference: patientReference },
         effectiveDateTime: new Date(entry.date).toISOString(),
-        valueInteger: Number(entry.metadata.score),
-        interpretation: [{ text: entry.metadata.interpretation as string }],
+        valueInteger: score,
+        interpretation: [{ text: entry.metadata?.interpretation as string }],
         note: [{ text: entry.content }]
     };
 }

--- a/lib/report-service.test.ts
+++ b/lib/report-service.test.ts
@@ -262,3 +262,45 @@ test('generatePatientReport renders explicit empty states when data is missing',
     assert.ok(doc.texts.includes('Nessuna valutazione recente disponibile.'));
 }
 );
+
+/* @Codex WUL-327: lo zero è un punteggio valido e non deve degradare a '-'. */
+test('generatePatientReport rende lo zero valido e conserva il segnaposto per i punteggi assenti', async () => {
+    FakeJsPDF.pageHeight = 220;
+
+    const patient = {
+        firstName: 'Anna',
+        lastName: 'Verdi',
+        taxCode: 'VRDNNA80A41H501X',
+        monitoringProfile: 'episodic',
+        diagnoses: [],
+    };
+
+    const scaleWith = (id: string, score: unknown) => ({
+        id,
+        patientId: 'patient-2',
+        date: new Date('2025-03-11T00:00:00Z'),
+        type: 'scale',
+        title: 'Scala',
+        content: 'Score',
+        metadata: { title: 'PPS', score, interpretation: 'Stabile' },
+        createdAt: new Date('2025-03-10T00:00:00Z'),
+        updatedAt: new Date('2025-03-10T00:00:00Z'),
+    });
+
+    const lastScales = [
+        scaleWith('scale-zero', 0),
+        scaleWith('scale-zero-string', '0'),
+        scaleWith('scale-nonzero', 28),
+        scaleWith('scale-text', '28/30'),
+        scaleWith('scale-nan', Number.NaN),
+        scaleWith('scale-missing', undefined),
+        scaleWith('scale-empty', ''),
+        scaleWith('scale-whitespace', '   '),
+    ];
+
+    const doc = await renderReport(patient, [], lastScales, [], []);
+
+    assert.equal(doc.autoTableCalls.length, 1);
+    const scores = doc.autoTableCalls[0].body.map((row) => row[2]);
+    assert.deepEqual(scores, [0, '0', 28, '28/30', '-', '-', '-', '   ']);
+});

--- a/lib/report-service.ts
+++ b/lib/report-service.ts
@@ -10,6 +10,16 @@ export interface JsPDFWithAutoTable extends jsPDF {
     lastAutoTable: { finalY: number };
 }
 
+/* @Codex WUL-327: lo zero è un punteggio valido e non deve degradare al
+   segnaposto. Solo i numeri non finiti diventano '-'; le stringhe conservano
+   il comportamento attuale e non vengono mai coerte a numero. */
+const formatScaleScore = (score: unknown): string | number => {
+    if (typeof score === 'number') {
+        return Number.isFinite(score) ? score : '-';
+    }
+    return (score as string | undefined) || '-';
+};
+
 export const generatePatientReport = (
     patient: Patient,
     entries: ClinicalEntry[],
@@ -316,7 +326,7 @@ export const generatePatientReport = (
         const scaleData = lastScales.map(s => [
             formatDate(s.date),
             s.metadata?.title || 'Scala',
-            s.metadata?.score || '-',
+            formatScaleScore(s.metadata?.score),
             s.metadata?.interpretation || '-'
         ]);
 


### PR DESCRIPTION
## Summary
- preserva il valore numerico `0` nelle Observation FHIR delle scale cliniche
- evita di convertire stringhe vuote, valori non numerici o non finiti in uno score inventato
- conserva lo zero nei report PDF e aggiunge regressioni sintetiche sui due percorsi

## Verification
- Node 24.18.0: `node scripts/node-runtime-contract.mjs verify-node`
- `node scripts/run-strip-types.mjs --test lib/fhir/clinical-adapter.test.ts lib/report-service.test.ts` (7/7)
- `npx eslint --quiet lib/fhir/clinical-adapter.ts lib/fhir/clinical-adapter.test.ts lib/report-service.ts lib/report-service.test.ts`
- `npm run typecheck`
- `git diff --check origin/main...HEAD`
- verifica indipendente Luna Max sulla slice rebased: test, lint, typecheck e boundary check verdi; tier Fast richiesto ma non attestabile dalla superficie

## Risk / Notes
- Slice circoscritta alla semantica dello score; nessuna migrazione o modifica di schema.
- WUL-327 comprende altri sottoproblemi: questa PR non chiude il ticket.
- Solo fixture sintetiche; nessuna PHI/PII o evidenza clinica reale.

## Ticket
Refs WUL-327