### PR TITLE
Cabla in CI i tre gate davvero orfani (WUL-543)

### DIFF
--- a/.github/workflows/apple-native.yml
+++ b/.github/workflows/apple-native.yml
@@ -49,7 +49,18 @@ jobs:
       - name: Generate project + guards (structure + entitlements)
         run: scripts/generate-apple-xcodeproj.sh
       - name: SwiftPM tests
-        run: scripts/native-test.sh
+        run: |
+          set -o pipefail
+          scripts/native-test.sh 2>&1 | tee "${RUNNER_TEMP}/swiftpm-tests.log"
+
+      # Terza fase di `npm run check:terminology-parity`, sull'output della run
+      # appena fatta invece che su un secondo `swift test --filter`: su un runner
+      # macOS fatturato 10x la riesecuzione costerebbe due minuti per riasserire
+      # test già girati. Le altre due fasi del gate girano altrove — la prima in
+      # web-core.yml via test:unit, la seconda in e2e.yml.
+      - name: Terminology parity, i quattro test Apple sono passati per nome
+        if: ${{ !cancelled() }}
+        run: scripts/assert-apple-terminology-tests.sh "${RUNNER_TEMP}/swiftpm-tests.log"
       - name: Build macOS app
         run: |
           xcodebuild -project native/MediFlowAppleApp/MediFlowAppleApp.xcodeproj \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -83,6 +83,15 @@ jobs:
       - name: Run Playwright suite
         run: npx playwright test --workers=1
 
+      # Seconda fase di `npm run check:terminology-parity`, l'unica che non
+      # girava da nessuna parte. Avvia un proprio Next dev su 127.0.0.1:3200 in
+      # un workspace effimero, quindi non tocca il server e2e sulla 3123. Sta
+      # qui e non in Repository Guards perché avviare un server è esattamente
+      # ciò che questo workflow fa già, e Repository Guards deve restare
+      # deterministico e veloce.
+      - name: Lettura catalogo home-base, smoke paired e capability-gated
+        run: npm run test:network:home-base-catalog-read
+
       - name: Stop Next.js dev server
         if: always()
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -89,7 +89,14 @@ jobs:
       # qui e non in Repository Guards perché avviare un server è esattamente
       # ciò che questo workflow fa già, e Repository Guards deve restare
       # deterministico e veloce.
+      # E2E_BASE_URL va riscritto per questo step: il job lo fissa a :3123 per
+      # Playwright, ma lo smoke legge la stessa variabile per decidere su quale
+      # porta avviare il PROPRIO server (`${E2E_BASE_URL:-…:3200}`). Ereditando
+      # :3123 tenta di occupare una porta già presa e muore in attesa di
+      # readiness. Il default dello script è 3200: qui va reso esplicito.
       - name: Lettura catalogo home-base, smoke paired e capability-gated
+        env:
+          E2E_BASE_URL: http://127.0.0.1:3200
         run: npm run test:network:home-base-catalog-read
 
       - name: Stop Next.js dev server

--- a/.github/workflows/openapi-contract-guard.yml
+++ b/.github/workflows/openapi-contract-guard.yml
@@ -46,6 +46,20 @@ jobs:
       - name: Never-regress guard
         if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: npm run check:never-regress
+
+      # Puro fs.readFileSync su cinque file: nessuna rete, nessun DB, nessuna
+      # toolchain, ~150 ms. È a contatori espliciti, quindi si romperà a ogni
+      # aggiunta legittima di una capability — è il comportamento voluto, come
+      # per check:lume-tokens, non un difetto da scoprire dopo.
+      - name: Apple wide QA manifest guard
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
+        run: npm run check:apple-wide-qa
+
+      # Otto controlli di presenza che fissano il confine «MLX è benchmark-visible,
+      # non runtime clinico». Non richiede MLX, né Ollama, né socket: ~150 ms.
+      - name: MLX operational parity guard
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
+        run: npm run check:mlx-operational-parity
       - name: OpenAPI contract guard
         if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: npm run check:openapi:drift -- --base-ref origin/main

