### PR TITLE
fix(ci): conserva le chiavi del selettore simulatore

### DIFF
--- a/.github/workflows/apple-native.yml
+++ b/.github/workflows/apple-native.yml
@@ -269,7 +269,8 @@ jobs:
               for device in by_runtime[runtime]
               if device["name"].startswith(prefix)
           ), None)
-          print(f"{selected['name']}\t{selected['udid']}" if selected else "")
+          # @Codex: this Python program is shell-quoted with single quotes.
+          print(selected["name"] + "\t" + selected["udid"] if selected else "")
           ')
           IFS=$'\t' read -r NAME UDID <<< "$SELECTION"
           [ -n "$NAME" ] && [ -n "$UDID" ] || { echo "No $IDIOM simulator available" >&2; exit 1; }


### PR DESCRIPTION
## Summary
- Corregge il programma Python inline usato per selezionare i simulatori Apple.
- Evita che la shell rimuova gli apici dalle chiavi `name` e `udid`.
- Mantiene invariato il formato `nome\tUDID` consumato dal workflow.

## Verification
- Xcode 27.0 build 27A5194q: selezione reale di iPhone 17 Pro e iPad Pro 13-inch (M5).
- Parsing YAML con Ruby: PASS.
- `git diff --check`: PASS.
- Autoreview Codex Sol High: clean, zero finding azionabili.

## Risk / Notes
- Fix limitato al workflow Apple; nessuna modifica al prodotto o ai dati.
- Il confine finale è il passaggio reale dei job `ui-tests (iPhone)` e `ui-tests (iPad)` dopo integrazione.
- Nessuna PHI/PII o credenziale inclusa.

## Ticket
Refs WUL-544