### PR TITLE
Confine prescrittivo: rimuovi la coda morta e fissa il contratto reale

### DIFF
--- a/lib/prescription-boundary.test.ts
+++ b/lib/prescription-boundary.test.ts
@@ -1,0 +1,27 @@
+/* @Codex */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+    filterServicePrescriptionTherapyCandidates,
+    isServicePrescriptionLikeTherapy,
+} from './prescription-boundary';
+
+/* @Codex */
+test('prescription boundary excludes service identities and retains a drug with specialist-visit evidence', () => {
+    const servicePrescription = {
+        drugMention: 'Visita cardiologica',
+        evidence: 'Prescritta visita cardiologica di controllo',
+    };
+    const drugTherapy = {
+        drugMention: 'Amoxicillina',
+        activePrinciple: 'Amoxicillina',
+        evidence: 'Prescritta dopo visita specialistica',
+    };
+
+    assert.equal(isServicePrescriptionLikeTherapy(servicePrescription), true);
+    assert.equal(isServicePrescriptionLikeTherapy(drugTherapy), false);
+    assert.deepEqual(
+        filterServicePrescriptionTherapyCandidates([servicePrescription, drugTherapy]),
+        [drugTherapy],
+    );
+});

--- a/lib/prescription-boundary.test.ts
+++ b/lib/prescription-boundary.test.ts
@@ -25,3 +25,33 @@ test('prescription boundary excludes service identities and retains a drug with 
         [drugTherapy],
     );
 });
+
+/* @Codex */
+// Fissa il contratto reale: la decisione guarda solo l'identità. Se un giorno dosaggio,
+// motivazione, nota di revisione o evidenza dovranno pesare, è questo test a doversi
+// rompere per primo — e la domanda aperta annotata in prescription-boundary.ts a dover
+// ricevere una risposta.
+test('prescription boundary decides on identity alone: dosage, motivation, review note and evidence are inert', () => {
+    const identityOnly = { drugMention: 'Amoxicillina' };
+    const withNoise = {
+        drugMention: 'Amoxicillina',
+        dosage: '500 mg',
+        motivation: 'Prescritta impegnativa per visita specialistica',
+        reviewNote: 'Controllo cardiologico da programmare',
+        evidence: 'Richiesta prestazione ambulatoriale',
+    };
+
+    assert.equal(isServicePrescriptionLikeTherapy(identityOnly), false);
+    assert.equal(isServicePrescriptionLikeTherapy(withNoise), false,
+        'i campi non identitari non devono spostare la classificazione');
+
+    // Simmetrico: una posologia esplicita non riporta un'identità di prestazione fra i
+    // farmaci. È il caso che la domanda aperta dovrà decidere.
+    const serviceIdentityWithDosage = { drugMention: 'Visita di controllo', dosage: '500 mg' };
+    assert.equal(isServicePrescriptionLikeTherapy(serviceIdentityWithDosage), true);
+
+    // Candidato vuoto: nessuna identità, nessuna classificazione.
+    assert.equal(isServicePrescriptionLikeTherapy({}), false);
+    assert.equal(isServicePrescriptionLikeTherapy({ evidence: 'Visita cardiologica' }), false,
+        'la sola evidenza non basta a classificare come prestazione');
+});

--- a/lib/prescription-boundary.ts
+++ b/lib/prescription-boundary.ts
@@ -10,9 +10,6 @@ export interface PrescriptionBoundaryCandidate {
 }
 
 /* @Codex */
-const DRUG_DOSAGE_OR_FORM_REGEX = /\b\d+(?:[.,]\d+)?\s*(?:mg|mcg|g|ml|ui|u|cp|cps|cpr|caps(?:ule)?|compress(?:a|e)|gtt|fial(?:a|e)|spruzzi?)\b|\b(?:farmaco|farmaci|principio\s+attivo|posologia|compress(?:a|e)|capsul(?:a|e)|gocce|fial(?:a|e)|aifa|aic|atc|terapia\s+farmacologica)\b/i;
-
-/* @Codex */
 const SERVICE_IDENTITY_REGEX = /\b(?:visita|prestazion(?:e|i)|specialistic(?:a|he|o|i)|consulenza|consulto|controllo\s+specialistic(?:o|a)|esame|accertamento|prelievo|ecografia|eco(?:grafia|color\s*doppler|colordoppler|doppler)?|color\s*doppler|colordoppler|doppler|radiografia|rx|tc|tac|rm|risonanza|ecg|elettrocardiogramma|spirometria|otorinolaringoiatric(?:a|o|he|i)|orl|cardiologic(?:a|o|he|i)|endocrinologic(?:a|o|he|i)|neurologic(?:a|o|he|i)|dermatologic(?:a|o|he|i)|oculistic(?:a|o|he|i)|fisiatric(?:a|o|he|i)|ortopedic(?:a|o|he|i)|gastroenterologic(?:a|o|he|i)|urologic(?:a|o|he|i)|pneumologic(?:a|o|he|i)|angiologic(?:a|o|he|i)|vascolar(?:e|i)|fisioterapi(?:a|e|co|ca|ci|che)|riabilitazion(?:e|i)|riabilitativ(?:a|o|he|i)|emocromo|hba1c|emoglobina\s+glic(?:ata|osilata))\b/i;
 
 /* @Codex */
