### PR TITLE
fix(pdf): hardening parsing paziente e date (WUL-330)

### DIFF
--- a/lib/pdf-service.test.ts
+++ b/lib/pdf-service.test.ts
@@ -290,6 +290,8 @@ test('parsePatientData recognizes birthplace dates without promoting partial or 
         '2024-02-29',
     );
     assert.equal(parsePatientData('nata a Milano il referto è stato emesso il 05/03/2024').birthDate, undefined);
+    assert.equal(parsePatientData('nata a Milano il il 05/03/2024').birthDate, undefined);
+    assert.equal(parsePatientData('nata a Milano il controllo è avvenuto il 05/03/2024').birthDate, undefined);
     assert.equal(parsePatientData('La paziente e rinata il 12/03/1990').birthDate, undefined);
     assert.equal(parsePatientData('nata12/03/1990').birthDate, undefined);
     assert.equal(parsePatientData('Referto del 05/03/2024').birthDate, undefined);

--- a/lib/pdf-service.test.ts
+++ b/lib/pdf-service.test.ts
@@ -236,6 +236,60 @@ test('parsePatientData handles surname-first Piano Terapeutico patient labels an
     assert.doesNotMatch(parsed.notes || '', /CELLCEPT/i);
 });
 
+test('parsePatientData accepts standard and omocodia tax codes without matching adjacent tokens', () => {
+    assert.equal(
+        parsePatientData('Codice Fiscale: RSSMRA94T57A271J').taxCode,
+        'RSSMRA94T57A271J',
+    );
+    assert.equal(
+        parsePatientData('Codice Fiscale: RSSMRA94T57A27MJ').taxCode,
+        'RSSMRA94T57A27MJ',
+    );
+    assert.equal(
+        parsePatientData('Identificativo: XRSSMRA94T57A271JY').taxCode,
+        undefined,
+    );
+    assert.equal(
+        parsePatientData('Codice Fiscale: RSSMRAA4T57A271J').taxCode,
+        undefined,
+    );
+});
+
+test('parsePatientData rejects tax codes embedded in Unicode letter or number tokens', () => {
+    for (const token of [
+        'ÀRSSMRA94T57A271J',
+        'RSSMRA94T57A271Jè',
+        '١RSSMRA94T57A271J',
+        'RSSMRA94T57A271Jα',
+    ]) {
+        assert.equal(parsePatientData(token).taxCode, undefined);
+    }
+});
+
+test('parsePatientData rejects Unicode case-folded characters in tax code bodies', () => {
+    assert.equal(parsePatientData('KSSMRA94T57A271J').taxCode, undefined);
+    assert.equal(parsePatientData('RſSMRA94T57A271J').taxCode, undefined);
+});
+
+test('parsePatientData validates calendar birth dates, including leap years', () => {
+    assert.equal(
+        parsePatientData('Nata il 29/02/2024').birthDate?.toISOString().slice(0, 10),
+        '2024-02-29',
+    );
+    assert.equal(parsePatientData('Nato il 31/04/1990').birthDate, undefined);
+    assert.equal(parsePatientData('Nata il 29/02/2023').birthDate, undefined);
+});
+
+test('parsePatientData recognizes birthplace dates without promoting partial or unanchored dates', () => {
+    assert.equal(
+        parsePatientData('Mario Rossi, nato a Milano il 23/02/1932').birthDate?.toISOString().slice(0, 10),
+        '1932-02-23',
+    );
+    assert.equal(parsePatientData('La paziente e rinata il 12/03/1990').birthDate, undefined);
+    assert.equal(parsePatientData('nata12/03/1990').birthDate, undefined);
+    assert.equal(parsePatientData('Referto del 05/03/2024').birthDate, undefined);
+});
+
 test('parsePatientData preserves name-first patient labels when casing is not surname-first', () => {
     const parsed = parsePatientData('Paziente: Mario Rossi\nData di nascita: 01/02/1970');
 
@@ -263,4 +317,13 @@ test('mergeExtractedPatientDataWithTextFallback keeps AI omocodia tax codes inst
     );
 
     assert.equal(merged.taxCode, 'RSSMRA94T57A27MJ');
+});
+
+test('mergeExtractedPatientDataWithTextFallback replaces an invalid AI tax code from text', () => {
+    const merged = mergeExtractedPatientDataWithTextFallback(
+        { rawText: '', source: 'ai', confidence: 0.9, taxCode: 'INVALID' },
+        'Codice Fiscale: RSSMRA94T57A271J',
+    );
+
+    assert.equal(merged.taxCode, 'RSSMRA94T57A271J');
 });

