### PR TITLE
Header di sicurezza HTTP sulla UI che decifra PHI (WUL-343)

### DIFF
--- a/e2e/header-sicurezza.spec.ts
+++ b/e2e/header-sicurezza.spec.ts
@@ -1,0 +1,89 @@
+/* WUL-343. Gli header di sicurezza e, soprattutto, la prova che la CSP non
+   rompa la UI: una policy troppo stretta si manifesta come pagina muta, non
+   come errore di build, quindi va falsificata a runtime raccogliendo gli eventi
+   securitypolicyviolation invece che leggendo il config. */
+import { expect, test, type Page } from '@playwright/test';
+import { bootstrapUnlockedSession } from './utils';
+
+const ATTESI: Array<{ header: string; atteso: RegExp }> = [
+  { header: 'x-frame-options', atteso: /^DENY$/i },
+  { header: 'x-content-type-options', atteso: /^nosniff$/i },
+  { header: 'referrer-policy', atteso: /^no-referrer$/i },
+  { header: 'permissions-policy', atteso: /camera=\(\)/ },
+  { header: 'cross-origin-opener-policy', atteso: /^same-origin$/i },
+];
+
+const DIRETTIVE_CSP = [
+  "default-src 'self'",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+];
+
+const SUPERFICI = ['/', '/diary', '/analytics', '/scales', '/settings', '/settings/ai'] as const;
+
+type Violazione = { direttiva: string; risorsa: string; url: string };
+
+async function raccogliViolazioni(page: Page): Promise<Violazione[]> {
+  const violazioni: Violazione[] = [];
+  await page.exposeFunction('__registraViolazioneCsp', (v: Violazione) => {
+    violazioni.push(v);
+  });
+  await page.addInitScript(() => {
+    document.addEventListener('securitypolicyviolation', (event) => {
+      const e = event as SecurityPolicyViolationEvent;
+      // @ts-expect-error binding esposto da Playwright
+      window.__registraViolazioneCsp({
+        direttiva: e.violatedDirective,
+        risorsa: (e.blockedURI || '').slice(0, 120),
+        url: location.pathname,
+      });
+    });
+  });
+  return violazioni;
+}
+
+test('gli header di sicurezza sono presenti sul documento', async ({ page }) => {
+  const risposta = await page.goto('/');
+  expect(risposta, 'la root deve rispondere').not.toBeNull();
+  const headers = risposta!.headers();
+
+  for (const { header, atteso } of ATTESI) {
+    expect(headers[header], `header ${header} (ricevuto: ${headers[header] ?? 'assente'})`).toMatch(atteso);
+  }
+
+  const csp = headers['content-security-policy'];
+  expect(csp, 'Content-Security-Policy deve essere emessa').toBeTruthy();
+  for (const direttiva of DIRETTIVE_CSP) {
+    expect(csp, `la CSP deve contenere «${direttiva}»`).toContain(direttiva);
+  }
+
+  /* Il percorso AI del browser passa dalla stessa origine, ma i runtime locali
+     restano raggiungibili: se questo salta, l'inferenza host-only si spegne. */
+  expect(csp, 'la CSP deve ammettere il loopback in connect-src').toContain('http://127.0.0.1:*');
+
+  /* HSTS e' opt-in: su 127.0.0.1 in HTTP inchioderebbe l'origine a TLS. */
+  if (process.env.MEDIFLOW_ENABLE_HSTS === '1') {
+    expect(headers['strict-transport-security']).toContain('max-age=');
+  } else {
+    expect(headers['strict-transport-security'], 'HSTS non va emesso senza opt-in').toBeUndefined();
+  }
+});
+
+test('la CSP non blocca nessuna risorsa delle superfici principali', async ({ page }) => {
+  test.setTimeout(180_000);
+  const violazioni = await raccogliViolazioni(page);
+  await page.setViewportSize({ width: 1440, height: 960 });
+  await bootstrapUnlockedSession(page, process.env.E2E_PIN || '1234');
+
+  for (const superficie of SUPERFICI) {
+    await page.goto(superficie, { waitUntil: 'domcontentloaded' });
+    await page.waitForTimeout(1_200);
+  }
+
+  expect(
+    violazioni,
+    `la CSP ha bloccato risorse:\n${violazioni.map((v) => `  ${v.url}: ${v.direttiva} → ${v.risorsa}`).join('\n')}`,
+  ).toEqual([]);
+});

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,62 @@ import type { NextConfig } from "next";
 /* @Codex */
 const distDir = process.env.MEDIFLOW_NEXT_DIST_DIR || '.next';
 
