### PR TITLE
Gate: ogni tabella dello schema deve avere un writer, e lease di promozione per i branch

### DIFF
--- a/.github/workflows/openapi-contract-guard.yml
+++ b/.github/workflows/openapi-contract-guard.yml
@@ -28,6 +28,11 @@ jobs:
         run: |
           npm run check:claims
           npm run check:claims -- --self-test
+      - name: Schema writer guard and self-test
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
+        run: |
+          npm run check:schema-writers
+          npm run check:schema-writers -- --self-test
       - name: Never-regress guard
         if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: npm run check:never-regress

--- a/docs/repository-topology.md
+++ b/docs/repository-topology.md
@@ -7,7 +7,7 @@ read_when:
 
 # Repository Topology: MediFlow
 
-Ultimo aggiornamento: 2026-07-24
+Ultimo aggiornamento: 2026-08-07
 
 Mappa concisa delle aree top-level del repository, pensata per orientare agent e
 contributor: distingue il **runtime clinico** (codice che gira con dati paziente)
@@ -94,3 +94,44 @@ conversazionale e l'automazione graduata restano roadmap.
   per branch, push e release deve puntare alla repository pubblica canonica.
 - Per la lista completa dei `.md` tracciati, vedi
   [docs/markdown-index.md](./markdown-index.md).
+
+## Ciclo di vita dei branch — lease di promozione
+
+Regola adottata il 2026-08-07, dopo il collegio sul residuo `WUL-362`.
+
+> Ogni branch diverso da `main` deve essere **o** il branch attivo di un worktree
+> dedicato a un'issue aperta, **o** la head di esattamente una pull request aperta
+> verso `main`. Quando nessuna delle due condizioni vale, il branch è **senza lease**:
+> non può ricevere altri commit.
+
+Chiudere un branch richiede una **disposizione terminale esplicita**, registrata
+nell'issue o nel run record, e solo dopo si rimuove il ref:
+
+| disposizione | quando | cosa registrare |
+|---|---|---|
+| `merged` | il lavoro è entrato via PR | il numero di PR |
+| `superseded-by <PR o SHA>` | il lavoro è arrivato su `main` per altra via, o è stato reimplementato | la destinazione verificabile |
+| `abandoned` | il lavoro non serve più | il motivo |
+
+Il motivo della regola. Il residuo `codex/WUL-362-contract-gates` non era un branch
+d'integrazione: era un branch di lavoro ordinario creato da `main` il 21 luglio, a cui
+il 6 agosto è stato aggiunto un commit `wip: igiene di sessione` — la stessa spazzata
+applicata in contemporanea ad altri quattro branch. Quel commit ha reso il branch
+indistinguibile da uno con lavoro residuo, e ogni triage successivo ha dovuto
+ridimostrare da zero che non contenesse nulla. La lease impedisce esattamente questo:
+un branch senza lease non può essere contaminato da una spazzata.
+
+Due avvertenze che il collegio ha ritenuto vincolanti:
+
+- **`git cherry` è un segnale, non l'autorità di cancellazione.** Si fonda
+  sull'equivalenza di patch-id, quindi è cieco al lavoro reimplementato invece che
+  ricopiato; e se `main` applica una patch e poi la reverte, `git cherry` continua a
+  mostrarla come integrata. Usarlo nel closeout, mai come criterio automatico.
+- **Il confronto blob-per-blob non lo sostituisce**: fallisce su rename, refactor e
+  reimplementazioni semantiche.
+
+La lease governa il *ciclo di vita del ref*, non la *completezza del lavoro*. Un branch
+può scadere correttamente portandosi via lavoro mai promosso e mai notato — è successo
+con il writer di `document_diagnosis_proposals`, mentre la sua tabella era già su
+`main`. La contromisura per quel fallimento è di natura diversa: un gate che verifica
+la coerenza dell'albero, come `npm run check:schema-writers`.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "typecheck": "tsc -p tsconfig.typecheck.json --noEmit",
     "check:openapi:drift": "node scripts/check-openapi-drift.mjs",
     "check:schema-drift": "node scripts/check-schema-drift.mjs",
+    "check:schema-writers": "node scripts/check-schema-writers.mjs",
     "check:node-runtime": "node scripts/node-runtime-contract.mjs verify",
     "check:standalone-runtime-bundle": "node scripts/check-standalone-runtime-bundle.mjs",
     "check:mlx-operational-parity": "node scripts/check-mlx-operational-parity.mjs",

