### PR TITLE
test(db): guard AST sul soft delete (WUL-336)

### DIFF
--- a/scripts/patient-soft-delete.test.mjs
+++ b/scripts/patient-soft-delete.test.mjs
@@ -5,6 +5,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
+import ts from 'typescript';
 
 const ROOT_DIR = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
 
@@ -96,18 +97,21 @@ test('the membership-clear helper tombstones with the dedicated reason', () => {
     assert.doesNotMatch(source, /patients\.ambulatoryId/, 'helper must not read the stale legacy column (WUL-300)');
 });
 
-// ADR 0066 allowlist guard (WUL-316 style): patients reads outside this list must go
-// through the shared activePatients() predicate; hard deletes are confined to the
-// canonical cascade modules.
-const UNFILTERED_PATIENTS_READ_ALLOWLIST = new Set([
-    'app/api/system/backup-restore/route.ts', // backups must carry tombstones (ADR 0066)
-    'app/api/system/fix-orphans/route.ts', // relink + orphan sweep operate on all rows
-    'app/api/system/migrate/route.ts', // legacy ambulatory backfill, admin maintenance
-    'app/api/system/migrate-m2m/route.ts', // legacy ambulatory backfill, admin maintenance
-    'app/api/system/purge-patient/route.ts', // purge must address tombstoned patients
-    'app/api/system/restore-patient/route.ts', // restore must list/read tombstones
-    'lib/patient-cascade.ts', // orphan subquery scans the full patients table
-]);
+// ADR 0066 allowlist guard (WUL-316 style): unfiltered reads are intentional only
+// at these stable AST fingerprints. The number is the expected multiplicity.
+const UNFILTERED_PATIENTS_READ_ALLOWLIST = [
+    ['app/api/system/backup-restore/route.ts', 'tx.select().from(patients).all()', 1],
+    ['app/api/system/fix-orphans/route.ts', 'dbServer.select({ id: patients.id }).from(patients)', 2],
+    ['app/api/system/migrate/route.ts', 'dbServer.select().from(patients).where(isNull(patients.ambulatoryId))', 1],
+    ['app/api/system/migrate-m2m/route.ts', 'dbServer.select().from(patients).where(isNotNull(patients.ambulatoryId))', 1],
+    ['app/api/system/purge-patient/route.ts', 'dbServer .select({ id: patients.id, version: patients.version, deletedAt: patients.deletedAt }) .from(patients) .where(eq(patients.id, patientId)) .get()', 1],
+    ['app/api/system/restore-patient/route.ts', 'dbServer .select({ id: patients.id, firstName: patients.firstName, lastName: patients.lastName, deletedAt: patients.deletedAt, deletionReason: patients.deletionReason, version: patients.version, }) .from(patients) .where(isNotNull(patients.deletedAt)) .orderBy(desc(patients.deletedAt))', 1],
+    ['app/api/system/restore-patient/route.ts', 'dbServer .select({ id: patients.id, version: patients.version, deletedAt: patients.deletedAt }) .from(patients) .where(eq(patients.id, patientId)) .get()', 1],
+    ['lib/network-patient-lifecycle.ts', 'tx .select({ id: patients.id, version: patients.version, updatedAt: patients.updatedAt, isArchived: patients.isArchived, }) .from(patients) .where(and(eq(patients.id, patientId), isNotNull(patients.deletedAt))) .get()', 1],
+    ['lib/network-patient-lifecycle.ts', 'tx .select({ patient: patients }) .from(patients) .innerJoin(patientsToAmbulatories, eq(patients.id, patientsToAmbulatories.patientId)) .where(and(eq(patients.id, context.patientId), eq(patientsToAmbulatories.ambulatoryId, context.scopeAmbulatoryId), isNotNull(patients.deletedAt))) .get()', 1],
+    ['lib/network-patient-read.ts', 'dbServer .select({ patient: patients }) .from(patients) .innerJoin(patientsToAmbulatories, eq(patients.id, patientsToAmbulatories.patientId)) .where(and(...filters)) .orderBy(desc(patients.updatedAt))', 1],
+    ['lib/patient-cascade.ts', 'runner.select({ id: patients.id }).from(patients)', 2],
+];
 
 const PATIENTS_HARD_DELETE_ALLOWLIST = new Set([
     'app/api/system/purge-patient/route.ts', // ADR 0066 audited admin erasure
@@ -127,17 +131,116 @@ function* walkSources(directory) {
     }
 }
 
+// @Codex
+const AST_PRINTER = ts.createPrinter({ removeComments: true });
+
+function propertyName(call) {
+    return ts.isPropertyAccessExpression(call.expression) ? call.expression.name.text : null;
+}
+
+function directReceiverCall(call) {
+    const parent = call.parent;
+    return ts.isPropertyAccessExpression(parent) && parent.expression === call && ts.isCallExpression(parent.parent)
+        ? parent.parent
+        : null;
+}
+
+function isFromPatients(node) {
+    return ts.isCallExpression(node)
+        && propertyName(node) === 'from'
+        && node.arguments.length === 1
+        && ts.isIdentifier(node.arguments[0])
+        && node.arguments[0].text === 'patients';
+}
+
+function isActivePatientsPredicate(node) {
+    if (ts.isFunctionLike(node)) return false;
+    if (!ts.isCallExpression(node)) return false;
+    if (ts.isIdentifier(node.expression) && node.expression.text === 'activePatients') return node.arguments.length === 0;
+    return ts.isIdentifier(node.expression) && node.expression.text === 'and'
+        && node.arguments.some(isActivePatientsPredicate);
+}
+
+function patientReadIsFiltered(fromCall) {
+    for (let call = fromCall; call; call = directReceiverCall(call)) {
+        if (propertyName(call) === 'where' && call.arguments.some(isActivePatientsPredicate)) return true;
+    }
+    return false;
+}
+
+function patientReadFingerprint(sourceFile, fromCall) {
+    let query = fromCall;
+    for (let next = directReceiverCall(query); next; next = directReceiverCall(query)) query = next;
+    return AST_PRINTER.printNode(ts.EmitHint.Unspecified, query, sourceFile).replace(/\s+/g, ' ').trim();
+}
+
+function scriptKind(relativePath) {
+    return relativePath.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS;
+}
+
+function unfilteredPatientReads(relativePath, source) {
+    const sourceFile = ts.createSourceFile(relativePath, source, ts.ScriptTarget.Latest, true, scriptKind(relativePath));
+    assert.equal(sourceFile.parseDiagnostics.length, 0, `Cannot parse ${relativePath}: ${sourceFile.parseDiagnostics.map(({ code }) => code).join(', ')}`);
+    const reads = [];
+    const visit = (node) => {
+        if (isFromPatients(node) && !patientReadIsFiltered(node)) {
+            reads.push({ relativePath, fingerprint: patientReadFingerprint(sourceFile, node) });
+        }
+        ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+    return reads;
+}
+
+function assertAllowlistedPatientReads(reads, allowlist = UNFILTERED_PATIENTS_READ_ALLOWLIST) {
+    const pending = new Map(allowlist.map(([relativePath, fingerprint, count]) => [`${relativePath}\0${fingerprint}`, count]));
+    for (const read of reads) {
+        const key = `${read.relativePath}\0${read.fingerprint}`;
+        const count = pending.get(key);
+        assert.notEqual(count, undefined, `Unexpected unfiltered patient read: ${read.relativePath} :: ${read.fingerprint}`);
+        if (count === 1) pending.delete(key);
+        else pending.set(key, count - 1);
+    }
+    assert.equal(pending.size, 0, `Stale unfiltered patient-read allowlist entries: ${[...pending.keys()].join(', ')}`);
+}
+
+test('AST guard isolates direct patient-read chains and normalizes their fingerprints', () => {
+    const source = [
+        'db.select().from(patients).where(activePatients()).get();',
+        'db.select()\n  .from(\n    patients\n  ).where(and(eq(patients.id, id), activePatients())).get();',
+        'db . select().from( patients ).where(activePatients()).get();',
+        'db.select().from(patients).get();',
+        'db.select().from(patients).where(db.select().from(patients).where(activePatients()).get()).get();',
+        'db.select().from(patients).where(activePatients()).get() ?? db.select().from(patients).get();',
+        'const marker = `;`; db.select().from(patients).where(() => activePatients()).get();',
+    ].join('\n');
+    const reads = unfilteredPatientReads('synthetic.ts', source);
+    assert.equal(reads.length, 4, 'only direct activePatients() filters the owning chain');
+    const baseline = unfilteredPatientReads('synthetic.ts', 'db.select().from(patients).get();');
+    const shifted = unfilteredPatientReads('synthetic.ts', '\n\n db . select() . from( patients ).get();');
+    assert.equal(baseline[0].fingerprint, shifted[0].fingerprint, 'line shifts and whitespace keep the fingerprint stable');
+    const assertion = 'const value = <Foo>input; db.select().from(patients).get();';
+    assert.equal(unfilteredPatientReads('synthetic.ts', assertion).length, 1, 'a .ts type assertion must keep its read visible');
+    assert.throws(() => unfilteredPatientReads('synthetic.tsx', assertion), /Cannot parse synthetic\.tsx/);
+    assert.throws(() => unfilteredPatientReads('synthetic.ts', 'const value = ;'), /Cannot parse synthetic\.ts/);
+});
+
+test('AST allowlist consumes fingerprints and rejects stale, substituted, or duplicate reads', () => {
+    const path = 'synthetic.ts';
+    const baseline = unfilteredPatientReads(path, 'db.select().from(patients).get();');
+    const allowlist = [[path, baseline[0].fingerprint, 1]];
+    assert.doesNotThrow(() => assertAllowlistedPatientReads(baseline, allowlist));
+    assert.throws(() => assertAllowlistedPatientReads(unfilteredPatientReads(path, 'db.select({ id: patients.id }).from(patients).get();'), allowlist));
+    assert.throws(() => assertAllowlistedPatientReads(unfilteredPatientReads(path, 'db.select().from(patients).get(); db.select().from(patients).get();'), allowlist));
+});
+
 test('patients table access stays behind activePatients() outside the allowlist', () => {
+    const unfilteredReads = [];
     for (const root of ['app', 'lib']) {
         for (const filePath of walkSources(path.join(ROOT_DIR, root))) {
             const relativePath = path.relative(ROOT_DIR, filePath);
             const source = fs.readFileSync(filePath, 'utf8');
-
-            if (source.includes('from(patients)')
-                && !source.includes('activePatients(')
-                && !UNFILTERED_PATIENTS_READ_ALLOWLIST.has(relativePath)) {
-                assert.fail(`${relativePath} reads from(patients) without activePatients() and is not allowlisted`);
-            }
+            unfilteredReads.push(...unfilteredPatientReads(relativePath, source));
 
             if (source.includes('.delete(patients)')
                 && !PATIENTS_HARD_DELETE_ALLOWLIST.has(relativePath)) {
@@ -145,4 +248,5 @@ test('patients table access stays behind activePatients() outside the allowlist'
             }
         }
     }
+    assertAllowlistedPatientReads(unfilteredReads);
 });


### PR DESCRIPTION
Sostituisce il guard substring con guard AST + test per allowlist e parent guard. Mirati 27/27.

Ribasato su origin/main senza conflitti; test mirati, typecheck e lint verdi in locale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)