### PR TITLE
feat(aip): aggiungi il servizio broker sintetico

### DIFF
--- a/lib/agent-interface/trusted-service.test.ts
+++ b/lib/agent-interface/trusted-service.test.ts
@@ -5,7 +5,7 @@ import test from 'node:test';
 import { createSyntheticTrustedAgentService, type AgentServiceResult } from './trusted-service';
 
 const request = (command: string, args: Record<string, unknown> = {}, requestId = `request-${command}`) => ({
-    credential: 'synthetic-agent-credential', requestId, command, args,
+    credential: 'synthetic-agent-credential', requestId: requestId.replace('.', '-'), command, args,
 });
 function denial(result: AgentServiceResult): string {
     assert.equal(result.ok, false);
@@ -13,7 +13,7 @@ function denial(result: AgentServiceResult): string {
 }
 
 test('espone il contratto sintetico read-only con receipt PHI-safe', () => {
-    const service = createSyntheticTrustedAgentService();
+    const { service } = createSyntheticTrustedAgentService();
     const result = service.execute(request('open-loops', { patientRef: 'synthetic-patient-001' }));
     assert.equal(result.ok, true);
     if (!result.ok) return;
@@ -25,7 +25,7 @@ test('espone il contratto sintetico read-only con receipt PHI-safe', () => {
 });
 
 test('rifiuta authority caller-supplied, proprietà ereditate e replay', () => {
-    const service = createSyntheticTrustedAgentService();
+    const { service } = createSyntheticTrustedAgentService();
     assert.equal(denial(service.execute({ ...request('whoami'), session: { revocationState: 'active' } })), 'REQUEST_INVALID');
     assert.equal(denial(service.execute({ ...request('whoami'), now: 0 })), 'REQUEST_INVALID');
     const inherited = Object.assign(Object.create({ lease: { patientRef: 'forged' } }), request('whoami'));
@@ -35,12 +35,16 @@ test('rifiuta authority caller-supplied, proprietà ereditate e replay', () => {
     Object.defineProperty(accessor, 'credential', { enumerable: true, get: () => { getterRead = true; return 'synthetic-agent-credential'; } });
     assert.equal(denial(service.execute(accessor)), 'REQUEST_INVALID');
     assert.equal(getterRead, false);
+    const clinicalId = request('whoami', {}, 'patient:synthetic-patient-001|Paziente Sintetico Uno');
+    const invalidId = service.execute(clinicalId);
+    assert.equal(denial(invalidId), 'REQUEST_INVALID');
+    assert.equal(JSON.stringify(invalidId.receipt).includes('synthetic-patient-001'), false);
     assert.equal(service.execute(request('whoami', {}, 'replay')).ok, true);
     assert.equal(denial(service.execute(request('whoami', {}, 'replay'))), 'REQUEST_REPLAYED');
 });
 
 test('nega credential, cross-patient e apply', () => {
-    const service = createSyntheticTrustedAgentService();
+    const { service } = createSyntheticTrustedAgentService();
     assert.equal(denial(service.execute({ ...request('whoami'), credential: 'local-api-token' })), 'CREDENTIAL_INVALID');
     assert.equal(denial(service.execute(request('open-loops', { patientRef: 'synthetic-patient-other' }))), 'PATIENT_MISMATCH');
     assert.equal(denial(service.execute(request('apply', { patientRef: 'synthetic-patient-001' }))), 'APPLY_DENIED');
@@ -48,10 +52,34 @@ test('nega credential, cross-patient e apply', () => {
 
 test('usa expiry e revoca broker-owned', () => {
     const base = createSyntheticTrustedAgentService();
-    base.revoke();
-    assert.equal(denial(base.execute(request('whoami'))), 'SESSION_REVOKED');
+    base.control.revoke();
+    assert.equal(denial(base.service.execute(request('whoami'))), 'SESSION_REVOKED');
 
     const now = Date.parse('2026-08-21T12:00:00.000Z');
     const expired = createSyntheticTrustedAgentService(now, () => now + 300_000);
-    assert.equal(denial(expired.execute(request('whoami'))), 'SESSION_EXPIRED');
+    assert.equal(denial(expired.service.execute(request('whoami'))), 'SESSION_EXPIRED');
+});
+
+test('restituisce snapshot detached e rifiuta query bulk vuote senza consumare requestId', () => {
+    const { service } = createSyntheticTrustedAgentService();
+    const empty = request('patient.search', { query: '   ' }, 'search-retry');
+    assert.equal(denial(service.execute(empty)), 'REQUEST_INVALID');
+    assert.equal(service.execute(request('patient.search', { query: 'Sintetico' }, 'search-retry')).ok, true);
+
+    const first = service.execute(request('patient.show', { patientRef: 'synthetic-patient-001' }, 'show-one'));
+    assert.equal(first.ok, true);
+    if (first.ok) (first.data as { displayName: string }).displayName = 'mutated';
+    const second = service.execute(request('patient.show', { patientRef: 'synthetic-patient-001' }, 'show-two'));
+    assert.equal(second.ok && (second.data as { displayName: string }).displayName, 'Paziente Sintetico Uno');
+
+    const loops = service.execute(request('open-loops', { patientRef: 'synthetic-patient-001' }, 'loops-one'));
+    if (loops.ok) (loops.data as { items: Array<{ sourceRef: { id: string } }> }).items[0].sourceRef.id = 'mutated';
+    const loopsAgain = service.execute(request('open-loops', { patientRef: 'synthetic-patient-001' }, 'loops-two'));
+    assert.equal(loopsAgain.ok && (loopsAgain.data as { items: Array<{ sourceRef: { id: string } }> }).items[0].sourceRef.id, 'synthetic-item-001');
+});
+
+test('il cambio selectionEpoch host-owned invalida prima della prossima azione', () => {
+    const plane = createSyntheticTrustedAgentService();
+    plane.control.changeSelection();
+    assert.equal(denial(plane.service.execute(request('whoami'))), 'SELECTION_CHANGED');
 });

--- a/lib/agent-interface/trusted-service.test.ts
+++ b/lib/agent-interface/trusted-service.test.ts
@@ -1,0 +1,57 @@
+/* @Codex */
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createSyntheticTrustedAgentService, type AgentServiceResult } from './trusted-service';
+
+const request = (command: string, args: Record<string, unknown> = {}, requestId = `request-${command}`) => ({
+    credential: 'synthetic-agent-credential', requestId, command, args,
+});
+function denial(result: AgentServiceResult): string {
+    assert.equal(result.ok, false);
+    return result.ok ? 'unexpected-success' : result.error;
+}
+
+test('espone il contratto sintetico read-only con receipt PHI-safe', () => {
+    const service = createSyntheticTrustedAgentService();
+    const result = service.execute(request('open-loops', { patientRef: 'synthetic-patient-001' }));
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal((result.data as { items: unknown[] }).items.length, 1);
+    const receipt = JSON.stringify(result.receipt);
+    assert.equal(receipt.includes('Paziente Sintetico'), false);
+    assert.equal(receipt.includes('synthetic-patient-001'), false);
+    assert.equal(receipt.includes('synthetic-agent-credential'), false);
+});
+
+test('rifiuta authority caller-supplied, proprietà ereditate e replay', () => {
+    const service = createSyntheticTrustedAgentService();
+    assert.equal(denial(service.execute({ ...request('whoami'), session: { revocationState: 'active' } })), 'REQUEST_INVALID');
+    assert.equal(denial(service.execute({ ...request('whoami'), now: 0 })), 'REQUEST_INVALID');
+    const inherited = Object.assign(Object.create({ lease: { patientRef: 'forged' } }), request('whoami'));
+    assert.equal(denial(service.execute(inherited)), 'REQUEST_INVALID');
+    let getterRead = false;
+    const accessor = request('whoami');
+    Object.defineProperty(accessor, 'credential', { enumerable: true, get: () => { getterRead = true; return 'synthetic-agent-credential'; } });
+    assert.equal(denial(service.execute(accessor)), 'REQUEST_INVALID');
+    assert.equal(getterRead, false);
+    assert.equal(service.execute(request('whoami', {}, 'replay')).ok, true);
+    assert.equal(denial(service.execute(request('whoami', {}, 'replay'))), 'REQUEST_REPLAYED');
+});
+
+test('nega credential, cross-patient e apply', () => {
+    const service = createSyntheticTrustedAgentService();
+    assert.equal(denial(service.execute({ ...request('whoami'), credential: 'local-api-token' })), 'CREDENTIAL_INVALID');
+    assert.equal(denial(service.execute(request('open-loops', { patientRef: 'synthetic-patient-other' }))), 'PATIENT_MISMATCH');
+    assert.equal(denial(service.execute(request('apply', { patientRef: 'synthetic-patient-001' }))), 'APPLY_DENIED');
+});
+
+test('usa expiry e revoca broker-owned', () => {
+    const base = createSyntheticTrustedAgentService();
+    base.revoke();
+    assert.equal(denial(base.execute(request('whoami'))), 'SESSION_REVOKED');
+
+    const now = Date.parse('2026-08-21T12:00:00.000Z');
+    const expired = createSyntheticTrustedAgentService(now, () => now + 300_000);
+    assert.equal(denial(expired.execute(request('whoami'))), 'SESSION_EXPIRED');
+});

--- a/lib/agent-interface/trusted-service.ts
+++ b/lib/agent-interface/trusted-service.ts
@@ -1,0 +1,125 @@
+/* @Codex */
+import { createHash } from 'node:crypto';
+
+import { projectPatientOpenLoops, type PatientOpenLoopsProjection } from './projections/patient-open-loops';
+
+export type MiniPilotCommand = 'whoami' | 'capabilities' | 'patient.search' | 'patient.show'
+    | 'open-loops' | 'draft.preview' | 'apply';
+export type AgentServiceError = 'REQUEST_INVALID' | 'CREDENTIAL_INVALID' | 'SESSION_EXPIRED'
+    | 'SESSION_REVOKED' | 'REQUEST_REPLAYED' | 'PATIENT_NOT_FOUND' | 'PATIENT_MISMATCH' | 'APPLY_DENIED';
+export type AgentServiceReceipt = Readonly<{
+    schemaVersion: 'mediflow.agent.receipt.v1'; requestId: string; actionId: string;
+    capability: MiniPilotCommand; stage: 'observe' | 'read' | 'preview' | 'apply';
+    status: 'succeeded' | 'denied'; leaseRef: string | null; at: string;
+    previewDigest?: string; issues: readonly AgentServiceError[];
+}>;
+export type AgentServiceResult = Readonly<{ ok: true; data: unknown; receipt: AgentServiceReceipt }>
+    | Readonly<{ ok: false; error: AgentServiceError; receipt: AgentServiceReceipt }>;
+
+type PatientDirectoryEntry = Readonly<{
+    patientRef: string; displayName: string; birthYear: number; archived: boolean; version: number;
+}>;
+type TrustedPilotState = Readonly<{
+    credential: string; sessionRef: string; ambulatoryRef: string; leaseRef: string;
+    selectedPatientRef: string; issuedAt: number; expiresAt: number;
+    directory: readonly PatientDirectoryEntry[]; projection: PatientOpenLoopsProjection;
+}>;
+
+const COMMANDS: Readonly<Record<MiniPilotCommand, { stage: AgentServiceReceipt['stage']; disposition: string }>> = Object.freeze({
+    whoami: { stage: 'observe', disposition: 'available' }, capabilities: { stage: 'observe', disposition: 'available' },
+    'patient.search': { stage: 'read', disposition: 'available' }, 'patient.show': { stage: 'read', disposition: 'available' },
+    'open-loops': { stage: 'read', disposition: 'available' }, 'draft.preview': { stage: 'preview', disposition: 'proposal_only' },
+    apply: { stage: 'apply', disposition: 'unavailable' },
+});
+const REQUEST_KEYS = ['args', 'command', 'credential', 'requestId'];
+const ARG_KEYS: Readonly<Record<MiniPilotCommand, readonly string[]>> = Object.freeze({
+    whoami: [], capabilities: [], 'patient.search': ['query'], 'patient.show': ['patientRef'],
+    'open-loops': ['patientRef'], 'draft.preview': ['patientRef'], apply: ['patientRef'],
+});
+
+function isPlainExact(value: unknown, keys: readonly string[]): value is Record<string, unknown> {
+    if (typeof value !== 'object' || value === null || Array.isArray(value) || Object.getPrototypeOf(value) !== Object.prototype) return false;
+    const own = Reflect.ownKeys(value);
+    return own.length === keys.length && own.every((key) => typeof key === 'string' && keys.includes(key))
+        && own.every((key) => { const descriptor = Object.getOwnPropertyDescriptor(value, key); return descriptor?.enumerable === true && 'value' in descriptor; });
+}
+function isText(value: unknown): value is string { return typeof value === 'string' && value.trim().length > 0; }
+function isCommand(value: unknown): value is MiniPilotCommand { return isText(value) && Object.hasOwn(COMMANDS, value); }
+
+export type TrustedAgentService = Readonly<{
+    execute(input: unknown): AgentServiceResult;
+    revoke(): void;
+}>;
+
+class TrustedAgentInterfaceService implements TrustedAgentService {
+    readonly #state: TrustedPilotState;
+    readonly #clock: () => number;
+    readonly #seen = new Set<string>();
+    #revoked = false;
+
+    constructor(state: TrustedPilotState, clock: () => number) {
+        this.#state = structuredClone(state);
+        this.#clock = clock;
+    }
+
+    revoke(): void { this.#revoked = true; }
+
+    execute(input: unknown): AgentServiceResult {
+        const fallback = this.#receipt('invalid', 'capabilities', 'denied', null, ['REQUEST_INVALID']);
+        if (!isPlainExact(input, REQUEST_KEYS) || !isText(input.requestId) || !isText(input.credential)
+            || !isCommand(input.command) || !isPlainExact(input.args, ARG_KEYS[input.command])) {
+            return { ok: false, error: 'REQUEST_INVALID', receipt: fallback };
+        }
+        const { requestId, credential, command, args } = input;
+        const deny = (error: AgentServiceError) => ({ ok: false, error, receipt: this.#receipt(requestId, command, 'denied', null, [error]) } as const);
+        if (credential !== this.#state.credential) return deny('CREDENTIAL_INVALID');
+        if (this.#revoked) return deny('SESSION_REVOKED');
+        if (this.#clock() >= this.#state.expiresAt) return deny('SESSION_EXPIRED');
+        if (this.#seen.has(requestId)) return deny('REQUEST_REPLAYED');
+        this.#seen.add(requestId);
+        if (command === 'apply') return deny('APPLY_DENIED');
+
+        const patientRef = args.patientRef;
+        if (patientRef !== undefined && !isText(patientRef)) return deny('REQUEST_INVALID');
+        if ((command === 'open-loops' || command === 'draft.preview') && patientRef !== this.#state.selectedPatientRef) return deny('PATIENT_MISMATCH');
+        const patient = isText(patientRef) ? this.#state.directory.find((item) => item.patientRef === patientRef) : undefined;
+        if (command === 'patient.show' && !patient) return deny('PATIENT_NOT_FOUND');
+
+        let data: unknown;
+        if (command === 'whoami') data = { sessionRef: this.#state.sessionRef, ambulatoryRef: this.#state.ambulatoryRef, expiresAt: new Date(this.#state.expiresAt).toISOString() };
+        else if (command === 'capabilities') data = Object.entries(COMMANDS).map(([name, value]) => ({ command: name, ...value }));
+        else if (command === 'patient.search') {
+            if (typeof args.query !== 'string') return deny('REQUEST_INVALID');
+            const query = args.query.trim().toLocaleLowerCase('it');
+            data = this.#state.directory.filter((item) => item.displayName.toLocaleLowerCase('it').includes(query));
+        } else if (command === 'patient.show') data = patient;
+        else if (command === 'open-loops') data = this.#state.projection;
+        else {
+            const draft = { kind: 'follow_up', text: 'Anteprima sintetica: verificare gli open loop selezionati.' };
+            const digest = createHash('sha256').update(JSON.stringify(draft)).digest('hex');
+            return { ok: true, data: draft, receipt: this.#receipt(requestId, command, 'succeeded', digest, []) };
+        }
+        return { ok: true, data, receipt: this.#receipt(requestId, command, 'succeeded', null, []) };
+    }
+
+    #receipt(requestId: string, command: MiniPilotCommand, status: AgentServiceReceipt['status'], digest: string | null, issues: readonly AgentServiceError[]): AgentServiceReceipt {
+        return Object.freeze({ schemaVersion: 'mediflow.agent.receipt.v1', requestId, actionId: `action:${requestId}`,
+            capability: command, stage: COMMANDS[command].stage, status,
+            leaseRef: status === 'succeeded' ? this.#state.leaseRef : null, at: new Date(this.#clock()).toISOString(),
+            ...(digest ? { previewDigest: digest } : {}), issues: Object.freeze([...issues]) });
+    }
+}
+
+export function createSyntheticTrustedAgentService(
+    now = Date.parse('2026-08-21T12:00:00.000Z'), clock: () => number = () => now,
+): TrustedAgentService {
+    const patientRef = 'synthetic-patient-001';
+    return new TrustedAgentInterfaceService({
+        credential: 'synthetic-agent-credential', sessionRef: 'session-synthetic-001', ambulatoryRef: 'ambulatory-synthetic-001',
+        leaseRef: 'lease-synthetic-001', selectedPatientRef: patientRef, issuedAt: now - 60_000, expiresAt: now + 300_000,
+        directory: [{ patientRef, displayName: 'Paziente Sintetico Uno', birthYear: 1970, archived: false, version: 3 }],
+        projection: projectPatientOpenLoops({ patientRef, expectedSourceVersion: 3, items: [{ id: 'synthetic-item-001', patientId: patientRef,
+            prescriptionId: 'synthetic-prescription-001', status: 'prescribed', serviceName: 'Controllo sintetico', createdAt: '2026-08-01T00:00:00.000Z' }],
+        observations: [], now: new Date(now) }),
+    }, clock);
+}

--- a/lib/agent-interface/trusted-service.ts
+++ b/lib/agent-interface/trusted-service.ts
@@ -6,7 +6,8 @@ import { projectPatientOpenLoops, type PatientOpenLoopsProjection } from './proj
 export type MiniPilotCommand = 'whoami' | 'capabilities' | 'patient.search' | 'patient.show'
     | 'open-loops' | 'draft.preview' | 'apply';
 export type AgentServiceError = 'REQUEST_INVALID' | 'CREDENTIAL_INVALID' | 'SESSION_EXPIRED'
-    | 'SESSION_REVOKED' | 'REQUEST_REPLAYED' | 'PATIENT_NOT_FOUND' | 'PATIENT_MISMATCH' | 'APPLY_DENIED';
+    | 'SESSION_REVOKED' | 'SELECTION_CHANGED' | 'REQUEST_REPLAYED' | 'PATIENT_NOT_FOUND'
+    | 'PATIENT_MISMATCH' | 'APPLY_DENIED';
 export type AgentServiceReceipt = Readonly<{
     schemaVersion: 'mediflow.agent.receipt.v1'; requestId: string; actionId: string;
     capability: MiniPilotCommand; stage: 'observe' | 'read' | 'preview' | 'apply';
@@ -21,7 +22,7 @@ type PatientDirectoryEntry = Readonly<{
 }>;
 type TrustedPilotState = Readonly<{
     credential: string; sessionRef: string; ambulatoryRef: string; leaseRef: string;
-    selectedPatientRef: string; issuedAt: number; expiresAt: number;
+    selectedPatientRef: string; selectionEpoch: number; issuedAt: number; expiresAt: number;
     directory: readonly PatientDirectoryEntry[]; projection: PatientOpenLoopsProjection;
 }>;
 
@@ -44,29 +45,34 @@ function isPlainExact(value: unknown, keys: readonly string[]): value is Record<
         && own.every((key) => { const descriptor = Object.getOwnPropertyDescriptor(value, key); return descriptor?.enumerable === true && 'value' in descriptor; });
 }
 function isText(value: unknown): value is string { return typeof value === 'string' && value.trim().length > 0; }
+function isOpaqueRef(value: unknown): value is string { return typeof value === 'string' && /^[a-z0-9][a-z0-9-]{0,39}$/.test(value); }
 function isCommand(value: unknown): value is MiniPilotCommand { return isText(value) && Object.hasOwn(COMMANDS, value); }
 
 export type TrustedAgentService = Readonly<{
     execute(input: unknown): AgentServiceResult;
-    revoke(): void;
 }>;
+export type TrustedAgentHostControl = Readonly<{ revoke(): void; changeSelection(): void }>;
+export type SyntheticTrustedAgentPlane = Readonly<{ service: TrustedAgentService; control: TrustedAgentHostControl }>;
 
 class TrustedAgentInterfaceService implements TrustedAgentService {
     readonly #state: TrustedPilotState;
     readonly #clock: () => number;
     readonly #seen = new Set<string>();
+    #selectionEpoch: number;
     #revoked = false;
 
     constructor(state: TrustedPilotState, clock: () => number) {
         this.#state = structuredClone(state);
         this.#clock = clock;
+        this.#selectionEpoch = state.selectionEpoch;
     }
 
     revoke(): void { this.#revoked = true; }
+    changeSelection(): void { this.#selectionEpoch += 1; }
 
     execute(input: unknown): AgentServiceResult {
         const fallback = this.#receipt('invalid', 'capabilities', 'denied', null, ['REQUEST_INVALID']);
-        if (!isPlainExact(input, REQUEST_KEYS) || !isText(input.requestId) || !isText(input.credential)
+        if (!isPlainExact(input, REQUEST_KEYS) || !isOpaqueRef(input.requestId) || !isText(input.credential)
             || !isCommand(input.command) || !isPlainExact(input.args, ARG_KEYS[input.command])) {
             return { ok: false, error: 'REQUEST_INVALID', receipt: fallback };
         }
@@ -74,23 +80,25 @@ class TrustedAgentInterfaceService implements TrustedAgentService {
         const deny = (error: AgentServiceError) => ({ ok: false, error, receipt: this.#receipt(requestId, command, 'denied', null, [error]) } as const);
         if (credential !== this.#state.credential) return deny('CREDENTIAL_INVALID');
         if (this.#revoked) return deny('SESSION_REVOKED');
+        if (this.#selectionEpoch !== this.#state.selectionEpoch) return deny('SELECTION_CHANGED');
         if (this.#clock() >= this.#state.expiresAt) return deny('SESSION_EXPIRED');
-        if (this.#seen.has(requestId)) return deny('REQUEST_REPLAYED');
-        this.#seen.add(requestId);
-        if (command === 'apply') return deny('APPLY_DENIED');
 
         const patientRef = args.patientRef;
+        const searchQuery = command === 'patient.search' && typeof args.query === 'string' ? args.query.trim() : null;
         if (patientRef !== undefined && !isText(patientRef)) return deny('REQUEST_INVALID');
+        if (command === 'patient.search' && !searchQuery) return deny('REQUEST_INVALID');
         if ((command === 'open-loops' || command === 'draft.preview') && patientRef !== this.#state.selectedPatientRef) return deny('PATIENT_MISMATCH');
         const patient = isText(patientRef) ? this.#state.directory.find((item) => item.patientRef === patientRef) : undefined;
         if (command === 'patient.show' && !patient) return deny('PATIENT_NOT_FOUND');
+        if (this.#seen.has(requestId)) return deny('REQUEST_REPLAYED');
+        this.#seen.add(requestId);
+        if (command === 'apply') return deny('APPLY_DENIED');
 
         let data: unknown;
         if (command === 'whoami') data = { sessionRef: this.#state.sessionRef, ambulatoryRef: this.#state.ambulatoryRef, expiresAt: new Date(this.#state.expiresAt).toISOString() };
         else if (command === 'capabilities') data = Object.entries(COMMANDS).map(([name, value]) => ({ command: name, ...value }));
         else if (command === 'patient.search') {
-            if (typeof args.query !== 'string') return deny('REQUEST_INVALID');
-            const query = args.query.trim().toLocaleLowerCase('it');
+            const query = searchQuery!.toLocaleLowerCase('it');
             data = this.#state.directory.filter((item) => item.displayName.toLocaleLowerCase('it').includes(query));
         } else if (command === 'patient.show') data = patient;
         else if (command === 'open-loops') data = this.#state.projection;
@@ -99,7 +107,7 @@ class TrustedAgentInterfaceService implements TrustedAgentService {
             const digest = createHash('sha256').update(JSON.stringify(draft)).digest('hex');
             return { ok: true, data: draft, receipt: this.#receipt(requestId, command, 'succeeded', digest, []) };
         }
-        return { ok: true, data, receipt: this.#receipt(requestId, command, 'succeeded', null, []) };
+        return { ok: true, data: structuredClone(data), receipt: this.#receipt(requestId, command, 'succeeded', null, []) };
     }
 
     #receipt(requestId: string, command: MiniPilotCommand, status: AgentServiceReceipt['status'], digest: string | null, issues: readonly AgentServiceError[]): AgentServiceReceipt {
@@ -112,14 +120,18 @@ class TrustedAgentInterfaceService implements TrustedAgentService {
 
 export function createSyntheticTrustedAgentService(
     now = Date.parse('2026-08-21T12:00:00.000Z'), clock: () => number = () => now,
-): TrustedAgentService {
+): SyntheticTrustedAgentPlane {
     const patientRef = 'synthetic-patient-001';
-    return new TrustedAgentInterfaceService({
+    const broker = new TrustedAgentInterfaceService({
         credential: 'synthetic-agent-credential', sessionRef: 'session-synthetic-001', ambulatoryRef: 'ambulatory-synthetic-001',
-        leaseRef: 'lease-synthetic-001', selectedPatientRef: patientRef, issuedAt: now - 60_000, expiresAt: now + 300_000,
+        leaseRef: 'lease-synthetic-001', selectedPatientRef: patientRef, selectionEpoch: 1, issuedAt: now - 60_000, expiresAt: now + 300_000,
         directory: [{ patientRef, displayName: 'Paziente Sintetico Uno', birthYear: 1970, archived: false, version: 3 }],
         projection: projectPatientOpenLoops({ patientRef, expectedSourceVersion: 3, items: [{ id: 'synthetic-item-001', patientId: patientRef,
             prescriptionId: 'synthetic-prescription-001', status: 'prescribed', serviceName: 'Controllo sintetico', createdAt: '2026-08-01T00:00:00.000Z' }],
         observations: [], now: new Date(now) }),
     }, clock);
+    return Object.freeze({
+        service: Object.freeze({ execute: broker.execute.bind(broker) }),
+        control: Object.freeze({ revoke: broker.revoke.bind(broker), changeSelection: broker.changeSelection.bind(broker) }),
+    });
 }


### PR DESCRIPTION
## Summary
- Aggiunge un servizio applicativo condiviso sintetico con authority, clock, revoca, replay set e context lease broker-owned.
- Espone soltanto credenziale breve, request ID opaco, comando e argomenti operativi validati con own-key exact allowlist.
- Restituisce snapshot deep-cloned; separa il control plane host-only e invalida il mandato al cambio `selectionEpoch`.
- Offre whoami, capabilities, patient search/show, open-loops e draft preview; query vuote e apply restano negate.
- Produce receipt deterministiche e PHI-safe senza testo clinico caller-supplied, riferimenti paziente, display name o credenziale.

## Verification
- `node scripts/run-strip-types.mjs --test lib/agent-interface/trusted-service.test.ts` — 6/6 pass
- `node scripts/run-strip-types.mjs --test --glob "lib/agent-interface/**/*.test.ts"` — 24/24 pass
- `npx eslint --quiet lib/agent-interface/trusted-service.ts lib/agent-interface/trusted-service.test.ts`
- `npm run typecheck -- --pretty false`
- `git diff --check`
- import scan: nessun fs/net/http/sqlite/fetch/child_process nel servizio

## Risk / Notes
- Packet stacked sulla ADR-only #185 e limitato a 222 LOC.
- Solo fixture sintetiche; nessun SQLite, filesystem clinico, dato reale, migrazione, rete, cloud o modello esterno.
- Nessun live broker o adapter Mini è promosso da questa PR.
- Mini resta bloccato finché questo servizio non è validato sul nuovo SHA.

## Ticket
Refs WUL-558

Linear: https://linear.app/wulfgardr/issue/WUL-558/adr-0093-e-trusted-agent-interface-plane