+/* WUL-343. La UI decifra PHI nel browser, quindi gli header valgono come
+   riduzione di superficie, non come formalita'.
+
+   Due scelte non ovvie, entrambe deliberate:
+
+   - 'unsafe-inline' su script-src e style-src resta necessario finche' Next
+     inietta lo script di bootstrap e gli stili critici inline. Toglierlo
+     richiede il nonce per-richiesta, che a sua volta richiede un middleware:
+     e' un lavoro a se', non un parametro da cambiare qui. Dichiararlo e'
+     meglio che ometterlo e credersi coperti.
+   - HSTS NON e' emesso di default. L'app e' local-first su 127.0.0.1 in HTTP:
+     li' l'header viene ignorato, ma se un giorno la stessa origine venisse
+     servita in HTTPS anche una sola volta il browser la inchioderebbe a TLS
+     per max-age. Si attiva con MEDIFLOW_ENABLE_HSTS=1, cioe' quando davanti
+     c'e' il proxy TLS (scripts/local-api-tls-proxy.mjs). */
+const isProduction = process.env.NODE_ENV === 'production';
+const hstsEnabled = process.env.MEDIFLOW_ENABLE_HSTS === '1';
+
+/* Il percorso AI del browser passa da /api/proxy/ollama/chat (stessa origine,
+   vedi lib/ai-providers/ollama.ts:113-123), ma il loopback resta ammesso per i
+   runtime locali che i componenti raggiungono direttamente. ws: serve a HMR in
+   sviluppo. */
+const connectSrc = [
+  "'self'",
+  'http://127.0.0.1:*',
+  'http://localhost:*',
+  ...(isProduction ? [] : ['ws://127.0.0.1:*', 'ws://localhost:*']),
+].join(' ');
+
+const contentSecurityPolicy = [
+  "default-src 'self'",
+  `script-src 'self' 'unsafe-inline'${isProduction ? '' : " 'unsafe-eval'"}`,
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob:",
+  "font-src 'self' data:",
+  "media-src 'self' blob:",
+  "worker-src 'self' blob:",
+  `connect-src ${connectSrc}`,
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+].join('; ');
+
+const securityHeaders = [
+  { key: 'Content-Security-Policy', value: contentSecurityPolicy },
+  { key: 'X-Frame-Options', value: 'DENY' },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'Referrer-Policy', value: 'no-referrer' },
+  { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=(), payment=(), usb=()' },
+  { key: 'Cross-Origin-Opener-Policy', value: 'same-origin' },
+  ...(hstsEnabled
+    ? [{ key: 'Strict-Transport-Security', value: 'max-age=31536000; includeSubDomains' }]
+    : []),
+];
+
 const nextConfig: NextConfig = {
   /* @Codex */
   distDir,
@@ -51,6 +107,10 @@ const nextConfig: NextConfig = {
       "./CONTRIBUTING.md",
       "./CHANGELOG.md",
     ],
+  },
+  /* WUL-343 */
+  async headers() {
+    return [{ source: '/:path*', headers: securityHeaders }];
   },
   turbopack: {},
   serverExternalPackages: ['pdfjs-dist', 'pm2'],


### PR DESCRIPTION
Chiude [WUL-343](https://linear.app/wulfgardr/issue/WUL-343/header-http-di-sicurezza-assenti-csp-hsts-x-frame-options-nosniff).

## Il difetto

`next.config.ts` non definiva alcun blocco `headers()`, e non esiste un `middleware.ts`. Su una UI che decifra PHI nel browser mancavano le difese di base contro clickjacking, MIME sniffing e injection.

## Header aggiunti su `/:path*`

| header | valore |
|---|---|
| `Content-Security-Policy` | vedi sotto |
| `X-Frame-Options` | `DENY` |
| `X-Content-Type-Options` | `nosniff` |
| `Referrer-Policy` | `no-referrer` |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=(), payment=(), usb=()` |
| `Cross-Origin-Opener-Policy` | `same-origin` |
| `Strict-Transport-Security` | **solo con `MEDIFLOW_ENABLE_HSTS=1`** |

## Due scelte deliberate

**`'unsafe-inline'` resta** su `script-src` e `style-src`. Next inietta lo script di bootstrap e gli stili critici inline; rimuoverlo richiede il nonce per-richiesta e quindi un middleware — un lavoro a sé, non un parametro da cambiare qui. Annotato nel sorgente: dichiararlo è meglio che ometterlo e credersi coperti.

**HSTS non è emesso di default.** L'app è local-first su `127.0.0.1` in HTTP, dove l'header è ignorato; ma se quella stessa origine venisse servita in HTTPS anche una sola volta, il browser la inchioderebbe a TLS per tutto `max-age`. Si attiva quando davanti c'è il proxy TLS del repo. L'issue chiedeva HSTS «quando servito via TLS», ed è esattamente questo.

## Rischio CSP, verificato invece che assunto

In produzione cadono `'unsafe-eval'` e gli schemi `ws:`. Verificato che sia sicuro: `pdfjs` gira **solo server-side** (`lib/pdfjs-server.ts`, `lib/pdf-service.ts`, nessun `'use client'`) e nel bundle client non compaiono né `eval(` né `new Function`.

`connect-src` ammette il loopback oltre a `'self'`, perché l'inferenza host-only non deve spegnersi: il percorso AI del browser passa dalla stessa origine (`lib/ai-providers/ollama.ts:113-123`), ma i runtime locali restano raggiungibili. La spec lo asserisce esplicitamente.

## Test

`e2e/header-sicurezza.spec.ts` fa due cose distinte:

1. asserisce gli header sul documento, incluso che HSTS **non** sia presente senza opt-in;
2. naviga sei superfici raccogliendo gli eventi `securitypolicyviolation` e pretende zero violazioni — perché una CSP troppo stretta si manifesta come pagina muta, non come errore di build.

Suite locale su sette spec (`web-smoke`, `lume-scheda`, `lume-quadro`, `motion-budget`, `document-stack-accessibility`, `contrasto-registri`, `header-sicurezza`): **21 passed**, zero violazioni CSP.

Gate locali verdi: `check:lume-tokens`, `check:motion-budget`, `check:claims`, `check:never-regress`, `check:schema-writers`, `check:ai-clinical-writes`, `check:node-runtime`, `lint`, `typecheck`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)