### PR TITLE
feat(documenti): definisci serie risultati clinici (WUL-516)

### DIFF
--- a/docs/analysis/2026-07-30-smart-import-clinical-series-run.md
+++ b/docs/analysis/2026-07-30-smart-import-clinical-series-run.md
@@ -1,0 +1,59 @@
+# Smart Import: serie di risultati clinici
+
+Stato: candidato locale. Dati usati: solo fixture sintetiche.
+
+## Capacità esistente, gap, estensione minima
+
+| Capacità esistente | Gap provato | Estensione minima |
+|---|---|---|
+| Smart Import revisiona diagnosi e terapie con fonti citabili | Nessun envelope per risultati clinici | Contratto `clinical_result_import.v1`, sempre `review_only` |
+| Osservazioni LOINC/UCUM e link esplicito a item prescrizione | Nessuna proposta fail-closed dal documento | Matching esatto, temporale e source-aware; ambiguità in review |
+| UI Smart Import con selezione e revisione prima della scrittura | I risultati clinici non sono presentati | Nessuna UI parallela in questa wave; estensione futura della UI esistente |
+| Provider AI dietro servizio clinico | Pipeline non utile senza AI | Normalizzazione e serie deterministiche; provider solo su residui |
+
+La verifica funzionale ha confermato il pannello Smart Import esistente e il
+contratto di revisione per diagnosi/terapie tramite test e codice. Un avvio web
+ha raggiunto soltanto la schermata di sblocco: è stato interrotto senza accesso
+perché non era ancora legato a un database sintetico. Non costituisce prova UI
+del nuovo contratto.
+
+## Contratto e decisioni
+
+- I fatti deterministici hanno precedenza e un provider non può sovrascriverli.
+- LOINC e UCUM compaiono solo da mapping esatti marcati come verificati.
+- La chiave idempotente combina hash documento, id referto, analita/codice,
+  data/ora, valore e unità.
+- La serie conserva tutti i risultati. `ultimi 3 + massimo 1 per anno
+  precedente` è soltanto una vista collassata.
+- Il collegamento prescrizione è una proposta: unico, ambiguo o non collegato.
+- Nessuna diagnosi, persistenza clinica, chiamata SISS/FSE o accesso al DB vivo.
+- La pipeline non-AI conserva normalizzazione, deduplica, serie e matching.
+
+Decision audit: **accettate** le decisioni sopra. **Corretta** la prima
+normalizzazione dei decimali, che ora gestisce tutte le virgole nel range.
+**Aperto**: integrazione del nuovo envelope nel pannello Smart Import e nella
+persistenza esplicita; questa wave non aggiunge una UI parallela né una write
+path. Il debito visivo della scheda paziente è trasferito a un task UI separato.
+
+## File posseduti e confini
+
+- `lib/domain/documents/clinical-result-import.ts`
+- `lib/domain/documents/clinical-result-import.test.ts`
+- questo run record
+- sorgente canonica toolkit:
+  `skills/data-entry-document-ops/references/mediflow.md`
+
+Nessun file di Intelligence Fabric, provider registry o lifecycle è stato
+modificato. Nessun overlap rilevato.
+
+## Verifica
+
+- Baseline Smart Import: 21 test superati.
+- Baseline observation range/open loops: 18 test superati.
+- Benchmark sintetico corrente: 9 casi; conferma copertura diagnosi/terapie,
+  non risultati clinici.
+- Test nuovi: nuovo referto, duplicato, date/unità/range diversi, LOINC assente,
+  link unico/ambiguo/assente, deterministico-only, locale/cloud e storico lungo.
+
+Stop rule: non promuovere a persistenza finché la UI esistente non presenta
+l’envelope e il clinico non approva esplicitamente ogni candidato e link.

--- a/docs/markdown-index.md
+++ b/docs/markdown-index.md
@@ -209,6 +209,8 @@ Ultimo aggiornamento: 2026-07-29
 
 ## ✅ Checklist manutenzione indice
 
+| [docs/analysis/2026-07-30-smart-import-clinical-series-run.md](./analysis/2026-07-30-smart-import-clinical-series-run.md) | Run record sintetico del contratto provider-neutral, serie temporali e collegamento prescrizioni per Smart Import. |
+
 1. Verifica inventario file: `rg --files -g '*.md' | sort`.
 2. Assicurati che ogni file appaia in questo indice con una descrizione.
 3. Aggiorna data "Ultimo aggiornamento".

