### PR TITLE
feat(documenti): parser lab_result_artifact.v1 (WUL-516)

### DIFF
--- a/lib/domain/documents/lab-result-artifact.test.ts
+++ b/lib/domain/documents/lab-result-artifact.test.ts
@@ -1,0 +1,55 @@
+/* @Codex */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { LAB_RESULT_ARTIFACT_SCHEMA_VERSION, readLabResultArtifact } from './lab-result-artifact.ts';
+
+const fact = (id = 'lab_result:1:1') => ({
+    id, kind: 'lab_result', label: 'Synthetic: 1 mg/dL', excerpt: 'Synthetic 1 mg/dL 0-2', sourceId: 'synthetic-doc', temporality: 'current', status: 'active', origin: 'documented', code: '1234-5', system: 'LOINC',
+    labResult: { analyte: 'Synthetic', value: '1', unit: 'mg/dL', referenceRange: { text: '0-2', low: '0', high: '2' }, flag: 'alto', lineNumber: 1, sourceLine: 'Synthetic 1 mg/dL 0-2' },
+    observationProposal: { requestId: 'lab_result:1:1234-5', codeSystem: 'LOINC', code: '1234-5', display: 'Synthetic', unitCode: 'mg/dL', value: '1', refLow: '0', refHigh: '2' },
+});
+const legacy = (facts: unknown[] = [fact('lab_result:1:1'), { kind: 'problem' }, fact('lab_result:2:1')]) => ({ schemaVersion: 'mediflow.document_evidence_pack.v2', source: { documentInsightId: 'synthetic-doc', fileName: 'synthetic.txt', documentDate: '2026-01-01', qualityLevel: 'green' }, facts });
+
+test('reads v1 and normalizes ordered legacy lab facts with source and nested proposal', () => {
+    const v1 = { schemaVersion: LAB_RESULT_ARTIFACT_SCHEMA_VERSION, reviewStatus: 'review_only', source: legacy().source, facts: [fact()] };
+    assert.equal(readLabResultArtifact(v1)?.schemaVersion, LAB_RESULT_ARTIFACT_SCHEMA_VERSION);
+    const artifact = readLabResultArtifact(legacy());
+    assert.deepEqual(artifact?.facts.map((item) => item.id), ['lab_result:1:1', 'lab_result:2:1']);
+    assert.deepEqual(artifact?.source, legacy().source);
+    assert.deepEqual(artifact?.facts[0].observationProposal, fact().observationProposal);
+});
+
+test('fails closed for invalid versions, empty or malformed review material', () => {
+    const cases: unknown[] = [
+        { ...legacy(), schemaVersion: undefined }, { ...legacy(), schemaVersion: 'v9' }, legacy([]), { schemaVersion: LAB_RESULT_ARTIFACT_SCHEMA_VERSION, reviewStatus: 'review_only', source: legacy().source, facts: [fact(), { kind: 'problem' }] }, legacy([{ ...fact(), persistence: 'automatic' }]), legacy([{ ...fact(), labResult: {} }]), legacy([{ ...fact(), observationProposal: {} }]), legacy([{ ...fact(), kind: 'unknown' }]), legacy([{ ...fact(), observationProposal: { ...fact().observationProposal, code: 'other' } }]),
+    ];
+    for (const value of cases) assert.equal(readLabResultArtifact(value), undefined);
+});
+
+for (const [name, mutate] of [
+    ['sourceId', (item: ReturnType<typeof fact>) => { item.sourceId = 'other-doc'; }],
+    ['value', (item: ReturnType<typeof fact>) => { item.observationProposal.value = '2'; }],
+    ['unitCode', (item: ReturnType<typeof fact>) => { item.observationProposal.unitCode = 'mmol/L'; }],
+    ['refLow different', (item: ReturnType<typeof fact>) => { item.observationProposal.refLow = '1'; }],
+    ['refLow extra', (item: ReturnType<typeof fact>) => { Reflect.deleteProperty(item.labResult.referenceRange, 'low'); }],
+    ['refLow missing', (item: ReturnType<typeof fact>) => { Reflect.deleteProperty(item.observationProposal, 'refLow'); }],
+    ['refHigh different', (item: ReturnType<typeof fact>) => { item.observationProposal.refHigh = '3'; }],
+    ['refHigh extra', (item: ReturnType<typeof fact>) => { Reflect.deleteProperty(item.labResult.referenceRange, 'high'); }],
+    ['refHigh missing', (item: ReturnType<typeof fact>) => { Reflect.deleteProperty(item.observationProposal, 'refHigh'); }],
+    ['requestId', (item: ReturnType<typeof fact>) => { item.observationProposal.requestId = 'other'; }],
+] as const) test(`rejects a mismatched proposal ${name}`, () => {
+    const item = fact();
+    mutate(item);
+    assert.equal(readLabResultArtifact({ schemaVersion: LAB_RESULT_ARTIFACT_SCHEMA_VERSION, reviewStatus: 'review_only', source: legacy().source, facts: [item] }), undefined);
+});
+
+test('accepts a non-empty proposal display different from the analyte', () => {
+    const item = fact();
+    item.observationProposal.display = 'Synthetic clinical display';
+    assert.notEqual(readLabResultArtifact({ schemaVersion: LAB_RESULT_ARTIFACT_SCHEMA_VERSION, reviewStatus: 'review_only', source: legacy().source, facts: [item] }), undefined);
+});
+
+test('exports no automatic write API', async () => {
+    const artifactModule = await import('./lab-result-artifact.ts');
+    assert.equal(Object.keys(artifactModule).some((name) => /(?:write|save|persist)/i.test(name)), false);
+});

