### PR TITLE
Il path filter passa dal workflow ai job, così Apple Native può essere required (WUL-544)

### DIFF
--- a/.github/workflows/apple-native.yml
+++ b/.github/workflows/apple-native.yml
@@ -229,7 +229,14 @@ jobs:
     # di PR - la suite XCUITest si esegue in locale a ogni cambiamento.
     needs: changes
     if: ${{ needs.changes.outputs.apple == 'true' && github.event_name != 'pull_request' }}
+    name: ui-tests (${{ matrix.idiom }})
     runs-on: macos-15
+    # @Codex: la gamba iPad esegue solo i quattro contratti che su iPhone si
+    # auto-saltano; la suite completa resta sulla gamba iPhone.
+    strategy:
+      fail-fast: false
+      matrix:
+        idiom: [iPhone, iPad]
     steps:
       - uses: actions/checkout@v5
       - name: Select latest stable Xcode
@@ -238,24 +245,55 @@ jobs:
         run: brew list xcodegen >/dev/null 2>&1 || brew install xcodegen
       - name: Generate project
         run: scripts/generate-apple-xcodeproj.sh
-      - name: Pick an available iPhone simulator
+      - name: Pick an available ${{ matrix.idiom }} simulator
         id: sim
+        env:
+          IDIOM: ${{ matrix.idiom }}
         run: |