--- a/lib/domain/documents/clinical-result-import.test.ts
+++ b/lib/domain/documents/clinical-result-import.test.ts
@@ -1,0 +1,74 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildClinicalResultImportEnvelope,
+  buildClinicalResultSeries,
+  proposePrescriptionLink,
+  type RawClinicalResult,
+} from './clinical-result-import';
+
+const base: RawClinicalResult = {
+  analyte: 'Emoglobina', value: '13,4', unit: 'g/dL', referenceRange: '12,0 - 16,0',
+  observedAt: '2026-07-01T08:00:00+02:00', reportId: 'R-001', specimen: 'Sangue',
+};
+const terminology = [{ analyte: 'Emoglobina', loinc: '718-7', unit: 'g/dL', ucum: 'g/dL', verified: true as const }];
+const envelope = (deterministic: RawClinicalResult[], provider?: { lane: 'local' | 'cloud'; results: RawClinicalResult[] }) =>
+  buildClinicalResultImportEnvelope({ patientId: 'synthetic-patient', documentHash: 'sha256:synthetic', deterministic, provider, terminology });
+
+test('normalizza un nuovo referto e conserva provenienza, range e terminologie verificate', () => {
+  const result = envelope([base]).candidates[0];
+  assert.equal(result.value, '13.4');
+  assert.deepEqual(result.referenceRange, { original: '12,0 - 16,0', low: 12, high: 16 });
+  assert.equal(result.analyte.loinc, '718-7');
+  assert.equal(result.provenance.lane, 'deterministic');
+});
+
+test('deduplica lo stesso referto ma conserva stessa analisi in date, unità e range diversi', () => {
+  const rows = [
+    envelope([base]).candidates[0],
+    envelope([base]).candidates[0],
+    envelope([{ ...base, observedAt: '2026-06-01T08:00:00Z' }]).candidates[0],
+    envelope([{ ...base, unit: 'g/L', value: 134 }]).candidates[0],
+    envelope([{ ...base, referenceRange: '11 - 15', reportId: 'R-002' }]).candidates[0],
+  ];
+  const series = buildClinicalResultSeries('synthetic-patient', rows);
+  assert.equal(series.length, 1);
+  assert.equal(series[0].all.length, 4);
+});
+
+test('non inventa LOINC quando il mapping manca', () => {
+  const result = buildClinicalResultImportEnvelope({
+    patientId: 'synthetic-patient', documentHash: 'sha256:x',
+    deterministic: [{ ...base, analyte: 'Test locale non codificato' }],
+  }).candidates[0];
+  assert.equal(result.analyte.loinc, undefined);
+  assert.equal(result.analyte.original, 'Test locale non codificato');
+});
+
+test('provider locale e cloud non sovrascrivono fatti deterministici', () => {
+  const conflict = { ...base, value: '99' };
+  for (const lane of ['local', 'cloud'] as const) {
+    const result = envelope([base], { lane, results: [conflict] });
+    assert.equal(result.candidates[0].value, '13.4');
+    assert.equal(result.candidates.length, 1);
+    assert.equal(result.issues.length, 1);
+  }
+  assert.deepEqual(envelope([base]).candidates[0], envelope([base], { lane: 'local', results: [base] }).candidates[0]);
+});
+
+test('propone link unico, blocca link ambiguo e lascia non collegato senza evidenza', () => {
+  const result = envelope([base]).candidates[0];
+  const one = [{ id: 'p1', code: '718-7', description: 'Emoglobina', prescribedAt: '2026-06-20T00:00:00Z' }];
+  assert.equal(proposePrescriptionLink(result, one).state, 'collegato');
+  assert.equal(proposePrescriptionLink(result, [...one, { ...one[0], id: 'p2' }]).state, 'ambiguo');
+  assert.equal(proposePrescriptionLink(result, []).state, 'non_collegato');
+});
+
+test('collassa lo storico a ultimi 3 più massimo uno per anno precedente senza cancellare dati', () => {
+  const rows = Array.from({ length: 9 }, (_, index) =>
+    envelope([{ ...base, reportId: `R-${index}`, observedAt: `${2026 - Math.floor(index / 2)}-0${(index % 2) + 1}-01T08:00:00Z` }]).candidates[0]);
+  const series = buildClinicalResultSeries('synthetic-patient', rows)[0];
+  assert.equal(series.all.length, 9);
+  assert.equal(series.collapsed.length, 6);
+  assert.equal(new Set(series.collapsed.slice(3).map(item => item.observedAt.slice(0, 4))).size, 3);
+});

