### PR TITLE
feat: add agent capability manifest drift gate

### DIFF
--- a/lib/agent-interface/manifest.test.ts
+++ b/lib/agent-interface/manifest.test.ts
@@ -26,3 +26,19 @@ test('rifiuta una capability senza una classificazione sorgente esplicita', () =
         `${first.id}: at least one source classification is required`,
     ]);
 });
+
+test('rifiuta ID capability duplicati', () => {
+    const [first] = AGENT_INTERFACE_MANIFEST;
+    assert.ok(first);
+    assert.deepEqual(validateAgentInterfaceManifest([first, { ...first }]), [
+        `${first.id}: duplicated capability id`,
+    ]);
+});
+
+test('rifiuta una versione schema diversa dal contratto', () => {
+    const [first] = AGENT_INTERFACE_MANIFEST;
+    assert.ok(first);
+    assert.deepEqual(validateAgentInterfaceManifest([{ ...first, schemaVersion: 'mediflow.agent-interface.manifest.v2' as never }]), [
+        `${first.id}: schemaVersion must be mediflow.agent-interface.manifest.v1`,
+    ]);
+});

--- a/lib/agent-interface/manifest.test.ts
+++ b/lib/agent-interface/manifest.test.ts
@@ -1,0 +1,28 @@
+/* @Codex */
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    AGENT_INTERFACE_MANIFEST,
+    validateAgentInterfaceManifest,
+} from './manifest.ts';
+
+test('classifica ogni capability dichiarata senza renderla disponibile', () => {
+    assert.deepEqual(validateAgentInterfaceManifest(AGENT_INTERFACE_MANIFEST), []);
+    assert.ok(AGENT_INTERFACE_MANIFEST.every((capability) => capability.headlessDisposition !== 'available'));
+});
+
+test('rifiuta una capability manuale priva di motivazione', () => {
+    const [first] = AGENT_INTERFACE_MANIFEST;
+    assert.ok(first);
+    assert.deepEqual(validateAgentInterfaceManifest([{ ...first, reason: null }]), [
+        `${first.id}: reason is required for manual_only`,
+    ]);
+});
+
+test('rifiuta una capability senza una classificazione sorgente esplicita', () => {
+    const [first] = AGENT_INTERFACE_MANIFEST;
+    assert.ok(first);
+    assert.deepEqual(validateAgentInterfaceManifest([{ ...first, sources: {} }]), [
+        `${first.id}: at least one source classification is required`,
+    ]);
+});