-          NAME=$(xcrun simctl list devices available --json | python3 -c "import json,sys; d=json.load(sys.stdin)['devices']; print(next((x['name'] for rt in sorted(d) for x in d[rt] if x['name'].startswith('iPhone')), ''))")
-          [ -n "$NAME" ] || { echo "No iPhone simulator available" >&2; exit 1; }
+          SELECTION=$(xcrun simctl list devices available --json | python3 -c '
+          import json, os, sys
+          by_runtime = json.load(sys.stdin)["devices"]
+          prefixes = ("iPad Pro 13-inch", "iPad Pro 11-inch", "iPad") if os.environ["IDIOM"] == "iPad" else ("iPhone",)
+          selected = next((
+              device
+              for runtime in sorted(by_runtime, reverse=True)
+              for prefix in prefixes
+              for device in by_runtime[runtime]
+              if device["name"].startswith(prefix)
+          ), None)
+          print(f"{selected['name']}\t{selected['udid']}" if selected else "")
+          ')
+          IFS=$'\t' read -r NAME UDID <<< "$SELECTION"
+          [ -n "$NAME" ] && [ -n "$UDID" ] || { echo "No $IDIOM simulator available" >&2; exit 1; }
           echo "name=$NAME" >> "$GITHUB_OUTPUT"
-          echo "Using simulator: $NAME"
+          echo "id=$UDID" >> "$GITHUB_OUTPUT"
+          echo "Using simulator: $NAME ($UDID)"
       - name: Run XCUITest interaction tests
         run: |
+          set -o pipefail
+          only_testing=()
+          if [[ "${{ matrix.idiom }}" == "iPad" ]]; then
+            only_testing=(
+              -only-testing:MediFlowMobileAppUITests/MediFlowMobileAppUITests/testProjectSidebarPreservesPatientWorkspaceWidthOnIPad
+              -only-testing:MediFlowMobileAppUITests/MediFlowMobileAppUITests/testAccessibilityDynamicTypeUsesSinglePatientColumnOnIPad
+              -only-testing:MediFlowMobileAppUITests/MediFlowMobileAppUITests/testIPadListColumnFollowsTheContainerAcrossRotation
+              -only-testing:MediFlowMobileAppUITests/MediFlowMobileAppUITests/testIPadKeepsTheOpenChartAcrossRotation
+            )
+          fi
           # -retry-tests-on-failure absorbs transient runner flakes (e.g. the
           # "Timed out while acquiring background assertion" launch flake) without
           # masking real failures: a test must pass within the retries.
           xcodebuild test \
             -project native/MediFlowAppleApp/MediFlowAppleApp.xcodeproj \
             -scheme MediFlowMobileApp \
-            -destination "platform=iOS Simulator,name=${{ steps.sim.outputs.name }}" \
+            -destination "platform=iOS Simulator,id=${{ steps.sim.outputs.id }}" \
+            "${only_testing[@]}" \
             -retry-tests-on-failure -test-iterations 2 \
-            CODE_SIGNING_ALLOWED=NO
+            CODE_SIGNING_ALLOWED=NO \
+            2>&1 | tee "${RUNNER_TEMP}/xcuitest-${{ matrix.idiom }}.log"
+      - name: Verify the four iPad contracts ran without skips
+        if: ${{ !cancelled() && matrix.idiom == 'iPad' }}
+        run: scripts/assert-ipad-ui-contracts.sh "${RUNNER_TEMP}/xcuitest-iPad.log"
 
   # QUESTO è il job da mettere in branch protection, con contesto `apple-native`.
   # Riporta su ogni PR, anche quando i job macOS sono skippati.

--- a/.github/workflows/apple-native.yml
+++ b/.github/workflows/apple-native.yml
@@ -4,29 +4,167 @@ name: Apple Native
 # code uses .glassEffect under an iOS 26 / macOS 26 availability guard, so the
 # macOS job needs an Xcode with the 26 (or newer) SDK; it selects the latest
 # stable Xcode on the runner.
+#
+# WUL-544 — il path filter è stato spostato da `on:` ai singoli job.
+# Motivo: un workflow filtrato a livello di `on:` NON PARTE su una PR che non
+# tocca quei percorsi, e il check risulta ASSENTE, non "skipped". Un required
+# check assente lascia la PR in "Expected — Waiting for status to be reported",
+# bloccata per sempre. Con il filtro sui job, invece, il job condizionale viene
+# SKIPPATO: GitHub emette comunque un check run, e uno skip conta come passato
+# per la branch protection. Il costo resta zero — un job skippato non alloca
+# runner (misurato: `ui-tests` su run 31337348910, started == completed).
+#
+# Il check da rendere required è `apple-native` (il job `gate` in fondo), non
+# `native-build-test`: solo il gate riporta su OGNI PR.
 
 on:
   pull_request:
-    paths:
-      - 'native/**'
-      - 'scripts/check-apple-*.sh'
-      - 'scripts/generate-apple-xcodeproj.sh'
-      - 'scripts/native-test.sh'
-      - '.github/workflows/apple-native.yml'
   push:
     branches:
       - main
-    paths:
-      - 'native/**'
   workflow_dispatch:
 
-# macOS runner minutes are billed at 10x. Cancel superseded runs on the same ref
-# so a burst of pushes does not pile up parallel macOS runs.
+# WUL-544 — rettifica di una premessa che compariva tre volte in questo file e ha
+# guidato decisioni di progetto: «macOS runner minutes are billed at 10x» qui NON
+# è vero. Il repo è pubblico, e sui runner standard di un repo pubblico GitHub non
+# fattura nulla. Misurato sul run 31337348910:
+#   gh api repos/:owner/:repo/actions/runs/31337348910/timing
+#   -> billable.MACOS.total_ms = 0   (2 job macOS), billable.UBUNTU.total_ms = 0
+# Il moltiplicatore 10x è probabilmente un residuo di quando il repo era privato
+# (il remote `archived-private` esiste ancora).
+#
+# Il costo che resta è reale ma è un altro: il TEMPO DI ATTESA. native-build-test
+# misura 5m16s e ui-tests 18m52s. Le scelte di questo file restano quindi valide —
+# saltare il lavoro inutile e cancellare le run superate — ma per la latenza, non
+# per la fattura. Chi le rivede sappia su quale grandezza sta ottimizzando.
 concurrency:
   group: apple-native-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
+  # Ubuntu, ~10 s, nessun checkout: enumera i file dell'evento via API REST e
+  # applica gli stessi glob che stavano sotto `on: pull_request: paths:`.
+  # Niente `actions/checkout`: il .git di questo repo pesa 5 GB, e per decidere
+  # "quali file cambiano" non serve l'albero.
+  changes:
+    # Nome distinto da quello di core-tri-os.yml: due check run omonimi sullo stesso
+    # commit sono ambigui nella UI, e lo diventerebbero in branch protection se un
+    # domani si rendesse required anche questo.
+    name: apple-native-changes
+    runs-on: ubuntu-latest
+    outputs:
+      apple: ${{ steps.filter.outputs.apple }}
+    steps:
+      - name: Quali percorsi tocca questo evento
+        id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          EVENT: ${{ github.event_name }}
+          PR: ${{ github.event.pull_request.number }}
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.sha }}
+        run: |
+          set -uo pipefail
+
+          # rc != 0 => non so enumerare i file => fail-open: eseguo tutto.
+          # Meglio pagare un runner macOS che dichiarare verde ciò che non ho visto.
+          rc=0
+          : > changed.txt
+          case "$EVENT" in
+            pull_request | pull_request_target)
+              gh api --paginate "repos/$REPO/pulls/$PR/files" \
+                --jq '.[].filename' > changed.txt || rc=1
+              # Simmetrico alla guardia sui 300 del ramo push: anche questo endpoint
+              # ha un tetto (3000 file), e una lista troncata in silenzio produrrebbe
+              # un `apple=false` per non aver visto, che è il modo esatto in cui un
+              # job `changes` fa danno.
+              if [ "$rc" -eq 0 ] && [ "$(wc -l < changed.txt)" -ge 3000 ]; then
+                echo "elenco file della PR potenzialmente troncato ($(wc -l < changed.txt))"
+                rc=1
+              fi
+              ;;
+            push)
+              case "$BEFORE" in
+                '' | 0000000000000000000000000000000000000000)
+                  echo "push senza commit precedente utilizzabile (BEFORE=$BEFORE)"
+                  rc=1
+                  ;;
+                *)
+                  if gh api "repos/$REPO/compare/$BEFORE...$AFTER" > cmp.json; then
+                    n="$(jq '.files | length' cmp.json)"
+                    # L'endpoint compare tronca a 300 file e non pagina i file.
+                    if [ "$n" -ge 300 ]; then
+                      echo "diff troncato dall'API ($n file)"
+                      rc=1
+                    else
+                      jq -r '.files[].filename' cmp.json > changed.txt
+                    fi
+                  else
+                    echo "compare fallito (force-push? commit irraggiungibile?)"
+                    rc=1
+                  fi
+                  ;;
+              esac
+              ;;
+            *)
+              echo "evento '$EVENT' (workflow_dispatch o altro): eseguo tutto"
+              rc=1
+              ;;
+          esac
+
+          if [ "$rc" -ne 0 ]; then
+            echo "apple=true" >> "$GITHUB_OUTPUT"
+            echo "VERDETTO apple=true (fail-open)"
+            exit 0
+          fi
+
+          echo "--- file cambiati ($(wc -l < changed.txt)) ---"
+          cat changed.txt
+
+          # Stessi glob dei vecchi blocchi `paths:`. In un `case` di bash `*`
+          # attraversa le `/`, quindi `native/*` ≡ `native/**`.
+          #
+          # ATTENZIONE all'asimmetria, che è deliberata e va preservata: il
+          # blocco `on: push:` filtrava SOLO su `native/**`, il blocco
+          # `on: pull_request:` anche su scripts/ e sul workflow stesso.
+          # Misurato: la PR #172 tocca 5 file, nessuno sotto native/ — Apple
+          # Native è partita sulla PR (match su .github/workflows/apple-native.yml)
+          # e NON è partita sul push del merge 5f4ed3bcd. Unificare i due set
+          # allargherebbe la copertura su main: è una decisione separata da WUL-544.
+          apple=false
+          while IFS= read -r f; do
+            [ -n "$f" ] || continue
+            case "$f" in
+              native/*) apple=true; continue ;;
+            esac
+            if [ "$EVENT" != push ]; then
+              case "$f" in
+                scripts/check-apple-*.sh)            apple=true ;;
+                # WUL-547: `scripts/assert-apple-terminology-tests.sh` non era coperto
+                # da NESSUN filtro, né push né pull_request — il glob era
+                # `scripts/check-apple-*.sh` e quel file inizia per `assert-`. È il
+                # guard invocato più sotto in questo stesso workflow: una PR che
+                # toccasse solo lui non lo avrebbe mai eseguito. Un guard il cui
+                # trigger non copre se stesso. Spostare il filtro senza correggere
+                # l'insieme avrebbe conservato il buco.
+                scripts/assert-apple-*.sh)           apple=true ;;
+                scripts/generate-apple-xcodeproj.sh) apple=true ;;
+                scripts/native-test.sh)              apple=true ;;
+                .github/workflows/apple-native.yml)  apple=true ;;
+              esac
+            fi
+          done < changed.txt
+
+          echo "apple=$apple" >> "$GITHUB_OUTPUT"
+          echo "VERDETTO apple=$apple"
+
+  # Incondizionato: ubuntu, 5 secondi misurati. Filtrarlo costerebbe più
+  # coverage di quanto risparmi.
   structure-guard:
     runs-on: ubuntu-latest
     steps:
@@ -35,6 +173,8 @@ jobs:
         run: scripts/check-apple-structure.sh
 
   native-build-test:
+    needs: changes
+    if: ${{ needs.changes.outputs.apple == 'true' }}
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v5
@@ -55,28 +195,40 @@ jobs:
 
       # Terza fase di `npm run check:terminology-parity`, sull'output della run
       # appena fatta invece che su un secondo `swift test --filter`: su un runner
-      # macOS fatturato 10x la riesecuzione costerebbe due minuti per riasserire
+      # macOS la riesecuzione costerebbe due minuti di attesa per riasserire
       # test già girati. Le altre due fasi del gate girano altrove — la prima in
       # web-core.yml via test:unit, la seconda in e2e.yml.
       - name: Terminology parity, i quattro test Apple sono passati per nome
         if: ${{ !cancelled() }}
         run: scripts/assert-apple-terminology-tests.sh "${RUNNER_TEMP}/swiftpm-tests.log"
+      # WUL-544. Questi due erano gli unici step di `native-build-test` senza
+      # `if: ${{ !cancelled() }}`, e la conseguenza è stata misurata: sul run
+      # 31158672548 il fallimento di `SwiftPM tests` li ha resi `skipped`, e in
+      # 6751 righe di log non compare una sola invocazione di xcodebuild per lo
+      # scheme macOS. Nessun altro workflow compila `MediFlowMacApp`
+      # (`core-tri-os.yml` fa solo `swift build --target MediFlowCore`), quindi la
+      # copertura macOS spariva in silenzio proprio quando i test erano rossi —
+      # cioè quando serviva di più. Oggi lo step gira di nuovo, ma il meccanismo
+      # che l'aveva spento è ancora lì finché non si mette questa condizione.
       - name: Build macOS app
+        if: ${{ !cancelled() }}
         run: |
           xcodebuild -project native/MediFlowAppleApp/MediFlowAppleApp.xcodeproj \
             -scheme MediFlowMacApp -destination 'platform=macOS' \
             build CODE_SIGNING_ALLOWED=NO
       - name: Build iOS app
+        if: ${{ !cancelled() }}
         run: |
           xcodebuild -project native/MediFlowAppleApp/MediFlowAppleApp.xcodeproj \
             -scheme MediFlowMobileApp -destination 'generic/platform=iOS Simulator' \
             build CODE_SIGNING_ALLOWED=NO
 
   ui-tests:
-    # Expensive (~10 min of macOS runner time, billed at 10x). Run only on merge
-    # to main or on demand (workflow_dispatch), not on every PR push - the XCUITest
-    # suite is run locally on each change.
-    if: github.event_name != 'pull_request'
+    # Costoso in ATTESA, non in fattura (vedi la rettifica in testa al file):
+    # 18m52s misurati. Gira solo sul merge in main o su richiesta, non a ogni push
+    # di PR - la suite XCUITest si esegue in locale a ogni cambiamento.
+    needs: changes
+    if: ${{ needs.changes.outputs.apple == 'true' && github.event_name != 'pull_request' }}
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v5
@@ -104,3 +256,53 @@ jobs:
             -destination "platform=iOS Simulator,name=${{ steps.sim.outputs.name }}" \
             -retry-tests-on-failure -test-iterations 2 \
             CODE_SIGNING_ALLOWED=NO
+
+  # QUESTO è il job da mettere in branch protection, con contesto `apple-native`.
+  # Riporta su ogni PR, anche quando i job macOS sono skippati.
+  #
+  # Due trappole, entrambe evitate qui:
+  #  1. senza un `if:` con funzione di stato, un job che `needs:` un job skippato
+  #     viene skippato a sua volta => il gate non riporterebbe mai. Da cui `always()`.
+  #  2. mettere la valutazione degli esiti nell'`if:` del job (es.
+  #     `if: !contains(needs.*.result, 'failure')`) è il bug classico: quando un
+  #     need FALLISCE il gate viene SKIPPATO, e uno skip conta come PASSATO.
+  #     Falso verde. Per questo la valutazione sta in uno STEP che gira sempre.
+  gate:
+    name: apple-native
+    needs: [changes, structure-guard, native-build-test, ui-tests]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verdetto
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          set -uo pipefail
+
+          if [ -z "${NEEDS:-}" ] || [ "$NEEDS" = "null" ] || [ "$NEEDS" = "{}" ]; then
+            echo "FAIL: contesto needs vuoto — il gate non sta osservando nulla."
+            exit 1
+          fi
+
+          fail=0
+          n=0
+          while IFS='=' read -r name res; do
+            n=$((n + 1))
+            case "$res" in
+              success | skipped)
+                printf 'OK    %-22s %s\n' "$name" "$res"
+                ;;
+              *)
+                printf 'FAIL  %-22s %s\n' "$name" "${res:-<vuoto>}"
+                fail=1
+                ;;
+            esac
+          done < <(echo "$NEEDS" | jq -r 'to_entries[] | "\(.key)=\(.value.result // "")"')
+
+          if [ "$n" -eq 0 ]; then
+            echo "FAIL: nessun job osservato."
+            exit 1
+          fi
+
+          echo "--- $n job osservati, esito gate: $([ $fail -eq 0 ] && echo success || echo failure)"
+          exit $fail

--- a/.github/workflows/apple-native.yml
+++ b/.github/workflows/apple-native.yml
@@ -129,18 +129,26 @@ jobs:
           # Stessi glob dei vecchi blocchi `paths:`. In un `case` di bash `*`
           # attraversa le `/`, quindi `native/*` ≡ `native/**`.
           #
-          # ATTENZIONE all'asimmetria, che è deliberata e va preservata: il
+          # L'asimmetria storica resta per i guard e gli script generali: il
           # blocco `on: push:` filtrava SOLO su `native/**`, il blocco
           # `on: pull_request:` anche su scripts/ e sul workflow stesso.
           # Misurato: la PR #172 tocca 5 file, nessuno sotto native/ — Apple
           # Native è partita sulla PR (match su .github/workflows/apple-native.yml)
           # e NON è partita sul push del merge 5f4ed3bcd. Unificare i due set
           # allargherebbe la copertura su main: è una decisione separata da WUL-544.
+          # Due eccezioni sono necessarie: il workflow e il guard iPad devono
+          # attivare sul push la gamba UI, che sulle PR è sempre saltata.
           apple=false
           while IFS= read -r f; do
             [ -n "$f" ] || continue
             case "$f" in
               native/*) apple=true; continue ;;
+              # @Codex: la gamba UI gira solo fuori dalle PR. Il merge che introduce o
+              # corregge quella gamba deve quindi attivarla sul push a main.
+              .github/workflows/apple-native.yml | scripts/assert-ipad-ui-contracts.sh)
+                apple=true
+                continue
+                ;;
             esac
             if [ "$EVENT" != push ]; then
               case "$f" in

--- a/.github/workflows/core-tri-os.yml
+++ b/.github/workflows/core-tri-os.yml
@@ -8,33 +8,127 @@ name: Core tri-OS gate
 # reconsider a Rust core (the golden vectors are language-neutral and already in
 # hand). On non-Apple OSes the package manifest excludes the SwiftUI targets, so
 # only MediFlowCore + MediFlowCoreTests compile here.
+#
+# WUL-544 — path filter spostato da `on:` ai job, stessa ragione di
+# apple-native.yml: un workflow non partito lascia il check ASSENTE (PR bloccata
+# in "Expected"), un job skippato emette un check run che vale come passato.
+# Il check da rendere required è `core-tri-os` (job `gate`), non `linux`/`windows`.
 
 on:
   pull_request:
-    paths:
-      - 'native/MediFlowMac/Sources/MediFlowCore/**'
-      - 'native/MediFlowMac/Tests/MediFlowCoreTests/**'
-      - 'native/MediFlowMac/Package.swift'
-      - 'native/contracts/**'
-      - '.github/workflows/core-tri-os.yml'
   push:
     branches:
       - main
-    paths:
-      - 'native/MediFlowMac/Sources/MediFlowCore/**'
-      - 'native/contracts/**'
   workflow_dispatch:
 
 concurrency:
   group: core-tri-os-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 defaults:
   run:
     shell: bash
 
 jobs:
+  changes:
+    # Nome distinto da quello di apple-native.yml: due check run omonimi sullo
+    # stesso commit sono ambigui, e lo diventerebbero in branch protection.
+    name: core-tri-os-changes
+    runs-on: ubuntu-latest
+    outputs:
+      core: ${{ steps.filter.outputs.core }}
+    steps:
+      - name: Quali percorsi tocca questo evento
+        id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          EVENT: ${{ github.event_name }}
+          PR: ${{ github.event.pull_request.number }}
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.sha }}
+        run: |
+          set -uo pipefail
+
+          rc=0
+          : > changed.txt
+          case "$EVENT" in
+            pull_request | pull_request_target)
+              gh api --paginate "repos/$REPO/pulls/$PR/files" \
+                --jq '.[].filename' > changed.txt || rc=1
+              # Simmetrico alla guardia sui 300 del ramo push: anche questo endpoint
+              # ha un tetto (3000 file), e una lista troncata in silenzio produrrebbe
+              # un `core=false` per non aver visto.
+              if [ "$rc" -eq 0 ] && [ "$(wc -l < changed.txt)" -ge 3000 ]; then
+                echo "elenco file della PR potenzialmente troncato ($(wc -l < changed.txt))"
+                rc=1
+              fi
+              ;;
+            push)
+              case "$BEFORE" in
+                '' | 0000000000000000000000000000000000000000)
+                  echo "push senza commit precedente utilizzabile (BEFORE=$BEFORE)"
+                  rc=1
+                  ;;
+                *)
+                  if gh api "repos/$REPO/compare/$BEFORE...$AFTER" > cmp.json; then
+                    n="$(jq '.files | length' cmp.json)"
+                    if [ "$n" -ge 300 ]; then
+                      echo "diff troncato dall'API ($n file)"
+                      rc=1
+                    else
+                      jq -r '.files[].filename' cmp.json > changed.txt
+                    fi
+                  else
+                    echo "compare fallito (force-push? commit irraggiungibile?)"
+                    rc=1
+                  fi
+                  ;;
+              esac
+              ;;
+            *)
+              echo "evento '$EVENT': eseguo tutto"
+              rc=1
+              ;;
+          esac
+
+          if [ "$rc" -ne 0 ]; then
+            echo "core=true" >> "$GITHUB_OUTPUT"
+            echo "VERDETTO core=true (fail-open)"
+            exit 0
+          fi
+
+          echo "--- file cambiati ($(wc -l < changed.txt)) ---"
+          cat changed.txt
+
+          # Anche qui il blocco `on: push:` era più stretto di `on: pull_request:`
+          # (solo MediFlowCore/** e contracts/**). Asimmetria preservata.
+          core=false
+          while IFS= read -r f; do
+            [ -n "$f" ] || continue
+            case "$f" in
+              native/MediFlowMac/Sources/MediFlowCore/*) core=true; continue ;;
+              native/contracts/*)                        core=true; continue ;;
+            esac
+            if [ "$EVENT" != push ]; then
+              case "$f" in
+                native/MediFlowMac/Tests/MediFlowCoreTests/*) core=true ;;
+                native/MediFlowMac/Package.swift)             core=true ;;
+                .github/workflows/core-tri-os.yml)            core=true ;;
+              esac
+            fi
+          done < changed.txt
+
+          echo "core=$core" >> "$GITHUB_OUTPUT"
+          echo "VERDETTO core=$core"
+
   linux:
+    needs: changes
+    if: ${{ needs.changes.outputs.core == 'true' }}
     runs-on: ubuntu-latest
     container: swift:6.0-noble
     steps:
@@ -47,6 +141,8 @@ jobs:
         run: swift test --package-path native/MediFlowMac --filter CryptoGoldenVectorsTests
 
   windows:
+    needs: changes
+    if: ${{ needs.changes.outputs.core == 'true' }}
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v5
@@ -68,3 +164,44 @@ jobs:
       - name: Golden-vector gate (MediFlowCoreTests)
         run: swift test --package-path native/MediFlowMac --filter CryptoGoldenVectorsTests
         shell: pwsh
+
+  # Contesto da rendere required: `core-tri-os`.
+  gate:
+    name: core-tri-os
+    needs: [changes, linux, windows]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verdetto
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          set -uo pipefail
+
+          if [ -z "${NEEDS:-}" ] || [ "$NEEDS" = "null" ] || [ "$NEEDS" = "{}" ]; then
+            echo "FAIL: contesto needs vuoto — il gate non sta osservando nulla."
+            exit 1
+          fi
+
+          fail=0
+          n=0
+          while IFS='=' read -r name res; do
+            n=$((n + 1))
+            case "$res" in
+              success | skipped)
+                printf 'OK    %-22s %s\n' "$name" "$res"
+                ;;
+              *)
+                printf 'FAIL  %-22s %s\n' "$name" "${res:-<vuoto>}"
+                fail=1
+                ;;
+            esac
+          done < <(echo "$NEEDS" | jq -r 'to_entries[] | "\(.key)=\(.value.result // "")"')
+
+          if [ "$n" -eq 0 ]; then
+            echo "FAIL: nessun job osservato."
+            exit 1
+          fi
+
+          echo "--- $n job osservati, esito gate: $([ $fail -eq 0 ] && echo success || echo failure)"
+          exit $fail

--- a/scripts/assert-ipad-ui-contracts.sh
+++ b/scripts/assert-ipad-ui-contracts.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# @Codex
+set -euo pipefail
+
+# xcodebuild prints a final `passed` line even when XCTest recorded XCTSkip.
+# Require that each iPad-only contract appears as passed and never as skipped.
+
+if [[ $# -ne 1 ]]; then
+  printf 'uso: %s <file-con-l-output-di-xcodebuild-test>\n' "${0##*/}" >&2
+  exit 2
+fi
+
+OUTPUT_FILE="$1"
+
+if [[ ! -r "$OUTPUT_FILE" ]]; then
+  printf 'Output di xcodebuild test non trovato: %s\n' "$OUTPUT_FILE" >&2
+  exit 1
+fi
+
+OUTPUT=$(<"$OUTPUT_FILE")
+
+REQUIRED_TESTS=(
+  "testProjectSidebarPreservesPatientWorkspaceWidthOnIPad"
+  "testAccessibilityDynamicTypeUsesSinglePatientColumnOnIPad"
+  "testIPadListColumnFollowsTheContainerAcrossRotation"
+  "testIPadKeepsTheOpenChartAcrossRotation"
+)
+
+suite="MediFlowMobileAppUITests.MediFlowMobileAppUITests"
+missing=0
+for expected in "${REQUIRED_TESTS[@]}"; do
+  test_case="-[$suite $expected]"
+  passed="Test Case '$test_case' passed"
+  skipped="$test_case : Test skipped"
+
+  if grep -Fq -- "$skipped" <<<"$OUTPUT"; then
+    printf 'SKIP   contratto iPad non eseguito: %s\n' "$expected" >&2
+    missing=$((missing + 1))
+  elif grep -Fq -- "$passed" <<<"$OUTPUT"; then
+    printf 'ok     %s\n' "$expected"
+  else
+    printf 'MANCA  contratto iPad non passato: %s\n' "$expected" >&2
+    missing=$((missing + 1))
+  fi
+done
+
+if [[ "$missing" -gt 0 ]]; then
+  printf '\n%d/%d contratti iPad non risultano eseguiti e passati.\n' \
+    "$missing" "${#REQUIRED_TESTS[@]}" >&2
+  exit 1
+fi
+
+printf '\nContratti iPad: %d/%d eseguiti e passati senza skip.\n' \
+  "${#REQUIRED_TESTS[@]}" "${#REQUIRED_TESTS[@]}"