@@ -26,34 +23,32 @@ function normalizeText(value: string | undefined): string {
 }
 
 /* @Codex */
+// La decisione dipende solo dall'identità del candidato: `drugMention`, `drugQuery` e
+// `activePrinciple`. `dosage`, `motivation`, `reviewNote` ed `evidence` sono dichiarati
+// da `PrescriptionBoundaryCandidate` ma non influenzano il risultato.
+//
+// Non è una semplificazione introdotta qui: lo era già alla prima comparsa del file
+// (`1804b698c`, export OSS 0.7). La coda della funzione — un marker prescrittivo e un
+// controllo su dosaggio e forma farmaceutica — era irraggiungibile per costruzione,
+// perché arrivarci richiedeva `SERVICE_IDENTITY_REGEX` falso mentre entrambi i rami
+// residui la richiedevano vera o tornavano comunque `false`. Rimossa in due passi
+// (`5de97b5fe` e questo commit); recuperabile da git se servisse.
+//
+// Resta aperta una domanda di contratto che questo commit **non** decide, perché la
+// storia del file non conserva l'intento: se una terapia con posologia esplicita debba
+// restare un farmaco anche quando l'identità cita una prestazione (`Visita di controllo
+// 500 mg`), il controllo sul dosaggio andrebbe *prima* della classificazione, non dopo.
+// Oggi non lo è, e spostarlo cambierebbe il comportamento di un confine clinico: serve
+// una decisione, non un'inferenza.
 export function isServicePrescriptionLikeTherapy(candidate: PrescriptionBoundaryCandidate): boolean {
     const identityText = [
         candidate.drugMention,
         candidate.drugQuery,
         candidate.activePrinciple,
     ].filter(Boolean).join(' ');
-    const fullText = [
-        identityText,
-        candidate.dosage,
-        candidate.motivation,
-        candidate.reviewNote,
-        candidate.evidence,
-    ].filter(Boolean).join(' ');
 
-    if (!fullText.trim()) return false;
-
-    const normalizedIdentity = normalizeText(identityText);
-    const identityLooksService = SERVICE_IDENTITY_REGEX.test(identityText)
-        || /\bvisita\b|\bprestazione\b|\besame\b|\bconsulenza\b/.test(normalizedIdentity);
-    if (identityLooksService) return true;
-
-    const identityOrDosageText = [
-        identityText,
-        candidate.dosage,
-    ].filter(Boolean).join(' ');
-    if (DRUG_DOSAGE_OR_FORM_REGEX.test(identityOrDosageText)) return false;
-
-    return false;
+    return SERVICE_IDENTITY_REGEX.test(identityText)
+        || /\bvisita\b|\bprestazione\b|\besame\b|\bconsulenza\b/.test(normalizeText(identityText));
 }
 
 /* @Codex */

