### PR TITLE
feat: add fail-closed agent session and context lease

### DIFF
--- a/lib/agent-interface/authority.test.ts
+++ b/lib/agent-interface/authority.test.ts
@@ -1,0 +1,121 @@
+/* @Codex */
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+    evaluateAgentContextAccess,
+    type AgentContextAccessRequest,
+    type AgentContextLease,
+    type AgentSession,
+} from './authority.ts';
+
+const NOW = Date.parse('2026-08-19T10:00:00.000Z');
+
+const SESSION: AgentSession = {
+    schemaVersion: 'mediflow.agent.session.v1',
+    sessionRef: 'agent-session-synthetic-1',
+    credentialClass: 'agent_session',
+    authorityPlane: 'agent_interface',
+    physicianSessionRef: 'physician-session-synthetic-1',
+    ambulatoryId: 'ambulatory-synthetic-1',
+    capabilityGrants: [{ capabilityId: 'agent.context.describe', maximumStage: 'read' }],
+    issuedAt: NOW - 60_000,
+    expiresAt: NOW + 60_000,
+    revocationState: 'active',
+};
+
+const LEASE: AgentContextLease = {
+    schemaVersion: 'mediflow.agent.context-lease.v1',
+    leaseRef: 'context-lease-synthetic-1',
+    sessionRef: SESSION.sessionRef,
+    patientId: 'patient-synthetic-1',
+    purpose: 'describe-selected-context',
+    scopes: ['patient.summary'],
+    issuedAt: NOW - 30_000,
+    expiresAt: NOW + 30_000,
+    revocationState: 'active',
+};
+
+const REQUEST: AgentContextAccessRequest = {
+    accessMode: 'single_patient', ambulatoryId: SESSION.ambulatoryId,
+    patientId: LEASE.patientId, purpose: LEASE.purpose, scope: 'patient.summary',
+    capabilityId: 'agent.context.describe', stage: 'read',
+};
+
+function decide(input: {
+    session?: AgentSession; lease?: AgentContextLease;
+    request?: AgentContextAccessRequest; now?: number;
+} = {}) {
+    return evaluateAgentContextAccess({
+        session: input.session ?? SESSION, lease: input.lease ?? LEASE,
+        request: input.request ?? REQUEST, now: input.now ?? NOW,
+    });
+}
+
+test('allows a bounded agent session and matching single-patient lease', () => {
+    assert.deepEqual(decide(), { allowed: true });
+    assert.deepEqual(evaluateAgentContextAccess(null), { allowed: false, reason: 'REQUEST_INVALID' });
+});
+
+test('denies expired, revoked, broad-credential, and foreign-authority sessions', () => {
+    const cases: Array<[Partial<AgentSession>, string]> = [
+        [{ expiresAt: NOW }, 'SESSION_EXPIRED'],
+        [{ revocationState: 'revoked' }, 'SESSION_REVOKED'],
+        [{ credentialClass: 'local_api_token' as 'agent_session' }, 'AGENT_CREDENTIAL_REQUIRED'],
+        [{ credentialClass: 'paired_credential' as 'agent_session' }, 'AGENT_CREDENTIAL_REQUIRED'],
+        [{ authorityPlane: 'clinical_application' as 'agent_interface' }, 'AUTHORITY_PROFILE_FORBIDDEN'],
+        [{ authorityPlane: 'engineering_operator' as 'agent_interface' }, 'AUTHORITY_PROFILE_FORBIDDEN'],
+        [{ authorityPlane: 'admin' as 'agent_interface' }, 'AUTHORITY_PROFILE_FORBIDDEN'],
+    ];
+
+    for (const [override, reason] of cases) {
+        assert.deepEqual(decide({ session: { ...SESSION, ...override } }), {
+            allowed: false, reason,
+        });
+    }
+});
+
+test('denies expired, revoked, or foreign-session context leases', () => {
+    const cases: Array<[Partial<AgentContextLease>, string]> = [
+        [{ expiresAt: NOW }, 'LEASE_EXPIRED'],
+        [{ revocationState: 'revoked' }, 'LEASE_REVOKED'],
+        [{ sessionRef: 'agent-session-synthetic-other' }, 'SESSION_LEASE_MISMATCH'],
+    ];
+
+    for (const [override, reason] of cases) {
+        assert.deepEqual(decide({ lease: { ...LEASE, ...override } }), {
+            allowed: false, reason,
+        });
+    }
+});
+
+test('keeps lease access single-patient and bound to ambulatory, purpose, and scope', () => {
+    const cases: Array<[Record<string, unknown>, string]> = [
+        [{ accessMode: 'bulk' }, 'BULK_ACCESS_DENIED'],
+        [{ patientId: 'patient-synthetic-other' }, 'PATIENT_MISMATCH'],
+        [{ ambulatoryId: 'ambulatory-synthetic-other' }, 'AMBULATORY_MISMATCH'],
+        [{ purpose: 'unrelated-purpose' }, 'PURPOSE_MISMATCH'],
+        [{ scope: 'patient.all-records' }, 'SCOPE_MISMATCH'],
+    ];
+
+    for (const [override, reason] of cases) {
+        assert.deepEqual(decide({
+            request: { ...REQUEST, ...override } as AgentContextAccessRequest,
+        }), { allowed: false, reason });
+    }
+});
+
+test('denies capability mismatch, stage escalation, authorize, and apply', () => {
+    const cases: Array<[Record<string, unknown>, string]> = [
+        [{ capabilityId: 'agent.patient.bulk' }, 'CAPABILITY_NOT_GRANTED'],
+        [{ stage: 'compute' }, 'STAGE_EXCEEDS_GRANT'],
+        [{ stage: 'authorize' }, 'STAGE_NOT_DELEGABLE'],
+        [{ stage: 'apply' }, 'STAGE_NOT_DELEGABLE'],
+    ];
+
+    for (const [override, reason] of cases) {
+        assert.deepEqual(decide({
+            request: { ...REQUEST, ...override } as AgentContextAccessRequest,
+        }), { allowed: false, reason });
+    }
+});