--- a/lib/agent-interface/manifest.ts
+++ b/lib/agent-interface/manifest.ts
@@ -1,0 +1,78 @@
+/* @Codex */
+
+export const AGENT_INTERFACE_MANIFEST_SCHEMA = 'mediflow.agent-interface.manifest.v1' as const;
+
+type SourceKind = 'openApi' | 'paired' | 'fabric';
+type SourceClassifications = Partial<Record<SourceKind, readonly string[]>>;
+type HeadlessDisposition = 'available' | 'proposal_only' | 'manual_only' | 'unavailable';
+
+export interface AgentInterfaceCapability {
+    readonly id: string;
+    readonly schemaVersion: typeof AGENT_INTERFACE_MANIFEST_SCHEMA;
+    readonly maximumStage: 'observe' | 'read' | 'compute' | 'propose' | 'preview' | 'apply';
+    readonly headlessDisposition: HeadlessDisposition;
+    readonly requiredContext: readonly string[];
+    readonly venue: readonly string[];
+    readonly egress: 'none';
+    readonly fallback: 'denied_by_contract';
+    readonly reason: string | null;
+    readonly sources: SourceClassifications;
+}
+
+const OPENAPI_OPERATIONS = [
+    'GET /api/v1/patients', 'GET /api/v1/patients/{id}', 'PUT /api/v1/patients/{id}', 'DELETE /api/v1/patients/{id}',
+    'GET /api/v1/network/node', 'GET /api/v1/network/session', 'GET /api/v1/network/capabilities', 'GET /api/v1/network/identity', 'GET /api/v1/network/revision', 'GET /api/v1/network/ai-runtime', 'POST /api/v1/network/visit-draft',
+    'GET /api/v1/network/pairing-intents', 'POST /api/v1/network/pairing-intents', 'POST /api/v1/network/pairing-intents/{intentId}/confirm', 'DELETE /api/v1/network/pairing-clients/{clientId}',
+    'GET /api/v1/network/ambulatories', 'POST /api/v1/network/ambulatories', 'PUT /api/v1/network/ambulatories/{id}', 'DELETE /api/v1/network/ambulatories/{id}', 'POST /api/v1/network/ambulatories/clear',
+    'GET /api/v1/network/drugs', 'GET /api/v1/network/exemptions', 'GET /api/v1/network/terminology/search', 'GET /api/v1/network/terminology/resolve', 'GET /api/v1/network/terminology/systems',
+    'GET /api/v1/network/service-prescriptions', 'POST /api/v1/network/service-prescriptions', 'PUT /api/v1/network/service-prescriptions/{id}', 'GET /api/v1/network/service-prescription-items', 'POST /api/v1/network/service-prescription-items', 'PUT /api/v1/network/service-prescription-items/{id}', 'GET /api/v1/network/service-catalog',
+    'GET /api/v1/network/prosthetic-prescriptions', 'POST /api/v1/network/prosthetic-prescriptions', 'PUT /api/v1/network/prosthetic-prescriptions/{id}',
+    'GET /api/v1/network/patients', 'POST /api/v1/network/patients', 'GET /api/v1/network/checkups', 'GET /api/v1/network/entries', 'GET /api/v1/network/patients/{id}', 'PUT /api/v1/network/patients/{id}', 'DELETE /api/v1/network/patients/{id}', 'POST /api/v1/network/patients/{id}/restore',
+    'GET /api/v1/network/patients/{id}/entries', 'POST /api/v1/network/patients/{id}/entries', 'GET /api/v1/network/patients/{id}/entries/{entryId}', 'PUT /api/v1/network/patients/{id}/entries/{entryId}',
+    'GET /api/v1/network/patients/{id}/therapies', 'POST /api/v1/network/patients/{id}/therapies', 'GET /api/v1/network/patients/{id}/therapies/{therapyId}', 'PUT /api/v1/network/patients/{id}/therapies/{therapyId}',
+    'GET /api/v1/network/patients/{id}/checkups', 'POST /api/v1/network/patients/{id}/checkups', 'GET /api/v1/network/patients/{id}/checkups/{checkupId}', 'PUT /api/v1/network/patients/{id}/checkups/{checkupId}',
+    'GET /api/v1/network/patients/{id}/observations', 'POST /api/v1/network/patients/{id}/observations', 'GET /api/v1/network/patients/{id}/observations/{observationId}', 'PUT /api/v1/network/patients/{id}/observations/{observationId}',
+    'GET /api/v1/network/patients/{id}/attachments', 'POST /api/v1/network/patients/{id}/attachments', 'GET /api/v1/network/patients/{id}/attachments/{attachmentId}', 'GET /api/v1/network/fse/validate-patient', 'POST /api/v1/network/fse/validate-document',
+] as const;
+
+const PAIRED_CAPABILITIES = [
+    'network.pairing.bootstrap', 'network.ambulatories.write', 'network.replica.readonly-patients', 'network.replica.readonly-clinical-diary', 'network.replica.write-patient-profile', 'network.replica.write-patient-lifecycle', 'network.replica.write-clinical-diary', 'network.replica.readonly-therapies', 'network.replica.write-therapies', 'network.replica.readonly-checkups', 'network.replica.readonly-agenda', 'network.replica.readonly-clinical-diary-global', 'network.replica.write-checkups', 'network.replica.readonly-observations', 'network.replica.write-observations', 'network.replica.readonly-service-prescriptions', 'network.replica.write-service-prescriptions', 'network.replica.readonly-prosthetic-prescriptions', 'network.replica.write-prosthetic-prescriptions', 'network.fse.validate', 'network.catalogs.readonly', 'network.replica.readonly-documents', 'network.replica.write-documents', 'network.compute.visit-draft', 'network.replica.sync', 'network.ai.central-runtime', 'network.catalogs.sync', 'local.backup.artifact.v1', 'local.backup.scheduler.macos',
+] as const;
+
+const FABRIC_CAPABILITIES = [
+    'patient_insight', 'smart_import', 'document_synthesis', 'ocr', 'treatment_reasoning',
+    'icd_lookup', 'aifa_drug_search', 'service_prescription_matching', 'evidence_absorption', 'patient_open_loops', 'fhir_export', 'document_classification', 'document_identity_resolution', 'pii_redaction_layer1', 'fse_document_validation', 'observation_range_classification',
+] as const;
+
+const MANUAL_REASON = 'ADR 0093 remains Proposed: no agent session, context lease, or adapter authorizes this capability.';
+
+function classified(kind: SourceKind, identifiers: readonly string[]): AgentInterfaceCapability[] {
+    return identifiers.map((identifier) => Object.freeze({
+        id: `agent.interface.${kind}.${identifier.replace(/[^a-z0-9]+/gi, '-').replace(/^-|-$/g, '').toLowerCase()}.v1`,
+        schemaVersion: AGENT_INTERFACE_MANIFEST_SCHEMA,
+        maximumStage: 'observe',
+        headlessDisposition: 'manual_only',
+        requiredContext: Object.freeze([]),
+        venue: Object.freeze(['local_process']),
+        egress: 'none',
+        fallback: 'denied_by_contract',
+        reason: MANUAL_REASON,
+        sources: Object.freeze({ [kind]: Object.freeze([identifier]) }),
+    }));
+}
+
+export const AGENT_INTERFACE_MANIFEST: readonly AgentInterfaceCapability[] = Object.freeze([
+    ...classified('openApi', OPENAPI_OPERATIONS),
+    ...classified('paired', PAIRED_CAPABILITIES),
+    ...classified('fabric', FABRIC_CAPABILITIES),
+]);
+
+export function validateAgentInterfaceManifest(manifest: readonly AgentInterfaceCapability[]): string[] {
+    const errors: string[] = [];
+    for (const capability of manifest) {
+        if (!capability.id || !capability.schemaVersion || !capability.maximumStage || !capability.headlessDisposition) errors.push(`${capability.id}: required declaration is missing`);
+        if (capability.headlessDisposition !== 'available' && !capability.reason) errors.push(`${capability.id}: reason is required for ${capability.headlessDisposition}`);
+        if (!Object.values(capability.sources).some((identifiers) => identifiers?.length)) errors.push(`${capability.id}: at least one source classification is required`);
+    }
+    return errors;
+}

