### PR TITLE
feat(backup): indicizza i link ambulatoriali nell'export (WUL-301)

### DIFF
--- a/app/api/system/backup-restore/route.ts
+++ b/app/api/system/backup-restore/route.ts
@@ -33,17 +33,12 @@ import {
     type BackupDataset,
     serializeBackupArtifact,
 } from '@/lib/backup-artifact';
+import { enrichBackupPatientsWithAmbulatoryLinks } from '@/lib/backup-patient-ambulatory-links';
 import { restoreBackupArtifact } from '@/lib/backup-restore-executor';
 import { runBackupRestorePreflight } from '@/lib/backup-restore-preflight';
 
 /* @Codex */
 export const dynamic = 'force-dynamic';
-
-type PatientAmbulatoryLinkRow = {
-    patientId: string;
-    ambulatoryId: string;
-    assignedAt: Date | null;
-};
 
 /* @Codex */
 function sortBackupRows<T extends Record<string, unknown>>(rows: T[]): T[] {
@@ -52,51 +47,6 @@ function sortBackupRows<T extends Record<string, unknown>>(rows: T[]): T[] {
         const rightKey = String(right.id ?? right.key ?? right.code ?? right.aic ?? right.patientId ?? right.conversationId ?? '');
         return leftKey.localeCompare(rightKey);
     });
-}
-
-/* @Codex */
-function buildAssignedAmbulatoryIds(
-    patient: Record<string, unknown>,
-    rows: PatientAmbulatoryLinkRow[]
-): string[] {
-    const ids = new Set<string>();
-
-    if (typeof patient.ambulatoryId === 'string' && patient.ambulatoryId.trim().length > 0) {
-        ids.add(patient.ambulatoryId);
-    }
-
-    for (const row of rows) {
-        if (row.patientId === patient.id && row.ambulatoryId.trim().length > 0) {
-            ids.add(row.ambulatoryId);
-        }
-    }
-
-    return Array.from(ids).sort((left, right) => left.localeCompare(right));
-}
-
-/* @Codex */
-function buildAssignedAmbulatoryMemberships(
-    patient: Record<string, unknown>,
-    rows: PatientAmbulatoryLinkRow[],
-): Array<{ ambulatoryId: string; assignedAt: Date | null }> {
-    const memberships = new Map<string, Date | null>();
-    for (const row of rows) {
-        if (row.patientId === patient.id && row.ambulatoryId.trim().length > 0) {
-            memberships.set(row.ambulatoryId, row.assignedAt);
-        }
-    }
-
-    if (typeof patient.ambulatoryId === 'string' && patient.ambulatoryId.trim().length > 0 && !memberships.has(patient.ambulatoryId)) {
-        const fallback = patient.updatedAt instanceof Date
-            ? patient.updatedAt
-            : patient.createdAt instanceof Date
-                ? patient.createdAt
-                : null;
-        memberships.set(patient.ambulatoryId, fallback);
-    }
-
-    return Array.from(memberships, ([ambulatoryId, assignedAt]) => ({ ambulatoryId, assignedAt }))
-        .sort((left, right) => left.ambulatoryId.localeCompare(right.ambulatoryId));
 }
 
 /* @Codex */
