### PR TITLE
Nessuna route API rimanda il messaggio grezzo dell'eccezione (WUL-347)

### DIFF
--- a/.github/workflows/openapi-contract-guard.yml
+++ b/.github/workflows/openapi-contract-guard.yml
@@ -38,6 +38,11 @@ jobs:
         run: |
           npm run check:ai-clinical-writes
           npm run check:ai-clinical-writes -- --self-test
+      - name: API error leak guard and self-test
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
+        run: |
+          npm run check:api-error-leak
+          npm run check:api-error-leak -- --self-test
       - name: Never-regress guard
         if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: npm run check:never-regress

--- a/app/api/ocr/extract/route.ts
+++ b/app/api/ocr/extract/route.ts
@@ -23,6 +23,7 @@ import {
     AI_OCR_KILL_SWITCH_KEY,
     isAiOcrEnabledValue,
 } from '@/lib/ai-ocr-kill-switch';
+import { apiInternalError } from '@/lib/api-error-response';
 
 /* @Codex */
 const execFileAsync = promisify(execFile);
@@ -225,11 +226,12 @@ export async function POST(request: NextRequest) {
         });
 
     } catch (error) {
-        console.error('[API] OCR extraction error:', error);
-        return NextResponse.json(
-            { error: error instanceof Error ? error.message : 'OCR extraction failed' },
-            { status: 500 }
-        );
+        /* Il messaggio grezzo qui puo' contenere il percorso del file caricato e
+           dettagli del runtime OCR. */
+        return apiInternalError('OCR extraction', error, {
+            code: 'ocr_extraction_failed',
+            message: 'Estrazione OCR non riuscita.',
+        });
     }
 }
 

--- a/app/api/system/backup-restore/route.ts
+++ b/app/api/system/backup-restore/route.ts
@@ -36,6 +36,7 @@ import {
 import { enrichBackupPatientsWithAmbulatoryLinks } from '@/lib/backup-patient-ambulatory-links';
 import { restoreBackupArtifact } from '@/lib/backup-restore-executor';
 import { runBackupRestorePreflight } from '@/lib/backup-restore-preflight';
+import { apiInternalError } from '@/lib/api-error-response';
 
 /* @Codex */
 export const dynamic = 'force-dynamic';
@@ -165,9 +166,17 @@ export async function POST(request: Request) {
             counts: artifact.manifest.recordCounts,
         });
     } catch (error) {
-        console.error('[MediFlow] Backup restore failed:', error);
-        const message = error instanceof Error ? error.message : 'Restore failed.';
-        const status = error instanceof SyntaxError ? 400 : 500;
-        return NextResponse.json({ success: false, error: message }, { status });
+        /* La distinzione 400/500 resta: un artefatto malformato e' colpa del
+           chiamante, il resto no. Cio' che non torna piu' e' il dettaglio, che
+           su un restore contiene percorsi e struttura del manifest. */
+        const malformato = error instanceof SyntaxError;
+        return apiInternalError('Backup restore failed', error, {
+            status: malformato ? 400 : 500,
+            code: malformato ? 'invalid_backup_artifact' : 'restore_failed',
+            message: malformato ? 'Artefatto di backup non valido.' : 'Ripristino non riuscito.',
+            /* La route espone `success` anche negli altri due rami d'errore
+               (righe 140 e 154): il campo resta per non spezzarne il contratto. */
+            extra: { success: false },
+        });
     }
 }

--- a/app/api/system/backup-scheduler/route.ts
+++ b/app/api/system/backup-scheduler/route.ts
@@ -18,6 +18,7 @@ import {
 } from '@/lib/backup-scheduler';
 /* @Codex */
 import { buildBackupSchedulerStatus, getSchedulerAdapter } from '@/lib/backup-scheduler-adapter';
+import { apiInternalError } from '@/lib/api-error-response';
 
 export const dynamic = 'force-dynamic';
 