--- a/lib/agent-interface/manifest.ts
+++ b/lib/agent-interface/manifest.ts
@@ -69,8 +69,12 @@ export const AGENT_INTERFACE_MANIFEST: readonly AgentInterfaceCapability[] = Obj
 
 export function validateAgentInterfaceManifest(manifest: readonly AgentInterfaceCapability[]): string[] {
     const errors: string[] = [];
+    const capabilityIds = new Set<string>();
     for (const capability of manifest) {
+        if (capabilityIds.has(capability.id)) errors.push(`${capability.id}: duplicated capability id`);
+        capabilityIds.add(capability.id);
         if (!capability.id || !capability.schemaVersion || !capability.maximumStage || !capability.headlessDisposition) errors.push(`${capability.id}: required declaration is missing`);
+        if (capability.schemaVersion !== AGENT_INTERFACE_MANIFEST_SCHEMA) errors.push(`${capability.id}: schemaVersion must be ${AGENT_INTERFACE_MANIFEST_SCHEMA}`);
         if (capability.headlessDisposition !== 'available' && !capability.reason) errors.push(`${capability.id}: reason is required for ${capability.headlessDisposition}`);
         if (!Object.values(capability.sources).some((identifiers) => identifiers?.length)) errors.push(`${capability.id}: at least one source classification is required`);
     }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "check:mlx-operational-parity": "node scripts/check-mlx-operational-parity.mjs",
     "check:apple-wide-qa": "node scripts/check-apple-wide-qa-manifest.mjs",
     "check:claims": "node scripts/check-claims-guard.mjs",
-    "check:agent-interface-manifest": "node scripts/check-agent-interface-manifest.mjs",
+    "check:agent-interface-manifest": "node scripts/run-strip-types.mjs scripts/check-agent-interface-manifest.mjs",
     "check:terminology-parity": "bash scripts/check-terminology-parity.sh",
     "workflow-monitor": "node scripts/codex-workflow-monitor.mjs",
     "rehearse:api-v1-compatibility": "node scripts/api-v1-compatibility-rehearsal.mjs",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "check:mlx-operational-parity": "node scripts/check-mlx-operational-parity.mjs",
     "check:apple-wide-qa": "node scripts/check-apple-wide-qa-manifest.mjs",
     "check:claims": "node scripts/check-claims-guard.mjs",
+    "check:agent-interface-manifest": "node scripts/check-agent-interface-manifest.mjs",
     "check:terminology-parity": "bash scripts/check-terminology-parity.sh",
     "workflow-monitor": "node scripts/codex-workflow-monitor.mjs",
     "rehearse:api-v1-compatibility": "node scripts/api-v1-compatibility-rehearsal.mjs",

--- a/scripts/check-agent-interface-manifest.mjs
+++ b/scripts/check-agent-interface-manifest.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+// @Codex: ADR 0093 source-classification drift gate.
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const ROOT = process.cwd();
+const sourceKinds = ['openApi', 'paired', 'fabric'];
+
+export function validateSourceCoverage(manifest, inventory) {
+  const errors = [];
+  for (const kind of sourceKinds) {
+    const classified = manifest.flatMap((capability) => capability.sources?.[kind] ?? []);
+    for (const identifier of inventory[kind]) if (!classified.includes(identifier)) errors.push(`${kind}: unclassified ${identifier}`);
+    for (const identifier of classified) if (!inventory[kind].includes(identifier)) errors.push(`${kind}: stale ${identifier}`);
+    for (const identifier of new Set(classified)) if (classified.filter((item) => item === identifier).length > 1) errors.push(`${kind}: duplicated ${identifier}`);
+  }
+  return errors;
+}
+
+function openApiOperations(source) {
+  let currentPath = '';
+  return source.split('\n').flatMap((line) => {
+    const pathMatch = line.match(/^  (\/api\/v1[^:]*):$/);
+    if (pathMatch) { currentPath = pathMatch[1]; return []; }
+    const methodMatch = line.match(/^    (get|post|put|patch|delete):$/);
+    return methodMatch && currentPath ? [`${methodMatch[1].toUpperCase()} ${currentPath}`] : [];
+  });
+}
+
+async function inventories() {
+  const pairedSource = readFileSync(path.join(ROOT, 'lib/network-contract.ts'), 'utf8');
+  const deterministicSource = readFileSync(path.join(ROOT, 'lib/ai-providers/fabric/deterministic-catalog.ts'), 'utf8');
+  const generativeSource = readFileSync(path.join(ROOT, 'lib/ai-providers/fabric/generative-catalog.ts'), 'utf8');
+  return {
+    openApi: openApiOperations(readFileSync(path.join(ROOT, 'docs/openapi/mediflow-v1.yaml'), 'utf8')),
+    paired: [
+      ...pairedSource.matchAll(/capability\(\s*'([^']+)'/g),
+      ...pairedSource.matchAll(/const\s+NETWORK_[A-Z_]+CAPABILITY\s*=\s*'([^']+)'/g),
+    ].map(([, key]) => key),
+    fabric: [...deterministicSource.matchAll(/id:\s*'([^']+)'/g), ...generativeSource.matchAll(/descriptor\(\s*'([^']+)'/g)].map(([, id]) => id),
+  };
+}
+
+async function main() {
+  const [{ AGENT_INTERFACE_MANIFEST, validateAgentInterfaceManifest }, inventory] = await Promise.all([
+    import(pathToFileURL(path.join(ROOT, 'lib/agent-interface/manifest.ts')).href), inventories(),
+  ]);
+  const errors = [...validateAgentInterfaceManifest(AGENT_INTERFACE_MANIFEST), ...validateSourceCoverage(AGENT_INTERFACE_MANIFEST, inventory)];
+  if (errors.length) throw new Error(`Agent Interface manifest drift:\n${errors.join('\n')}`);
+  console.log(`Agent Interface manifest OK: ${AGENT_INTERFACE_MANIFEST.length} explicit classifications.`);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main().catch((error) => { console.error(error.message); process.exitCode = 1; });

--- a/scripts/check-agent-interface-manifest.test.mjs
+++ b/scripts/check-agent-interface-manifest.test.mjs
@@ -1,0 +1,27 @@
+// @Codex
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { validateSourceCoverage } from './check-agent-interface-manifest.mjs';
+
+const manifest = [
+  { id: 'agent.interface.synthetic.v1', sources: { openApi: ['GET /api/v1/synthetic'], paired: ['network.synthetic'], fabric: ['synthetic'] } },
+];
+
+test('accetta inventari completamente classificati', () => {
+  assert.deepEqual(validateSourceCoverage(manifest, {
+    openApi: ['GET /api/v1/synthetic'], paired: ['network.synthetic'], fabric: ['synthetic'],
+  }), []);
+});
+
+test('rifiuta sorgenti senza classificazione e duplicati', () => {
+  assert.deepEqual(validateSourceCoverage([
+    ...manifest,
+    { id: 'agent.interface.duplicate.v1', sources: { paired: ['network.synthetic'] } },
+  ], {
+    openApi: ['GET /api/v1/synthetic', 'GET /api/v1/unclassified'], paired: ['network.synthetic'], fabric: ['synthetic'],
+  }), [
+    'openApi: unclassified GET /api/v1/unclassified',
+    'paired: duplicated network.synthetic',
+  ]);
+});


### PR DESCRIPTION
## Summary
- Classifies every declared MediFlow capability for the proposed headless interface.
- Adds manifest identity and source-inventory drift validation.
- Keeps all entries unavailable for runtime agent execution.

## Verification
- `npm run check:agent-interface-manifest`
- Manifest unit tests
- Parent integration branch: typecheck, lint, policy gates, and focused AIP tests

## Risk / Notes
- Synthetic metadata only; no PHI/PII, credentials, egress, database writes, or clinical capability.
- ADR 0093 remains Proposed. This draft is not runtime or release evidence.
- This draft stays open for traceability; no further implementation should land here.

## Lineage
- **Disposition: superseded-by #180.**
- Content-equivalent commits already integrated in the parent: `4a34d739` → `ccc300481`; `0116b83b` → `b86b061aa`; `e91907d2` → `943e38be`.
- #180 is the canonical review and correction surface.

## Ticket
Refs WUL-553