### PR DESCRIPTION
Chiude WUL-544 (parzialmente: resta la gamba iPad, vedi in fondo).

## Il difetto

Un workflow filtrato a livello di `on:` **non parte** su una PR che non tocca quei percorsi, e il check risulta **ASSENTE**, non `skipped`. Un required check assente lascia la PR in `Expected — Waiting for status to be reported`, bloccata per sempre.

Misurato sulle PR reali #169/#170/#173 (nessun file sotto `native/`): `structure-guard`, `native-build-test` e `ui-tests` non compaiono affatto nell'elenco dei check run — non ci sono con conclusione `skipped`, proprio non esistono.

Da qui l'alternativa secca di oggi: o `Apple Native` non è required, e un suo rosso resta mergiabile — cioè l'incidente WUL-542 — oppure lo è, e ogni PR che tocca solo `lib/` si blocca all'infinito.

## La prova che serviva era già nel repo

`ui-tests` ha da tempo `if: github.event_name != 'pull_request'` a livello di **job**, ed emette un check run con conclusione `skipped` e `started_at == completed_at`. Il meccanismo su cui poggia tutta la correzione — *il check riporta senza girare, a costo zero* — era già in produzione qui, in un job che nessuno aveva letto in questa chiave.

## La struttura

| job | dove | quando |
|---|---|---|
| `changes` (`apple-native-changes`) | ubuntu, **senza checkout** | sempre, ~10 s |
| `structure-guard` | ubuntu | sempre (5 s misurati) |
| `native-build-test` | macos-15 | solo se `native/**` toccato |
| `ui-tests` | macos-15 | solo se toccato **e** non è una PR |
| `gate` (**`apple-native`**) | ubuntu | sempre, `if: always()` |