@@ -144,8 +145,10 @@ export async function POST(request: Request) {
 
         return NextResponse.json(buildBackupSchedulerStatus(JSON.stringify(nextState)));
     } catch (error) {
-        console.error('POST backup scheduler failed:', error);
-        const message = error instanceof Error ? error.message : 'Failed to save backup scheduler settings.';
-        return NextResponse.json({ error: message }, { status: 500 });
+        /* Il messaggio grezzo qui contiene la destinazione del backup. */
+        return apiInternalError('POST backup scheduler', error, {
+            code: 'backup_scheduler_save_failed',
+            message: 'Salvataggio delle impostazioni di backup non riuscito.',
+        });
     }
 }

--- a/app/api/system/mlx/route.ts
+++ b/app/api/system/mlx/route.ts
@@ -4,6 +4,7 @@ import { PM2Manager } from '@/lib/pm2-manager';
 import { requireSession, requireSessionOrLocalToken, unauthorizedResponse, forbiddenResponse } from '@/lib/security/server-auth';
 /* @Codex */
 import { isWebAdminSession } from '@/lib/security/server-auth-policy';
+import { apiInternalError } from '@/lib/api-error-response';
 
 /* @Codex */
 // MLX (mlx_lm) and the PM2-managed inference server run only on macOS Apple Silicon.
@@ -33,8 +34,8 @@ export async function GET(request: Request) {
     try {
         const status = await PM2Manager.withConnection(() => PM2Manager.getStatus());
         return NextResponse.json(status);
-    } catch (e: any) {
-        return NextResponse.json({ error: e.message }, { status: 500 });
+    } catch (error) {
+        return apiInternalError('GET /api/system/mlx', error);
     }
 }
 
@@ -49,8 +50,8 @@ export async function POST() {
     try {
         await PM2Manager.withConnection(() => PM2Manager.start());
         return NextResponse.json({ success: true, message: "Avvio PM2 richiesto; verifica lo stato locale." });
-    } catch (e: any) {
-        return NextResponse.json({ error: e.message }, { status: 500 });
+    } catch (error) {
+        return apiInternalError('POST /api/system/mlx', error);
     }
 }
 
@@ -65,7 +66,7 @@ export async function DELETE() {
     try {
         await PM2Manager.withConnection(() => PM2Manager.stop());
         return NextResponse.json({ success: true, message: "Stopped" });
-    } catch (e: any) {
-        return NextResponse.json({ error: e.message }, { status: 500 });
+    } catch (error) {
+        return apiInternalError('DELETE /api/system/mlx', error);
     }
 }

--- a/app/api/system/native/route.ts
+++ b/app/api/system/native/route.ts
@@ -6,6 +6,7 @@ import fs from 'fs';
 import path from 'path';
 /* @Codex */
 import { requireSession, unauthorizedResponse, forbiddenResponse } from '@/lib/security/server-auth';
+import { apiInternalError } from '@/lib/api-error-response';
 
 const execFileAsync = promisify(execFile);
 const APP_NAME = 'MediFlowMac';
@@ -35,8 +36,8 @@ export async function POST(request: Request) {
             await execFileAsync('open', ['-a', APP_NAME]);
         }
         return NextResponse.json({ success: true });
-    } catch (error: unknown) {
-        const message = error instanceof Error ? error.message : 'Unknown error';
-        return NextResponse.json({ error: message }, { status: 500 });
+    } catch (error) {
+        /* Il messaggio grezzo qui conterrebbe il percorso dell'applicazione. */
+        return apiInternalError('POST /api/system/native (open)', error);
     }
 }

--- a/app/api/system/treatment-reasoning/athena-mlx/route.ts
+++ b/app/api/system/treatment-reasoning/athena-mlx/route.ts
@@ -10,6 +10,7 @@ import {
 } from '@/lib/ai-treatment-reasoning-kill-switch';
 import { generateWithAthenaMlx, resolveAthenaMlxMaxTokens } from '@/lib/athena-mlx-runtime';
 import { TREATMENT_REASONING_SCHEMA_VERSION } from '@/lib/treatment-reasoning-contract';