--- a/lib/prescription-boundary.ts
+++ b/lib/prescription-boundary.ts
@@ -13,9 +13,6 @@ export interface PrescriptionBoundaryCandidate {
 const DRUG_DOSAGE_OR_FORM_REGEX = /\b\d+(?:[.,]\d+)?\s*(?:mg|mcg|g|ml|ui|u|cp|cps|cpr|caps(?:ule)?|compress(?:a|e)|gtt|fial(?:a|e)|spruzzi?)\b|\b(?:farmaco|farmaci|principio\s+attivo|posologia|compress(?:a|e)|capsul(?:a|e)|gocce|fial(?:a|e)|aifa|aic|atc|terapia\s+farmacologica)\b/i;
 
 /* @Codex */
-const SERVICE_PRESCRIPTION_MARKER_REGEX = /\b(?:impegnativa|ricetta|prescrizione|prescritta|prescritto|richiesta|richiesto|promemoria|nre|codice\s+prestazione|prestazione\s+codificata|branca\s+specialistica)\b/i;
-
-/* @Codex */
 const SERVICE_IDENTITY_REGEX = /\b(?:visita|prestazion(?:e|i)|specialistic(?:a|he|o|i)|consulenza|consulto|controllo\s+specialistic(?:o|a)|esame|accertamento|prelievo|ecografia|eco(?:grafia|color\s*doppler|colordoppler|doppler)?|color\s*doppler|colordoppler|doppler|radiografia|rx|tc|tac|rm|risonanza|ecg|elettrocardiogramma|spirometria|otorinolaringoiatric(?:a|o|he|i)|orl|cardiologic(?:a|o|he|i)|endocrinologic(?:a|o|he|i)|neurologic(?:a|o|he|i)|dermatologic(?:a|o|he|i)|oculistic(?:a|o|he|i)|fisiatric(?:a|o|he|i)|ortopedic(?:a|o|he|i)|gastroenterologic(?:a|o|he|i)|urologic(?:a|o|he|i)|pneumologic(?:a|o|he|i)|angiologic(?:a|o|he|i)|vascolar(?:e|i)|fisioterapi(?:a|e|co|ca|ci|che)|riabilitazion(?:e|i)|riabilitativ(?:a|o|he|i)|emocromo|hba1c|emoglobina\s+glic(?:ata|osilata))\b/i;
 
 /* @Codex */
@@ -56,10 +53,7 @@ export function isServicePrescriptionLikeTherapy(candidate: PrescriptionBoundary
     ].filter(Boolean).join(' ');
     if (DRUG_DOSAGE_OR_FORM_REGEX.test(identityOrDosageText)) return false;
 
-    const prescriptionLooksService = SERVICE_PRESCRIPTION_MARKER_REGEX.test(fullText)
-        && SERVICE_IDENTITY_REGEX.test(identityText);
-
-    return prescriptionLooksService;
+    return false;
 }
 
 /* @Codex */


### PR DESCRIPTION
Chiude il branch `codex/WUL-327-prescription-boundary-guard`, rimasto senza disposizione terminale dopo il commit del 2026-08-08. Due commit: il primo era già sul branch, il secondo completa il lavoro.

## Che cosa era morto, e da quando

`isServicePrescriptionLikeTherapy` aveva una coda irraggiungibile per costruzione. Per arrivarci serviva `SERVICE_IDENTITY_REGEX` falso, ma il ramo residuo la richiedeva vera:

```js
const prescriptionLooksService = SERVICE_PRESCRIPTION_MARKER_REGEX.test(fullText)
    && SERVICE_IDENTITY_REGEX.test(identityText);   // sempre false qui
```

Il primo commit toglieva quel marker. Lasciava però dietro un secondo pezzo che la rimozione rendeva provabilmente morto — entrambi i rami tornano `false`:

```js
if (DRUG_DOSAGE_OR_FORM_REGEX.test(identityOrDosageText)) return false;
return false;
```

Con esso cadono `fullText`, `identityOrDosageText` e la guardia sul testo vuoto, tutti privi di effetto.

**Non è una semplificazione introdotta ora**: la coda era morta fin dalla prima comparsa del file (`1804b698c`, export OSS 0.7). La storia del repo non ne conserva l'intento.

## Il contratto reale

La funzione decide sulla **sola identità** del candidato — `drugMention`, `drugQuery`, `activePrinciple`. Gli altri quattro campi dichiarati da `PrescriptionBoundaryCandidate` (`dosage`, `motivation`, `reviewNote`, `evidence`) non influenzano la classificazione.

Il nuovo test lo fissa, inclusa la parte controintuitiva: un candidato con posologia, motivazione, nota ed evidenza tutte riferite a una prestazione resta classificato sull'identità. Se un giorno quei campi dovranno pesare, è quel test a doversi rompere per primo.

## Verifica

**Differenziale contro `main`**, non solo contro il commit precedente: entrambe le versioni compilate e confrontate su **170.723 combinazioni** dei sette campi del candidato — identità di servizio, farmaci, dosaggi, marker prescrittivi, stringhe vuote. **Zero divergenze.**

`test:unit` 1074/1074 · `lint` · `typecheck` puliti.

## Una domanda che questa PR non decide

Se una terapia con posologia esplicita debba restare un farmaco anche quando l'identità cita una prestazione (`Visita di controllo 500 mg`), il controllo sul dosaggio andrebbe **prima** della classificazione, non dopo. Oggi non lo è.

Spostarlo cambierebbe il comportamento di un confine clinico, e la storia del file non conserva l'intento originale: serve una decisione, non un'inferenza. È annotata nel sorgente perché il prossimo lettore non rifaccia l'analisi da capo.

I tre consumer — `ai-task-contracts.ts`, `patient-smart-import-service.ts`, `patient-document-import-service.ts` — stanno tutti sul percorso AI/import documentale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)