### PR TITLE
docs(aip): formalizza il gate del broker fidato

### DIFF
--- a/docs/adr/0093-agent-interface-plane-headless-capability-contract.md
+++ b/docs/adr/0093-agent-interface-plane-headless-capability-contract.md
@@ -180,21 +180,114 @@ Restano fuori scope:
 - billing enterprise o cambi al modello open-source di MediFlow;
 - nuovi claim clinici, regolatori o di completezza runtime.
 
-## Decisioni aperte prima dell'accettazione
+## Pacchetto decisionale owner-visible
 
-Questi punti bloccano il passaggio ad `Accepted` e la promozione runtime:
+Le cinque proposte seguenti sono candidate collegate a `WUL-558`. Restano un
+unico gate: il proprietario deve accettarle o correggerle esplicitamente prima
+di cambiare lo stato dell'ADR. Fino ad allora vale
+`HOLD_CONTRACT — TRUSTED_BROKER_BOUNDARY_UNDECIDED` e nessun runtime e
+autorizzato.
 
-1. collocazione del context broker e confine delle chiavi tra web, native e
-   servizio host;
-2. prima projection clinica e insieme minimo dei campi;
-3. ordine degli adapter iniziali: servizio applicativo, MCP stdio e CLI;
-4. schema preciso della sessione, revoca e legame con lo step-up di `WUL-282`;
-5. conferma che il primo pilot resti senza egress e senza modelli esterni.
+### D1. Context broker, chiavi e authority issuance
+
+**Candidato.** Il broker vive in memoria nel processo host locale `home-base`,
+nello stesso trust domain dei servizi applicativi. Il client medico conserva la
+master key, decifra e minimizza dopo unlock e selezione esplicita, poi consegna
+la projection tramite un canale applicativo locale autenticato. Il broker non
+riceve la master key e non legge SQLite, filesystem clinico o ciphertext.
+
+Il broker possiede le copie canoniche di sessione, grant, lease, manifest,
+clock, revoca e `selectionEpoch`. Emette una credenziale breve e handle opachi.
+Sessione, lease, grant, clock, revoca o projection forniti dal chiamante sono
+input non fidati e vengono rifiutati tramite allowlist di sole own-key.
+
+**Alternative.** Tenere il broker nel client medico; usare un daemon locale
+separato; riusare token `/api/v1` o credenziali paired. L'ultima alternativa e
+incompatibile con il mandato minimo perche identifica un client o una sessione
+ampia, non concede autorita agentica delimitata.
+
+**Falsificatore.** Il candidato va riaperto se il canale non puo autenticare
+origine e lifecycle senza trasferire master key o token generale, oppure se
+lock, logout e cambio selezione non possono invalidare lo stato prima della
+richiesta successiva.
+
+### D2. Prima projection clinica
+
+**Candidato.** `patient_open_loops.v1`, per un solo paziente selezionato, con
+attese deterministiche, riferimenti sorgente tipizzati, provenienza, freshness
+e versione attesa. Niente anagrafica completa, note libere o allegati. La
+directory minima per `patient search/show` resta distinta e limitata a
+riferimento opaco, nome visualizzato, anno di nascita, stato archivio e
+versione nello stesso ambulatorio e mandato.
+
+**Alternative.** Iniziare senza projection paziente; usare un riepilogo
+clinico generale; esporre direttamente il record applicativo. Le ultime due
+aumentano dati e ambiguita prima di provare il confine minimo.
+
+**Falsificatore.** La projection va ridisegnata se non basta a calcolare gli
+open loop in modo deterministico o se richiede testo libero, query bulk o dati
+non legati alla selezione corrente.
+
+### D3. Ordine degli adapter
+
+**Candidato.** Servizio applicativo condiviso, poi Mini CLI pipe-first, poi MCP
+`stdio`. REST agentico richiede un packet successivo su trasporto e threat
+model. Ogni adapter resta sottile e non ricostruisce authority.
+
+**Alternative.** MCP prima della CLI; REST come primo adapter; implementazioni
+indipendenti per venue. REST e adapter indipendenti ampliano il confine prima
+che il contratto condiviso sia verificato.
+
+**Falsificatore.** L'ordine va riaperto se Mini richiede logica clinica o
+authority specifica della CLI invece di limitarsi a validazione input, invio e
+rendering del contratto comune.
+
+### D4. Sessione, revoca e step-up
+
+**Candidato.** Un mandato breve lega medico, ambulatorio, capability, stadio
+massimo, versione manifest e `selectionEpoch`. Il broker usa il proprio clock.
+Lock, logout, cambio paziente, revoca, expiry o manifest incompatibile
+invalidano sessione e lease. `apply` resta escluso. Un futuro step-up `WUL-282`
+e broker-owned, monouso e legato anche a target, digest anteprima e versione.
+
+**Alternative.** Riutilizzare token locale o paired; accettare timestamp e
+claim firmati dall'adapter; mantenere grant riutilizzabili. Queste alternative
+non danno al broker autorita corrente su freshness, revoca e primo tentativo.
+
+**Falsificatore.** Il contratto va riaperto se una revoca non puo precedere la
+richiesta successiva, se un replay sopravvive al cambio selezione o se uno
+step-up puo essere riusato dopo mismatch o primo tentativo.
+
+### D5. Pilot senza egress
+
+**Candidato.** `egress=none`, `fallback=denied_by_contract`, fixture solo
+sintetiche e nessun adapter di rete, provider cloud, modello esterno o tool con
+rete. Un endpoint loopback non prova da solo l'assenza di egress.
+
+**Alternative.** Modello locale loopback; provider esterno con minimizzazione;
+tool di rete allowlisted. Restano fuori dal primo pilot e richiedono confini e
+prove dedicati.
+
+**Falsificatore.** Il pilot va fermato se una capability dichiarata disponibile
+richiede rete, dati reali o dipendenze non dichiarate per produrre il proprio
+risultato o la receipt.
+
+### Registrazione della decisione
+
+Il proprietario deve registrare in `WUL-558` una delle seguenti conclusioni:
+
+- accettazione di D1-D5 senza modifiche;
+- accettazione con correzioni nominate per ogni decisione interessata;
+- rifiuto con alternativa scelta e nuovo falsificatore verificabile.
+
+Solo dopo quella registrazione l'ADR puo passare ad `Accepted`. L'accettazione
+autorizza prima il servizio condiviso; Mini resta bloccato finche quel servizio
+non e validato.
 
 ## First Thin Slice
 