--- a/lib/domain/documents/clinical-result-import.ts
+++ b/lib/domain/documents/clinical-result-import.ts
@@ -1,0 +1,226 @@
+/* @Codex */
+export const CLINICAL_RESULT_IMPORT_SCHEMA = 'mediflow.clinical_result_import.v1' as const;
+
+export type ImportLane = 'deterministic' | 'local' | 'cloud';
+export type ExplicitResultFlag = 'low' | 'high' | 'critical';
+
+export interface RawClinicalResult {
+  analyte: string;
+  value: string | number;
+  unit?: string;
+  referenceRange?: string;
+  observedAt: string;
+  laboratory?: string;
+  specimen?: string;
+  reportId?: string;
+  explicitFlag?: ExplicitResultFlag;
+  loinc?: string;
+  ucum?: string;
+}
+
+export interface VerifiedTerminology {
+  analyte: string;
+  loinc: string;
+  unit?: string;
+  ucum?: string;
+  verified: true;
+}
+
+export interface ClinicalResultCandidate {
+  idempotencyKey: string;
+  analyte: { original: string; normalized: string; loinc?: string };
+  value: string;
+  unit: { original?: string; ucum?: string };
+  referenceRange?: { original: string; low?: number; high?: number };
+  explicitFlag?: ExplicitResultFlag;
+  observedAt: string;
+  laboratory?: string;
+  specimen?: string;
+  reportId?: string;
+  provenance: { documentHash: string; lane: ImportLane };
+  confidence: { score: number; reason: string };
+}
+
+export interface ClinicalResultImportEnvelope {
+  schema: typeof CLINICAL_RESULT_IMPORT_SCHEMA;
+  mode: 'review_only';
+  patientId: string;
+  documentHash: string;
+  candidates: ClinicalResultCandidate[];
+  issues: string[];
+}
+
+const normalizeText = (value: string): string =>
+  value.normalize('NFKC').trim().toLocaleLowerCase('it-IT').replace(/\s+/g, ' ');
+
+const normalizeValue = (value: string | number): string =>
+  String(value).trim().replace(',', '.');
+
+const tinyHash = (value: string): string => {
+  let hash = 2166136261;
+  for (const char of value) {
+    hash ^= char.codePointAt(0) ?? 0;
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0');
+};
+
+const parseRange = (original?: string): ClinicalResultCandidate['referenceRange'] => {
+  if (!original) return undefined;
+  const normalized = original.replaceAll(',', '.').trim();
+  const between = normalized.match(/^(-?\d+(?:\.\d+)?)\s*[-–]\s*(-?\d+(?:\.\d+)?)$/);
+  if (between) return { original, low: Number(between[1]), high: Number(between[2]) };
+  const upper = normalized.match(/^<\s*(-?\d+(?:\.\d+)?)$/);
+  if (upper) return { original, high: Number(upper[1]) };
+  const lower = normalized.match(/^>\s*(-?\d+(?:\.\d+)?)$/);
+  if (lower) return { original, low: Number(lower[1]) };
+  return { original };
+};
+
+export function normalizeClinicalResult(
+  raw: RawClinicalResult,
+  documentHash: string,
+  lane: ImportLane,
+  terminology: VerifiedTerminology[] = [],
+): ClinicalResultCandidate {
+  const analyte = normalizeText(raw.analyte);
+  const exact = terminology.find(item => normalizeText(item.analyte) === analyte);
+  const loinc = exact?.loinc;
+  const ucum = exact && (!exact.unit || normalizeText(exact.unit) === normalizeText(raw.unit ?? ''))
+    ? exact.ucum
+    : undefined;
+  const value = normalizeValue(raw.value);
+  const observedAt = new Date(raw.observedAt).toISOString();
+  const identity = [
+    documentHash,
+    raw.reportId ?? '',
+    loinc ?? analyte,
+    observedAt,
+    value,
+    ucum ?? normalizeText(raw.unit ?? ''),
+  ].join('|');
+  return {
+    idempotencyKey: `clinical-result:${tinyHash(identity)}:${tinyHash(documentHash)}`,
+    analyte: { original: raw.analyte, normalized: analyte, ...(loinc ? { loinc } : {}) },
+    value,
+    unit: { ...(raw.unit ? { original: raw.unit } : {}), ...(ucum ? { ucum } : {}) },
+    ...(raw.referenceRange ? { referenceRange: parseRange(raw.referenceRange) } : {}),
+    ...(raw.explicitFlag ? { explicitFlag: raw.explicitFlag } : {}),
+    observedAt,
+    ...(raw.laboratory ? { laboratory: raw.laboratory } : {}),
+    ...(raw.specimen ? { specimen: raw.specimen } : {}),
+    ...(raw.reportId ? { reportId: raw.reportId } : {}),
+    provenance: { documentHash, lane },
+    confidence: {
+      score: lane === 'deterministic' ? 1 : 0.65,
+      reason: lane === 'deterministic' ? 'campi normalizzati da evidenza strutturata' : 'proposta provider da revisionare',
+    },
+  };
+}
+
+export function buildClinicalResultImportEnvelope(input: {
+  patientId: string;
+  documentHash: string;
+  deterministic: RawClinicalResult[];
+  provider?: { lane: Exclude<ImportLane, 'deterministic'>; results: RawClinicalResult[] };
+  terminology?: VerifiedTerminology[];
+}): ClinicalResultImportEnvelope {
+  const stable = input.deterministic.map(item =>
+    normalizeClinicalResult(item, input.documentHash, 'deterministic', input.terminology));
+  const candidates = [...stable];
+  const issues: string[] = [];
+  for (const raw of input.provider?.results ?? []) {
+    const proposal = normalizeClinicalResult(
+      raw,
+      input.documentHash,
+      input.provider!.lane,
+      input.terminology,
+    );
+    const sameFact = stable.find(item =>
+      item.analyte.normalized === proposal.analyte.normalized
+      && item.observedAt === proposal.observedAt);
+    if (sameFact) {
+      if (sameFact.value !== proposal.value || sameFact.unit.original !== proposal.unit.original) {
+        issues.push(`provider_conflict:${sameFact.idempotencyKey}`);
+      }
+      continue;
+    }
+    candidates.push(proposal);
+  }
+  return {
+    schema: CLINICAL_RESULT_IMPORT_SCHEMA,
+    mode: 'review_only',
+    patientId: input.patientId,
+    documentHash: input.documentHash,
+    candidates,
+    issues,
+  };
+}
+
+export interface ClinicalResultSeries {
+  key: string;
+  all: ClinicalResultCandidate[];
+  collapsed: ClinicalResultCandidate[];
+}
+
+export function buildClinicalResultSeries(
+  patientId: string,
+  observations: ClinicalResultCandidate[],
+): ClinicalResultSeries[] {
+  const unique = new Map(observations.map(item => [item.idempotencyKey, item]));
+  const groups = new Map<string, ClinicalResultCandidate[]>();
+  for (const item of unique.values()) {
+    const key = `${patientId}|${item.analyte.loinc ?? item.analyte.normalized}`;
+    groups.set(key, [...(groups.get(key) ?? []), item]);
+  }
+  return [...groups].map(([key, allUnsorted]) => {
+    const all = allUnsorted.toSorted((a, b) => b.observedAt.localeCompare(a.observedAt));
+    const collapsed = all.slice(0, 3);
+    const recentYears = new Set(collapsed.map(item => new Date(item.observedAt).getUTCFullYear()));
+    const olderYears = new Set<number>();
+    for (const item of all.slice(3)) {
+      const year = new Date(item.observedAt).getUTCFullYear();
+      if (!recentYears.has(year) && !olderYears.has(year)) {
+        collapsed.push(item);
+        olderYears.add(year);
+      }
+    }
+    return { key, all, collapsed };
+  });
+}
+
+export interface PrescriptionCandidate {
+  id: string;
+  code?: string;
+  description: string;
+  prescribedAt: string;
+  reportId?: string;
+}
+
+export type PrescriptionLinkProposal =
+  | { state: 'collegato'; prescriptionId: string; reason: string }
+  | { state: 'ambiguo'; prescriptionIds: string[]; reason: string }
+  | { state: 'non_collegato'; reason: string };
+
+export function proposePrescriptionLink(
+  result: ClinicalResultCandidate,
+  prescriptions: PrescriptionCandidate[],
+  windowDays = 90,
+): PrescriptionLinkProposal {
+  const observed = new Date(result.observedAt).getTime();
+  const matches = prescriptions.filter(item => {
+    const exactIdentity = Boolean(
+      result.analyte.loinc && item.code === result.analyte.loinc,
+    ) || normalizeText(item.description) === result.analyte.normalized;
+    const temporal = Math.abs(observed - new Date(item.prescribedAt).getTime()) <= windowDays * 86_400_000;
+    const reportCompatible = !item.reportId || item.reportId === result.reportId;
+    return exactIdentity && temporal && reportCompatible;
+  });
+  if (matches.length === 1) {
+    return { state: 'collegato', prescriptionId: matches[0].id, reason: 'identità esatta e finestra temporale' };
+  }
+  if (matches.length > 1) {
+    return { state: 'ambiguo', prescriptionIds: matches.map(item => item.id), reason: 'più prescrizioni compatibili' };
+  }
+  return { state: 'non_collegato', reason: 'evidenza insufficiente' };
+}


### PR DESCRIPTION
## Contenuto

Fondazione review-only del contratto `clinical_result_import.v1` per lo smart import delle serie di risultati clinici: contratto, validazione e test dedicati. Nessuna modifica a DB, UI o percorsi di apply.

- 4 file, +361 (docs contratto + `lib/domain/documents/clinical-result-import*`)
- Ribasato su `origin/main` senza conflitti (b9c2c9116 → 64309c993)

## Verifica locale

- Test mirati `clinical-result-import.test.ts`: 6/6
- `test:unit`: 907/907 — typecheck, lint, claims (0 high-risk), never-regress: PASS

Rif. Linear: WUL-516

🤖 Generated with [Claude Code](https://claude.com/claude-code)