--- a/lib/pdf-service.test.ts
+++ b/lib/pdf-service.test.ts
@@ -285,6 +285,11 @@ test('parsePatientData recognizes birthplace dates without promoting partial or 
         parsePatientData('Mario Rossi, nato a Milano il 23/02/1932').birthDate?.toISOString().slice(0, 10),
         '1932-02-23',
     );
+    assert.equal(
+        parsePatientData('nata a L’Aquila il 29-2-2024').birthDate?.toISOString().slice(0, 10),
+        '2024-02-29',
+    );
+    assert.equal(parsePatientData('nata a Milano il referto è stato emesso il 05/03/2024').birthDate, undefined);
     assert.equal(parsePatientData('La paziente e rinata il 12/03/1990').birthDate, undefined);
     assert.equal(parsePatientData('nata12/03/1990').birthDate, undefined);
     assert.equal(parsePatientData('Referto del 05/03/2024').birthDate, undefined);

--- a/lib/pdf-service.ts
+++ b/lib/pdf-service.ts
@@ -862,7 +862,7 @@ export function parsePatientData(text: string): ExtractedPatientData {
     // Only keyword-anchored dates qualify: an unanchored fallback would promote the first
     // date in the document (visit/print/report date) to birth date, which is clinically
     // worse than leaving birthDate empty.
-    const dateKeywords = /\b(?:nato|nata|nascita)\b(?:\s+a\s+(?:(?!\bil\b)[A-Za-zÀ-ÖØ-öø-ÿ'\u2019 -]){2,80}?\s+il)?(?:\s+il)?\s*[:\.]?\s*(\d{1,2}[\/\-\.]\d{1,2}[\/\-\.]\d{4})/i;
+    const dateKeywords = /\b(?:nato|nata|nascita)\b(?:\s+a\s+(?:(?!\bil\b)[A-Za-zÀ-ÖØ-öø-ÿ'\u2019 -]){2,80}?\s+il|\s+il)?\s*[:\.]?\s*(\d{1,2}[\/\-\.]\d{1,2}[\/\-\.]\d{4})/i;
     const dateMatch = cleanText.match(dateKeywords);
     if (dateMatch) {
         const [, dateStr] = dateMatch;

--- a/lib/pdf-service.ts
+++ b/lib/pdf-service.ts
@@ -862,7 +862,7 @@ export function parsePatientData(text: string): ExtractedPatientData {
     // Only keyword-anchored dates qualify: an unanchored fallback would promote the first
     // date in the document (visit/print/report date) to birth date, which is clinically
     // worse than leaving birthDate empty.
-    const dateKeywords = /\b(?:nato|nata|nascita)\b(?:\s+a\s+[A-Za-zÀ-ÖØ-öø-ÿ' -]{2,80}?\s+il)?(?:\s+il)?\s*[:\.]?\s*(\d{1,2}[\/\-\.]\d{1,2}[\/\-\.]\d{4})/i;
+    const dateKeywords = /\b(?:nato|nata|nascita)\b(?:\s+a\s+(?:(?!\bil\b)[A-Za-zÀ-ÖØ-öø-ÿ'\u2019 -]){2,80}?\s+il)?(?:\s+il)?\s*[:\.]?\s*(\d{1,2}[\/\-\.]\d{1,2}[\/\-\.]\d{4})/i;
     const dateMatch = cleanText.match(dateKeywords);
     if (dateMatch) {
         const [, dateStr] = dateMatch;

--- a/lib/pdf-service.ts
+++ b/lib/pdf-service.ts
@@ -793,6 +793,18 @@ function isValidCodiceFiscale(cf: string): boolean {
 }
 
 /* @Codex */
+function parseItalianBirthDate(value: string): Date | undefined {
+    const [day, month, year] = value.split(/[\/\-.]/).map(Number);
+    const date = new Date(Date.UTC(year, month - 1, day));
+
+    return date.getUTCFullYear() === year
+        && date.getUTCMonth() === month - 1
+        && date.getUTCDate() === day
+        ? date
+        : undefined;
+}
+
+/* @Codex */
 export function mergeExtractedPatientDataWithTextFallback(
     aiResult: ExtractedPatientData,
     fallbackText: string,
@@ -842,7 +854,7 @@ export function parsePatientData(text: string): ExtractedPatientData {
     const cleanText = text.replace(/\s+/g, ' ');
 
     // 1. C.F.
-    const cfRegex = /[A-Z]{6}\d{2}[A-Z]\d{2}[A-Z]\d{3}[A-Z]/i;
+    const cfRegex = /(?<![\p{L}\p{N}])[A-Za-z]{6}[0-9LMNPQRSTUVlmnpqrstuv]{2}[A-Za-z][0-9LMNPQRSTUVlmnpqrstuv]{2}[A-Za-z][0-9LMNPQRSTUVlmnpqrstuv]{3}[A-Za-z](?![\p{L}\p{N}])/u;
     const cfMatch = cleanText.match(cfRegex);
     if (cfMatch) data.taxCode = cfMatch[0].toUpperCase();
 
@@ -850,14 +862,11 @@ export function parsePatientData(text: string): ExtractedPatientData {
     // Only keyword-anchored dates qualify: an unanchored fallback would promote the first
     // date in the document (visit/print/report date) to birth date, which is clinically
     // worse than leaving birthDate empty.
-    const dateKeywords = /(?:nato|nata|nascita)(?:\s+(?:il|a))?\s*[:\.]?\s*(\d{1,2}[\/\-\.]\d{1,2}[\/\-\.]\d{4})/i;
+    const dateKeywords = /\b(?:nato|nata|nascita)\b(?:\s+a\s+[A-Za-zÀ-ÖØ-öø-ÿ' -]{2,80}?\s+il)?(?:\s+il)?\s*[:\.]?\s*(\d{1,2}[\/\-\.]\d{1,2}[\/\-\.]\d{4})/i;
     const dateMatch = cleanText.match(dateKeywords);
     if (dateMatch) {
         const [, dateStr] = dateMatch;
-        const parts = dateStr.split(/[\/\-\.]/);
-        // Zero-pad so Date() always parses as UTC: '1980-1-1' parses as local midnight
-        // and shifts to the previous day on toISOString() in timezones ahead of UTC.
-        if (parts.length === 3) data.birthDate = new Date(`${parts[2]}-${parts[1].padStart(2, '0')}-${parts[0].padStart(2, '0')}`);
+        data.birthDate = parseItalianBirthDate(dateStr);
     }
 
     // 3. NAME


### PR DESCRIPTION
Hardening del parsing PDF (follow-up WUL-324): omocodie/Unicode nel parsing paziente, prevenzione over-capture delle date, rifiuto dei marcatori duplicati. Riconciliato sul router WUL-412 (nessuna sovrapposizione: il router instrada, il parsing resta in pdf-service).

Verifica locale: PDF/regex 25/25; file router 53/53; unit 952/952; typecheck, lint PASS. CI GitHub in outage: gate locali completi come sostituto.

Rif. Linear: WUL-330

🤖 Generated with [Claude Code](https://claude.com/claude-code)