-La prima slice proposta, collegata a `WUL-518`, e solo locale, read-only e
-sintetica:
+La prima slice proposta, collegata a `WUL-558`, e solo locale, read-only e
+sintetica. Puo iniziare soltanto dopo l'accettazione di D1-D5:
 
 1. definire uno schema macchina per il manifest AIP;
 2. classificare le capability esistenti senza renderne disponibili di nuove;

--- a/docs/adr/0093-agent-interface-plane-headless-capability-contract.md
+++ b/docs/adr/0093-agent-interface-plane-headless-capability-contract.md
@@ -1,7 +1,8 @@
 # ADR 0093: Agent Interface Plane headless
 
 Date: 2026-08-19
-Status: Proposed
+Accepted: 2026-08-21
+Status: Accepted
 
 ---
 
@@ -68,11 +69,12 @@ versionata, anche quando resta manuale o non disponibile.
 - **Opzione 4**: puo restare uno strumento di test o compatibilita, ma e fragile,
   poco osservabile e non offre un confine di autorita sufficiente.
 
-## Decisione proposta
+## Decisione
 
-Si propone l'opzione 3: un **Agent Interface Plane (AIP)** locale, applicativo e
-fail-closed. Lo stato `Proposed` non autorizza ancora implementazione runtime o
-scritture.
+Si adotta l'opzione 3: un **Agent Interface Plane (AIP)** locale, applicativo e
+fail-closed. L'accettazione autorizza soltanto le slice che rispettano D1-D5 e
+non autorizza scritture cliniche, accesso diretto ai dati o adapter che
+ricostruiscono autorita da contenuto fornito dal chiamante.
 
 ### 1. Un solo contratto di capability
 
@@ -182,11 +184,9 @@ Restano fuori scope:
 
 ## Pacchetto decisionale owner-visible
 
-Le cinque proposte seguenti sono candidate collegate a `WUL-558`. Restano un
-unico gate: il proprietario deve accettarle o correggerle esplicitamente prima
-di cambiare lo stato dell'ADR. Fino ad allora vale
-`HOLD_CONTRACT — TRUSTED_BROKER_BOUNDARY_UNDECIDED` e nessun runtime e
-autorizzato.
+Le cinque decisioni seguenti sono state accettate come bundle dal proprietario
+in `WUL-558` il 2026-08-21. Alternative e falsificatori restano parte del
+contratto: un falsificatore osservato riapre l'ADR e blocca la promozione.
 
 ### D1. Context broker, chiavi e authority issuance
 
@@ -274,20 +274,13 @@ risultato o la receipt.
 
 ### Registrazione della decisione
 
-Il proprietario deve registrare in `WUL-558` una delle seguenti conclusioni:
-
-- accettazione di D1-D5 senza modifiche;
-- accettazione con correzioni nominate per ogni decisione interessata;
-- rifiuto con alternativa scelta e nuovo falsificatore verificabile.
-
-Solo dopo quella registrazione l'ADR puo passare ad `Accepted`. L'accettazione
-autorizza prima il servizio condiviso; Mini resta bloccato finche quel servizio
-non e validato.
+Il proprietario ha registrato in `WUL-558` l'accettazione di D1-D5 senza
+modifiche. L'accettazione autorizza prima il servizio condiviso; Mini resta
+bloccato finche quel servizio non e validato.
 
 ## First Thin Slice
 
-La prima slice proposta, collegata a `WUL-558`, e solo locale, read-only e
-sintetica. Puo iniziare soltanto dopo l'accettazione di D1-D5:
+La prima slice, collegata a `WUL-558`, e solo locale, read-only e sintetica:
 
 1. definire uno schema macchina per il manifest AIP;
 2. classificare le capability esistenti senza renderne disponibili di nuove;


### PR DESCRIPTION
## Summary
- Mantiene ADR 0093 in `Proposed` e pubblica D1-D5 come decision packet owner-visible.
- Definisce candidato, alternative e falsificatore per broker/chiavi, projection, adapter, lifecycle/step-up e pilot no-egress.
- Blocca esplicitamente runtime e Mini finché il proprietario non accetta il bundle e il servizio condiviso non è validato.

## Verification
- `git diff --check`
- `rg --files -g "*.md" | sort`

## Risk / Notes
- PR solo documentale, stacked sulla draft #180.
- Nessuna PHI/PII, dato paziente reale, migrazione, cloud, egress o scrittura clinica.
- Stato intenzionale: `HOLD_CONTRACT — TRUSTED_BROKER_BOUNDARY_UNDECIDED`.
- Nessun runtime è promosso da questa PR.

## Ticket
Refs WUL-558

Linear: https://linear.app/wulfgardr/issue/WUL-558/adr-0093-e-trusted-agent-interface-plane