@@ -134,13 +84,7 @@ function buildBackupDataset(): BackupDataset {
         const patientAmbulatoryRows = tx.select().from(patientsToAmbulatories).all();
 
     const normalizedPatientAmbulatoryRows = sortBackupRows(patientAmbulatoryRows);
-    const enrichedPatients = patientsRows.map((patient) => {
-        const assignedAmbulatoryIds = buildAssignedAmbulatoryIds(patient, normalizedPatientAmbulatoryRows);
-        const assignedAmbulatoryMemberships = buildAssignedAmbulatoryMemberships(patient, normalizedPatientAmbulatoryRows);
-        return assignedAmbulatoryIds.length > 0
-            ? { ...patient, assignedAmbulatoryIds, assignedAmbulatoryMemberships }
-            : patient;
-    });
+    const enrichedPatients = enrichBackupPatientsWithAmbulatoryLinks(patientsRows, normalizedPatientAmbulatoryRows);
     const patientIds = new Set(
         enrichedPatients
             .map((patient) => patient.id)

--- a/lib/backup-patient-ambulatory-links.test.ts
+++ b/lib/backup-patient-ambulatory-links.test.ts
@@ -1,0 +1,36 @@
+/* @Codex */
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { enrichBackupPatientsWithAmbulatoryLinks } from './backup-patient-ambulatory-links';
+
+test('indexes backup ambulatory links once without changing patient membership semantics', () => {
+    assert.deepEqual(enrichBackupPatientsWithAmbulatoryLinks([], []), []);
+
+    const patients = [
+        { id: 'patient-a', ambulatoryId: 'ambulatory-fallback', updatedAt: new Date('2024-01-01T00:00:00.000Z') },
+        { id: 'patient-b', ambulatoryId: null, updatedAt: new Date('2024-01-02T00:00:00.000Z') },
+    ];
+    const enriched = enrichBackupPatientsWithAmbulatoryLinks(patients, [
+        { patientId: 'patient-a', ambulatoryId: 'ambulatory-z', assignedAt: new Date('2024-01-03T00:00:00.000Z') },
+        { patientId: 'patient-b', ambulatoryId: 'ambulatory-x', assignedAt: new Date('2024-01-04T00:00:00.000Z') },
+        { patientId: 'patient-a', ambulatoryId: 'ambulatory-a', assignedAt: new Date('2024-01-05T00:00:00.000Z') },
+        { patientId: 'patient-a', ambulatoryId: 'ambulatory-a', assignedAt: new Date('2024-01-06T00:00:00.000Z') },
+    ]);
+
+    assert.deepEqual(enriched.map((patient) => ({
+        id: patient.id,
+        ids: patient.assignedAmbulatoryIds,
+        memberships: patient.assignedAmbulatoryMemberships?.map(({ ambulatoryId, assignedAt }) => [ambulatoryId, assignedAt?.toISOString()]),
+    })), [
+        {
+            id: 'patient-a',
+            ids: ['ambulatory-a', 'ambulatory-fallback', 'ambulatory-z'],
+            memberships: [['ambulatory-a', '2024-01-06T00:00:00.000Z'], ['ambulatory-fallback', '2024-01-01T00:00:00.000Z'], ['ambulatory-z', '2024-01-03T00:00:00.000Z']],
+        },
+        {
+            id: 'patient-b',
+            ids: ['ambulatory-x'],
+            memberships: [['ambulatory-x', '2024-01-04T00:00:00.000Z']],
+        },
+    ]);
+});

--- a/lib/backup-patient-ambulatory-links.ts
+++ b/lib/backup-patient-ambulatory-links.ts
@@ -7,6 +7,60 @@ export type RestoredPatientAmbulatoryLink = {
     assignedAt: Date;
 };
 
+type BackupPatientAmbulatoryLinkRow = {
+    patientId: string;
+    ambulatoryId: string;
+    assignedAt: Date | null;
+};
+
+type BackupPatientAmbulatoryAssignments = {
+    assignedAmbulatoryIds?: string[];
+    assignedAmbulatoryMemberships?: Array<{ ambulatoryId: string; assignedAt: Date | null }>;
+};
+
+export function enrichBackupPatientsWithAmbulatoryLinks<T extends object>(
+    patients: T[],
+    rows: BackupPatientAmbulatoryLinkRow[],
+): Array<T & BackupPatientAmbulatoryAssignments> {
+    const rowsByPatientId = new Map<string, BackupPatientAmbulatoryLinkRow[]>();
+    for (const row of rows) {
+        const patientRows = rowsByPatientId.get(row.patientId);
+        if (patientRows) patientRows.push(row);
+        else rowsByPatientId.set(row.patientId, [row]);
+    }
+
+    return patients.map((patient) => {
+        const record = patient as Record<string, unknown>;
+        const fallbackAmbulatoryId = typeof record.ambulatoryId === 'string' && record.ambulatoryId.trim().length > 0
+            ? record.ambulatoryId
+            : null;
+        const fallbackAssignedAt = record.updatedAt instanceof Date
+            ? record.updatedAt
+            : record.createdAt instanceof Date
+                ? record.createdAt
+                : null;
+        const ids = new Set<string>(fallbackAmbulatoryId ? [fallbackAmbulatoryId] : []);
+        const memberships = new Map<string, Date | null>();
+
+        for (const row of typeof record.id === 'string' ? rowsByPatientId.get(record.id) ?? [] : []) {
+            if (row.ambulatoryId.trim().length === 0) continue;
+            ids.add(row.ambulatoryId);
+            memberships.set(row.ambulatoryId, row.assignedAt);
+        }
+        if (fallbackAmbulatoryId && !memberships.has(fallbackAmbulatoryId)) memberships.set(fallbackAmbulatoryId, fallbackAssignedAt);
+
+        const assignedAmbulatoryIds = Array.from(ids).sort((left, right) => left.localeCompare(right));
+        return assignedAmbulatoryIds.length > 0
+            ? {
+                ...patient,
+                assignedAmbulatoryIds,
+                assignedAmbulatoryMemberships: Array.from(memberships, ([ambulatoryId, assignedAt]) => ({ ambulatoryId, assignedAt }))
+                    .sort((left, right) => left.ambulatoryId.localeCompare(right.ambulatoryId)),
+            }
+            : patient;
+    });
+}
+
 function parseAssignedAmbulatoryIds(value: unknown): string[] {
     if (!Array.isArray(value)) return [];
     return Array.from(new Set(


### PR DESCRIPTION
Helper di batching per l'indicizzazione dei link paziente-ambulatorio durante l'export di backup. Test mirato 1/1.

Ribasato su origin/main senza conflitti; test mirati, typecheck e lint verdi in locale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)