--- a/lib/domain/documents/lab-result-artifact.ts
+++ b/lib/domain/documents/lab-result-artifact.ts
@@ -1,0 +1,56 @@
+/* @Codex */
+export const LAB_RESULT_ARTIFACT_SCHEMA_VERSION = 'mediflow.lab_result_artifact.v1';
+const LEGACY_SCHEMA_VERSION = 'mediflow.document_evidence_pack.v2';
+type Source = { documentInsightId: string; fileName: string; documentDate: string; qualityLevel?: 'green' | 'yellow' | 'red' };
+type Proposal = { requestId: string; codeSystem: 'LOINC'; code: string; display: string; unitCode: string; value: string; refLow?: string; refHigh?: string };
+type LabResult = { analyte: string; value: string; unit: string; referenceRange: { text: string; low?: string; high?: string }; flag?: 'basso' | 'alto'; lineNumber: number; sourceLine: string };
+export type LabResultFact = { id: string; kind: 'lab_result'; label: string; excerpt: string; sourceId: string; temporality: 'current'; status: 'active'; origin: 'documented'; labResult: LabResult; code?: string; system?: 'LOINC'; observationProposal?: Proposal };
+export type LabResultArtifact = { schemaVersion: typeof LAB_RESULT_ARTIFACT_SCHEMA_VERSION; reviewStatus: 'review_only'; source: Source; facts: LabResultFact[] };
+
+/* @Codex */
+const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null && !Array.isArray(value);
+const nonEmpty = (value: unknown): value is string => typeof value === 'string' && Boolean(value.trim());
+const only = (value: Record<string, unknown>, allowed: string[]) => Object.keys(value).every((key) => allowed.includes(key));
+const optionalString = (value: unknown) => value === undefined || nonEmpty(value);
+
+/* @Codex */
+function readSource(value: unknown): Source | undefined {
+    if (!isRecord(value) || !only(value, ['documentInsightId', 'fileName', 'documentDate', 'qualityLevel'])) return undefined;
+    if (![value.documentInsightId, value.fileName, value.documentDate].every(nonEmpty)) return undefined;
+    if (value.qualityLevel !== undefined && !['green', 'yellow', 'red'].includes(value.qualityLevel as string)) return undefined;
+    return value.qualityLevel === undefined
+        ? { documentInsightId: value.documentInsightId as string, fileName: value.fileName as string, documentDate: value.documentDate as string }
+        : { documentInsightId: value.documentInsightId as string, fileName: value.fileName as string, documentDate: value.documentDate as string, qualityLevel: value.qualityLevel as Source['qualityLevel'] };
+}
+
+/* @Codex */
+function readFact(value: unknown, source: Source): LabResultFact | undefined {
+    if (!isRecord(value) || !only(value, ['id', 'kind', 'label', 'excerpt', 'sourceId', 'temporality', 'status', 'origin', 'labResult', 'code', 'system', 'observationProposal'])) return undefined;
+    if (value.kind !== 'lab_result' || value.temporality !== 'current' || value.status !== 'active' || value.origin !== 'documented' || ![value.id, value.label, value.excerpt, value.sourceId].every(nonEmpty) || value.sourceId !== source.documentInsightId) return undefined;
+    const lab = value.labResult;
+    if (!isRecord(lab) || !only(lab, ['analyte', 'value', 'unit', 'referenceRange', 'flag', 'lineNumber', 'sourceLine']) || ![lab.analyte, lab.value, lab.unit, lab.sourceLine].every(nonEmpty) || !Number.isInteger(lab.lineNumber) || (lab.lineNumber as number) < 1) return undefined;
+    const range = lab.referenceRange;
+    if (!isRecord(range) || !only(range, ['text', 'low', 'high']) || !nonEmpty(range.text) || !optionalString(range.low) || !optionalString(range.high) || (lab.flag !== undefined && lab.flag !== 'basso' && lab.flag !== 'alto')) return undefined;
+    const rawProposal = value.observationProposal;
+    if (rawProposal !== undefined && (!isRecord(rawProposal) || !only(rawProposal, ['requestId', 'codeSystem', 'code', 'display', 'unitCode', 'value', 'refLow', 'refHigh']) || rawProposal.codeSystem !== 'LOINC' || ![rawProposal.requestId, rawProposal.code, rawProposal.display, rawProposal.unitCode, rawProposal.value].every(nonEmpty) || !optionalString(rawProposal.refLow) || !optionalString(rawProposal.refHigh) || value.system !== 'LOINC' || value.code !== rawProposal.code || rawProposal.value !== lab.value || rawProposal.unitCode !== lab.unit || rawProposal.refLow !== range.low || rawProposal.refHigh !== range.high || rawProposal.requestId !== `lab_result:${lab.lineNumber}:${rawProposal.code}`)) return undefined;
+    if (rawProposal === undefined && (value.code !== undefined || value.system !== undefined)) return undefined;
+    const proposal = rawProposal as Proposal | undefined;
+    return { id: value.id as string, kind: 'lab_result', label: value.label as string, excerpt: value.excerpt as string, sourceId: value.sourceId as string, temporality: 'current', status: 'active', origin: 'documented', labResult: { analyte: lab.analyte as string, value: lab.value as string, unit: lab.unit as string, referenceRange: { text: range.text as string, ...(range.low ? { low: range.low as string } : {}), ...(range.high ? { high: range.high as string } : {}) }, ...(lab.flag ? { flag: lab.flag as 'basso' | 'alto' } : {}), lineNumber: lab.lineNumber as number, sourceLine: lab.sourceLine as string }, ...(proposal ? { code: proposal.code, system: 'LOINC' as const, observationProposal: { ...proposal } } : {}) };
+}
+
+/* @Codex */
+export function readLabResultArtifact(value: unknown): LabResultArtifact | undefined {
+    if (!isRecord(value)) return undefined;
+    const legacy = value.schemaVersion === LEGACY_SCHEMA_VERSION;
+    if (value.schemaVersion !== LAB_RESULT_ARTIFACT_SCHEMA_VERSION && !legacy) return undefined;
+    if (!only(value, legacy ? ['schemaVersion', 'source', 'facts', 'sourceGovernance'] : ['schemaVersion', 'reviewStatus', 'source', 'facts']) || (!legacy && value.reviewStatus !== 'review_only') || !Array.isArray(value.facts)) return undefined;
+    const source = readSource(value.source);
+    if (!source) return undefined;
+    const facts: LabResultFact[] = [];
+    for (const item of value.facts) {
+        if (!isRecord(item) || !['problem', 'medication', 'followup', 'care_setting', 'functional_status', 'lab_result'].includes(item.kind as string)) return undefined;
+        if (!legacy && item.kind !== 'lab_result') return undefined;
+        if (item.kind === 'lab_result') { const fact = readFact(item, source); if (!fact) return undefined; facts.push(fact); }
+    }
+    return facts.length ? { schemaVersion: LAB_RESULT_ARTIFACT_SCHEMA_VERSION, reviewStatus: 'review_only', source, facts } : undefined;
+}


### PR DESCRIPTION
Parser e test del contratto lab_result_artifact.v1, complementare a clinical_result_import.v1 (PR #151): nessuna sovrapposizione di file. Mirati 14/14.

Ribasato su origin/main senza conflitti; test mirati, typecheck e lint verdi in locale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)