### PR TITLE
feat: project synthetic patient open loops read-only

### DIFF
--- a/lib/agent-interface/projections/patient-open-loops.test.ts
+++ b/lib/agent-interface/projections/patient-open-loops.test.ts
@@ -1,0 +1,75 @@
+/* @Codex */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { projectPatientOpenLoops } from './patient-open-loops';
+
+test('projects deterministic open loops in a minimal selected-patient envelope', () => {
+    const projection = projectPatientOpenLoops({
+        patientRef: 'synthetic-patient-001',
+        expectedSourceVersion: 7,
+        items: [{
+            id: 'synthetic-item-001',
+            patientId: 'synthetic-patient-001',
+            prescriptionId: 'synthetic-prescription-001',
+            status: 'prescribed',
+            serviceName: 'Glicemia',
+            createdAt: '2026-06-01T00:00:00.000Z',
+        }],
+        observations: [],
+        now: new Date('2026-07-01T12:00:00.000Z'),
+    });
+
+    assert.deepEqual(projection, {
+        projectionVersion: 'mediflow.agent.patient_open_loops.v1',
+        patientRef: 'synthetic-patient-001',
+        provenance: {
+            source: 'patient_open_loops',
+            derivation: 'deterministic',
+        },
+        freshness: {
+            asOf: '2026-07-01T12:00:00.000Z',
+        },
+        expectedSourceVersion: 7,
+        issues: [],
+        items: [{
+            kind: 'results_pending',
+            label: 'Glicemia',
+            status: {
+                sinceDate: new Date('2026-06-01T00:00:00.000Z'),
+                elapsedDays: 30,
+            },
+            sourceRef: {
+                type: 'service_prescription_item',
+                id: 'synthetic-item-001',
+                prescriptionId: 'synthetic-prescription-001',
+                serviceName: 'Glicemia',
+            },
+            suggestedAction: 'insert_results',
+        }],
+    });
+});
+
+test('excludes records outside the selected patient context without exposing them', () => {
+    const projection = projectPatientOpenLoops({
+        patientRef: 'synthetic-patient-001',
+        expectedSourceVersion: 7,
+        items: [{
+            id: 'synthetic-item-other-patient',
+            patientId: 'synthetic-patient-002',
+            prescriptionId: 'synthetic-prescription-002',
+            status: 'prescribed',
+            serviceName: 'Creatinina',
+            createdAt: '2026-06-01T00:00:00.000Z',
+        }],
+        observations: [],
+        now: new Date('2026-07-01T12:00:00.000Z'),
+    });
+
+    assert.deepEqual(projection.items, []);
+    assert.deepEqual(projection.issues, [{
+        code: 'outside_selected_patient_context',
+        severity: 'warning',
+    }]);
+});

--- a/lib/agent-interface/projections/patient-open-loops.ts
+++ b/lib/agent-interface/projections/patient-open-loops.ts
@@ -1,0 +1,80 @@
+/* @Codex */
+
+import {
+    deriveOpenLoops,
+    type OpenLoop,
+    type OpenLoopObservation,
+    type OpenLoopServicePrescriptionItem,
+} from '../../patient-open-loops';
+
+export const PATIENT_OPEN_LOOPS_PROJECTION_VERSION = 'mediflow.agent.patient_open_loops.v1';
+
+type WithoutPatientId<Value> = Value extends unknown ? Omit<Value, 'patientId'> : never;
+
+export type PatientOpenLoopItem = WithoutPatientId<OpenLoop>;
+
+export type PatientOpenLoopsProjectionIssue = {
+    code: 'outside_selected_patient_context';
+    severity: 'warning';
+};
+
+export type PatientOpenLoopsProjection = {
+    projectionVersion: typeof PATIENT_OPEN_LOOPS_PROJECTION_VERSION;
+    patientRef: string;
+    provenance: {
+        source: 'patient_open_loops';
+        derivation: 'deterministic';
+    };
+    freshness: {
+        asOf: string;
+    };
+    expectedSourceVersion: number;
+    issues: PatientOpenLoopsProjectionIssue[];
+    items: PatientOpenLoopItem[];
+};
+
+export type PatientOpenLoopsProjectionInput = {
+    patientRef: string;
+    expectedSourceVersion: number;
+    items: OpenLoopServicePrescriptionItem[];
+    observations: OpenLoopObservation[];
+    now: Date;
+};
+
+function withoutPatientId(loop: OpenLoop): PatientOpenLoopItem {
+    const { patientId, ...item } = loop;
+    void patientId;
+    return item;
+}
+
+/**
+ * Builds the selected patient's deterministic open-loop projection. The caller
+ * supplies a single in-memory patient context; this module never reads a store.
+ */
+export function projectPatientOpenLoops(input: PatientOpenLoopsProjectionInput): PatientOpenLoopsProjection {
+    const scopedItems = input.items.filter((item) => item.patientId === input.patientRef);
+    const scopedObservations = input.observations.filter((observation) => observation.patientId === input.patientRef);
+    const omittedOutsideContext = scopedItems.length !== input.items.length
+        || scopedObservations.length !== input.observations.length;
+
+    return {
+        projectionVersion: PATIENT_OPEN_LOOPS_PROJECTION_VERSION,
+        patientRef: input.patientRef,
+        provenance: {
+            source: 'patient_open_loops',
+            derivation: 'deterministic',
+        },
+        freshness: {
+            asOf: input.now.toISOString(),
+        },
+        expectedSourceVersion: input.expectedSourceVersion,
+        issues: omittedOutsideContext
+            ? [{ code: 'outside_selected_patient_context', severity: 'warning' }]
+            : [],
+        items: deriveOpenLoops({
+            items: scopedItems,
+            observations: scopedObservations,
+            now: input.now,
+        }).map(withoutPatientId),
+    };
+}


### PR DESCRIPTION
## Summary
- Adds a deterministic read-only projection for one selected synthetic patient context.
- Removes patient identifiers from projected items and reports omitted out-of-context input.
- Keeps projection construction in memory with no route, database, model, or write path.

## Verification
- Focused projection tests
- Parent integration branch: typecheck, lint, policy gates, and focused AIP tests

## Risk / Notes
- Synthetic fixtures only; no PHI/PII, credentials, egress, database writes, or clinical writes.
- ADR 0093 remains Proposed. Context-bound request validation, authoritative freshness, and receipt/envelope contracts remain open.
- This draft stays open for traceability; no further implementation should land here.

## Lineage
- **Disposition: superseded-by #180.**
- Content-equivalent commit already integrated in the parent: `5a5813c8` → `6e7ee207`.
- #180 is the canonical review and correction surface.

## Ticket
Refs WUL-554