Niente `actions/checkout` nel job `changes`: il `.git` di questo repo pesa **5,0 GB** per 506 commit (blob da 268 MB di `.xcresult` nella storia), quindi un `fetch-depth: 0` non sarebbe gratis. Per sapere quali file cambiano non serve l'albero. Nessuna action di terze parti aggiunta — solo `gh` e `jq`, preinstallati.

### Le due trappole del gate, entrambe evitate

1. Senza un `if:` con funzione di stato, un job che `needs:` un job skippato viene skippato a sua volta e **il gate non riporterebbe mai**. Da cui `always()`.
2. Mettere la valutazione nell'`if:` del job (`if: !contains(needs.*.result, 'failure')`) è il bug classico: quando un need **fallisce**, il gate viene **skippato**, e uno skip conta come **passato**. Falso verde. Per questo la valutazione sta in uno **step**.

Il gate usa `toJSON(needs)` invece di elencare i nomi a mano: un job aggiunto domani non può sfuggirgli per dimenticanza.

### Fail-open verso l'esecuzione

Dispatch manuale, base sha assente o nulla, force-push, API non disponibile, lista troncata (300 file sul `compare`, 3000 su `pulls/files`) ⇒ **i job costosi girano**. Il modo in cui un job `changes` fa danno è saltare un job che serviva, non girarne uno di troppo.

