### PR TITLE
chore(release): finalizza MediFlow 0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,71 @@ e questo progetto aderisce al [Semantic Versioning](https://semver.org/spec/v2.0
   vendor, cloud, on-device, AI paired e persistenza della review restano
   bloccati o fuori scope. Nessuna voce promuove la release 0.8.
 
+## [0.8.2] - NON PUBBLICATA
+
+> Candidata preparata il 2026-08-10. Questa voce descrive il delta previsto,
+> non il solo contenuto della branch di metadati. Le correzioni WUL-547 e
+> WUL-544 diventano parte della release soltanto dopo la pubblicazione delle
+> teste revisionate nelle PR 174 e 175, la nuova CI verde e l'integrazione in
+> `main`. Non dichiara una pubblicazione App Store, una certificazione o
+> conformità completa.
+
+### Sicurezza e privacy
+
+- Le proposte AI non possono scrivere dati clinici senza revisione umana
+  esplicita. Il gate copre il percorso applicativo e i relativi test.
+- La UI locale invia gli header HTTP di sicurezza previsti dal progetto.
+- Dopo l'integrazione di WUL-547, le route API non restituiranno il messaggio
+  grezzo di un'eccezione.
+- Il candidato WUL-547 estende il guard degli errori a cast, optional chaining
+  e assegnazioni che restano visibili dopo un blocco `catch`.
+- Nessun nuovo cloud, egress, segreto o dato clinico reale entra nella release.
+
+### Affidabilità dei contratti
+
+- Ogni tabella dello schema deve avere un writer autorizzato oppure
+  un'eccezione documentata.
+- La classificazione delle prescrizioni usa il confine reale del codice.
+  La release rimuove una coda morta e rende il contratto verificabile.
+- Il controllo OpenAPI confronta anche le proprietà annidate.
+- Tre guard prima scollegati sono ora eseguiti dalla CI.
+- I guard di release rilevano anche prove live non valide e permessi troppo
+  ampi.
+
+### Interfaccia e coerenza Apple
+
+- Il segnale «Zona Pericolo» rispetta il contrasto previsto nel tema grafite.
+- Il controllo MLX usa il registry corrente e non un pinning rimosso.
+- La fixture Apple del runtime AI usa lo stesso contratto dell'host.
+- Dopo l'integrazione di WUL-544, il workflow Apple deciderà i job dai file
+  modificati. I job required potranno terminare senza saltare l'intero
+  workflow.
+- Il candidato WUL-544 aggiunge una gamba iPad con quattro contratti UI su
+  iPadOS 27. La prova conservata registra 4 test passati, nessun fallimento e
+  nessuno skip.
+
+### Provenienza e verifica
+
+- Le PR 163-175 includono almeno un commit con attribuzione Claude.
+- Codex ha corretto i due finding finali sui guard WUL-547 e WUL-544.
+- DeepSeek V4 Flash ha restituito una review JSON valida e pulita sui due
+  commit finali.
+- Codex Sol ha verificato il codice reale e i test focalizzati.
+
+### Migrazioni
+
+- La release non introduce migrazioni del database.
+- Il runtime Node supportato resta `24.x`.
+- Le versioni web e Apple sono allineate a `0.8.2` nei metadati di build.
+
+### Limiti dichiarati
+
+- La compatibilità tra un client Apple aggiornato e un host precedente resta
+  aperta in WUL-546.
+- I token non sono attribuibili alla sola MediFlow o alla sola release.
+- I check GitHub devono rieseguire sulle teste pubblicate delle PR 174 e 175.
+- Il tag e la GitHub Release richiedono un'autorizzazione separata.
+
 ## [0.8.1] - 2026-08-07
 
 > Questa voce descrive la release sorgente `0.8.1`. Non dichiara una

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,24 +58,19 @@ e questo progetto aderisce al [Semantic Versioning](https://semver.org/spec/v2.0
   vendor, cloud, on-device, AI paired e persistenza della review restano
   bloccati o fuori scope. Nessuna voce promuove la release 0.8.
 
-## [0.8.2] - NON PUBBLICATA
+## [0.8.2] - 2026-08-11
 
-> Candidata preparata il 2026-08-10. Questa voce descrive il delta previsto,
-> non il solo contenuto della branch di metadati. Le correzioni WUL-547 e
-> WUL-544 diventano parte della release soltanto dopo la pubblicazione delle
-> teste revisionate nelle PR 174 e 175, la nuova CI verde e l'integrazione in
-> `main`. Non dichiara una pubblicazione App Store, una certificazione o
-> conformità completa.
+> Questa voce descrive la release sorgente `0.8.2`. Non dichiara una
+> pubblicazione App Store, una certificazione o conformità completa.
 
 ### Sicurezza e privacy
 
 - Le proposte AI non possono scrivere dati clinici senza revisione umana
   esplicita. Il gate copre il percorso applicativo e i relativi test.
 - La UI locale invia gli header HTTP di sicurezza previsti dal progetto.
-- Dopo l'integrazione di WUL-547, le route API non restituiranno il messaggio
-  grezzo di un'eccezione.
-- Il candidato WUL-547 estende il guard degli errori a cast, optional chaining
-  e assegnazioni che restano visibili dopo un blocco `catch`.
+- Le route API non restituiscono il messaggio grezzo di un'eccezione.
+- Il guard degli errori riconosce cast, optional chaining e assegnazioni che
+  restano visibili dopo un blocco `catch`.
 - Nessun nuovo cloud, egress, segreto o dato clinico reale entra nella release.
 
 ### Affidabilità dei contratti
@@ -94,17 +89,18 @@ e questo progetto aderisce al [Semantic Versioning](https://semver.org/spec/v2.0
 - Il segnale «Zona Pericolo» rispetta il contrasto previsto nel tema grafite.
 - Il controllo MLX usa il registry corrente e non un pinning rimosso.
 - La fixture Apple del runtime AI usa lo stesso contratto dell'host.
-- Dopo l'integrazione di WUL-544, il workflow Apple deciderà i job dai file
-  modificati. I job required potranno terminare senza saltare l'intero
-  workflow.
-- Il candidato WUL-544 aggiunge una gamba iPad con quattro contratti UI su
-  iPadOS 27. La prova conservata registra 4 test passati, nessun fallimento e
-  nessuno skip.
+- Il workflow Apple decide i job dai file modificati. I job required possono
+  terminare senza saltare l'intero workflow.
+- La gamba iPad esegue quattro contratti UI su iPadOS 27. Il push verificato su
+  `main` registra 4 test passati, nessun fallimento e nessuno skip.
+- Il selettore dei simulatori conserva correttamente le chiavi Python anche
+  dentro lo script shell del workflow.
 
 ### Provenienza e verifica
 
 - Le PR 163-175 includono almeno un commit con attribuzione Claude.
 - Codex ha corretto i due finding finali sui guard WUL-547 e WUL-544.
+- Codex ha corretto e verificato il selettore simulatori nella PR 176.
 - DeepSeek V4 Flash ha restituito una review JSON valida e pulita sui due
   commit finali.
 - Codex Sol ha verificato il codice reale e i test focalizzati.
@@ -120,8 +116,8 @@ e questo progetto aderisce al [Semantic Versioning](https://semver.org/spec/v2.0
 - La compatibilità tra un client Apple aggiornato e un host precedente resta
   aperta in WUL-546.
 - I token non sono attribuibili alla sola MediFlow o alla sola release.
-- I check GitHub devono rieseguire sulle teste pubblicate delle PR 174 e 175.
-- Il tag e la GitHub Release richiedono un'autorizzazione separata.
+- La suite iPhone passa con quattro skip previsti: sono i contratti eseguiti
+  separatamente dalla gamba iPad.
 
 ## [0.8.1] - 2026-08-07
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ _by Ordito & Concilio_
 
 **Porta l'informazione giusta nel momento giusto.**
 
-[![Versione](https://img.shields.io/badge/candidata-0.8.2-1f6feb)](./CHANGELOG.md)
+[![Versione](https://img.shields.io/badge/versione-0.8.2-1f6feb)](./CHANGELOG.md)
 [![Licenza](https://img.shields.io/badge/licenza-MIT-2ea043)](./LICENSE)
 [![Local-first](https://img.shields.io/badge/dati-local--first-8957e5)](#confini-dichiarati)
-[![Core Swift](https://img.shields.io/badge/core%20Swift-macOS%20%7C%20Linux%20%7C%20Windows-6e7681)](#candidata-sorgente-082)
+[![Core Swift](https://img.shields.io/badge/core%20Swift-macOS%20%7C%20Linux%20%7C%20Windows-6e7681)](#release-sorgente-082)
 
-[In breve](#mediflow-in-breve) · [Uso attuale](#come-si-usa-oggi) · [Architettura](#come-collaborano-le-app) · [Schermate](#come-si-presenta) · [Stato](#candidata-sorgente-082) · [Avvio](#avvio-rapido) · [Sviluppo](#sviluppo-assistito)
+[In breve](#mediflow-in-breve) · [Uso attuale](#come-si-usa-oggi) · [Architettura](#come-collaborano-le-app) · [Schermate](#come-si-presenta) · [Stato](#release-sorgente-082) · [Avvio](#avvio-rapido) · [Sviluppo](#sviluppo-assistito)
 
 </div>
 
@@ -164,15 +164,14 @@ a dimensioni telefono o tablet restano evidenze di test e non fanno parte
 della galleria. Il [manifest media 0.8](./screenshots/0.8/manifest.json)
 registra dispositivo, runtime, scena, commit sorgente e hash._
 
-## Candidata sorgente 0.8.2
+## Release sorgente 0.8.2
 
-`0.8.2` è il prossimo progressivo sorgente. Questa branch prepara i metadati e
-le note, ma non è una release pubblicata e non contiene ancora i commit finali
-delle PR 174 e 175. Tag, GitHub Release e merge richiedono un'autorizzazione
-separata.
+La release `0.8.2` distribuisce il codice sorgente verificato. Non costituisce
+una pubblicazione App Store, una certificazione o una dichiarazione di
+conformità completa.
 
-Il delta previsto rafforza i confini di scrittura clinica, i messaggi delle API
-e i controlli di CI. Allinea anche le fixture Apple ai contratti dell'host.
+La release rafforza i confini di scrittura clinica, i messaggi delle API e i
+controlli di CI. Allinea anche le fixture Apple ai contratti dell'host.
 
 La prova iPad aggiunge quattro contratti UI su Xcode 27 e iPadOS 27. I quattro
 test sono passati senza fallimenti e senza skip. Le prove usano solo fixture
@@ -182,17 +181,15 @@ Queste prove non dichiarano parity completa o conformità accessibilità. Il
 limite VoiceOver mobile resta registrato in
 [`docs/known-limitations.md`](./docs/known-limitations.md).
 
-### Stato del delta
+### Aggiornamenti integrati
 
-Le modifiche già presenti su `main` richiedono una revisione umana prima di
-ogni scrittura clinica proposta dall'AI. Il candidato WUL-547 impedisce alle
-API di esporre messaggi grezzi delle eccezioni; resta fuori da questa branch
-finché la testa revisionata non viene pubblicata e integrata tramite PR 174.
+La tranche integrata richiede una revisione umana prima di ogni scrittura
+clinica proposta dall'AI. Le API non espongono messaggi grezzi delle eccezioni.
 
-I controlli dello schema e OpenAPI sono già collegati ai workflow pertinenti.
-Il candidato WUL-544 completa il percorso Apple e iPad; resta fuori da questa
-branch finché la testa revisionata non viene pubblicata e integrata tramite PR
-175.
+I controlli dello schema, OpenAPI e Apple sono collegati ai workflow pertinenti.
+La CI distingue un job non necessario da un controllo mancante. Sul push a
+`main`, la gamba iPad ha eseguito e superato i quattro contratti previsti senza
+skip.
 
 La compatibilità tra un client Apple aggiornato e un host precedente resta
 aperta. WUL-546 conserva il limite e la decisione di contratto.
@@ -326,9 +323,9 @@ controllare: test reali e guard automatici decidono se una modifica regge.
 
 | Snapshot | Periodo dei log disponibili | Token di sessione | Ripartizione | Cache letta | Copertura storica |
 | :-- | :-- | --: | :-- | --: | :-- |
-| **10 agosto 2026** | 2026-04-20 → 2026-08-10 | **34.402.274.768** | Codex 26.627.582.540 · Claude Code 7.774.692.228 | 32.815.994.682 (95,4%) | Codex UNKNOWN · Claude Code attestata |
+| **11 agosto 2026** | 2026-04-20 → 2026-08-11 | **35.977.536.317** | Codex 28.202.844.089 · Claude Code 7.774.692.228 | 34.309.804.858 (95,4%) | Codex UNKNOWN · Claude Code attestata |
 
-<img src="./screenshots/token-models.svg" alt="Snapshot 10 agosto 2026: 34,4 Mld token di sessione, 26,63 Mld in Codex e 7,77 Mld in Claude Code; 32,82 Mld da cache letta." width="720" loading="lazy"/>
+<img src="./screenshots/token-models.svg" alt="Snapshot 11 agosto 2026: 35,98 Mld token di sessione, 28,2 Mld in Codex e 7,77 Mld in Claude Code; 34,31 Mld da cache letta." width="720" loading="lazy"/>
 
 La fonte è **CodexBar 0.48.1**, comando locale `cost --refresh`, con una finestra massima di 365 giorni. Il conteggio usa gli aggregati disponibili per Codex e Claude Code e non è filtrato per repository. CodexBar attribuisce ogni token al processo che lo registra. Un worker OpenAI avviato da Claude Code compare quindi nel totale Claude Code. Il grafico indica lo strumento che registra i token, non il fornitore del modello.
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ _by Ordito & Concilio_
 
 **Porta l'informazione giusta nel momento giusto.**
 
-[![Versione](https://img.shields.io/badge/versione-0.8.0-1f6feb)](./CHANGELOG.md)
+[![Versione](https://img.shields.io/badge/candidata-0.8.2-1f6feb)](./CHANGELOG.md)
 [![Licenza](https://img.shields.io/badge/licenza-MIT-2ea043)](./LICENSE)
 [![Local-first](https://img.shields.io/badge/dati-local--first-8957e5)](#confini-dichiarati)
-[![Core Swift](https://img.shields.io/badge/core%20Swift-macOS%20%7C%20Linux%20%7C%20Windows-6e7681)](#release-sorgente-080)
+[![Core Swift](https://img.shields.io/badge/core%20Swift-macOS%20%7C%20Linux%20%7C%20Windows-6e7681)](#candidata-sorgente-082)
 
-[In breve](#mediflow-in-breve) · [Uso attuale](#come-si-usa-oggi) · [Architettura](#come-collaborano-le-app) · [Schermate](#come-si-presenta) · [Stato](#release-sorgente-080) · [Avvio](#avvio-rapido) · [Sviluppo](#sviluppo-assistito)
+[In breve](#mediflow-in-breve) · [Uso attuale](#come-si-usa-oggi) · [Architettura](#come-collaborano-le-app) · [Schermate](#come-si-presenta) · [Stato](#candidata-sorgente-082) · [Avvio](#avvio-rapido) · [Sviluppo](#sviluppo-assistito)
 
 </div>
 
@@ -164,39 +164,38 @@ a dimensioni telefono o tablet restano evidenze di test e non fanno parte
 della galleria. Il [manifest media 0.8](./screenshots/0.8/manifest.json)
 registra dispositivo, runtime, scena, commit sorgente e hash._
 
-## Release sorgente 0.8.0
+## Candidata sorgente 0.8.2
 
-La release `0.8.0` distribuisce il codice sorgente verificato. Non costituisce
-una pubblicazione App Store, una certificazione o una dichiarazione di
-conformità completa.
+`0.8.2` è il prossimo progressivo sorgente. Questa branch prepara i metadati e
+le note, ma non è una release pubblicata e non contiene ancora i commit finali
+delle PR 174 e 175. Tag, GitHub Release e merge richiedono un'autorizzazione
+separata.
 
-La release consolida contratti AI review-first, hardening del pacchetto
-autonomo e una UI clinico-semantica coerente su localhost, macOS, iPhone e iPad.
-Le prove usano solo fixture sintetiche:
+Il delta previsto rafforza i confini di scrittura clinica, i messaggi delle API
+e i controlli di CI. Allinea anche le fixture Apple ai contratti dell'host.
 
-- iPhone: XCUITest 2/2 sul simulatore iOS 27;
-- iPad: XCUITest 7/7 sul simulatore iPadOS 27;
-- macOS: build, resize, focus, tastiera, Cmd-R contestuale e VoiceOver manuale;
-- localhost: 82/82 test, viewport 320/390/768/1440 e zoom reale 200%/400%.
+La prova iPad aggiunge quattro contratti UI su Xcode 27 e iPadOS 27. I quattro
+test sono passati senza fallimenti e senza skip. Le prove usano solo fixture
+sintetiche.
 
-Queste prove non dichiarano parity completa o conformità accessibilità. Gli
-audit automatici su iPhone e iPad sono verdi, ma VoiceOver reale mobile non è
-provato. L'API assistiva pubblica della beta Xcode 27 non ha raggiunto uno stato
-terminale nel simulatore. Il limite è registrato in
+Queste prove non dichiarano parity completa o conformità accessibilità. Il
+limite VoiceOver mobile resta registrato in
 [`docs/known-limitations.md`](./docs/known-limitations.md).
 
-### Aggiornamenti integrati
+### Stato del delta
 
-La tranche integrata rafforza i contratti dei contenitori JSON (`envelope`) AI.
-Un output AI deve rispettare il contratto dell'attività richiesta prima di
-diventare materiale di revisione. Un contenitore ambiguo, incompleto, multiplo o
-con chiavi riservate duplicate non può attivare il recupero legacy né essere
-usato.
+Le modifiche già presenti su `main` richiedono una revisione umana prima di
+ogni scrittura clinica proposta dall'AI. Il candidato WUL-547 impedisce alle
+API di esporre messaggi grezzi delle eccezioni; resta fuori da questa branch
+finché la testa revisionata non viene pubblicata e integrata tramite PR 174.
 
-Le diagnosi estratte da documento restano materiale di revisione: la sintesi
-non le aggiunge automaticamente alla scheda. Codex Operator personale non è
-incluso: i relativi limiti di sicurezza richiedono decisioni e correzioni
-separate.
+I controlli dello schema e OpenAPI sono già collegati ai workflow pertinenti.
+Il candidato WUL-544 completa il percorso Apple e iPad; resta fuori da questa
+branch finché la testa revisionata non viene pubblicata e integrata tramite PR
+175.
+
+La compatibilità tra un client Apple aggiornato e un host precedente resta
+aperta. WUL-546 conserva il limite e la decisione di contratto.
 
 Il dettaglio è nel [CHANGELOG](./CHANGELOG.md). La fotografia completa vive in
 [`docs/STATE_OF_THE_SYSTEM.md`](./docs/STATE_OF_THE_SYSTEM.md); la matrice
@@ -325,13 +324,15 @@ controllare: test reali e guard automatici decidono se una modifica regge.
 
 <!-- usage-dashboard:start -->
 
-| Snapshot | Periodo dei log disponibili | Token di sessione | Ripartizione | Cache letta |
-| :-- | :-- | --: | :-- | --: |
-| **29 luglio 2026** | 2026-02-01 → 2026-07-29 | **34.887.730.402** | Codex 25.026.076.888 · Claude Code 9.861.653.514 | 32.999.582.699 (94,6%) |
+| Snapshot | Periodo dei log disponibili | Token di sessione | Ripartizione | Cache letta | Copertura storica |
+| :-- | :-- | --: | :-- | --: | :-- |
+| **10 agosto 2026** | 2026-04-20 → 2026-08-10 | **34.402.274.768** | Codex 26.627.582.540 · Claude Code 7.774.692.228 | 32.815.994.682 (95,4%) | Codex UNKNOWN · Claude Code attestata |
 
-<img src="./screenshots/token-models.svg" alt="Snapshot 29 luglio 2026: 34,89 Mld token di sessione, 25,03 Mld in Codex e 9,86 Mld in Claude Code; 33 Mld da cache letta." width="720" loading="lazy"/>
+<img src="./screenshots/token-models.svg" alt="Snapshot 10 agosto 2026: 34,4 Mld token di sessione, 26,63 Mld in Codex e 7,77 Mld in Claude Code; 32,82 Mld da cache letta." width="720" loading="lazy"/>
 
-La fonte è **CodexBar 0.45.2**, comando locale `cost --refresh`, con una finestra massima di 365 giorni. Il conteggio usa gli aggregati disponibili per Codex e Claude Code e non è filtrato per repository. CodexBar attribuisce ogni token al processo che lo registra. Un worker OpenAI avviato da Claude Code compare quindi nel totale Claude Code. Il grafico indica lo strumento che registra i token, non il fornitore del modello.
+La fonte è **CodexBar 0.48.1**, comando locale `cost --refresh`, con una finestra massima di 365 giorni. Il conteggio usa gli aggregati disponibili per Codex e Claude Code e non è filtrato per repository. CodexBar attribuisce ogni token al processo che lo registra. Un worker OpenAI avviato da Claude Code compare quindi nel totale Claude Code. Il grafico indica lo strumento che registra i token, non il fornitore del modello.
+
+**ATTESTATO:** i valori sono le somme esatte dei log disponibili nel periodo indicato. **STIMATO:** nessun valore. **UNKNOWN:** la completezza storica resta sconosciuta quando CodexBar non la attesta. L'attribuzione a MediFlow, a una release, a una PR o a un commit è sempre sconosciuta.
 
 Rigenera il grafico con `npm run build:usage-dashboard`. Usa `CODEXBAR_BIN` per scegliere un eseguibile diverso e `USAGE_DASHBOARD_DAYS` per impostare una finestra da 1 a 365 giorni.
 

--- a/docs/STATE_OF_THE_SYSTEM.md
+++ b/docs/STATE_OF_THE_SYSTEM.md
@@ -18,11 +18,12 @@ read_when:
 > prevalgono [AGENTS.md](../AGENTS.md) e
 > [docs/repository-topology.md](./repository-topology.md).
 
-Ultimo aggiornamento: 2026-08-10 (preparazione release sorgente v0.8.2)
+Ultimo aggiornamento: 2026-08-11 (release sorgente v0.8.2)
 
 > [!NOTE]
-> La candidata v0.8.2 non è ancora pubblicata. Il tag remoto più recente resta
-> `v0.8.0`. Tag, GitHub Release e merge richiedono un'autorizzazione separata.
+> Questo documento prepara la release sorgente per il tag `v0.8.2`. Il tag e
+> la GitHub Release devono essere verificati sul repository remoto prima di
+> usarli come prova di pubblicazione. Non dichiara una pubblicazione App Store.
 > La deroga VoiceOver mobile e i rischi residui restano documentati.
 
 ---
@@ -75,9 +76,9 @@ La fotografia corrente e questa:
   VoiceOver reale mobile non è provato per il limite esterno della beta Xcode
   27; la deroga vale solo per la release sorgente e non autorizza claim di
   conformità.
-- **Checkpoint 0.8.2**: le PR 163-173 sono su `main`. Le PR 174 e 175 restano
-  aperte. I due commit finali hanno review DeepSeek pulita e verifica Sol.
-  La prova iPad registra 4/4 contratti UI passati senza skip su iPadOS 27.
+- **Checkpoint 0.8.2**: le PR 163-176 sono su `main`. I commit finali hanno
+  review DeepSeek e Sol pulite. Sul push a `main`, Apple Native ha superato
+  build, suite iPhone e 4/4 contratti iPad senza skip.
 - **Document intelligence**: Smart Import, nuova anagrafica da documento e
   `AI Patient Insight` restano reviewable; gli allegati possono persistere
   artifact cifrati `parse/evidence` con prime ancore sezionali. Il fallback OCR

--- a/docs/STATE_OF_THE_SYSTEM.md
+++ b/docs/STATE_OF_THE_SYSTEM.md
@@ -18,13 +18,12 @@ read_when:
 > prevalgono [AGENTS.md](../AGENTS.md) e
 > [docs/repository-topology.md](./repository-topology.md).
 
-Ultimo aggiornamento: 2026-07-29 (release sorgente v0.8)
+Ultimo aggiornamento: 2026-08-10 (preparazione release sorgente v0.8.2)
 
 > [!NOTE]
-> La v0.8 descritta qui è una release sorgente verificata. Il tag e la GitHub
-> Release non equivalgono a una pubblicazione App Store o a una certificazione.
-> I gate, la deroga VoiceOver mobile e il rischio residuo restano registrati
-> nei documenti canonici dell'area.
+> La candidata v0.8.2 non è ancora pubblicata. Il tag remoto più recente resta
+> `v0.8.0`. Tag, GitHub Release e merge richiedono un'autorizzazione separata.
+> La deroga VoiceOver mobile e i rischi residui restano documentati.
 
 ---
 
@@ -76,6 +75,9 @@ La fotografia corrente e questa:
   VoiceOver reale mobile non è provato per il limite esterno della beta Xcode
   27; la deroga vale solo per la release sorgente e non autorizza claim di
   conformità.
+- **Checkpoint 0.8.2**: le PR 163-173 sono su `main`. Le PR 174 e 175 restano
+  aperte. I due commit finali hanno review DeepSeek pulita e verifica Sol.
+  La prova iPad registra 4/4 contratti UI passati senza skip su iPadOS 27.
 - **Document intelligence**: Smart Import, nuova anagrafica da documento e
   `AI Patient Insight` restano reviewable; gli allegati possono persistere
   artifact cifrati `parse/evidence` con prime ancore sezionali. Il fallback OCR

--- a/native/MediFlowAppleApp/MediFlowAppleApp.xcodeproj/project.pbxproj
+++ b/native/MediFlowAppleApp/MediFlowAppleApp.xcodeproj/project.pbxproj
@@ -315,7 +315,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.8.0;
+				MARKETING_VERSION = 0.8.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mediflow.mobile;
 				PRODUCT_NAME = MediFlow;
 				SDKROOT = macosx;
@@ -352,7 +352,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.8.0;
+				MARKETING_VERSION = 0.8.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mediflow.mobile;
 				PRODUCT_NAME = MediFlow;
 				SDKROOT = macosx;
@@ -371,7 +371,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.8.0;
+				MARKETING_VERSION = 0.8.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mediflow.mobile;
 				PRODUCT_NAME = MediFlow;
 				SDKROOT = iphoneos;
@@ -392,7 +392,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.8.0;
+				MARKETING_VERSION = 0.8.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mediflow.mobile;
 				PRODUCT_NAME = MediFlow;
 				SDKROOT = iphoneos;

--- a/native/MediFlowAppleApp/Sources/MediFlowMacApp/Info.plist
+++ b/native/MediFlowAppleApp/Sources/MediFlowMacApp/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.8.0</string>
+	<string>0.8.2</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSApplicationCategoryType</key>

--- a/native/MediFlowAppleApp/Sources/MediFlowMobileApp/Info.plist
+++ b/native/MediFlowAppleApp/Sources/MediFlowMobileApp/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.8.0</string>
+	<string>0.8.2</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSApplicationCategoryType</key>

--- a/native/MediFlowAppleApp/project.yml
+++ b/native/MediFlowAppleApp/project.yml
@@ -23,7 +23,7 @@ targets:
       path: Sources/MediFlowMobileApp/Info.plist
       properties:
         CFBundleDisplayName: MediFlow
-        CFBundleShortVersionString: 0.8.0
+        CFBundleShortVersionString: 0.8.2
         LSApplicationCategoryType: public.app-category.medical
         UIApplicationSupportsIndirectInputEvents: true
         # Local-network discovery: required so Bonjour home-base discovery and
@@ -47,7 +47,7 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.mediflow.mobile
         PRODUCT_NAME: MediFlow
         TARGETED_DEVICE_FAMILY: "1,2"
-        MARKETING_VERSION: 0.8.0
+        MARKETING_VERSION: 0.8.2
         CURRENT_PROJECT_VERSION: 1
         SUPPORTS_MACCATALYST: NO
   MediFlowMacApp:
@@ -65,7 +65,7 @@ targets:
       path: Sources/MediFlowMacApp/Info.plist
       properties:
         CFBundleDisplayName: MediFlow
-        CFBundleShortVersionString: 0.8.0
+        CFBundleShortVersionString: 0.8.2
         LSApplicationCategoryType: public.app-category.medical
         # Local-network discovery for the home-base Bonjour service. Guarded by
         # check-apple-network-entitlements.sh.
@@ -78,7 +78,7 @@ targets:
         # Same bundle id as iOS for a single universal-purchase app record.
         PRODUCT_BUNDLE_IDENTIFIER: com.mediflow.mobile
         PRODUCT_NAME: MediFlow
-        MARKETING_VERSION: 0.8.0
+        MARKETING_VERSION: 0.8.2
         CURRENT_PROJECT_VERSION: 1
   MediFlowMobileAppUITests:
     type: bundle.ui-testing

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "medical-record-app",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "medical-record-app",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "hasInstallScript": true,
       "dependencies": {
         "@firecrawl/pdf-inspector": "1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medical-record-app",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": false,
   "engines": {
     "node": ">=24 <25"

--- a/screenshots/token-models.svg
+++ b/screenshots/token-models.svg
@@ -1,42 +1,42 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 720" width="920" height="720" role="img" aria-label="Dashboard token di sessione del 10 agosto 2026: totale 34.402.274.768, Codex 26.627.582.540, Claude Code 7.774.692.228.">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 720" width="920" height="720" role="img" aria-label="Dashboard token di sessione del 11 agosto 2026: totale 35.977.536.317, Codex 28.202.844.089, Claude Code 7.774.692.228.">
   <style>
     .frame{fill:#fbfaf7;stroke:#d9d7d1}.panel,.track{fill:#f0eee8}.rule{stroke:#e1ded8}.ink{fill:#181a1d}.muted{fill:#66707b}.body{fill:#31363d}.guide{stroke:#c9c6bf}
   </style>
   <defs><clipPath id="codex-bar"><rect x="48" y="168" width="824" height="38" rx="19"/></clipPath><clipPath id="claude-bar"><rect x="48" y="407" width="824" height="38" rx="19"/></clipPath></defs>
   <rect class="frame" x="6" y="6" width="908" height="708" rx="28" stroke-width="1.5"/>
   <text class="ink" x="48" y="62" font-family="Inter,-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="25" font-weight="720">Il lavoro assistito per ambiente</text>
-  <text class="muted" x="48" y="92" font-family="Inter,-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="13">CodexBar 0.48.1 · log 2026-04-20–2026-08-10 · snapshot 10 agosto 2026</text>
-  <rect class="panel" x="692" y="40" width="180" height="64" rx="16"/><text class="muted" x="712" y="62" font-family="Inter,sans-serif" font-size="10.5" font-weight="700" letter-spacing="0.8">TOTALE</text><text class="ink" x="712" y="90" font-family="Inter,sans-serif" font-size="23" font-weight="760">34,4 Mld</text>
+  <text class="muted" x="48" y="92" font-family="Inter,-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="13">CodexBar 0.48.1 · log 2026-04-20–2026-08-11 · snapshot 11 agosto 2026</text>
+  <rect class="panel" x="692" y="40" width="180" height="64" rx="16"/><text class="muted" x="712" y="62" font-family="Inter,sans-serif" font-size="10.5" font-weight="700" letter-spacing="0.8">TOTALE</text><text class="ink" x="712" y="90" font-family="Inter,sans-serif" font-size="23" font-weight="760">35,98 Mld</text>
   <line class="rule" x1="48" y1="126" x2="872" y2="126"/>
-  <text class="ink" x="48" y="153" font-family="Inter,sans-serif" font-size="15" font-weight="700">Codex</text><text x="872" y="153" text-anchor="end" font-family="IBM Plex Mono,ui-monospace,monospace" font-size="15" font-weight="650" fill="#7568c7">26,63 Mld</text>
-  <rect class="track" x="48" y="168" width="824" height="38" rx="19"/><g clip-path="url(#codex-bar)"><rect x="48.00" y="168" width="682.02" height="38" fill="#5f50b7"/>
-    <rect x="730.02" y="168" width="74.52" height="38" fill="#312968"/>
-    <rect x="804.53" y="168" width="58.42" height="38" fill="#887bcf"/>
-    <rect x="862.95" y="168" width="5.72" height="38" fill="#a99fdd"/>
-    <rect x="868.67" y="168" width="1.59" height="38" fill="#b8b1d8"/>
-    <rect x="870.26" y="168" width="1.49" height="38" fill="#cbc5e7"/>
-    <rect x="871.75" y="168" width="0.23" height="38" fill="#ddd9ec"/>
-    <rect x="871.98" y="168" width="0.01" height="38" fill="#4b3f97"/>
+  <text class="ink" x="48" y="153" font-family="Inter,sans-serif" font-size="15" font-weight="700">Codex</text><text x="872" y="153" text-anchor="end" font-family="IBM Plex Mono,ui-monospace,monospace" font-size="15" font-weight="650" fill="#7568c7">28,2 Mld</text>
+  <rect class="track" x="48" y="168" width="824" height="38" rx="19"/><g clip-path="url(#codex-bar)"><rect x="48.00" y="168" width="652.40" height="38" fill="#5f50b7"/>
+    <rect x="700.40" y="168" width="107.01" height="38" fill="#312968"/>
+    <rect x="807.40" y="168" width="56.01" height="38" fill="#887bcf"/>
+    <rect x="863.41" y="168" width="5.40" height="38" fill="#a99fdd"/>
+    <rect x="868.81" y="168" width="1.50" height="38" fill="#b8b1d8"/>
+    <rect x="870.32" y="168" width="1.42" height="38" fill="#cbc5e7"/>
+    <rect x="871.73" y="168" width="0.23" height="38" fill="#ddd9ec"/>
+    <rect x="871.97" y="168" width="0.03" height="38" fill="#4b3f97"/>
     <rect x="872.00" y="168" width="0.00" height="38" fill="#9b90d3"/></g>
-  <g font-family="Inter,-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="10.5"><rect x="48" y="228" width="10" height="10" rx="3" fill="#5f50b7"/><text class="body" x="65" y="237">GPT-5.6 Sol · 22,04 Mld</text>
-    <rect x="460" y="228" width="10" height="10" rx="3" fill="#312968"/><text class="body" x="477" y="237">GPT-5.5 storico · 2,41 Mld</text>
-    <rect x="48" y="253" width="10" height="10" rx="3" fill="#887bcf"/><text class="body" x="65" y="262">GPT-5.6 Terra · 1,89 Mld</text>
+  <g font-family="Inter,-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="10.5"><rect x="48" y="228" width="10" height="10" rx="3" fill="#5f50b7"/><text class="body" x="65" y="237">GPT-5.6 Sol · 22,33 Mld</text>
+    <rect x="460" y="228" width="10" height="10" rx="3" fill="#312968"/><text class="body" x="477" y="237">GPT-5.5 storico · 3,66 Mld</text>
+    <rect x="48" y="253" width="10" height="10" rx="3" fill="#887bcf"/><text class="body" x="65" y="262">GPT-5.6 Terra · 1,92 Mld</text>
     <rect x="460" y="253" width="10" height="10" rx="3" fill="#a99fdd"/><text class="body" x="477" y="262">GPT-5.6 Luna · 184,8 Mln</text>
     <rect x="48" y="278" width="10" height="10" rx="3" fill="#b8b1d8"/><text class="body" x="65" y="287">Modello non registrato · 51,41 Mln</text>
-    <rect x="460" y="278" width="10" height="10" rx="3" fill="#cbc5e7"/><text class="body" x="477" y="287">Codex Auto Review · 48,2 Mln</text>
-    <rect x="48" y="303" width="10" height="10" rx="3" fill="#ddd9ec"/><text class="body" x="65" y="312">Altri modelli Codex · 7,4 Mln</text>
-    <rect x="460" y="303" width="10" height="10" rx="3" fill="#4b3f97"/><text class="body" x="477" y="312">GPT-5.4 + mini · 452,9K</text>
+    <rect x="460" y="278" width="10" height="10" rx="3" fill="#cbc5e7"/><text class="body" x="477" y="287">Codex Auto Review · 48,47 Mln</text>
+    <rect x="48" y="303" width="10" height="10" rx="3" fill="#ddd9ec"/><text class="body" x="65" y="312">Altri modelli Codex · 8,01 Mln</text>
+    <rect x="460" y="303" width="10" height="10" rx="3" fill="#4b3f97"/><text class="body" x="477" y="312">GPT-5.4 + mini · 1,06 Mln</text>
     <rect x="48" y="328" width="10" height="10" rx="3" fill="#9b90d3"/><text class="body" x="65" y="337">GPT-5.3 Codex + Spark · 114,32K</text></g>
   <line class="rule" x1="48" y1="365" x2="872" y2="365"/>
   <text class="ink" x="48" y="392" font-family="Inter,sans-serif" font-size="15" font-weight="700">Claude Code</text><text x="872" y="392" text-anchor="end" font-family="IBM Plex Mono,ui-monospace,monospace" font-size="15" font-weight="650" fill="#cf7450">7,77 Mld</text>
-  <rect class="track" x="48" y="407" width="824" height="38" rx="19"/><g clip-path="url(#claude-bar)"><rect x="48.00" y="407" width="67.38" height="38" fill="#b95f3e"/>
-    <rect x="115.38" y="407" width="52.04" height="38" fill="#9f4b31"/>
-    <rect x="167.42" y="407" width="49.87" height="38" fill="#cf7450"/>
-    <rect x="217.29" y="407" width="41.55" height="38" fill="#8d412d"/>
-    <rect x="258.84" y="407" width="16.41" height="38" fill="#7568c7"/>
-    <rect x="275.26" y="407" width="13.21" height="38" fill="#e5a17e"/>
-    <rect x="288.47" y="407" width="0.12" height="38" fill="#edb99f"/>
-    <rect x="288.59" y="407" width="0.00" height="38" fill="#f2d2c2"/></g><line class="guide" x1="872" y1="164" x2="872" y2="449" stroke-dasharray="3 5"/>
+  <rect class="track" x="48" y="407" width="824" height="38" rx="19"/><g clip-path="url(#claude-bar)"><rect x="48.00" y="407" width="63.62" height="38" fill="#b95f3e"/>
+    <rect x="111.62" y="407" width="49.13" height="38" fill="#9f4b31"/>
+    <rect x="160.75" y="407" width="47.09" height="38" fill="#cf7450"/>
+    <rect x="207.84" y="407" width="39.23" height="38" fill="#8d412d"/>
+    <rect x="247.07" y="407" width="15.50" height="38" fill="#7568c7"/>
+    <rect x="262.56" y="407" width="12.47" height="38" fill="#e5a17e"/>
+    <rect x="275.04" y="407" width="0.11" height="38" fill="#edb99f"/>
+    <rect x="275.15" y="407" width="0.00" height="38" fill="#f2d2c2"/></g><line class="guide" x1="872" y1="164" x2="872" y2="449" stroke-dasharray="3 5"/>
   <g font-family="Inter,-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="10.5"><rect x="48" y="467" width="10" height="10" rx="3" fill="#b95f3e"/><text class="body" x="65" y="476">Opus 5 · 2,18 Mld</text>
     <rect x="460" y="467" width="10" height="10" rx="3" fill="#9f4b31"/><text class="body" x="477" y="476">Opus 4.8 · 1,68 Mld</text>
     <rect x="48" y="492" width="10" height="10" rx="3" fill="#cf7450"/><text class="body" x="65" y="501">Fable 5 · 1,61 Mld</text>
@@ -45,6 +45,6 @@
     <rect x="460" y="517" width="10" height="10" rx="3" fill="#e5a17e"/><text class="body" x="477" y="526">Sonnet 5 · 426,96 Mln</text>
     <rect x="48" y="542" width="10" height="10" rx="3" fill="#edb99f"/><text class="body" x="65" y="551">Haiku storico · 3,87 Mln</text>
     <rect x="460" y="542" width="10" height="10" rx="3" fill="#f2d2c2"/><text class="body" x="477" y="551">Modelli locali e residui · 48,6K</text></g>
-  <rect class="panel" x="48" y="594" width="824" height="60" rx="18"/><text class="muted" x="68" y="617" font-family="Inter,sans-serif" font-size="11" font-weight="700" letter-spacing="0.45">LETTURA DEL DATO</text><text class="ink" x="68" y="641" font-family="IBM Plex Mono,ui-monospace,monospace" font-size="13" font-weight="600">Cache letta: 32,82 Mld token (95,4% del contesto).</text>
+  <rect class="panel" x="48" y="594" width="824" height="60" rx="18"/><text class="muted" x="68" y="617" font-family="Inter,sans-serif" font-size="11" font-weight="700" letter-spacing="0.45">LETTURA DEL DATO</text><text class="ink" x="68" y="641" font-family="IBM Plex Mono,ui-monospace,monospace" font-size="13" font-weight="600">Cache letta: 34,31 Mld token (95,4% del contesto).</text>
   <text class="muted" x="48" y="691" font-family="Inter,sans-serif" font-size="10">Copertura: Codex UNKNOWN · Claude Code attestata</text><text class="muted" x="872" y="691" text-anchor="end" font-family="Inter,sans-serif" font-size="10">Stessa scala per entrambe le barre · valori arrotondati</text>
 </svg>

--- a/screenshots/token-models.svg
+++ b/screenshots/token-models.svg
@@ -1,50 +1,50 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 720" width="920" height="720" role="img" aria-label="Dashboard token di sessione del 29 luglio 2026: totale 34.887.730.402, Codex 25.026.076.888, Claude Code 9.861.653.514.">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 720" width="920" height="720" role="img" aria-label="Dashboard token di sessione del 10 agosto 2026: totale 34.402.274.768, Codex 26.627.582.540, Claude Code 7.774.692.228.">
   <style>
     .frame{fill:#fbfaf7;stroke:#d9d7d1}.panel,.track{fill:#f0eee8}.rule{stroke:#e1ded8}.ink{fill:#181a1d}.muted{fill:#66707b}.body{fill:#31363d}.guide{stroke:#c9c6bf}
   </style>
   <defs><clipPath id="codex-bar"><rect x="48" y="168" width="824" height="38" rx="19"/></clipPath><clipPath id="claude-bar"><rect x="48" y="407" width="824" height="38" rx="19"/></clipPath></defs>
   <rect class="frame" x="6" y="6" width="908" height="708" rx="28" stroke-width="1.5"/>
   <text class="ink" x="48" y="62" font-family="Inter,-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="25" font-weight="720">Il lavoro assistito per ambiente</text>
-  <text class="muted" x="48" y="92" font-family="Inter,-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="13">CodexBar 0.45.2 · log 2026-02-01–2026-07-29 · snapshot 29 luglio 2026</text>
-  <rect class="panel" x="692" y="40" width="180" height="64" rx="16"/><text class="muted" x="712" y="62" font-family="Inter,sans-serif" font-size="10.5" font-weight="700" letter-spacing="0.8">TOTALE</text><text class="ink" x="712" y="90" font-family="Inter,sans-serif" font-size="23" font-weight="760">34,89 Mld</text>
+  <text class="muted" x="48" y="92" font-family="Inter,-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="13">CodexBar 0.48.1 · log 2026-04-20–2026-08-10 · snapshot 10 agosto 2026</text>
+  <rect class="panel" x="692" y="40" width="180" height="64" rx="16"/><text class="muted" x="712" y="62" font-family="Inter,sans-serif" font-size="10.5" font-weight="700" letter-spacing="0.8">TOTALE</text><text class="ink" x="712" y="90" font-family="Inter,sans-serif" font-size="23" font-weight="760">34,4 Mld</text>
   <line class="rule" x1="48" y1="126" x2="872" y2="126"/>
-  <text class="ink" x="48" y="153" font-family="Inter,sans-serif" font-size="15" font-weight="700">Codex</text><text x="872" y="153" text-anchor="end" font-family="IBM Plex Mono,ui-monospace,monospace" font-size="15" font-weight="650" fill="#7568c7">25,03 Mld</text>
-  <rect class="track" x="48" y="168" width="824" height="38" rx="19"/><g clip-path="url(#codex-bar)"><rect x="48.00" y="168" width="467.23" height="38" fill="#5f50b7"/>
-    <rect x="515.23" y="168" width="160.25" height="38" fill="#312968"/>
-    <rect x="675.47" y="168" width="117.23" height="38" fill="#4b3f97"/>
-    <rect x="792.70" y="168" width="43.00" height="38" fill="#887bcf"/>
-    <rect x="835.70" y="168" width="14.30" height="38" fill="#b8b1d8"/>
-    <rect x="850.00" y="168" width="13.47" height="38" fill="#9b90d3"/>
-    <rect x="863.47" y="168" width="3.58" height="38" fill="#a99fdd"/>
-    <rect x="867.06" y="168" width="3.53" height="38" fill="#ddd9ec"/>
-    <rect x="870.59" y="168" width="1.41" height="38" fill="#cbc5e7"/></g>
-  <g font-family="Inter,-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="10.5"><rect x="48" y="228" width="10" height="10" rx="3" fill="#5f50b7"/><text class="body" x="65" y="237">GPT-5.6 Sol · 14,19 Mld</text>
-    <rect x="460" y="228" width="10" height="10" rx="3" fill="#312968"/><text class="body" x="477" y="237">GPT-5.5 storico · 4,87 Mld</text>
-    <rect x="48" y="253" width="10" height="10" rx="3" fill="#4b3f97"/><text class="body" x="65" y="262">GPT-5.4 + mini · 3,56 Mld</text>
-    <rect x="460" y="253" width="10" height="10" rx="3" fill="#887bcf"/><text class="body" x="477" y="262">GPT-5.6 Terra · 1,31 Mld</text>
-    <rect x="48" y="278" width="10" height="10" rx="3" fill="#b8b1d8"/><text class="body" x="65" y="287">Modello non registrato · 434,42 Mln</text>
-    <rect x="460" y="278" width="10" height="10" rx="3" fill="#9b90d3"/><text class="body" x="477" y="287">GPT-5.3 Codex + Spark · 409,07 Mln</text>
-    <rect x="48" y="303" width="10" height="10" rx="3" fill="#a99fdd"/><text class="body" x="65" y="312">GPT-5.6 Luna · 108,85 Mln</text>
-    <rect x="460" y="303" width="10" height="10" rx="3" fill="#ddd9ec"/><text class="body" x="477" y="312">Altri modelli Codex · 107,29 Mln</text>
-    <rect x="48" y="328" width="10" height="10" rx="3" fill="#cbc5e7"/><text class="body" x="65" y="337">Codex Auto Review · 42,84 Mln</text></g>
+  <text class="ink" x="48" y="153" font-family="Inter,sans-serif" font-size="15" font-weight="700">Codex</text><text x="872" y="153" text-anchor="end" font-family="IBM Plex Mono,ui-monospace,monospace" font-size="15" font-weight="650" fill="#7568c7">26,63 Mld</text>
+  <rect class="track" x="48" y="168" width="824" height="38" rx="19"/><g clip-path="url(#codex-bar)"><rect x="48.00" y="168" width="682.02" height="38" fill="#5f50b7"/>
+    <rect x="730.02" y="168" width="74.52" height="38" fill="#312968"/>
+    <rect x="804.53" y="168" width="58.42" height="38" fill="#887bcf"/>
+    <rect x="862.95" y="168" width="5.72" height="38" fill="#a99fdd"/>
+    <rect x="868.67" y="168" width="1.59" height="38" fill="#b8b1d8"/>
+    <rect x="870.26" y="168" width="1.49" height="38" fill="#cbc5e7"/>
+    <rect x="871.75" y="168" width="0.23" height="38" fill="#ddd9ec"/>
+    <rect x="871.98" y="168" width="0.01" height="38" fill="#4b3f97"/>
+    <rect x="872.00" y="168" width="0.00" height="38" fill="#9b90d3"/></g>
+  <g font-family="Inter,-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="10.5"><rect x="48" y="228" width="10" height="10" rx="3" fill="#5f50b7"/><text class="body" x="65" y="237">GPT-5.6 Sol · 22,04 Mld</text>
+    <rect x="460" y="228" width="10" height="10" rx="3" fill="#312968"/><text class="body" x="477" y="237">GPT-5.5 storico · 2,41 Mld</text>
+    <rect x="48" y="253" width="10" height="10" rx="3" fill="#887bcf"/><text class="body" x="65" y="262">GPT-5.6 Terra · 1,89 Mld</text>
+    <rect x="460" y="253" width="10" height="10" rx="3" fill="#a99fdd"/><text class="body" x="477" y="262">GPT-5.6 Luna · 184,8 Mln</text>
+    <rect x="48" y="278" width="10" height="10" rx="3" fill="#b8b1d8"/><text class="body" x="65" y="287">Modello non registrato · 51,41 Mln</text>
+    <rect x="460" y="278" width="10" height="10" rx="3" fill="#cbc5e7"/><text class="body" x="477" y="287">Codex Auto Review · 48,2 Mln</text>
+    <rect x="48" y="303" width="10" height="10" rx="3" fill="#ddd9ec"/><text class="body" x="65" y="312">Altri modelli Codex · 7,4 Mln</text>
+    <rect x="460" y="303" width="10" height="10" rx="3" fill="#4b3f97"/><text class="body" x="477" y="312">GPT-5.4 + mini · 452,9K</text>
+    <rect x="48" y="328" width="10" height="10" rx="3" fill="#9b90d3"/><text class="body" x="65" y="337">GPT-5.3 Codex + Spark · 114,32K</text></g>
   <line class="rule" x1="48" y1="365" x2="872" y2="365"/>
-  <text class="ink" x="48" y="392" font-family="Inter,sans-serif" font-size="15" font-weight="700">Claude Code</text><text x="872" y="392" text-anchor="end" font-family="IBM Plex Mono,ui-monospace,monospace" font-size="15" font-weight="650" fill="#cf7450">9,86 Mld</text>
-  <rect class="track" x="48" y="407" width="824" height="38" rx="19"/><g clip-path="url(#claude-bar)"><rect x="48.00" y="407" width="140.45" height="38" fill="#9f4b31"/>
-    <rect x="188.45" y="407" width="64.03" height="38" fill="#cf7450"/>
-    <rect x="252.48" y="407" width="44.21" height="38" fill="#8d412d"/>
-    <rect x="296.68" y="407" width="37.41" height="38" fill="#b95f3e"/>
-    <rect x="334.09" y="407" width="17.56" height="38" fill="#e5a17e"/>
-    <rect x="351.66" y="407" width="17.46" height="38" fill="#7568c7"/>
-    <rect x="369.12" y="407" width="3.58" height="38" fill="#edb99f"/>
-    <rect x="372.70" y="407" width="0.00" height="38" fill="#f2d2c2"/></g><line class="guide" x1="872" y1="164" x2="872" y2="449" stroke-dasharray="3 5"/>
-  <g font-family="Inter,-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="10.5"><rect x="48" y="467" width="10" height="10" rx="3" fill="#9f4b31"/><text class="body" x="65" y="476">Opus 4.8 · 4,27 Mld</text>
-    <rect x="460" y="467" width="10" height="10" rx="3" fill="#cf7450"/><text class="body" x="477" y="476">Fable 5 · 1,94 Mld</text>
-    <rect x="48" y="492" width="10" height="10" rx="3" fill="#8d412d"/><text class="body" x="65" y="501">Opus 4.7 storico · 1,34 Mld</text>
-    <rect x="460" y="492" width="10" height="10" rx="3" fill="#b95f3e"/><text class="body" x="477" y="501">Opus 5 · 1,14 Mld</text>
-    <rect x="48" y="517" width="10" height="10" rx="3" fill="#e5a17e"/><text class="body" x="65" y="526">Sonnet 5 · 533,38 Mln</text>
-    <rect x="460" y="517" width="10" height="10" rx="3" fill="#7568c7"/><text class="body" x="477" y="526">OpenAI via Claude Code · 530,42 Mln</text>
-    <rect x="48" y="542" width="10" height="10" rx="3" fill="#edb99f"/><text class="body" x="65" y="551">Haiku storico · 108,7 Mln</text>
+  <text class="ink" x="48" y="392" font-family="Inter,sans-serif" font-size="15" font-weight="700">Claude Code</text><text x="872" y="392" text-anchor="end" font-family="IBM Plex Mono,ui-monospace,monospace" font-size="15" font-weight="650" fill="#cf7450">7,77 Mld</text>
+  <rect class="track" x="48" y="407" width="824" height="38" rx="19"/><g clip-path="url(#claude-bar)"><rect x="48.00" y="407" width="67.38" height="38" fill="#b95f3e"/>
+    <rect x="115.38" y="407" width="52.04" height="38" fill="#9f4b31"/>
+    <rect x="167.42" y="407" width="49.87" height="38" fill="#cf7450"/>
+    <rect x="217.29" y="407" width="41.55" height="38" fill="#8d412d"/>
+    <rect x="258.84" y="407" width="16.41" height="38" fill="#7568c7"/>
+    <rect x="275.26" y="407" width="13.21" height="38" fill="#e5a17e"/>
+    <rect x="288.47" y="407" width="0.12" height="38" fill="#edb99f"/>
+    <rect x="288.59" y="407" width="0.00" height="38" fill="#f2d2c2"/></g><line class="guide" x1="872" y1="164" x2="872" y2="449" stroke-dasharray="3 5"/>
+  <g font-family="Inter,-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="10.5"><rect x="48" y="467" width="10" height="10" rx="3" fill="#b95f3e"/><text class="body" x="65" y="476">Opus 5 · 2,18 Mld</text>
+    <rect x="460" y="467" width="10" height="10" rx="3" fill="#9f4b31"/><text class="body" x="477" y="476">Opus 4.8 · 1,68 Mld</text>
+    <rect x="48" y="492" width="10" height="10" rx="3" fill="#cf7450"/><text class="body" x="65" y="501">Fable 5 · 1,61 Mld</text>
+    <rect x="460" y="492" width="10" height="10" rx="3" fill="#8d412d"/><text class="body" x="477" y="501">Opus 4.7 storico · 1,34 Mld</text>
+    <rect x="48" y="517" width="10" height="10" rx="3" fill="#7568c7"/><text class="body" x="65" y="526">OpenAI via Claude Code · 530,42 Mln</text>
+    <rect x="460" y="517" width="10" height="10" rx="3" fill="#e5a17e"/><text class="body" x="477" y="526">Sonnet 5 · 426,96 Mln</text>
+    <rect x="48" y="542" width="10" height="10" rx="3" fill="#edb99f"/><text class="body" x="65" y="551">Haiku storico · 3,87 Mln</text>
     <rect x="460" y="542" width="10" height="10" rx="3" fill="#f2d2c2"/><text class="body" x="477" y="551">Modelli locali e residui · 48,6K</text></g>
-  <rect class="panel" x="48" y="594" width="824" height="60" rx="18"/><text class="muted" x="68" y="617" font-family="Inter,sans-serif" font-size="11" font-weight="700" letter-spacing="0.45">LETTURA DEL DATO</text><text class="ink" x="68" y="641" font-family="IBM Plex Mono,ui-monospace,monospace" font-size="13" font-weight="600">Cache letta: 33 Mld token (94,6% del contesto).</text>
-  <text class="muted" x="872" y="691" text-anchor="end" font-family="Inter,sans-serif" font-size="10">Stessa scala per entrambe le barre · valori arrotondati</text>
+  <rect class="panel" x="48" y="594" width="824" height="60" rx="18"/><text class="muted" x="68" y="617" font-family="Inter,sans-serif" font-size="11" font-weight="700" letter-spacing="0.45">LETTURA DEL DATO</text><text class="ink" x="68" y="641" font-family="IBM Plex Mono,ui-monospace,monospace" font-size="13" font-weight="600">Cache letta: 32,82 Mld token (95,4% del contesto).</text>
+  <text class="muted" x="48" y="691" font-family="Inter,sans-serif" font-size="10">Copertura: Codex UNKNOWN · Claude Code attestata</text><text class="muted" x="872" y="691" text-anchor="end" font-family="Inter,sans-serif" font-size="10">Stessa scala per entrambe le barre · valori arrotondati</text>
 </svg>

--- a/scripts/build-usage-dashboard.mjs
+++ b/scripts/build-usage-dashboard.mjs
@@ -77,6 +77,7 @@ console.log(`Totale ${formatInteger(total.totalTokens)} token`);
 console.log(`Codex ${formatInteger(codex.totalTokens)} token`);
 console.log(`Claude Code ${formatInteger(claude.totalTokens)} token`);
 console.log(`Cache letta ${formatInteger(total.cacheReadTokens)} token (${formatPct(total.cacheReadTokens, total.totalTokens)})`);
+console.log(`Copertura Codex ${coverageLabel(codex)}, Claude Code ${coverageLabel(claude)}`);
 console.log(`Fonte ${version}, finestra richiesta ${HISTORY_DAYS} giorni`);
 
 function readCodexBarVersion() {
@@ -181,10 +182,14 @@ function readProvider(provider) {
   if (!Number.isFinite(updatedAt)) {
     throw new Error(`Timestamp CodexBar non interpretabile per ${provider}.`);
   }
+  if (typeof record.historyCoverageIsEstablished !== 'boolean') {
+    throw new Error(`Copertura storica CodexBar non dichiarata per ${provider}.`);
+  }
 
   return {
     provider,
     updatedAt,
+    historyCoverageIsEstablished: record.historyCoverageIsEstablished,
     totalTokens,
     cacheReadTokens,
     models,
@@ -232,11 +237,12 @@ function groupFamilies(models, definitions, expectedTotal) {
 function buildReadmeBlock({ codex, claude, total, snapshot, period, version }) {
   const alt = `Snapshot ${snapshot.label}: ${formatCompact(total.totalTokens)} token di sessione, ${formatCompact(codex.totalTokens)} in Codex e ${formatCompact(claude.totalTokens)} in Claude Code; ${formatCompact(total.cacheReadTokens)} da cache letta.`;
   return `${START}\n\n` +
-    `| Snapshot | Periodo dei log disponibili | Token di sessione | Ripartizione | Cache letta |\n` +
-    `| :-- | :-- | --: | :-- | --: |\n` +
-    `| **${snapshot.label}** | ${period.first} → ${period.last} | **${formatInteger(total.totalTokens)}** | Codex ${formatInteger(codex.totalTokens)} · Claude Code ${formatInteger(claude.totalTokens)} | ${formatInteger(total.cacheReadTokens)} (${formatPct(total.cacheReadTokens, total.totalTokens)}) |\n\n` +
+    `| Snapshot | Periodo dei log disponibili | Token di sessione | Ripartizione | Cache letta | Copertura storica |\n` +
+    `| :-- | :-- | --: | :-- | --: | :-- |\n` +
+    `| **${snapshot.label}** | ${period.first} → ${period.last} | **${formatInteger(total.totalTokens)}** | Codex ${formatInteger(codex.totalTokens)} · Claude Code ${formatInteger(claude.totalTokens)} | ${formatInteger(total.cacheReadTokens)} (${formatPct(total.cacheReadTokens, total.totalTokens)}) | Codex ${coverageLabel(codex)} · Claude Code ${coverageLabel(claude)} |\n\n` +
     `<img src="./screenshots/token-models.svg" alt="${alt}" width="720" loading="lazy"/>\n\n` +
     `La fonte è **${version}**, comando locale \`cost --refresh\`, con una finestra massima di ${HISTORY_DAYS} giorni. Il conteggio usa gli aggregati disponibili per Codex e Claude Code e non è filtrato per repository. CodexBar attribuisce ogni token al processo che lo registra. Un worker OpenAI avviato da Claude Code compare quindi nel totale Claude Code. Il grafico indica lo strumento che registra i token, non il fornitore del modello.\n\n` +
+    `**ATTESTATO:** i valori sono le somme esatte dei log disponibili nel periodo indicato. **STIMATO:** nessun valore. **UNKNOWN:** la completezza storica resta sconosciuta quando CodexBar non la attesta. L'attribuzione a MediFlow, a una release, a una PR o a un commit è sempre sconosciuta.\n\n` +
     `Rigenera il grafico con \`npm run build:usage-dashboard\`. Usa \`CODEXBAR_BIN\` per scegliere un eseguibile diverso e \`USAGE_DASHBOARD_DAYS\` per impostare una finestra da 1 a 365 giorni.\n\n` +
     `Le barre sono divise per modello e usano la stessa scala. La cache letta è una parte dell'input Codex, mentre CodexBar la espone come categoria separata per Claude Code: per questo il grafico non impila categorie di token con semantiche diverse. Sono pubblicati soltanto aggregati. Nessun prompt, contenuto di sessione, costo o percorso locale entra nel README o nell'SVG.\n\n` +
     `Il dato misura contesto elaborato. Non misura righe di codice, costo o qualità.\n\n` +
@@ -278,7 +284,7 @@ function buildSvg({ codex, claude, total, snapshot, period, version, families })
   <rect class="track" x="48" y="407" width="824" height="38" rx="19"/><g clip-path="url(#claude-bar)">${segments(families.claude, 407)}</g><line class="guide" x1="872" y1="164" x2="872" y2="449" stroke-dasharray="3 5"/>
   <g font-family="Inter,-apple-system,BlinkMacSystemFont,Segoe UI,sans-serif" font-size="10.5">${legend(families.claude, 476, 2)}</g>
   <rect class="panel" x="48" y="594" width="824" height="60" rx="18"/><text class="muted" x="68" y="617" font-family="Inter,sans-serif" font-size="11" font-weight="700" letter-spacing="0.45">LETTURA DEL DATO</text><text class="ink" x="68" y="641" font-family="IBM Plex Mono,ui-monospace,monospace" font-size="13" font-weight="600">Cache letta: ${formatCompact(total.cacheReadTokens)} token (${formatPct(total.cacheReadTokens, total.totalTokens)} del contesto).</text>
-  <text class="muted" x="872" y="691" text-anchor="end" font-family="Inter,sans-serif" font-size="10">Stessa scala per entrambe le barre · valori arrotondati</text>
+  <text class="muted" x="48" y="691" font-family="Inter,sans-serif" font-size="10">Copertura: Codex ${coverageLabel(codex)} · Claude Code ${coverageLabel(claude)}</text><text class="muted" x="872" y="691" text-anchor="end" font-family="Inter,sans-serif" font-size="10">Stessa scala per entrambe le barre · valori arrotondati</text>
 </svg>\n`;
 }
 
@@ -315,6 +321,10 @@ function formatCompact(value) {
 function formatPct(part, whole) {
   if (!whole) return '0%';
   return `${new Intl.NumberFormat('it-IT', { maximumFractionDigits: 1 }).format(part * 100 / whole)}%`;
+}
+
+function coverageLabel(provider) {
+  return provider.historyCoverageIsEstablished ? 'attestata' : 'UNKNOWN';
 }
 
 function tokenInteger(value, label) {


### PR DESCRIPTION
## Summary
- Allinea package, lockfile e metadati Apple alla versione sorgente 0.8.2.
- Finalizza changelog, README e stato canonico con note in italiano tecnico semplificato.
- Rigenera il dashboard token separando dati attestati e valori UNKNOWN.
- Registra le prove post-merge Apple/iPad e i limiti ancora aperti.

## Verification
- Node 24.18.0: lint e typecheck PASS.
- Guard errori API: self-test 18/18 e scan 140 route, zero violazioni.
- Plist, YAML, progetto Xcode e version surfaces: PASS.
- GitHub `main` 67920e976: sei workflow verdi.
- Apple Native 31433472562: iPad 4/4 senza skip, iPhone 36 test con zero failure.
- Autoreview release: claim tag prematuro corretto; finding API grezzo corretto e integrato con PR 177.

## Risk / Notes
- Nessuna migrazione database.
- Lo snapshot token non è attribuibile alla sola MediFlow o alla release; copertura Codex UNKNOWN.
- Il manifest media `screenshots/0.8/manifest.json` resta storicamente 0.8.0.
- Tag `v0.8.2` e GitHub Release saranno creati solo dopo merge e CI verde di questa PR.
- Nessuna PHI/PII, credenziale o dato clinico reale incluso.

## Ticket
Refs WUL-481