--- a/scripts/assert-apple-terminology-tests.sh
+++ b/scripts/assert-apple-terminology-tests.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Asserisce che i quattro test Apple di parità terminologica risultino 'passed'
+# per NOME nell'output di `swift test`, invece di fidarsi del suo exit code.
+#
+# È l'unica parte del gate di parità che una run full-suite non fa: un verde
+# complessivo dice che nessun test è fallito, non che questi quattro siano
+# girati. Se uno viene rinominato o cancellato, `swift test` resta verde e solo
+# questa asserzione se ne accorge.
+#
+# Uso: assert-apple-terminology-tests.sh <file-con-l-output-di-swift-test>
+#
+# Estratto da check-terminology-parity.sh perché la CI ha già l'output di una
+# run completa (apple-native.yml) e rieseguire `swift test --filter` su un
+# runner macOS fatturato 10x sarebbe una duplicazione da due minuti.
+
+if [[ $# -ne 1 ]]; then
+  printf 'uso: %s <file-con-l-output-di-swift-test>\n' "${0##*/}" >&2
+  exit 2
+fi
+
+OUTPUT_FILE="$1"
+
+if [[ ! -f "$OUTPUT_FILE" ]]; then
+  printf 'Output di swift test non trovato: %s\n' "$OUTPUT_FILE" >&2
+  exit 1
+fi
+
+REQUIRED_TESTS=(
+  "HomeBasePatientsClientTests/testFetchTerminologySystemsUsesNetworkRouteAndTolerantDateDecode"
+  "HomeBasePatientsClientTests/testResolveTerminologyUsesNetworkRouteAndDecodesOpenAPIShape"
+  "HomeBasePatientsClientTests/testSearchTerminologyUsesNetworkRouteQueryAndDecodesOpenAPIShape"
+  "TerminologyParityContractTests/testSharedFixtureDecodesCanonicalTerminologyContract"
+)
+
+missing=0
+for expected in "${REQUIRED_TESTS[@]}"; do
+  test_case="${expected%%/*} ${expected#*/}]' passed"
+  if grep -Fq "$test_case" "$OUTPUT_FILE"; then
+    printf 'ok   %s\n' "$expected"
+  else
+    printf 'MANCA  test Apple di terminologia non passato: %s\n' "$expected" >&2
+    missing=$((missing + 1))
+  fi
+done
+
+if [[ "$missing" -gt 0 ]]; then
+  printf '\n%d test richiesti su %d non risultano passati.\n' "$missing" "${#REQUIRED_TESTS[@]}" >&2
+  exit 1
+fi
+
+printf '\nParità terminologica Apple: %d/%d test richiesti passati per nome.\n' \
+  "${#REQUIRED_TESTS[@]}" "${#REQUIRED_TESTS[@]}"

--- a/scripts/check-terminology-parity.sh
+++ b/scripts/check-terminology-parity.sh
@@ -15,19 +15,15 @@ node "$ROOT_DIR/scripts/run-strip-types.mjs" --test \
   "$ROOT_DIR/lib/drug-autocomplete-search.test.ts"
 bash "$ROOT_DIR/scripts/network-home-base-catalog-read-smoke.sh"
 
-if ! APPLE_TEST_OUTPUT="$(swift test --package-path "$ROOT_DIR/native/MediFlowMac" --filter Terminology 2>&1)"; then
-  printf '%s\n' "$APPLE_TEST_OUTPUT" >&2
+APPLE_TEST_LOG="$(mktemp -t mediflow-terminology-parity)"
+trap 'rm -f "$APPLE_TEST_LOG"' EXIT
+
+if ! swift test --package-path "$ROOT_DIR/native/MediFlowMac" --filter Terminology >"$APPLE_TEST_LOG" 2>&1; then
+  cat "$APPLE_TEST_LOG" >&2
   exit 1
 fi
-printf '%s\n' "$APPLE_TEST_OUTPUT"
-for expected in \
-  "HomeBasePatientsClientTests/testFetchTerminologySystemsUsesNetworkRouteAndTolerantDateDecode" \
-  "HomeBasePatientsClientTests/testResolveTerminologyUsesNetworkRouteAndDecodesOpenAPIShape" \
-  "HomeBasePatientsClientTests/testSearchTerminologyUsesNetworkRouteQueryAndDecodesOpenAPIShape" \
-  "TerminologyParityContractTests/testSharedFixtureDecodesCanonicalTerminologyContract"; do
-  test_case="${expected%%/*} ${expected#*/}]' passed"
-  if ! grep -Fq "$test_case" <<<"$APPLE_TEST_OUTPUT"; then
-    printf 'Required Apple terminology test did not pass: %s\n' "$expected" >&2
-    exit 1
-  fi
-done
+cat "$APPLE_TEST_LOG"
+
+# L'elenco dei quattro test vive in un solo posto: la CI riusa lo stesso script
+# sull'output della run completa, invece di rieseguire `swift test --filter`.
+bash "$ROOT_DIR/scripts/assert-apple-terminology-tests.sh" "$APPLE_TEST_LOG"


### PR DESCRIPTION
`mediflow-handover-20260809.md` §5 dice *«sette guard su quindici non girano in CI»*. Misurato: **sono tre**. Il criterio «il nome npm non compare in `.github/workflows/`» misura il cablaggio, non la copertura.

| gate | come gira già |
|---|---|
| `check:node-runtime` | `preinstall`/`postinstall`/`predev`/`prebuild`/`prestart` (`package.json:9,10,11,15,18`): a ogni `npm ci` e a ogni build. È il check più eseguito del repo. |
| `check:standalone-runtime-bundle` | seconda metà di `postbuild` (`package.json:17`) → `web-core.yml:24`, `cross-platform.yml:37` su tutta la matrice OS. |
| `check:schema-drift` | `scripts/check-schema-drift.test.ts:15` fa `spawnSync` del gate reale sul repo reale, dentro `test:unit` → `web-core.yml:28`. |
| `check:audit-quality-gate` | `scripts/audit-quality-gate.test.mjs:94` lo esegue su una fixture popolata con copie dei file reali (righe 78-93), exit 0 e zero findings preteso. Idem via `test:unit`. |

## I tre veri orfani, misurati

| gate | exit | durata | prerequisiti |
|---|---|---|---|
| `check:apple-wide-qa` | 0 | ~150 ms | nessuno |
| `check:mlx-operational-parity` | 0 | ~150 ms | nessuno, nemmeno `node_modules` |
| `check:terminology-parity` | 1 | 6,4 s | Xcode completo; muore alla fase 3 |

E anche il terzo è coperto per due terzi: la fase 1 rientra nel glob di `test:unit`, i quattro test Swift della fase 3 sono già fra i 560 di `apple-native.yml`.

## Cosa cambia

**`Repository Guards`** — i due a costo nullo. Restano deterministici: nessuna rete, nessun DB, nessuna toolchain.

**`E2E (Playwright)`** — la fase 2 di terminology-parity (`network-home-base-catalog-read-smoke.sh`), l'unica parte che non girava da nessuna parte. Sta qui e non in Repository Guards perché avvia un Next dev server sulla 3200, e Repository Guards deve restare veloce e deterministico per poter diventare un required check. Non collide con il server e2e sulla 3123.

**`Apple Native`** — l'asserzione **per nome** dei quattro test di terminologia, sull'output della run già fatta. È l'unica parte della fase 3 che una run full-suite non fa: un verde complessivo dice che nessun test è fallito, non che *questi quattro* siano girati. Se uno viene rinominato o cancellato, `swift test` resta verde e solo l'asserzione se ne accorge.

Non c'è un secondo `swift test --filter`: su un runner macOS fatturato 10x costerebbe due minuti per riasserire test già eseguiti. L'elenco dei quattro nomi è estratto in `scripts/assert-apple-terminology-tests.sh`, chiamato sia dal gate locale sia dalla CI, così vive in un solo posto.

## Falsificazione

I due guard nuovi in Repository Guards, prima di proporli:

- `apple-wide-qa` → exit 1 se si toglie una capability, se si ribalta `covered`→`gap`, se si rinomina una chiave di rete. I tre confronti incrociati contro `lib/network-contract.ts`, `lib/api/v1/types.ts` e `docs/openapi/mediflow-v1.yaml` rispondono davvero: non passa a vuoto.
- `mlx-operational-parity` → exit 1 se si neutralizza il `throw` fail-closed in `lib/ai-providers/registry.ts`, se si toglie WUL-165 da `docs/mlx-operational-parity.md`, se si cancella il file.

L'asserzione nuova, tre modi:

```
test rinominato          → exit 1  (suite comunque verde)
passed che diventa failed → exit 1
log assente              → exit 1
```

## Caveat da accettare consapevolmente

`check:apple-wide-qa` è a contatori espliciti: 66/30/13/0/23 (righe 16-23), esattamente 24 capability (riga 183), 25+2+2 chiavi (riga 162). **Si romperà a ogni aggiunta legittima di una capability**, in entrambe le direzioni — lo stesso comportamento già noto di `check:lume-tokens`. Entra in CI sapendo che è il suo comportamento voluto, non un difetto da scoprire dopo.

Closes WUL-543.

🤖 Generated with [Claude Code](https://claude.com/claude-code)