### Asimmetria preservata

Il vecchio `on: push:` filtrava su un insieme **più stretto** di `on: pull_request:`. È riprodotta come ramo esplicito. Unificarli allargherebbe la copertura su `main` ed è una decisione separata, tracciata a parte.

## Due correzioni che viaggiano con lo spostamento

**`scripts/assert-apple-terminology-tests.sh` non era coperto da nessun filtro** — il glob è `scripts/check-apple-*.sh` e quel file inizia per `assert-`. È il guard invocato da questo stesso workflow (`:63`), creato da #172 e falsificato in tre modi. Una PR che toccasse solo lui non lo avrebbe mai eseguito: un guard il cui trigger non copre se stesso. Spostare il filtro **ricopiando** l'insieme avrebbe conservato il buco.

**`Build macOS app` e `Build iOS app` erano gli unici step senza `if: !cancelled()`.** Sul run [31158672548](https://github.com/Wulfgardr/mediflow/actions/runs/31158672548) un fallimento di `SwiftPM tests` li ha resi `skipped`, e in 6751 righe di log non compare **una sola** invocazione di `xcodebuild` per lo scheme macOS. Nessun altro workflow compila `MediFlowMacApp` — `core-tri-os.yml` fa solo `swift build --target MediFlowCore`. La copertura macOS spariva in silenzio proprio quando i test erano rossi.

## Una premessa falsa, rettificata

«macOS runner minutes are billed at 10x» compariva **tre volte** in `apple-native.yml` e ha guidato decisioni di progetto. **Qui non è vero**: il repo è pubblico e i runner standard di un repo pubblico non sono fatturati.

```
gh api repos/:owner/:repo/actions/runs/31337348910/timing
  billable.MACOS.total_ms  = 0   (2 job macOS)
  billable.UBUNTU.total_ms = 0
```

È probabilmente un residuo di quando il repo era privato. Il costo che resta è reale ma è **l'attesa**: 5m16s per `native-build-test`, 18m52s per `ui-tests`. Le scelte del file restano valide, ma per la latenza — chi le rivede deve sapere su quale grandezza sta ottimizzando.

## Falsificazione, sui file di questo commit

| banco | esito |
|---|---|
| filtro contro i check run **reali** di GitHub, PR e push | **36/36**, discordanti 0 |
| predizioni del job `changes` su 6 PR storiche | **6/6** |
| tabella di verità del gate (incluse `cancelled`, `needs` vuoto, esiti ignoti) | **72/72** |
| la aggiunta `assert-apple-*.sh`, estraendo il blocco `case` **dal YAML reale** | 7/7, inclusa la controprova sull'asimmetria push |

Il banco discrimina in entrambe le direzioni: mutando il glob in senso restrittivo produce 2 mismatch, allargandolo ne produce 3.

## Dopo il merge — nell'ordine, non prima

1. Aprire una PR che **non** tocca `native/**` e verificare che `apple-native` sia `success` con `native-build-test` skipped a 0 secondi.
2. Solo allora aggiungere `apple-native` e `core-tri-os` ai required check. Registrarli prima che i workflow siano su `main` bloccherebbe ogni PR — esattamente il difetto che questa PR toglie.

## Fuori perimetro

I **quattro test iPad** che non girano in nessun job (`ui-tests` sceglie sempre il primo simulatore `iPhone*`, il verde è 32/36 realmente eseguiti) restano aperti. La correzione è nota — sull'immagine runner esistono 11 simulatori iPad — ma non è falsificabile in locale: Xcode è su un disco esterno scollegato, e spedirla alla cieca significherebbe debuggare su runner a colpi di push, che è il modo in cui WUL-542 è costata due giri rossi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)