--- a/scripts/check-schema-writers.mjs
+++ b/scripts/check-schema-writers.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+/* @Codex */
+
+// Ogni tabella dichiarata in lib/schema.ts deve avere almeno un writer specifico:
+// un modulo non-infrastrutturale che esegue .insert/.update/.delete su quel simbolo.
+//
+// Una tabella senza writer è un'affermazione di architettura non verificata: lo schema
+// dichiara una struttura dati che nessun codice popola. Il caso che ha motivato questo
+// gate è `document_diagnosis_proposals` (ADR 0087), presente nello schema, inclusa in
+// backup/restore/cascade, ma mai scritta da nessuno: il writer con il suo audit è
+// rimasto su un branch non integrato.
+//
+// I moduli infrastrutturali che enumerano *tutte* le tabelle (backup, restore, cascade,
+// scheduler) non contano come writer: farebbero risultare popolata qualunque tabella.
+//
+// L'allowlist è stale-sensitive nelle due direzioni: un'eccezione non più necessaria
+// fa fallire il gate tanto quanto una tabella orfana non dichiarata. È il meccanismo
+// che costringe a rivedere l'eccezione nel momento in cui il writer viene integrato.
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const schemaFile = 'lib/schema.ts';
+const roots = ['lib', 'app', 'scripts'];
+const extensions = new Set(['.ts', '.tsx', '.mjs', '.js']);
+const skipped = ['.git', '.next', 'node_modules', 'coverage', 'dist', 'out']
+  .map((item) => `${path.sep}${item}${path.sep}`);
+
+// Moduli che operano su ogni tabella per costruzione: non provano l'esistenza di un
+// percorso di scrittura reale per una tabella specifica.
+const infrastructure = new Set([
+  'lib/backup-artifact.ts',
+  'lib/backup-restore-executor.ts',
+  'lib/backup-restore-preflight.ts',
+  'lib/patient-cascade.ts',
+  'lib/db-server.ts',
+  'lib/db.ts',
+  'app/api/system/backup-restore/route.ts',
+  'scripts/run-scheduled-backup.mjs',
+]);
+
+// Tabelle senza writer, accettate consapevolmente. Ogni voce richiede un motivo e un
+// riferimento. Una voce che non serve più fa fallire il gate: va rimossa.
+const allowlist = [
+  {
+    table: 'document_diagnosis_proposals',
+    reason: 'foundation dati di ADR 0087 consegnata senza writer, route o UI; '
+      + 'l\'implementazione con audit è su codex/WUL-361-transplant-c3-writer-audit-0.8, non integrata',
+    reference: 'docs/adr/0087-registro-proposte-diagnostiche-documentali.md',
+  },
+];
+
+function toRelative(file) {
+  return path.relative(repoRoot, file).split(path.sep).join('/');
+}
+
+function shouldSkip(file) {
+  return skipped.some((fragment) => file.includes(fragment));
+}
+
+function collectFiles(root) {
+  const fullPath = path.join(repoRoot, root);
+  if (!fs.existsSync(fullPath)) return [];
+  return fs.readdirSync(fullPath, { withFileTypes: true }).flatMap((entry) => {
+    const child = path.join(fullPath, entry.name);
+    if (entry.isDirectory()) return shouldSkip(child + path.sep) ? [] : collectFiles(toRelative(child));
+    if (!entry.isFile() || !extensions.has(path.extname(child))) return [];
+    return shouldSkip(child) ? [] : [toRelative(child)];
+  });
+}
+
+export function parseTables(source) {
+  return [...source.matchAll(/export const (\w+) = sqliteTable\(\s*['"`]([\w_]+)['"`]/g)]
+    .map((match) => ({ symbol: match[1], table: match[2] }));
+}
+
+export function writesTable(source, symbol) {
+  return new RegExp(`\\.(?:insert|update|delete)\\(\\s*${symbol}\\b`).test(source);
+}
+
+function isTestFile(file) {
+  return /\.test\.|\.spec\./.test(file);
+}
+
+function findWriters(tables, files) {
+  const sources = new Map(files.map((file) => [file, fs.readFileSync(path.join(repoRoot, file), 'utf8')]));
+  return new Map(tables.map((entry) => {
+    const writers = [...sources]
+      .filter(([file]) => !isTestFile(file) && !infrastructure.has(file))
+      .filter(([, source]) => writesTable(source, entry.symbol))
+      .map(([file]) => file);
+    return [entry.table, writers];
+  }));
+}
+
+function main() {
+  const source = fs.readFileSync(path.join(repoRoot, schemaFile), 'utf8');
+  const tables = parseTables(source);
+  if (tables.length === 0) {
+    console.error(`Schema writer gate failed: no sqliteTable declaration found in ${schemaFile}.`);
+    process.exit(1);
+  }
+
+  const files = roots.flatMap(collectFiles);
+  const writers = findWriters(tables, files);
+  const allowed = new Map(allowlist.map((entry) => [entry.table, entry]));
+
+  const orphans = [];
+  const staleExceptions = [];
+
+  for (const { table } of tables) {
+    const found = writers.get(table) ?? [];
+    if (found.length === 0 && !allowed.has(table)) orphans.push(table);
+    if (found.length > 0 && allowed.has(table)) staleExceptions.push({ table, writers: found });
+  }
+
+  const unknownExceptions = allowlist
+    .filter((entry) => !tables.some(({ table }) => table === entry.table))
+    .map((entry) => entry.table);
+
+  if (orphans.length === 0 && staleExceptions.length === 0 && unknownExceptions.length === 0) {
+    const covered = tables.length - allowlist.length;
+    console.log(`Schema writer gate passed: ${covered}/${tables.length} table(s) with a specific writer, `
+      + `${allowlist.length} documented exception(s).`);
+    return;
+  }
+
+  console.error('Schema writer gate failed.');
+  for (const table of orphans) {
+    console.error(`- ORPHAN-TABLE ${table} (${schemaFile})`);
+    console.error('  Nessun modulo non-infrastrutturale scrive questa tabella.');
+    console.error('  Integra un writer, rimuovi la tabella, oppure aggiungi un\'eccezione motivata all\'allowlist.');
+  }
+  for (const { table, writers: found } of staleExceptions) {
+    console.error(`- STALE-EXCEPTION ${table}`);
+    console.error(`  La tabella ha ora un writer (${found.join(', ')}): rimuovi la voce dall'allowlist.`);
+    const entry = allowed.get(table);
+    if (entry) console.error(`  Motivo registrato: ${entry.reason}`);
+  }
+  for (const table of unknownExceptions) {
+    console.error(`- UNKNOWN-EXCEPTION ${table}`);
+    console.error(`  L'allowlist cita una tabella assente da ${schemaFile}: rimuovi la voce.`);
+  }
+  process.exit(1);
+}
+
+function selfTest() {
+  const failures = [];
+
+  const schema = [
+    "export const alpha = sqliteTable('alpha', {",
+    "export const beta = sqliteTable(\"beta\", {",
+    'const notExported = sqliteTable(\'gamma\', {',
+  ].join('\n');
+  const parsed = parseTables(schema);
+  if (parsed.length !== 2) failures.push(`parseTables: expected 2 tables, got ${parsed.length}`);
+  if (parsed[0]?.symbol !== 'alpha' || parsed[0]?.table !== 'alpha') failures.push('parseTables: single-quoted table not parsed');
+  if (parsed[1]?.table !== 'beta') failures.push('parseTables: double-quoted table not parsed');
+
+  const positives = [
+    'await db.insert(alpha).values(row);',
+    'await tx.update( alpha ).set(row);',
+    'await db.delete(alpha).where(eq(alpha.id, id));',
+  ];
+  for (const sample of positives) {
+    if (!writesTable(sample, 'alpha')) failures.push(`writesTable: missed a write in ${JSON.stringify(sample)}`);
+  }
+
+  const negatives = [
+    'await db.select().from(alpha);',
+    'await db.insert(alphaBeta).values(row);',
+    'const alpha = 1;',
+  ];
+  for (const sample of negatives) {
+    if (writesTable(sample, 'alpha')) failures.push(`writesTable: false positive on ${JSON.stringify(sample)}`);
+  }
+
+  for (const entry of allowlist) {
+    if (!entry.reason || !entry.reference) failures.push(`allowlist: ${entry.table} lacks a reason or a reference`);
+  }
+
+  if (failures.length === 0) {
+    console.log(`Schema writer gate self-test passed: ${positives.length} write form(s) detected, `
+      + `${negatives.length} non-write form(s) rejected, ${allowlist.length} exception(s) documented.`);
+    return;
+  }
+  console.error('Schema writer gate self-test failed:');
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+if (process.argv.includes('--self-test')) selfTest();
+else main();


### PR DESCRIPTION
Due controlli nati dallo stesso difetto, trovato indagando la sorte dei branch residui di Springforward: **stato importante tenuto in forma non verificabile meccanicamente, che sopravvive finché qualcuno ricorda perché esiste.**

## 1. Schema writer gate

`main` porta oggi la tabella `document_diagnosis_proposals` (`lib/schema.ts:308`, migration `0024`). È inclusa in backup, restore e cascade di cancellazione. **Nessun codice la scrive o la legge**: gli unici riferimenti sono infrastruttura generica che enumera tutte le tabelle. Il writer con il suo audit — `lib/document-diagnosis-proposal-write.ts`, 94 righe più 102 di test — è rimasto su `codex/WUL-361-transplant-c3-writer-audit-0.8`, mai integrato.

Non è un dettaglio contabile: quel registro è l'artefatto che tiene separata la proposta AI dalla diagnosi clinica, ed è a metà.

`scripts/check-schema-writers.mjs` esige che ogni tabella dichiarata in `lib/schema.ts` abbia almeno un writer **non infrastrutturale** — i moduli che enumerano tutte le tabelle non contano, altrimenti qualunque tabella risulterebbe popolata.

Stato: **20/21 tabelle con writer specifico, 1 eccezione documentata.** Zero falsi positivi sulle altre venti.

L'allowlist è **stale-sensitive nelle due direzioni**: un'eccezione diventata inutile fa fallire il gate quanto una tabella orfana non dichiarata. Quando il writer verrà integrato, il gate imporrà di rimuovere l'eccezione invece di lasciarla scadere in silenzio. Ogni voce richiede motivo e riferimento.

## 2. Lease di promozione (`docs/repository-topology.md`)

> Ogni branch dev'essere il branch attivo di un worktree su issue aperta, oppure la head di esattamente una PR aperta. Senza lease non può ricevere altri commit; il closeout richiede `merged` / `superseded-by <destinazione>` / `abandoned`.

Il caso che l'ha motivata: `codex/WUL-362-contract-gates` non era un branch d'integrazione ma un branch di lavoro ordinario creato da `main` il 21 luglio, reso ambiguo il 6 agosto da un commit `wip: igiene di sessione` applicato in contemporanea ad altri quattro branch. Da lì in poi era indistinguibile da un branch con lavoro residuo, e ogni triage ha dovuto ridimostrare da zero che fosse vuoto.

Registrati anche i due limiti riconosciuti:

- `git cherry` si fonda sull'equivalenza di patch-id: è cieco al lavoro reimplementato invece che ricopiato, e se `main` applica una patch e poi la reverte continua a mostrarla come integrata. Vale come segnale nel closeout, **mai** come criterio automatico di cancellazione.
- Il confronto blob-per-blob non lo sostituisce: fallisce su rename, refactor e reimplementazioni semantiche.

La lease governa il ciclo di vita del ref, non la completezza del lavoro — può far scadere correttamente un branch portandosi via lavoro mai promosso. Il gate del punto 1 è la contromisura per quel fallimento, non per questo.

## Verifica

Il gate è stato verificato nella capacità di **fallire**, non solo di passare. Sostituendo l'allowlist in una copia temporanea, scattano tutti e tre i modi con exit 1:

- `ORPHAN-TABLE` — tabella senza writer e senza eccezione
- `STALE-EXCEPTION` — eccezione per una tabella che ora ha un writer
- `UNKNOWN-EXCEPTION` — eccezione per una tabella assente dallo schema

Presente anche `--self-test` (3 forme di scrittura riconosciute, 3 non-scritture rifiutate, allowlist validata su motivo e riferimento), sul modello di `check-claims-guard.mjs`.

Nessuna regressione: `check:claims` (760 file), `check:schema-drift` (21 tabelle, 22 indici), `check:never-regress`, `eslint` sul nuovo file.

## CI

Aggiunto a `Repository Guards`, accanto al claims guard che presidia la stessa classe di problema e ne segue il pattern gate + self-test.

## Fuori scope

Il branch `codex/WUL-362-contract-gates` è stato cancellato in locale (superato: tre commit su quattro patch-identici a `main`, il quarto un `wip` identico o sottoinsieme). I quattro `codex/WUL-361-*` sono intatti: la sorte del writer va decisa prima, e riscriverlo da zero perderebbe l'audit già implementato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)