### PR TITLE
Correzione: l'assenza del writer del registro diagnostico è deliberata, non dimenticata

### DIFF
--- a/docs/repository-topology.md
+++ b/docs/repository-topology.md
@@ -130,8 +130,9 @@ Due avvertenze che il collegio ha ritenuto vincolanti:
 - **Il confronto blob-per-blob non lo sostituisce**: fallisce su rename, refactor e
   reimplementazioni semantiche.
 
-La lease governa il *ciclo di vita del ref*, non la *completezza del lavoro*. Un branch
-può scadere correttamente portandosi via lavoro mai promosso e mai notato — è successo
-con il writer di `document_diagnosis_proposals`, mentre la sua tabella era già su
-`main`. La contromisura per quel fallimento è di natura diversa: un gate che verifica
-la coerenza dell'albero, come `npm run check:schema-writers`.
+La lease governa il *ciclo di vita del ref*, non la *completezza del lavoro*: un branch
+può scadere correttamente portandosi via lavoro mai promosso e mai notato. La lease non
+se ne accorge, perché guarda il ref e non l'albero. La contromisura per quel fallimento
+è di natura diversa — un gate che verifica la coerenza dell'albero, come
+`npm run check:schema-writers`, che rende visibile in CI la differenza fra un'assenza
+decisa e un'assenza dimenticata: nello schema hanno lo stesso aspetto.

--- a/scripts/check-schema-writers.mjs
+++ b/scripts/check-schema-writers.mjs
@@ -4,11 +4,15 @@
 // Ogni tabella dichiarata in lib/schema.ts deve avere almeno un writer specifico:
 // un modulo non-infrastrutturale che esegue .insert/.update/.delete su quel simbolo.
 //
-// Una tabella senza writer è un'affermazione di architettura non verificata: lo schema
-// dichiara una struttura dati che nessun codice popola. Il caso che ha motivato questo
-// gate è `document_diagnosis_proposals` (ADR 0087), presente nello schema, inclusa in
-// backup/restore/cascade, ma mai scritta da nessuno: il writer con il suo audit è
-// rimasto su un branch non integrato.
+// Una tabella senza writer è, salvo decisione contraria e documentata, un'affermazione
+// di architettura non verificata: lo schema dichiara una struttura dati che nessun
+// codice popola. Il caso che ha motivato questo gate è `document_diagnosis_proposals`,
+// presente nello schema e inclusa in backup/restore/cascade ma mai scritta — dove però
+// l'assenza del writer è **deliberata** e messa a verbale da ADR 0087.
+//
+// È esattamente la distinzione che il gate serve a rendere visibile: un'assenza decisa
+// e un'assenza dimenticata hanno lo stesso aspetto nello schema, e si distinguono solo
+// leggendo un ADR. L'allowlist è il posto dove la decisione diventa leggibile in CI.
 //
 // I moduli infrastrutturali che enumerano *tutte* le tabelle (backup, restore, cascade,
 // scheduler) non contano come writer: farebbero risultare popolata qualunque tabella.
@@ -42,12 +46,15 @@ const infrastructure = new Set([
 ]);
 
 // Tabelle senza writer, accettate consapevolmente. Ogni voce richiede un motivo e un
-// riferimento. Una voce che non serve più fa fallire il gate: va rimossa.
+// riferimento a una decisione scritta. Una voce che non serve più fa fallire il gate:
+// va rimossa.
 const allowlist = [
   {
     table: 'document_diagnosis_proposals',
-    reason: 'foundation dati di ADR 0087 consegnata senza writer, route o UI; '
-      + 'l\'implementazione con audit è su codex/WUL-361-transplant-c3-writer-audit-0.8, non integrata',
+    reason: 'assenza deliberata, non dimenticanza: ADR 0087 (Accepted) consegna la sola '
+      + 'foundation persistente e rinvia writer, route, UI e transizioni a un packet '
+      + 'runtime separato, di cui elenca requisiti e regole di arresto. Integrare un '
+      + 'writer senza quel packet viola le regole di arresto dell\'ADR stesso.',
     reference: 'docs/adr/0087-registro-proposte-diagnostiche-documentali.md',
   },
 ];


### PR DESCRIPTION
Correzione fattuale a #163. La sostanza del gate non cambia; cambia il motivo registrato nell'allowlist, che era sbagliato in un modo che avrebbe indirizzato male il lavoro futuro.

## Cosa avevo affermato

Che `document_diagnosis_proposals` fosse una feature a metà: tabella su `main`, writer "rimasto su un branch non integrato", da recuperare.

## Cosa dice ADR 0087 su `main`

È `Status: Accepted`, e afferma l'opposto in modo esplicito. Sezione **Limite operativo**:

> La foundation non contiene un writer applicativo. Il tree corrente non espone una route, una UI o una transizione per creare, rivedere, accettare, rifiutare o sostituire proposte.

La sezione **Workflow futuro** rinvia il writer a un packet runtime separato e ne elenca sette requisiti — writer e validazioni, stati e transizioni, identità e provenienza, protezione dei payload, gesto esplicito dell'operatore con anteprima esatta, concorrenza/audit/rollback, test negativi sull'assenza di auto-apply — seguiti da regole di arresto esplicite.

L'assenza del writer è quindi **una decisione messa a verbale**, non una perdita.

## Il writer sul branch

`lib/document-diagnosis-proposal-write.ts` su `codex/WUL-361-transplant-c3-writer-audit-0.8` precede l'ADR nella sua forma accettata e ne copre una parte soltanto:

| requisito ADR 0087 | nel writer |
|---|---|
| writer e validazioni | sì — validazione ciphertext, parser create/update |
| concorrenza | sì — versione ottimistica |
| audit | sì — eventi via `safeWriteAuditEventFromRequest` |
| stati e transizioni | **no** |
| anteprima e gesto esplicito | **no** |
| rollback | **no** |
| test negativi sull'auto-apply | **no** |

Integrarlo così com'è violerebbe una regola di arresto dell'ADR: *"il writer usa il registro senza contratto di stato e validazioni verificati"*. Resta un input utile per il packet futuro, non un pezzo da rimettere a posto.

## Perché il gate serve comunque, e meglio

Un'assenza decisa e un'assenza dimenticata **hanno lo stesso aspetto nello schema**, e si distinguono solo leggendo un ADR. L'allowlist è il posto dove quella decisione diventa leggibile in CI, con motivo e riferimento obbligatori. Il valore del gate non era recuperare lavoro perduto: è rendere verificabile una distinzione che finora viveva solo nella memoria di chi c'era.

Corretto anche l'esempio in `docs/repository-topology.md`, che poggiava sulla stessa inferenza. Il limite generale della lease — governa il ciclo di vita del ref, non la completezza del lavoro — resta valido e resta scritto.

## Verifica

`check:schema-writers` e il suo `--self-test` passano, `check:claims` (760 file) non regredisce, `eslint` pulito. Verificato che l'eccezione stale continui a stampare il motivo registrato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)