### PR TITLE
Tre guard non vedevano ciò che dichiarano, due non giravano (WUL-547)

### DIFF
--- a/.github/workflows/openapi-contract-guard.yml
+++ b/.github/workflows/openapi-contract-guard.yml
@@ -65,3 +65,17 @@ jobs:
         run: |
           npm run check:openapi:drift -- --base-ref origin/main
           npm run check:openapi:drift -- --self-test
+
+      # WUL-547. Questi due gate non giravano in nessun workflow, e l'orfanità era
+      # invisibile per una ragione precisa: entrambi hanno un unit test che invoca il
+      # gate REALE (`check-schema-drift.test.ts:15` via spawnSync,
+      # `audit-quality-gate.test.mjs:94` su fixture), quindi risultavano coperti a
+      # chiunque contasse «il gate compare in test:unit». Ma quei test asseriscono il
+      # comportamento del gate su fixture, non lo stato di QUESTO repo: sono due
+      # domande diverse, e solo la seconda intercetta una deriva reale.
+      - name: Schema drift guard
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
+        run: npm run check:schema-drift
+      - name: Audit quality gate
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
+        run: npm run check:audit-quality-gate

--- a/app/api/auth/check/route.ts
+++ b/app/api/auth/check/route.ts
@@ -42,11 +42,16 @@ async function safeRequireSession(): Promise<boolean> {
 export async function GET() {
     /* @Codex */
     let dbHealth: ReturnType<typeof getDbHealth> | null = null;
-    let dbHealthError: string | null = null;
+    /* WUL-547. Qui passava `error.message` grezzo: percorsi del filesystem e
+       internals SQLite finivano nella risposta. Il ramo generico piu' sotto usava
+       gia' il classificatore; questo no, ed era l'unico che non lo faceva.
+       Il dettaglio resta nel log, al client va il messaggio autoriale. */
+    let dbHealthClassification: ReturnType<typeof classifyAuthHealthError> | null = null;
     try {
         dbHealth = getDbHealth();
     } catch (error) {
-        dbHealthError = error instanceof Error ? error.message : 'Unknown error';
+        dbHealthClassification = classifyAuthHealthError(error);
+        console.error('[auth-check]', dbHealthClassification.code, dbHealthClassification.message);
     }
     /* @Codex */
     const hasSession = await safeRequireSession();
@@ -56,10 +61,13 @@ export async function GET() {
             status: 'error',
             isSetup: false,
             hasSession,
+            /* `code`, `category` e `dbState` restano i valori stabili di prima: il
+               client Apple decodifica questa risposta con tipi non opzionali, e la
+               correzione del leak non e' il posto per cambiare il contratto. */
             error: {
                 code: 'DATA_DIR_UNAVAILABLE',
                 category: 'data-dir-unavailable',
-                message: dbHealthError || 'Data directory unavailable.',
+                message: dbHealthClassification?.message ?? 'Data directory unavailable.',
                 nextAction: 'Verify that the data directory exists and is writable, then retry.'
             },
             db: buildPublicDbState('unavailable')

--- a/app/api/settings/route.ts
+++ b/app/api/settings/route.ts
@@ -10,6 +10,7 @@ import { auditContextFromRequest, listChangedFields, requestIdFromRequest, withA
 import { normalizeSettingValue } from '@/lib/settings-value';
 /* @Codex */
 import { evaluateSettingsWrite } from '@/lib/security/settings-write-policy';
+import { apiInternalError } from '@/lib/api-error-response';
 
 export async function POST(request: Request) {
     /* @Codex */
@@ -64,9 +65,10 @@ export async function POST(request: Request) {
 
         return NextResponse.json({ success: true, key, value: persistedValue });
     } catch (error) {
-        console.error("POST Setting Error:", error);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const msg = (error as any)?.message || String(error);
-        return NextResponse.json({ error: `Failed to save setting: ${msg}` }, { status: 500 });
+        /* WUL-547. Qui il `message` grezzo dell'eccezione usciva verso il client
+           dentro un template literal, e il guard non lo vedeva perche' il cast
+           `(error as any)?` spezzava il match. apiInternalError() logga il
+           dettaglio e restituisce un messaggio stabile con un codice. */
+        return apiInternalError('POST /api/settings', error);
     }
 }

--- a/scripts/check-ai-clinical-write-gate.mjs
+++ b/scripts/check-ai-clinical-write-gate.mjs
@@ -52,8 +52,18 @@ const AI_PATH_GLOBS = [
     { dir: 'lib', prefix: 'patient-insight' },
     { dir: 'lib', prefix: 'patient-smart-import' },
     { dir: 'lib', prefix: 'treatment-reasoning' },
-    { dir: 'lib/ai-providers', prefix: '' },
-    { dir: 'lib/domain/documents', prefix: '' },
+    /* WUL-547. Queste due voci non filtrano per nome: dichiarano «questa directory È il
+       percorso AI». La discesa deve quindi essere ricorsiva. Non lo era, e i 13 moduli
+       non-test di `lib/ai-providers/fabric` restavano fuori: il gate stampava «75 file
+       sul percorso AI» su un insieme che è di 88. Oggi lì non ci sono scritture su tabelle
+       cliniche, solo `Set.add`, quindi nessun finding era sfuggito — ma un perimetro
+       dichiarato più grande di quello ispezionato è verde per il motivo sbagliato, ed è
+       la forma esatta di WUL-542.
+
+       Le voci con `prefix` restano piatte di proposito: il prefisso filtra il basename, e
+       ricorrere su tutto `lib/` (276 file in radice) tirerebbe dentro omonimi estranei. */
+    { dir: 'lib/ai-providers', prefix: '', ricorsiva: true },
+    { dir: 'lib/domain/documents', prefix: '', ricorsiva: true },
 ];
 
 // I soli campi di `patients` che il percorso AI può scrivere: proiezioni derivate e
@@ -156,14 +166,22 @@ function parse(relativePath, source) {
 
 function aiPathFiles() {
     const files = [];
-    for (const { dir, prefix } of AI_PATH_GLOBS) {
+    for (const { dir, prefix, ricorsiva } of AI_PATH_GLOBS) {
         const absolute = path.join(ROOT, dir);
         if (!fs.existsSync(absolute)) continue;
-        for (const name of fs.readdirSync(absolute)) {
+        const voci = fs.readdirSync(absolute, {
+            recursive: Boolean(ricorsiva),
+            withFileTypes: true,
+        });
+        for (const voce of voci) {
+            if (!voce.isFile()) continue;
+            const { name } = voce;
             if (!name.endsWith('.ts') && !name.endsWith('.tsx')) continue;
             if (name.includes('.test.') || name.includes('.fixtures.')) continue;
             if (!name.startsWith(prefix)) continue;
-            files.push(path.posix.join(dir, name));
+            /* Con `recursive` il file puo' stare in una sottodirectory: `parentPath` la porta. */
+            const relativa = path.relative(absolute, path.join(voce.parentPath ?? absolute, name));
+            files.push(path.posix.join(dir, relativa.split(path.sep).join('/')));
         }
     }
     return [...new Set(files)].sort();

--- a/scripts/check-api-error-leak.mjs
+++ b/scripts/check-api-error-leak.mjs
@@ -26,6 +26,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..');
@@ -145,6 +146,67 @@ function normalizza(testo, binding) {
         .replace(new RegExp(`\\b${b}\\s*\\?\\s*\\.`, 'g'), `${binding}.`);
 }
 
+/* @Codex: determina se un'assegnazione senza declarator risolve a un binding
+   lessicale del catch. L'AST distingue gli scope annidati e ignora testo che
+   sembra codice dentro commenti o stringhe. */
+function usaBindingLocaleCatch(corpo, nome, posizione) {
+    const prefisso = 'try {} catch (__errore) ';
+    const sorgente = ts.createSourceFile(
+        'catch-scope.ts',
+        `${prefisso}${corpo}`,
+        ts.ScriptTarget.Latest,
+        true,
+        ts.ScriptKind.TS,
+    );
+    const clausola = sorgente.statements.find(ts.isTryStatement)?.catchClause;
+    if (!clausola) return false;
+
+    const punto = prefisso.length + posizione;
+    let nodoPiuProfondo = clausola.block;
+    const trovaNodo = (nodo) => {
+        if (nodo.pos <= punto && punto < nodo.end) {
+            nodoPiuProfondo = nodo;
+            ts.forEachChild(nodo, trovaNodo);
+        }
+    };
+    trovaNodo(clausola.block);
+
+    const scopeAttivi = new Set();
+    for (let nodo = nodoPiuProfondo; nodo; nodo = nodo.parent) {
+        if (
+            ts.isBlock(nodo)
+            || ts.isForStatement(nodo)
+            || ts.isForInStatement(nodo)
+            || ts.isForOfStatement(nodo)
+        ) scopeAttivi.add(nodo);
+        if (nodo === clausola.block) break;
+    }
+
+    let locale = false;
+    const visita = (nodo) => {
+        if (locale) return;
+        if (ts.isVariableDeclaration(nodo) && ts.isIdentifier(nodo.name) && nodo.name.text === nome) {
+            const lista = nodo.parent;
+            const lessicale = ts.isVariableDeclarationList(lista)
+                && (lista.flags & (ts.NodeFlags.Let | ts.NodeFlags.Const)) !== 0;
+            if (lessicale) {
+                let scope = lista.parent;
+                while (
+                    scope
+                    && !ts.isBlock(scope)
+                    && !ts.isForStatement(scope)
+                    && !ts.isForInStatement(scope)
+                    && !ts.isForOfStatement(scope)
+                ) scope = scope.parent;
+                if (scope && scopeAttivi.has(scope)) locale = true;
+            }
+        }
+        ts.forEachChild(nodo, visita);
+    };
+    visita(clausola.block);
+    return locale;
+}
+
 /* Blocchi catch, con il loro binding e il corpo bilanciato. */
 function blocchiCatch(testo) {
     const blocchi = [];
@@ -177,23 +239,33 @@ function analizza(file) {
            facoltativo: `dbHealthError = error.message`, su una variabile dichiarata
            fuori dal catch, e' la forma che sfuggiva. */
         const derivate = new Set();
+        /* @Codex: separa i binding che sopravvivono alla chiusura del catch. */
+        const derivateVisibiliInCoda = new Set();
         const reDerivata = new RegExp(
-            `(?:(?:const|let|var)\\s+)?([A-Za-z_$][\\w$]*)\\s*=[^;=]*\\b${binding}\\s*\\.\\s*message`,
+            `(?:(const|let|var)\\s+)?([A-Za-z_$][\\w$]*)\\s*=[^;=]*\\b${binding}\\s*\\.\\s*message`,
             'g',
         );
         let d;
-        while ((d = reDerivata.exec(corpo)) !== null) derivate.add(d[1]);
+        while ((d = reDerivata.exec(corpo)) !== null) {
+            const nome = d[2];
+            derivate.add(nome);
+            /* Solo un'assegnazione a un binding non dichiarato nel catch puo'
+               sopravvivere alla chiusura del blocco. */
+            const dichiarataQui = d[1] === 'const' || d[1] === 'let';
+            const localeCatch = !d[1] && usaBindingLocaleCatch(corpo, nome, d.index);
+            if (!dichiarataQui && !localeCatch) derivateVisibiliInCoda.add(nome);
+        }
 
         const contenitore = handler.find((h) => inizio >= h.inizio && fine <= h.fine);
         const coda = contenitore ? normalizza(testo.slice(fine, contenitore.fine), binding) : '';
 
-        const cerca = (regione, ammettiDiretto) => {
+        const cerca = (regione, ammettiDiretto, nomiDerivati) => {
             const re = new RegExp(RISPOSTA.source, 'g');
             while (re.exec(regione) !== null) {
                 const arg = argomento(regione, re.lastIndex - 1);
                 const diretto = ammettiDiretto
                     && new RegExp(`\\b${binding}\\s*\\.\\s*message\\b`).test(arg);
-                const indiretta = [...derivate].find((v) => new RegExp(`\\b${v}\\b`).test(arg));
+                const indiretta = [...nomiDerivati].find((v) => new RegExp(`\\b${v}\\b`).test(arg));
                 if (diretto || indiretta) {
                     reperti.push({
                         file: relativo,
@@ -206,9 +278,9 @@ function analizza(file) {
             }
         };
 
-        cerca(corpo, true);
+        cerca(corpo, true, derivate);
         /* Fuori dal catch il binding non e' piu' in scope: solo le derivate. */
-        cerca(coda, false);
+        cerca(coda, false, derivateVisibiliInCoda);
     }
     return reperti;
 }
@@ -240,6 +312,11 @@ if (selfTest) {
         /* Confine della ricerca oltre il catch: una variabile omonima in un ALTRO
            handler dello stesso file non deve essere attribuita a questo catch. */
         { nome: 'variabile omonima in un altro handler', codice: "export async function GET(){try{}catch(error){const msg = error.message; console.error(msg)}}\nexport async function POST(){const msg = 'Richiesta non valida.'; return NextResponse.json({error:msg},{status:400})}", atteso: false },
+        /* @Codex: falsificatori per lo scope lessicale della ricerca in coda. */
+        { nome: 'variabile locale al catch ombreggiata nella coda', codice: "export async function GET(){try{}catch(error){const message = error.message; console.error(message)} const message = 'Errore interno.'; return NextResponse.json({error:message},{status:500})}", atteso: false },
+        { nome: 'assegnazione a locale dichiarata prima nel catch', codice: "export async function GET(){try{}catch(error){let message; message = error.message; console.error(message)} const message = 'Errore interno.'; return NextResponse.json({error:message},{status:500})}", atteso: false },
+        { nome: 'binding annidato non nasconde assegnazione esterna', codice: "export async function GET(){let message; try{}catch(error){message = error.message; if (debug) { const message = 'solo log'; console.error(message) }} return NextResponse.json({error:message},{status:500})}", atteso: true },
+        { nome: 'commenti e stringhe non dichiarano binding', codice: "export async function GET(){let message; try{}catch(error){message = error.message; console.error('const message = sicuro'); /* let message */} return NextResponse.json({error:message},{status:500})}", atteso: true },
     ];
     let falliti = 0;
     const tmp = path.join(repoRoot, '.tmp-api-error-leak-selftest.ts');

--- a/scripts/check-api-error-leak.mjs
+++ b/scripts/check-api-error-leak.mjs
@@ -83,6 +83,68 @@ function argomento(testo, start) {
     return testo.slice(start);
 }
 
+/* Indice della graffa che chiude quella aperta in `apertura`. */
+function fineBlocco(testo, apertura) {
+    let profondita = 0;
+    for (let i = apertura; i < testo.length; i += 1) {
+        if (testo[i] === '{') profondita += 1;
+        else if (testo[i] === '}') {
+            profondita -= 1;
+            if (profondita === 0) return i;
+        }
+    }
+    return testo.length;
+}
+
+/* Indice della parentesi che chiude quella aperta in `start`. */
+function chiusuraParen(testo, start) {
+    let profondita = 0;
+    for (let i = start; i < testo.length; i += 1) {
+        if (testo[i] === '(') profondita += 1;
+        else if (testo[i] === ')') {
+            profondita -= 1;
+            if (profondita === 0) return i;
+        }
+    }
+    return testo.length;
+}
+
+/* WUL-547. Estensione della regione di ricerca oltre il corpo del catch: una
+   variabile dichiarata fuori e assegnata dentro sopravvive al blocco, e la
+   risposta che la espone puo' stare dopo — e' la forma di
+   `app/api/auth/check/route.ts`, invisibile finche' si guardava il solo corpo.
+
+   La ricerca si ferma pero' alla fine dell'handler che contiene il catch. Senza
+   quel confine una variabile omonima in un altro handler dello stesso file
+   diventerebbe un falso positivo, e `msg`/`message` sono nomi comuni. */
+function handlerSpans(testo) {
+    const spans = [];
+    const re = /\bexport\s+(?:async\s+)?function\s+[A-Za-z_$][\w$]*\s*\(/g;
+    while (re.exec(testo) !== null) {
+        /* La lista parametri puo' contenere `{` (destructuring): si salta alla sua
+           parentesi di chiusura prima di cercare la graffa del corpo. */
+        const apertura = testo.indexOf('{', chiusuraParen(testo, re.lastIndex - 1));
+        if (apertura === -1) continue;
+        spans.push({ inizio: apertura, fine: fineBlocco(testo, apertura) });
+    }
+    return spans;
+}
+
+/* WUL-547. Fra il binding e `.message` possono stare un cast, un `!` di non-null
+   assertion e un `?.`: tre forme che non cambiano il valore letto ma spezzavano
+   il match, ed erano vive in `app/api/settings/route.ts`.
+
+   La normalizzazione e' ancorata al binding, quindi non tocca
+   `classification.message` ne' `result.message`, che non sono l'eccezione grezza
+   e non devono diventare falsi positivi. */
+function normalizza(testo, binding) {
+    const b = binding.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return testo
+        .replace(new RegExp(`\\(\\s*${b}\\s+as\\s+[^()]*\\)`, 'g'), binding)
+        .replace(new RegExp(`\\b${b}\\s*!`, 'g'), binding)
+        .replace(new RegExp(`\\b${b}\\s*\\?\\s*\\.`, 'g'), `${binding}.`);
+}
+
 /* Blocchi catch, con il loro binding e il corpo bilanciato. */
 function blocchiCatch(testo) {
     const blocchi = [];
@@ -90,18 +152,10 @@ function blocchiCatch(testo) {
     let m;
     while ((m = re.exec(testo)) !== null) {
         const apertura = testo.indexOf('{', m.index + m[0].length - 1);
-        let profondita = 0;
-        let fine = testo.length;
-        for (let i = apertura; i < testo.length; i += 1) {
-            if (testo[i] === '{') profondita += 1;
-            else if (testo[i] === '}') {
-                profondita -= 1;
-                if (profondita === 0) { fine = i; break; }
-            }
-        }
         blocchi.push({
             binding: m[1],
-            corpo: testo.slice(apertura, fine),
+            inizio: apertura,
+            fine: fineBlocco(testo, apertura),
             riga: testo.slice(0, m.index).split('\n').length,
         });
     }
@@ -113,32 +167,48 @@ function analizza(file) {
     const testo = fs.readFileSync(file, 'utf8');
     const reperti = [];
 
-    for (const blocco of blocchiCatch(testo)) {
-        const { binding, corpo } = blocco;
+    const handler = handlerSpans(testo);
 
-        /* Variabili che ereditano il messaggio dell'eccezione. */
+    for (const blocco of blocchiCatch(testo)) {
+        const { binding, inizio, fine } = blocco;
+        const corpo = normalizza(testo.slice(inizio, fine), binding);
+
+        /* Variabili che ereditano il messaggio dell'eccezione. Il declarator e'
+           facoltativo: `dbHealthError = error.message`, su una variabile dichiarata
+           fuori dal catch, e' la forma che sfuggiva. */
         const derivate = new Set();
         const reDerivata = new RegExp(
-            `(?:const|let|var)\\s+([A-Za-z_$][\\w$]*)\\s*=[^;]*\\b${binding}\\s*\\.\\s*message`,
+            `(?:(?:const|let|var)\\s+)?([A-Za-z_$][\\w$]*)\\s*=[^;=]*\\b${binding}\\s*\\.\\s*message`,
             'g',
         );
         let d;
         while ((d = reDerivata.exec(corpo)) !== null) derivate.add(d[1]);
 
-        RISPOSTA.lastIndex = 0;
-        let r;
-        while ((r = RISPOSTA.exec(corpo)) !== null) {
-            const arg = argomento(corpo, RISPOSTA.lastIndex - 1);
-            const diretto = new RegExp(`\\b${binding}\\s*\\.\\s*message\\b`).test(arg);
-            const indiretta = [...derivate].find((v) => new RegExp(`\\b${v}\\b`).test(arg));
-            if (diretto || indiretta) {
-                reperti.push({
-                    file: relativo,
-                    riga: blocco.riga,
-                    via: diretto ? `${binding}.message` : `variabile «${indiretta}» derivata da ${binding}.message`,
-                });
+        const contenitore = handler.find((h) => inizio >= h.inizio && fine <= h.fine);
+        const coda = contenitore ? normalizza(testo.slice(fine, contenitore.fine), binding) : '';
+
+        const cerca = (regione, ammettiDiretto) => {
+            const re = new RegExp(RISPOSTA.source, 'g');
+            while (re.exec(regione) !== null) {
+                const arg = argomento(regione, re.lastIndex - 1);
+                const diretto = ammettiDiretto
+                    && new RegExp(`\\b${binding}\\s*\\.\\s*message\\b`).test(arg);
+                const indiretta = [...derivate].find((v) => new RegExp(`\\b${v}\\b`).test(arg));
+                if (diretto || indiretta) {
+                    reperti.push({
+                        file: relativo,
+                        riga: blocco.riga,
+                        via: diretto
+                            ? `${binding}.message`
+                            : `variabile «${indiretta}» derivata da ${binding}.message`,
+                    });
+                }
             }
-        }
+        };
+
+        cerca(corpo, true);
+        /* Fuori dal catch il binding non e' piu' in scope: solo le derivate. */
+        cerca(coda, false);
     }
     return reperti;
 }
@@ -153,6 +223,23 @@ if (selfTest) {
         { nome: 'solo log server', codice: "export async function GET(){try{}catch(error){console.error('x', error.message); return NextResponse.json({error:'Errore interno.'},{status:500})}}", atteso: false },
         { nome: 'messaggio letterale', codice: "export async function GET(){try{}catch(error){return NextResponse.json({error:'Errore interno.',code:'internal_error'},{status:500})}}", atteso: false },
         { nome: 'helper', codice: "export async function GET(){try{}catch(error){return apiInternalError('GET /x', error)}}", atteso: false },
+
+        /* WUL-547. I tre casi che seguono sono le forme che il guard non vedeva:
+           erano vive in `app/api/settings/route.ts` e `app/api/auth/check/route.ts`
+           mentre il gate era verde. */
+        { nome: 'cast e optional chaining fra binding e .message', codice: "export async function POST(){try{}catch(error){const msg = (error as any)?.message || String(error); return NextResponse.json({error:`Fallito: ${msg}`},{status:500})}}", atteso: true },
+        { nome: 'assegnazione senza declarator, risposta fuori dal catch', codice: "export async function GET(){let dbHealthError = null; try{}catch(error){dbHealthError = error instanceof Error ? error.message : 'Unknown error'}; return NextResponse.json({error:{message: dbHealthError || 'Data directory unavailable.'}},{status:500})}", atteso: true },
+        { nome: 'non-null assertion', codice: "export async function GET(){try{}catch(error){return NextResponse.json({error:error!.message},{status:500})}}", atteso: true },
+
+        /* Controprova dell'allargamento: `.message` di un oggetto che NON e'
+           l'eccezione grezza deve restare pulito. Senza questi due casi, la
+           correzione di sopra si comprerebbe con dei falsi positivi. */
+        { nome: 'message di un errore di dominio classificato', codice: "export async function GET(){try{}catch(error){const classification = classifyAuthHealthError(error); return NextResponse.json({error:classification.message},{status:400})}}", atteso: false },
+        { nome: 'message di un risultato calcolato nel catch', codice: "export async function POST(){try{}catch(error){console.error(error); const result = buildFallback(); return NextResponse.json({error:result.message},{status:500})}}", atteso: false },
+
+        /* Confine della ricerca oltre il catch: una variabile omonima in un ALTRO
+           handler dello stesso file non deve essere attribuita a questo catch. */
+        { nome: 'variabile omonima in un altro handler', codice: "export async function GET(){try{}catch(error){const msg = error.message; console.error(msg)}}\nexport async function POST(){const msg = 'Richiesta non valida.'; return NextResponse.json({error:msg},{status:400})}", atteso: false },
     ];
     let falliti = 0;
     const tmp = path.join(repoRoot, '.tmp-api-error-leak-selftest.ts');

--- a/scripts/check-openapi-drift.mjs
+++ b/scripts/check-openapi-drift.mjs
@@ -147,7 +147,13 @@ function normalizeSchema(schema, document, seen = new Set()) {
     }
 
     const normalized = {};
-    for (const key of ['type', 'format', 'nullable', 'additionalProperties']) {
+    // WUL-547. `const` era assente da questo elenco, e non e' un dettaglio: lo spec
+    // la usa 65 volte per i valori fissi che stanno sul filo — nomi di header di
+    // auth, cookie, codici d'errore, porta TLS, `schemaVersion`. Non copiandola, due
+    // schemi che differiscono SOLO per quel valore normalizzavano identici, l'uguaglianza
+    // in testa a `schemaDiff` scattava, e il cambiamento usciva senza un solo segnale.
+    // Un client che fa match su quel valore si sarebbe rotto sotto un gate verde.
+    for (const key of ['type', 'format', 'nullable', 'additionalProperties', 'const']) {
         if (schema[key] !== undefined) normalized[key] = stable(schema[key]);
     }
     if (schema.enum) normalized.enum = [...schema.enum];
@@ -633,6 +639,26 @@ function runSelfTest() {
         {
             name: 'nessuna differenza → nessun segnale',
             run: () => diffOf(specWith(OBJ({ a: STR }, ['a'])), specWith(OBJ({ a: STR }, ['a']))),
+            expect: (d) => d.breaking.length === 0 && d.additive.length === 0
+        },
+        /* WUL-547. Il valore fisso di una proprieta' e' sul filo tanto quanto il suo
+           tipo: un client che fa match su `code: 'internal_error'` si rompe se quel
+           valore cambia. Prima che `const` entrasse in normalizeSchema questo caso
+           usciva con zero segnali — lo spec la usa 65 volte. */
+        {
+            name: 'valore fisso `const` cambiato → segnalato',
+            run: () => diffOf(
+                specWith(OBJ({ code: { type: 'string', const: 'internal_error' } }, ['code'])),
+                specWith(OBJ({ code: { type: 'string', const: 'internal_failure' } }, ['code']))
+            ),
+            expect: (d) => d.breaking.length + d.additive.length > 0
+        },
+        {
+            name: 'valore fisso `const` invariato → nessun segnale',
+            run: () => {
+                const shape = OBJ({ code: { type: 'string', const: 'internal_error' } }, ['code']);
+                return diffOf(specWith(shape), specWith(shape));
+            },
             expect: (d) => d.breaking.length === 0 && d.additive.length === 0
         }
     ];


### PR DESCRIPTION
Chiude WUL-547.

Misurato strumentando il percorso caldo di ogni guard di `Repository Guards` e **contando le invocazioni**, non rileggendo il codice. È il metodo che ha già trovato WUL-545 (venti righe di confronto per proprietà mai eseguite). Quattro guard risultano **sani con misura** — `schema-writers`, `apple-wide-qa`, `mlx-operational-parity`, `never-regress`. Questi tre no, e due non giravano affatto.

## 1. `check:api-error-leak` non vedeva due leak vivi

Erano in produzione mentre il gate era verde, e sono proprio la classe che WUL-347 dichiara chiusa.

`app/api/settings/route.ts` — fra il binding e `.message` c'era ` as any)?`, e `reDerivata` cerca `\b<binding>\s*\.\s*message`. Il messaggio grezzo usciva dentro un template literal.

`app/api/auth/check/route.ts` — due cecità sovrapposte: l'assegnazione non aveva un declarator dentro il catch, e la risposta stava **fuori** dal corpo, l'unica regione ispezionata.

La correzione normalizza cast, `!` e `?.` **ancorandosi al binding**, e estende la ricerca fino alla fine dell'handler che contiene il catch — non oltre. I due confini contano: senza il primo, `classification.message` diventerebbe un falso positivo; senza il secondo, un `msg` in un altro handler dello stesso file. Tre casi di self-test li fissano.

Il secondo leak è corretto usando `classifyAuthHealthError`, che il ramo generico sottostante **usava già**: era l'unico che non lo faceva. `code`, `category` e `dbState` restano i valori stabili di prima — il client Apple decodifica con tipi non opzionali e la correzione di un leak non è il posto per cambiare il contratto.

## 2. `check:openapi:drift` era cieco a `const`

`normalizeSchema()` copia un insieme chiuso di chiavi e `const` non c'era. Lo spec la usa **65 volte** per i valori fissi che stanno sul filo: nomi di header di auth, cookie, codici d'errore, porta TLS, `schemaVersion`. Due schemi che differivano solo lì normalizzavano identici, l'uguaglianza in testa a `schemaDiff` scattava, e il cambiamento usciva **senza un solo segnale**.

I vincoli numerici (86 occorrenze) restano fuori **di proposito**: allargare un `maximum` è additivo, e aggiungerli senza classificarli per direzione ricreerebbe le deroghe grossolane che #173 ha appena chiuso.

## 3. `check:ai-clinical-writes` ispezionava 75 file su un perimetro di 88

`readdirSync` non era ricorsiva, quindi i 13 moduli non-test di `lib/ai-providers/fabric` restavano fuori. La ricorsione è attiva **solo** dove il prefisso è vuoto — le voci che dichiarano «questa directory *è* il percorso AI». Ricorrere anche sulle voci con prefisso tirerebbe dentro omonimi estranei da 276 file in radice di `lib/`.

## 4. Due gate non giravano in nessun workflow

`check:schema-drift` e `check:audit-quality-gate`. L'orfanità era invisibile per una ragione precisa: entrambi hanno un unit test che invoca il **gate reale**, quindi risultano coperti a chiunque conti «il gate compare in `test:unit`». Ma quei test asseriscono il comportamento del gate su fixture, non lo stato di *questo* repo. Sono due domande diverse, e solo la seconda intercetta una deriva.

## Falsificazione — ogni correzione provata rompendola

| correzione | prova |
|---|---|
| api-error-leak | i 3 casi nuovi **falliscono** sul codice di prima; le 2 controprove restano pulite; sul repo reale trova i 2 leak **e nient'altro** su 140 route |
| openapi:drift | mutante senza `const` → `{"breaking":[],"additive":[]}`, silenzio totale. 13/13 self-test |
| ai-clinical-writes | piantata una scrittura su `observations` dentro `fabric`: il codice pre-correzione **esce 0 e non la vede**, quello corretto la intercetta con `AI_WRITE_UNDECLARED` |
| schema-drift | dichiarata una tabella mai migrata: il gate appena cablato diventa **rosso**, e torna verde al ripristino |

Suite completa in locale: 14 gate verdi su 14, `lint` e `typecheck` puliti.

## Fuori perimetro

Le 16 `breakingOverrides` stantie **non** sono rimosse: vanno tolte insieme al controllo di staleness, che dipende dalla scelta di un anchor ref — una decisione di prodotto ancora aperta. Stesso motivo per le allowlist morte di `check:claims` (7 su 13) e `NEVER_REGRESS_ALLOWLIST` (6 su 54), tracciate in WUL-547 §5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)