+import { apiInternalError } from '@/lib/api-error-response';
 
 export const dynamic = 'force-dynamic';
 
@@ -75,7 +76,11 @@ export async function POST(request: Request) {
             quantizationBits: result.quantizationBits,
         });
     } catch (error) {
-        const message = error instanceof Error ? error.message : 'ATHENA MLX generation failed.';
-        return NextResponse.json({ error: message }, { status: 500 });
+        /* Il messaggio grezzo qui espone percorsi del modello e argomenti del
+           runtime MLX. */
+        return apiInternalError('ATHENA MLX generation', error, {
+            code: 'athena_mlx_generation_failed',
+            message: 'Generazione ATHENA MLX non riuscita.',
+        });
     }
 }

--- a/app/api/therapies/route.ts
+++ b/app/api/therapies/route.ts
@@ -16,6 +16,7 @@ import { therapyCreateSchema } from '@/lib/api-schemas/clinical-writes';
 /* @Codex */
 import { parseApiBody } from '@/lib/api-schemas/parse';
 import { activePatients } from '@/lib/patient-lifecycle';
+import { apiInternalError } from '@/lib/api-error-response';
 
 // motivation is ENC:, so it is not sortable. Only plaintext columns here.
 const THERAPY_SORT_COLUMNS = {
@@ -141,7 +142,8 @@ export async function POST(request: Request) {
 
         return NextResponse.json({ id: newId, version: 1 }, { status: 201 });
     } catch (error) {
-        console.error("API POST /therapies error:", error);
-        return NextResponse.json({ error: `Create Failed: ${error instanceof Error ? error.message : String(error)}` }, { status: 500 });
+        /* Il messaggio grezzo qui e' quello di drizzle/SQLite: nome di tabella,
+           vincolo violato, a volte il valore. Resta nei log. */
+        return apiInternalError('POST /api/therapies', error);
     }
 }

--- a/lib/api-error-response.ts
+++ b/lib/api-error-response.ts
@@ -1,0 +1,61 @@
+/* WUL-347. Forma d'errore condivisa fra le route legacy e la v1.
+
+   Il problema che risolve non e' l'estetica del contratto: alcune route
+   rimandavano al client il `message` grezzo dell'eccezione, che su questo
+   prodotto puo' contenere percorsi del filesystem, dettagli SQLite e internals
+   di PM2. La UI decifra PHI, quindi ogni dettaglio interno che esce e' superficie
+   in piu' per chi sta gia' guardando.
+
+   La regola e' asimmetrica ed e' il punto di questo modulo: il dettaglio va
+   **loggato** sul server e **non** restituito. Cio' che torna al client e' un
+   messaggio stabile piu' un codice su cui si puo' fare match.
+
+   Non usare questi helper per i messaggi di dominio destinati all'operatore
+   (per esempio il rifiuto di un import AIFA malformato): quelli sono contenuto,
+   non fuga. Per loro esiste apiFailure(), che pretende un codice esplicito. */
+
+import { NextResponse } from 'next/server';
+
+export type ApiErrorBody = {
+    error: string;
+    code: string;
+};
+
+/* Alcune route hanno gia' un contratto d'errore piu' largo (per esempio
+   `success: false` o un blocco `preflight`). L'helper deve accomodarlo invece di
+   imporre una forma nuova, altrimenti non viene adottato e il leak resta dov'e'.
+   Cio' che non e' negoziabile e' l'altra meta': il dettaglio non esce. */
+type CampiExtra = Record<string, unknown>;
+
+const GENERIC_INTERNAL_MESSAGE = 'Errore interno del server.';
+
+/* Errore inatteso: il dettaglio resta nei log del server. `scope` serve a
+   ritrovarlo, ed e' l'unica cosa che il chiamante deve ricordarsi di passare. */
+export function apiInternalError(
+    scope: string,
+    error: unknown,
+    options: { status?: number; code?: string; message?: string; extra?: CampiExtra } = {},
+): NextResponse {
+    console.error(`[MediFlow] ${scope}:`, error);
+    const body: ApiErrorBody & CampiExtra = {
+        ...(options.extra ?? {}),
+        error: options.message ?? GENERIC_INTERNAL_MESSAGE,
+        code: options.code ?? 'internal_error',
+    };
+    const response = NextResponse.json(body, { status: options.status ?? 500 });
+    response.headers.set('Cache-Control', 'no-store');
+    return response;
+}
+
+/* Errore atteso e descrivibile: il messaggio e' contenuto scelto da chi scrive
+   la route, non il testo di un'eccezione. Il codice e' obbligatorio proprio per
+   rendere scomodo passare di qui per pigrizia. */
+export function apiFailure(
+    code: string,
+    message: string,
+    status: number,
+): NextResponse<ApiErrorBody> {
+    const response = NextResponse.json<ApiErrorBody>({ error: message, code }, { status });
+    response.headers.set('Cache-Control', 'no-store');
+    return response;
+}