--- a/lib/agent-interface/authority.ts
+++ b/lib/agent-interface/authority.ts
@@ -1,0 +1,176 @@
+/* @Codex */
+export type AgentDelegableStage = 'observe' | 'read' | 'compute' | 'propose' | 'preview';
+
+const DELEGABLE_STAGES = new Set<AgentDelegableStage>([
+    'observe', 'read', 'compute', 'propose', 'preview',
+]);
+const STAGE_RANK: Readonly<Record<AgentDelegableStage, number>> = Object.freeze({
+    observe: 0, read: 1, compute: 2, propose: 3, preview: 4,
+});
+
+export type AgentCapabilityGrant = Readonly<{
+    capabilityId: string;
+    maximumStage: AgentDelegableStage;
+}>;
+
+export type AgentSession = Readonly<{
+    schemaVersion: 'mediflow.agent.session.v1';
+    sessionRef: string;
+    credentialClass: 'agent_session';
+    authorityPlane: 'agent_interface';
+    physicianSessionRef: string;
+    ambulatoryId: string;
+    capabilityGrants: readonly AgentCapabilityGrant[];
+    issuedAt: number;
+    expiresAt: number;
+    revocationState: 'active' | 'revoked';
+}>;
+
+export type AgentContextLease = Readonly<{
+    schemaVersion: 'mediflow.agent.context-lease.v1';
+    leaseRef: string;
+    sessionRef: string;
+    patientId: string;
+    purpose: string;
+    scopes: readonly string[];
+    issuedAt: number;
+    expiresAt: number;
+    revocationState: 'active' | 'revoked';
+}>;
+
+export type AgentContextAccessRequest = Readonly<{
+    accessMode: 'single_patient' | 'bulk';
+    ambulatoryId: string;
+    patientId: string;
+    purpose: string;
+    scope: string;
+    capabilityId: string;
+    stage: AgentDelegableStage;
+}>;
+
+export type AgentAuthorityDenialReason =
+    | 'SESSION_INVALID'
+    | 'AGENT_CREDENTIAL_REQUIRED'
+    | 'AUTHORITY_PROFILE_FORBIDDEN'
+    | 'SESSION_NOT_YET_VALID'
+    | 'SESSION_EXPIRED'
+    | 'SESSION_REVOKED'
+    | 'LEASE_INVALID'
+    | 'LEASE_NOT_YET_VALID'
+    | 'LEASE_EXPIRED'
+    | 'LEASE_REVOKED'
+    | 'SESSION_LEASE_MISMATCH'
+    | 'REQUEST_INVALID'
+    | 'BULK_ACCESS_DENIED'
+    | 'PATIENT_MISMATCH'
+    | 'AMBULATORY_MISMATCH'
+    | 'PURPOSE_MISMATCH'
+    | 'SCOPE_MISMATCH'
+    | 'CAPABILITY_NOT_GRANTED'
+    | 'STAGE_NOT_DELEGABLE'
+    | 'STAGE_EXCEEDS_GRANT';
+
+export type AgentContextAccessDecision =
+    | Readonly<{ allowed: true }>
+    | Readonly<{ allowed: false; reason: AgentAuthorityDenialReason }>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isText(value: unknown): value is string {
+    return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isTime(value: unknown): value is number {
+    return typeof value === 'number' && Number.isSafeInteger(value);
+}
+
+function isCapabilityGrants(value: unknown): value is readonly AgentCapabilityGrant[] {
+    if (!Array.isArray(value)) return false;
+    const ids = new Set<string>();
+    return value.every((grant) => {
+        if (!isRecord(grant) || !isText(grant.capabilityId)
+            || !DELEGABLE_STAGES.has(grant.maximumStage as AgentDelegableStage)
+            || ids.has(grant.capabilityId)) return false;
+        ids.add(grant.capabilityId);
+        return true;
+    });
+}
+
+function deny(reason: AgentAuthorityDenialReason): AgentContextAccessDecision {
+    return Object.freeze({ allowed: false, reason });
+}
+
+export function validateAgentSession(value: unknown, now: number): AgentAuthorityDenialReason | null {
+    if (!isRecord(value) || !isTime(now)) return 'SESSION_INVALID';
+    if (value.credentialClass !== 'agent_session') return 'AGENT_CREDENTIAL_REQUIRED';
+    if (value.authorityPlane !== 'agent_interface') return 'AUTHORITY_PROFILE_FORBIDDEN';
+    if (value.schemaVersion !== 'mediflow.agent.session.v1'
+        || !isText(value.sessionRef) || !isText(value.physicianSessionRef)
+        || !isText(value.ambulatoryId) || !isCapabilityGrants(value.capabilityGrants)
+        || !isTime(value.issuedAt) || !isTime(value.expiresAt)
+        || value.issuedAt >= value.expiresAt
+        || (value.revocationState !== 'active' && value.revocationState !== 'revoked')) {
+        return 'SESSION_INVALID';
+    }
+    if (value.revocationState === 'revoked') return 'SESSION_REVOKED';
+    if (now < value.issuedAt) return 'SESSION_NOT_YET_VALID';
+    if (now >= value.expiresAt) return 'SESSION_EXPIRED';
+    return null;
+}
+
+function isScopes(value: unknown): value is readonly string[] {
+    return Array.isArray(value) && value.length > 0
+        && value.every(isText) && new Set(value).size === value.length;
+}
+
+export function validateAgentContextLease(value: unknown, now: number): AgentAuthorityDenialReason | null {
+    if (!isRecord(value) || !isTime(now)
+        || value.schemaVersion !== 'mediflow.agent.context-lease.v1'
+        || !isText(value.leaseRef) || !isText(value.sessionRef) || !isText(value.patientId)
+        || !isText(value.purpose) || !isScopes(value.scopes)
+        || !isTime(value.issuedAt) || !isTime(value.expiresAt)
+        || value.issuedAt >= value.expiresAt
+        || (value.revocationState !== 'active' && value.revocationState !== 'revoked')) {
+        return 'LEASE_INVALID';
+    }
+    if (value.revocationState === 'revoked') return 'LEASE_REVOKED';
+    if (now < value.issuedAt) return 'LEASE_NOT_YET_VALID';
+    if (now >= value.expiresAt) return 'LEASE_EXPIRED';
+    return null;
+}
+
+function isAccessRequest(value: unknown): value is AgentContextAccessRequest {
+    return isRecord(value)
+        && (value.accessMode === 'single_patient' || value.accessMode === 'bulk')
+        && isText(value.ambulatoryId) && isText(value.patientId) && isText(value.purpose)
+        && isText(value.scope) && isText(value.capabilityId) && isText(value.stage);
+}
+
+export function evaluateAgentContextAccess(input: unknown): AgentContextAccessDecision {
+    if (!isRecord(input) || !isTime(input.now)) return deny('REQUEST_INVALID');
+    const sessionDenial = validateAgentSession(input.session, input.now);
+    if (sessionDenial) return deny(sessionDenial);
+    const leaseDenial = validateAgentContextLease(input.lease, input.now);
+    if (leaseDenial) return deny(leaseDenial);
+    if (!isAccessRequest(input.request)) return deny('REQUEST_INVALID');
+    const session = input.session as AgentSession;
+    const lease = input.lease as AgentContextLease;
+    const request = input.request;
+    if (lease.sessionRef !== session.sessionRef) return deny('SESSION_LEASE_MISMATCH');
+    if (request.accessMode === 'bulk') return deny('BULK_ACCESS_DENIED');
+    if (request.patientId !== lease.patientId) return deny('PATIENT_MISMATCH');
+    if (request.ambulatoryId !== session.ambulatoryId) return deny('AMBULATORY_MISMATCH');
+    if (request.purpose !== lease.purpose) return deny('PURPOSE_MISMATCH');
+    if (!lease.scopes.includes(request.scope)) return deny('SCOPE_MISMATCH');
+    if (!DELEGABLE_STAGES.has(request.stage)) return deny('STAGE_NOT_DELEGABLE');
+    const grant = session.capabilityGrants.find(
+        (item) => item.capabilityId === request.capabilityId,
+    );
+    if (!grant) return deny('CAPABILITY_NOT_GRANTED');
+    if (STAGE_RANK[request.stage] > STAGE_RANK[grant.maximumStage]) {
+        return deny('STAGE_EXCEEDS_GRANT');
+    }
+    return Object.freeze({ allowed: true });
+}


### PR DESCRIPTION
## Summary
- Adds bounded agent-session and single-patient context-lease value contracts.
- Enforces expiry, revocation, purpose, scope, capability, stage, ambulatory, and patient checks.
- Keeps the slice pure and disconnected from routes, storage, brokers, and clinical writes.

## Verification
- Focused authority tests
- Parent integration branch: typecheck, lint, policy gates, and focused AIP tests

## Risk / Notes
- Synthetic contracts only; no PHI/PII, credentials, egress, database writes, or clinical writes.
- ADR 0093 remains Proposed. An authoritative broker, clock, revocation source, and exact manifest binding remain open contract work.
- This draft stays open for traceability; no further implementation should land here.

## Lineage
- **Disposition: superseded-by #180.**
- Content-equivalent commit already integrated in the parent: `a864cffb` → `52bd0825`.
- #180 is the canonical review and correction surface.

## Ticket
Refs WUL-555