--- a/package.json
+++ b/package.json
@@ -191,7 +191,9 @@
     "e2e:ai-rollout-readiness": "E2E_SPECS='e2e/ai-rollout-readiness-panel.spec.ts e2e/ai-rollout-guard-settings.spec.ts' bash scripts/e2e-smoke.sh",
     "e2e:ai-rollout-governance": "E2E_SPECS='e2e/ai-rollout-readiness-panel.spec.ts e2e/ai-rollout-guard-settings.spec.ts e2e/patient-insight-kill-switch.spec.ts e2e/smart-import-kill-switch.spec.ts e2e/document-synthesis-kill-switch.spec.ts e2e/treatment-reasoning-kill-switch.spec.ts' bash scripts/e2e-smoke.sh",
     "e2e:fabric-settings": "E2E_SPECS='e2e/settings-fabric.spec.ts' E2E_BASE_URL='http://127.0.0.1:3189' bash scripts/e2e-smoke.sh",
-    "e2e:smoke": "bash scripts/e2e-smoke.sh"
+    "e2e:smoke": "bash scripts/e2e-smoke.sh",
+    "check:api-error-leak": "node scripts/check-api-error-leak.mjs",
+    "test:api-error-leak": "node scripts/check-api-error-leak.mjs --self-test"
   },
   "dependencies": {
     "@firecrawl/pdf-inspector": "1.12.0",

--- a/scripts/check-api-error-leak.mjs
+++ b/scripts/check-api-error-leak.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+
+/* WUL-347. Nessuna route API deve rimandare al client il `message` grezzo di
+   un'eccezione.
+
+   Perche' un guard e non solo una correzione: le route sono 140 e ne nascono di
+   nuove. La correzione di oggi vale un giorno, la regola vale finche' gira.
+
+   Che cosa cerca, e perche' non basta una riga sola. Il caso ovvio e'
+   `NextResponse.json({ error: e.message })`. Quello che sfugge, e che nel repo
+   era la maggioranza, e' l'indiretto:
+
+       const message = error instanceof Error ? error.message : 'Unknown error';
+       return NextResponse.json({ error: message }, { status: 500 });
+
+   Il guard lavora quindi per blocco `catch`: dentro ogni catch traccia le
+   variabili che derivano da `<binding>.message` e segnala se una di quelle, o
+   `.message` direttamente, finisce dentro una risposta.
+
+   Cosa NON e' un leak: un messaggio di dominio scelto da chi scrive la route e
+   destinato all'operatore (per esempio il rifiuto di un import AIFA malformato).
+   Quelli stanno in ALLOWLIST con un motivo scritto, e l'allowlist e' verificata:
+   una voce che non corrisponde piu' a nulla fa fallire il guard invece di
+   restare li' a marcire. */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+const apiRoot = path.join(repoRoot, 'app', 'api');
+
+const ALLOWLIST = [
+    {
+        file: 'app/api/drugs/route.ts',
+        motivo:
+            "Il messaggio proviene da replaceAifaCatalog ed e' una diagnosi di dominio sull'import "
+            + "(file malformato, colonne mancanti), non il testo di un'eccezione di sistema. Rimuoverlo "
+            + 'lascerebbe l\'operatore senza indicazione su un import da centinaia di righe. Status 400, '
+            + 'non 500: e\' un rifiuto, non un guasto.',
+    },
+    {
+        file: 'app/api/siss/context/route.ts',
+        motivo:
+            "Il ramo segnalato e' `error instanceof SissPatientContextError`: una classe di dominio "
+            + 'tipizzata che porta gia' + "' `code`, `correlationId` e `status`. Il suo `message` e' testo "
+            + "d'errore autoriale sul flusso SISS, non il testo di un'eccezione di sistema, e serve "
+            + 'al supporto per correlare il fallimento. Il ramo generico sottostante non lo espone.',
+    },
+    {
+        file: 'app/api/siss/prescription/route.ts',
+        motivo:
+            "Stesso caso di siss/context, con SissPrescriptionError: errore di dominio tipizzato con "
+            + '`code` e `correlationId`, restituito deliberatamente. Il ramo generico sottostante non '
+            + 'espone il messaggio grezzo.',
+    },
+];
+
+const RISPOSTA = /\b(?:NextResponse|Response)\s*\.\s*json\s*\(/g;
+
+function elencaRoute(dir) {
+    const out = [];
+    for (const voce of fs.readdirSync(dir, { withFileTypes: true })) {
+        const p = path.join(dir, voce.name);
+        if (voce.isDirectory()) out.push(...elencaRoute(p));
+        else if (voce.name === 'route.ts') out.push(p);
+    }
+    return out;
+}
+
+/* Ritorna il testo fra la parentesi aperta a `start` e la sua chiusura. */
+function argomento(testo, start) {
+    let profondita = 0;
+    for (let i = start; i < testo.length; i += 1) {
+        const c = testo[i];
+        if (c === '(') profondita += 1;
+        else if (c === ')') {
+            profondita -= 1;
+            if (profondita === 0) return testo.slice(start + 1, i);
+        }
+    }
+    return testo.slice(start);
+}
+
+/* Blocchi catch, con il loro binding e il corpo bilanciato. */
+function blocchiCatch(testo) {
+    const blocchi = [];
+    const re = /catch\s*\(\s*([A-Za-z_$][\w$]*)[^)]*\)\s*\{/g;
+    let m;
+    while ((m = re.exec(testo)) !== null) {
+        const apertura = testo.indexOf('{', m.index + m[0].length - 1);
+        let profondita = 0;
+        let fine = testo.length;
+        for (let i = apertura; i < testo.length; i += 1) {
+            if (testo[i] === '{') profondita += 1;
+            else if (testo[i] === '}') {
+                profondita -= 1;
+                if (profondita === 0) { fine = i; break; }
+            }
+        }
+        blocchi.push({
+            binding: m[1],
+            corpo: testo.slice(apertura, fine),
+            riga: testo.slice(0, m.index).split('\n').length,
+        });
+    }
+    return blocchi;
+}
+
+function analizza(file) {
+    const relativo = path.relative(repoRoot, file).split(path.sep).join('/');
+    const testo = fs.readFileSync(file, 'utf8');
+    const reperti = [];
+
+    for (const blocco of blocchiCatch(testo)) {
+        const { binding, corpo } = blocco;
+
+        /* Variabili che ereditano il messaggio dell'eccezione. */
+        const derivate = new Set();
+        const reDerivata = new RegExp(
+            `(?:const|let|var)\\s+([A-Za-z_$][\\w$]*)\\s*=[^;]*\\b${binding}\\s*\\.\\s*message`,
+            'g',
+        );
+        let d;
+        while ((d = reDerivata.exec(corpo)) !== null) derivate.add(d[1]);
+
+        RISPOSTA.lastIndex = 0;
+        let r;
+        while ((r = RISPOSTA.exec(corpo)) !== null) {
+            const arg = argomento(corpo, RISPOSTA.lastIndex - 1);
+            const diretto = new RegExp(`\\b${binding}\\s*\\.\\s*message\\b`).test(arg);
+            const indiretta = [...derivate].find((v) => new RegExp(`\\b${v}\\b`).test(arg));
+            if (diretto || indiretta) {
+                reperti.push({
+                    file: relativo,
+                    riga: blocco.riga,
+                    via: diretto ? `${binding}.message` : `variabile «${indiretta}» derivata da ${binding}.message`,
+                });
+            }
+        }
+    }
+    return reperti;
+}
+
+const selfTest = process.argv.includes('--self-test');
+
+if (selfTest) {
+    const casi = [
+        { nome: 'diretto', codice: "export async function GET(){try{}catch(e){return NextResponse.json({error:e.message},{status:500})}}", atteso: true },
+        { nome: 'indiretto via const', codice: "export async function GET(){try{}catch(error){const message = error instanceof Error ? error.message : 'x'; return NextResponse.json({error:message},{status:500})}}", atteso: true },
+        { nome: 'template literal', codice: "export async function GET(){try{}catch(error){return NextResponse.json({error:`Fallito: ${error.message}`},{status:500})}}", atteso: true },
+        { nome: 'solo log server', codice: "export async function GET(){try{}catch(error){console.error('x', error.message); return NextResponse.json({error:'Errore interno.'},{status:500})}}", atteso: false },
+        { nome: 'messaggio letterale', codice: "export async function GET(){try{}catch(error){return NextResponse.json({error:'Errore interno.',code:'internal_error'},{status:500})}}", atteso: false },
+        { nome: 'helper', codice: "export async function GET(){try{}catch(error){return apiInternalError('GET /x', error)}}", atteso: false },
+    ];
+    let falliti = 0;
+    const tmp = path.join(repoRoot, '.tmp-api-error-leak-selftest.ts');
+    for (const caso of casi) {
+        fs.writeFileSync(tmp, caso.codice);
+        const trovato = analizza(tmp).length > 0;
+        const ok = trovato === caso.atteso;
+        if (!ok) falliti += 1;
+        console.log(`  ${ok ? 'ok  ' : 'FAIL'}  ${caso.nome} (atteso ${caso.atteso ? 'leak' : 'pulito'}, trovato ${trovato ? 'leak' : 'pulito'})`);
+    }
+    fs.rmSync(tmp, { force: true });
+    if (falliti > 0) { console.error(`\nself-test: ${falliti} caso/i fallito/i`); process.exitCode = 1; }
+    else console.log('\nself-test: tutti i casi passano');
+} else {
+    const route = elencaRoute(apiRoot);
+    const tutti = route.flatMap(analizza);
+    const consentiti = new Set(ALLOWLIST.map((v) => v.file));
+
+    const violazioni = tutti.filter((r) => !consentiti.has(r.file));
+    const usati = new Set(tutti.filter((r) => consentiti.has(r.file)).map((r) => r.file));
+    const stantii = ALLOWLIST.filter((v) => !usati.has(v.file));
+
+    console.log(JSON.stringify({
+        schemaVersion: 'mediflow.api-error-leak.v1',
+        routeAnalizzate: route.length,
+        violazioni,
+        allowlist: ALLOWLIST.map((v) => ({ file: v.file, ancoraNecessaria: usati.has(v.file) })),
+    }, null, 2));
+
+    if (violazioni.length > 0) {
+        console.error('\nLeak di error.message verso il client:');
+        for (const v of violazioni) console.error(`- ${v.file}:${v.riga} — ${v.via}`);
+        console.error('\nUsare apiInternalError() da lib/api-error-response.ts: logga il dettaglio e restituisce un messaggio stabile.');
+        process.exitCode = 1;
+    }
+    if (stantii.length > 0) {
+        console.error('\nVoci di allowlist che non corrispondono piu\' a nulla (rimuoverle):');
+        for (const v of stantii) console.error(`- ${v.file}`);
+        process.exitCode = 1;
+    }
+}


### PR DESCRIPTION
Chiude [WUL-347](https://linear.app/wulfgardr/issue/WUL-347/risposte-di-errore-api-incoerenti-e-leak-di-errormessage).

## Il difetto

Alcune route restituivano al client il `message` dell'eccezione. Su questo prodotto quel testo contiene percorsi del filesystem, vincoli SQLite violati, internals di PM2 e argomenti del runtime MLX — e la UI che li riceve è la stessa che decifra PHI.

## La regola

`lib/api-error-response.ts` la rende esplicita e asimmetrica: **il dettaglio si logga sul server, al client torna un messaggio stabile più un `code`.**

- `apiInternalError(scope, error, …)` per l'inatteso;
- `apiFailure(code, message, status)` per gli errori di dominio — il codice è obbligatorio, così passare di lì per pigrizia è scomodo.

L'helper accetta `extra` perché alcune route hanno già un contratto più largo (`success: false`, `preflight`): imporre una forma nuova avrebbe significato non farlo adottare, e il leak sarebbe rimasto dov'era.

## Otto occorrenze corrette in sette route

`system/mlx` (×3), `therapies`, `system/native`, `system/backup-restore`, `ocr/extract`, `system/backup-scheduler`, `system/treatment-reasoning/athena-mlx`.

In `backup-restore` la distinzione 400/500 su `SyntaxError` resta — un artefatto malformato è colpa del chiamante, il resto no — e resta `success: false`, che la route usa anche negli altri due rami d'errore.

## Il guard è la parte che dura

Le route sono **140** e ne nascono altre: la correzione di oggi vale un giorno, la regola vale finché gira.

`scripts/check-api-error-leak.mjs` lavora per blocco `catch` e traccia anche l'indiretto:

```ts
const message = error instanceof Error ? error.message : 'x';
return NextResponse.json({ error: message }, { status: 500 });
```

che nel repo era la forma **maggioritaria**. Infatti il guard ha trovato **cinque leak che la ricerca manuale aveva mancato** (`ocr/extract`, `backup-scheduler`, `athena-mlx`, e i due SISS poi riconosciuti legittimi).

## Tre casi in allowlist, con motivo

Non sono fughe ma contenuto:

| route | perché |
|---|---|
| `drugs` | diagnosi di dominio su un import AIFA malformato — 400, non 500. Genericizzarla lascerebbe l'operatore senza indicazione su un file da centinaia di righe |
| `siss/context`, `siss/prescription` | errore **tipizzato** (`SissPatientContextError` / `SissPrescriptionError`) con `code`, `correlationId` e `status`, di cui il supporto ha bisogno per correlare. Il ramo generico sottostante non espone nulla |

L'allowlist è verificata: una voce che non corrisponde più a nulla **fa fallire il guard** invece di restare a marcire.

## Agganciato a CI

Aggiunto a `Repository Guards` con il proprio `--self-test`. Un guard nuovo che non gira nascerebbe già orfano — e il repo ne ha già sette in quella condizione.

## Falsificazione

| prova | esito |
|---|---|
| leak reintrodotto in `therapies` | intercettato |
| voce di allowlist resa stantia | intercettata |
| self-test: diretto, indiretto via `const`, template literal | tutti e tre segnalati |
| self-test: log server-side, messaggio letterale, helper | nessun falso allarme |

## Gate

`check:api-error-leak` (+self-test), `check:claims`, `check:never-regress`, `check:schema-writers`, `check:ai-clinical-writes`, `check:mlx-operational-parity`, `check:lume-tokens`, `check:openapi:drift`, `lint`, `typecheck` — verdi.
Test: `api-schemas`, `api-v1-contract-negative`, `legacy-clinical-writes`, `backup-scheduler` — verdi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)