### PR TITLE
feat(ui): esplicita gli stati paired su iPhone e iPad

### DIFF
--- a/docs/NATIVE.md
+++ b/docs/NATIVE.md
@@ -222,9 +222,22 @@ ha preview e test sintetici, ma non è ancora cablata a metadata live: la cache
 oltre il TTL viene scartata. L'azione primaria misura almeno 48 pt, espone label
 VoiceOver e supporta `⌘R` e pointer su iPad.
 
-Questa superficie non concede capability. AIP/Mini e WUL-518 restano fonti
-host-only: manifest, receipt o stato headless non diventano un grant clinico nel
-client mobile.
+Questa superficie non concede capability. Il gate di consumo `WUL-557` usa il
+contratto machine-readable canonico
+`packages/mini/contracts/mini-parity.json`, verificato byte-identico nei head
+`3fd988bafe71a058fdd7d3c25ea569793dcba903` (PR #184) e
+`1e35733c0218eae67a1d6e158085aab7340bc26b` (PR #190). Il contratto dichiara
+4 righe `available` su 66 (`6.060606%`), 61 `manual_only`, 1 `proposal_only` e
+0 `unavailable`; le ragioni restano 23 `HOST_AUTHORITY_ONLY`, 38
+`NOT_IN_MINI_PILOT` e 1 `SYNTHETIC_PREVIEW_ONLY`.
+
+Per la slice `WUL-556`, `patient search/show` (riga 1), `whoami` (riga 39) e
+`capabilities` (riga 63) sono disponibili in Mini, ma non colmano i residui
+nativi e non diventano grant. La cache offline (riga 45) resta `manual_only`
+con ragione `NOT_IN_MINI_PILOT`, mentre iPhone/iPadOS restano `partial` per
+metadata stale live, dettaglio offline e write queue assenti. Manifest, receipt,
+stato paired e token locale non conferiscono autorità agentica. La parity resta
+incompleta fino alla verifica manager e a `WUL-564`.
 
 ---
 

--- a/docs/NATIVE.md
+++ b/docs/NATIVE.md
@@ -199,6 +199,33 @@ VoiceOver nel simulatore mobile; il limite e la deroga della sola candidata
 sorgente 0.8 sono registrati in
 [docs/known-limitations.md](./known-limitations.md).
 
+### 4. Temperamento mobile candidato e stato paired
+
+`WUL-556` usa **Guardia** come temperamento esplorativo su iPhone/iPadOS e
+**Carta** come substrato delle superfici cliniche. La scelta resta
+`PROPOSED_FOR_OWNER_REVIEW`: un rifiuto o un cambio del product owner blocca
+la promozione della candidata. Il client non forza il tema scuro; usa il canvas
+Guardia solo quando l'aspetto di sistema è scuro e mantiene componenti,
+materiali e navigazione di sistema.
+
+La decisione owner per questa slice è vincolante: **Carta descrive la grammatica
+del contenuto, non una palette**. Le superfici mobili non introducono crema,
+beige, avorio o parchment. Il giorno usa i colori neutrali adattivi già
+canonici (`canvas #eef0f2`, `field #f4f6f8`, `focal #fbfcfe`); il buio usa il
+canvas Guardia neutro `#0c0e12`. I colori success/warning/critical restano
+segnali funzionali e non derivano dalla metafora Carta. Le preview sintetiche
+coprono esplicitamente iPhone light e iPad dark.
+
+Il pannello `mobile-paired-status` rende distinguibili caricamento, errore,
+online, cache locale, offline in sola lettura e sessione scaduta. La resa stale
+ha preview e test sintetici, ma non è ancora cablata a metadata live: la cache
+oltre il TTL viene scartata. L'azione primaria misura almeno 48 pt, espone label
+VoiceOver e supporta `⌘R` e pointer su iPad.
+
+Questa superficie non concede capability. AIP/Mini e WUL-518 restano fonti
+host-only: manifest, receipt o stato headless non diventano un grant clinico nel
+client mobile.
+
 ---
 
 ## Architettura client-server

--- a/docs/apple-parity-matrix.json
+++ b/docs/apple-parity-matrix.json
@@ -730,6 +730,29 @@
       "partial": [0, 2, 3, 4, 7, 9, 11, 14, 15, 19, 31, 35, 44],
       "outOfScope": [8, 16, 18, 29, 30, 34, 42, 43, 45, 46, 47, 48, 49, 51, 52, 53, 57, 58, 59, 61, 63, 64, 65]
     },
+    "miniContractConsumption": {
+      "status": "CONSUMED / HOLD_PROMOTION",
+      "canonicalPath": "packages/mini/contracts/mini-parity.json",
+      "schemaVersion": "mediflow.mini.parity-manifest.v1",
+      "heads": {
+        "pr184": "3fd988bafe71a058fdd7d3c25ea569793dcba903",
+        "pr190": "1e35733c0218eae67a1d6e158085aab7340bc26b"
+      },
+      "contentSha256": "8f84108732b7a8a9c1feb20cdedee17f4865044de98d8d997896f3a914d0e4d9",
+      "mappingRule": "rows[sourceRow - 1] maps to capabilities[sourceRow]; Mini disposition and Apple gap remain separate axes.",
+      "metric": {"definition": "Rows with miniDisposition=available divided by canonical web capability rows.", "availableRows": 4, "totalRows": 66, "parityPercent": 6.060606},
+      "dispositionCounts": {"available": 4, "manual_only": 61, "proposal_only": 1, "unavailable": 0},
+      "reasonCounts": {"HOST_AUTHORITY_ONLY": 23, "NOT_IN_MINI_PILOT": 38, "SYNTHETIC_PREVIEW_ONLY": 1, "none": 4},
+      "wul556Rows": [
+        {"sourceRow": 1, "webCapabilityId": "web-01-anagrafica-paziente-lista-ricerca-view-create-update", "miniCommands": ["patient search", "patient show"], "miniDisposition": "available", "reason": null, "appleGap": "partial", "interpretation": "Mini covers search/show only; broader Apple row residues remain."},
+        {"sourceRow": 39, "webCapabilityId": "web-39-blocco-sessione-immediato-stato-sessione", "miniCommands": ["whoami"], "miniDisposition": "available", "reason": null, "appleGap": "full-parity", "interpretation": "Session identity is observable; pairing and local tokens are not agentic grants."},
+        {"sourceRow": 45, "webCapabilityId": "web-45-cache-pazienti-cifrata-offline-consultazione-degradata", "miniCommands": [], "miniDisposition": "manual_only", "reason": "NOT_IN_MINI_PILOT", "appleGap": "partial", "interpretation": "Encrypted read-only list exists; live stale metadata, offline detail and write queue remain absent."},
+        {"sourceRow": 63, "webCapabilityId": "web-63-get-api-v1-network-capabilities-api-v1-network-identity-api-v1-n", "miniCommands": ["capabilities"], "miniDisposition": "available", "reason": null, "appleGap": "full-parity", "interpretation": "Capability discovery does not authorize clinical operations."}
+      ],
+      "excludedAvailableRow": {"sourceRow": 11, "miniCommands": ["open-loops"], "reason": "Outside WUL-556 slice."},
+      "authorityGuard": "Manifest, receipt, paired state and local token do not grant agentic or clinical authority.",
+      "remainingGates": ["manager verification", "WUL-564"]
+    },
     "interactionParity": {
       "verifiedAutomatic": [0, 12, 13, 14, 15, 17, 20, 31, 32, 33],
       "verifiedRealInteraction": [0, 31, 32],
@@ -772,7 +795,7 @@
     },
     "verdict": "PARTIAL / HOLD_PROMOTION"
   },
-  "updated": "2026-08-07 (0.8.1): aligned the 66-row feature contract with the AI settings information architecture (Fabric registry and governance split); 2026-08-07: fixed matrix drift in the 'AI conversazionale' row — the cited app/api/proxy/ai/chat/route.ts does not exist in the checkout; repointed to the real app/api/proxy/ollama/{chat,generate}/route.ts (L4 verification, host-only classification and guarded counts 30/13/21 unchanged). Previous: 2026-07-28 reconciled the 64-row feature contract against current web, macOS and assistive-technology evidence",
+  "updated": "2026-08-22: consumed the byte-identical Mini parity manifest from PR #184 head 3fd988b and PR #190 head 1e35733 without changing Apple gap classifications; promotion remains held for manager verification and WUL-564. Previous: 2026-08-07 aligned the 66-row feature contract with the AI settings information architecture and corrected the AI conversational endpoint evidence.",
   "version": 2,
   "summary": {
     "total": 66,

--- a/docs/apple-parity-matrix.json
+++ b/docs/apple-parity-matrix.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-07-28",
+  "generated": "2026-08-21",
   "source": "MediFlow 0.8 parity closeout against the frozen local source candidate",
   "release08Gate": {
     "asOf": "2026-07-28",
@@ -497,11 +497,11 @@
       "area": "cache-offline",
       "feature": "Cache pazienti cifrata offline (consultazione degradata)",
       "web": "n-a (web è online contro DB locale)",
-      "native": "partial: snapshot cifrato AES-GCM lista pazienti (Keychain, TTL 24h, scoping server+ambulatorio), restore offline-degraded; SOLO lista, no dettaglio/sotto-risorse, NO write queue (HomeBasePatientCacheStore.swift)",
+      "native": "partial: iPhone/iPad mostrano loading/error/online/cache/offline/sessione scaduta con azione accessibile e snapshot cifrato AES-GCM lista pazienti (Keychain, TTL 24h, scoping server+ambulatorio); restore offline-degraded in sola lettura. Lo stato visuale stale e coperto da preview/test sintetici, ma il runtime scarta ancora lo snapshot oltre TTL perche il contratto non espone metadata separati. SOLO lista, no dettaglio/sotto-risorse, NO write queue (MobilePairedStatusView.swift; HomeBasePatientCacheStore.swift)",
       "boundary": "n-a: derivata dal boundary, mai autorevole (vincolo docs-plan: no seconda source of truth)",
       "gap": "partial",
       "wave": "W1-mobile-core",
-      "evidence": "native-ui.cache offline; gap corrente WUL-403; nessuna offline write queue"
+      "evidence": "WUL-556 candidate: MobilePairedStatusPresentationTests e XCUITest iPhone/iPad con fixture sintetiche; WUL-403 resta aperta per metadata stale live; nessuna offline write queue"
     },
     {
       "area": "settings-host",
@@ -759,7 +759,7 @@
       "webProduction": "104 pages and standalone build PASS; Chrome production at exact 200% and 400% zoom, main controls visible, no dev badge",
       "macOS": "clipping code integrated; built Xcode 27 bundle PASS at 1100, 1300 and 1600 points; click-map, focus, arrow input and real VoiceOver active before and after",
       "axProbe": "corrected to select native List rows, bind patient-specific detail content and avoid terminating external MediFlow sessions; typecheck and 6/6 tests PASS",
-      "offline": "WUL-403 remains open for visible TTL, stale state and explicit reconciliation"
+      "offline": "WUL-556 candidate makes loading/error/online/cache/offline/session-expired visible on iPhone/iPad and defines the stale presentation contract. WUL-403 remains open for live TTL metadata and stale-state wiring."
     },
     "controlToActionReference": {
       "canonicalDocument": "docs/parity-matrix.md#control-to-action-map",

--- a/docs/parity-matrix.md
+++ b/docs/parity-matrix.md
@@ -157,6 +157,23 @@ Owner: `WUL-403`.
 Rende visibili età/TTL della cache, stato stale, read-only e assenza di write
 queue. Non introduce sync multi-master né scritture offline.
 
+La candidata `WUL-556` aggiunge su iPhone e iPad un pannello nativo per gli
+stati `loading`, `error`, `online`, `cache`, `offline read-only` e
+`session-expired`. La preview e i test sintetici coprono anche la resa
+`stale`. Il runtime continua però a scartare lo snapshot oltre il TTL di 24
+ore: finché il contratto cache/headless non espone metadata separati, lo stato
+stale live resta `partial`, non `complete`.
+
+Per decisione owner, Carta resta una grammatica del contenuto e non introduce
+una palette calda. Le superfici della slice usano canvas e field neutrali
+adattivi; i soli colori non neutrali sono segnali funzionali di stato.
+
+| Superficie mobile | Stato candidata | Evidenza | Dipendenza host/headless |
+| --- | --- | --- | --- |
+| iPhone | `partial` | Test di presentazione, XCUITest e screenshot sintetico | Nessun grant nuovo; usa solo stato paired esistente |
+| iPadOS | `partial` | Stesso contratto, layout adattivo, `⌘R`, pointer, XCUITest e screenshot sintetico | Metadata TTL/stale live non esposti |
+| Capability AIP/Mini | `host-only / unavailable` | WUL-518 resta controller | Manifest e receipt non diventano autorità client |
+
 ### W6-C — decisione sul workflow documentale nativo
 
 Dipendenze: `WUL-417` (OCR Apple on-device), `WUL-383` (degradazione OCR) e

--- a/docs/parity-matrix.md
+++ b/docs/parity-matrix.md
@@ -168,11 +168,33 @@ Per decisione owner, Carta resta una grammatica del contenuto e non introduce
 una palette calda. Le superfici della slice usano canvas e field neutrali
 adattivi; i soli colori non neutrali sono segnali funzionali di stato.
 
+Il gate di consumo `WUL-557` è aperto sul manifest canonico
+`packages/mini/contracts/mini-parity.json`. I head PR #184
+`3fd988bafe71a058fdd7d3c25ea569793dcba903` e PR #190
+`1e35733c0218eae67a1d6e158085aab7340bc26b` espongono lo stesso contenuto
+(SHA-256 `8f84108732b7a8a9c1feb20cdedee17f4865044de98d8d997896f3a914d0e4d9`).
+La metrica Mini è 4/66 (`6.060606%`): 4 `available`, 61 `manual_only`, 1
+`proposal_only` e 0 `unavailable`. Le ragioni non vengono appiattite: 23 righe
+sono `HOST_AUTHORITY_ONLY`, 38 `NOT_IN_MINI_PILOT` e 1
+`SYNTHETIC_PREVIEW_ONLY`.
+
+| Riga web canonica | Contratto Mini esatto | Stato iPhone/iPadOS | Motivo residuo o confine |
+| --- | --- | --- | --- |
+| 1 — anagrafica paziente | `available`: `patient search`, `patient show` | `partial` | Mini copre ricerca/dettaglio; la riga Apple resta più ampia e mancano assign/unassign/move/duplicate |
+| 39 — blocco/stato sessione | `available`: `whoami` | `full-parity` nella matrice Apple; stati visuali coperti dalla slice | `whoami`, pairing o token locale non sono un grant agentico |
+| 45 — cache offline | `manual_only`: `NOT_IN_MINI_PILOT` | `partial` | Lista cifrata read-only; metadata stale live, dettaglio offline e write queue assenti |
+| 63 — discovery capability | `available`: `capabilities` | `full-parity` per consumo API | Il manifest descrive capability; non autorizza operazioni cliniche |
+
+`open-loops` (riga 11) è la quarta riga Mini `available`, ma non appartiene alla
+slice `WUL-556`. `draft preview` (riga 4) resta `proposal_only` con ragione
+`SYNTHETIC_PREVIEW_ONLY`. Le altre righe conservano la disposizione e la ragione
+del manifest; le 23 `HOST_AUTHORITY_ONLY` restano host-only nella matrice Apple.
+
 | Superficie mobile | Stato candidata | Evidenza | Dipendenza host/headless |
 | --- | --- | --- | --- |
 | iPhone | `partial` | Test di presentazione, XCUITest e screenshot sintetico | Nessun grant nuovo; usa solo stato paired esistente |
 | iPadOS | `partial` | Stesso contratto, layout adattivo, `⌘R`, pointer, XCUITest e screenshot sintetico | Metadata TTL/stale live non esposti |
-| Capability AIP/Mini | `host-only / unavailable` | WUL-518 resta controller | Manifest e receipt non diventano autorità client |
+| Capability AIP/Mini | Gap Apple e disposizione Mini restano assi separati | Manifest WUL-557: 4/66 disponibili | Le ragioni `partial`, host-only e `manual_only` restano esplicite; manifest e receipt non diventano autorità client; verifica manager e `WUL-564` bloccano la promozione |
 
 ### W6-C — decisione sul workflow documentale nativo
 

--- a/native/MediFlowAppleApp/Tests/MediFlowMobileAppUITests/MediFlowMobileAppUITests.swift
+++ b/native/MediFlowAppleApp/Tests/MediFlowMobileAppUITests/MediFlowMobileAppUITests.swift
@@ -272,6 +272,23 @@ final class MediFlowMobileAppUITests: XCTestCase {
         )
     }
 
+    /* @Codex */
+    func testPairedStatusIsVisibleAndReachableWithSyntheticPatients() throws {
+        launch(seedPatients: true)
+
+        let status = sectionView("mobile-paired-status")
+        XCTAssertTrue(status.waitForExistence(timeout: 20))
+        XCTAssertGreaterThanOrEqual(status.frame.height, 44)
+        XCTAssertFalse(status.value as? String == "")
+
+        let configure = app.buttons["Configura"]
+        XCTAssertTrue(configure.waitForExistence(timeout: 10))
+        XCTAssertGreaterThanOrEqual(configure.frame.height, 44)
+        attachScreenshot(named: UIDevice.current.userInterfaceIdiom == .pad
+            ? "WUL-556-iPad-Guardia-Carta"
+            : "WUL-556-iPhone-Guardia-Carta")
+    }
+
     // @Codex #142: AX Dynamic Type must select the existing single-column path.
     func testAccessibilityDynamicTypeUsesSinglePatientColumnOnIPad() throws {
         // Not applicable on iPhone: skipping keeps the iPhone suite meaningful

--- a/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/MobilePairedStatusView.swift
+++ b/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/MobilePairedStatusView.swift
@@ -1,0 +1,139 @@
+import SwiftUI
+
+/* @Codex */
+struct MobilePairedStatusPresentation: Equatable {
+    enum Phase: Equatable {
+        case loading, error, online, cached, offline, stale, sessionExpired, notLoaded
+    }
+
+    let phase: Phase
+    let title: String
+    let detail: String
+    let symbolName: String
+    let actionTitle: String?
+
+    static func make(
+        connectionState: PairedPatientsConnectionState,
+        isWorking: Bool,
+        errorMessage: String?,
+        reconciliationLine: String,
+        cacheIsStale: Bool = false
+    ) -> Self {
+        if isWorking {
+            return Self(phase: .loading, title: "Aggiornamento in corso", detail: "Mantieni aperto MediFlow.", symbolName: "arrow.triangle.2.circlepath", actionTitle: nil)
+        }
+        if errorMessage != nil {
+            return Self(phase: .error, title: "Aggiornamento non riuscito", detail: "I dati già visibili non vengono modificati.", symbolName: "exclamationmark.triangle.fill", actionTitle: "Riprova")
+        }
+        if cacheIsStale {
+            return Self(phase: .stale, title: "Cache scaduta", detail: "Ricollega l'home-base prima di usare questi dati.", symbolName: "clock.badge.exclamationmark", actionTitle: "Ricollega")
+        }
+        switch connectionState {
+        case .pairedOnline:
+            return Self(phase: .online, title: "Home-base collegato", detail: reconciliationLine, symbolName: "checkmark.circle.fill", actionTitle: "Aggiorna")
+        case .cached:
+            return Self(phase: .cached, title: "Cache locale", detail: reconciliationLine, symbolName: "clock.arrow.circlepath", actionTitle: "Aggiorna")
+        case .pairedOfflineDegraded:
+            return Self(phase: .offline, title: "Offline, sola lettura", detail: reconciliationLine, symbolName: "wifi.slash", actionTitle: "Riprova")
+        case .sessionExpired:
+            return Self(phase: .sessionExpired, title: "Sessione scaduta", detail: "Accedi di nuovo per leggere o modificare dati.", symbolName: "person.crop.circle.badge.exclamationmark", actionTitle: "Accedi")
+        case .notLoaded:
+            return Self(phase: .notLoaded, title: "Home-base non configurato", detail: "Collega questo dispositivo per caricare il perimetro autorizzato.", symbolName: "link.badge.plus", actionTitle: "Configura")
+        }
+    }
+}
+
+#if os(iOS)
+/* @Codex */
+struct MobilePairedStatusView: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    let presentation: MobilePairedStatusPresentation
+    let onPrimaryAction: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            statusSymbol
+            VStack(alignment: .leading, spacing: 4) {
+                Text(presentation.title)
+                    .font(.headline)
+                Text(presentation.detail)
+                    .font(.subheadline)
+                    .foregroundStyle(mutedColor)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 8)
+            if let actionTitle = presentation.actionTitle {
+                Button(action: onPrimaryAction) {
+                    Text(actionTitle)
+                        .foregroundStyle(colorScheme == .dark ? Color.black : Color.white)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.primary)
+                .controlSize(.large)
+                .frame(minWidth: 48, minHeight: 48)
+                .contentShape(.interaction, Rectangle())
+                .hoverEffect(.highlight)
+                .keyboardShortcut("r", modifiers: .command)
+                .accessibilityHint("Aggiorna lo stato del collegamento con l'home-base.")
+            }
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .lumeSurface(zone: .field)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Stato operativo")
+        .accessibilityValue("\(presentation.title). \(presentation.detail)")
+        .accessibilityIdentifier("mobile-paired-status")
+    }
+
+    @ViewBuilder
+    private var statusSymbol: some View {
+        if presentation.phase == .loading {
+            ProgressView()
+                .frame(width: 28, height: 28)
+        } else {
+            Image(systemName: presentation.symbolName)
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(tint)
+                .frame(width: 28, height: 28)
+        }
+    }
+
+    private var tint: Color {
+        switch presentation.phase {
+        case .online: return LumePalette.success
+        case .error, .stale: return LumePalette.critical
+        case .offline, .sessionExpired: return LumePalette.warning
+        case .loading, .cached, .notLoaded: return mutedColor
+        }
+    }
+
+    private var mutedColor: Color {
+        colorScheme == .dark
+            ? LumePalette.guardia.inkMuted
+            : LumePalette.giorno.inkMuted
+    }
+}
+
+#if DEBUG
+#Preview("iPhone, offline, light") {
+    MobilePairedStatusView(
+        presentation: .make(connectionState: .pairedOfflineDegraded, isWorking: false, errorMessage: nil, reconciliationLine: "Cache cifrata locale. Nessuna scrittura offline."),
+        onPrimaryAction: {}
+    )
+    .padding()
+    .preferredColorScheme(.light)
+}
+
+#Preview("iPad, cache scaduta, dark") {
+    MobilePairedStatusView(
+        presentation: .make(connectionState: .cached, isWorking: false, errorMessage: nil, reconciliationLine: "Snapshot locale.", cacheIsStale: true),
+        onPrimaryAction: {}
+    )
+    .padding()
+    .frame(width: 744)
+    .preferredColorScheme(.dark)
+}
+#endif
+#endif

--- a/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/PairedPatientsWorkspaceView.swift
+++ b/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/PairedPatientsWorkspaceView.swift
@@ -4,6 +4,7 @@ import PhotosUI
 struct PairedPatientsWorkspaceView: View {
     @Environment(\.scenePhase) private var scenePhase
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.colorScheme) private var colorScheme
     @ObservedObject private var model: PairedPatientsWorkspaceModel
     // S6 (D7-bis): gates the new document surfaces on the effective capability
     // matrix returned for this pairing. The server downgrades host-supported but
@@ -75,7 +76,7 @@ struct PairedPatientsWorkspaceView: View {
         )
         .modifier(MinimizedSearchToolbarBehavior())
         #else
-        .background(PlatformColors.groupedBackground)
+        .background(mobileCanvasColor)
         // Creating a patient is the home's primary action, so it belongs in the
         // navigation bar. Inline it consumed the first viewport at accessibility
         // text sizes and pushed the first patient off screen.
@@ -341,7 +342,7 @@ struct PairedPatientsWorkspaceView: View {
             HStack(spacing: 0) {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 12) {
-                        connectionSetupBanner
+                        mobilePairedStatus
                         workspaceFeedbackLine
                         patientsListContent
                             .padding(16)
@@ -401,12 +402,12 @@ struct PairedPatientsWorkspaceView: View {
                         selectedPatientSections(detail)
                             .compactContainerWidth(inset: 40)
                     } else {
-                        connectionSetupBanner
+                        mobilePairedStatus
                         workspaceFeedbackLine
                         patientsCard
                     }
                     #else
-                    connectionSetupBanner
+                    mobilePairedStatus
                     workspaceFeedbackLine
                     patientsCard
                     #endif
@@ -418,6 +419,32 @@ struct PairedPatientsWorkspaceView: View {
                 if let detail = model.selectedPatient {
                     compactPatientHeader(detail)
                 }
+            }
+        }
+    }
+
+    /* @Codex */
+    private var mobileCanvasColor: Color {
+        colorScheme == .dark
+            ? LumePalette.guardia.canvas
+            : PlatformColors.groupedBackground
+    }
+
+    /* @Codex */
+    private var mobilePairedStatus: some View {
+        MobilePairedStatusView(
+            presentation: .make(
+                connectionState: model.connectionState,
+                isWorking: model.isWorking,
+                errorMessage: model.errorMessage,
+                reconciliationLine: model.reconciliationLine
+            )
+        ) {
+            switch model.connectionState {
+            case .notLoaded, .sessionExpired:
+                showsConnectionSetup = true
+            case .cached, .pairedOnline, .pairedOfflineDegraded:
+                Task { await model.loadPatients() }
             }
         }
     }

--- a/native/MediFlowMac/Tests/MediFlowAppleSharedTests/MobilePairedStatusPresentationTests.swift
+++ b/native/MediFlowMac/Tests/MediFlowAppleSharedTests/MobilePairedStatusPresentationTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import MediFlowAppleShared
+
+/* @Codex */
+final class MobilePairedStatusPresentationTests: XCTestCase {
+    func testLoadingAndErrorTakePrecedenceOverConnectionState() {
+        let loading = MobilePairedStatusPresentation.make(
+            connectionState: .pairedOnline,
+            isWorking: true,
+            errorMessage: "errore sintetico",
+            reconciliationLine: "online"
+        )
+        XCTAssertEqual(loading.phase, .loading)
+
+        let error = MobilePairedStatusPresentation.make(
+            connectionState: .pairedOnline,
+            isWorking: false,
+            errorMessage: "errore sintetico",
+            reconciliationLine: "online"
+        )
+        XCTAssertEqual(error.phase, .error)
+        XCTAssertEqual(error.actionTitle, "Riprova")
+    }
+
+    func testOfflineIsExplicitlyReadOnly() {
+        let presentation = MobilePairedStatusPresentation.make(
+            connectionState: .pairedOfflineDegraded,
+            isWorking: false,
+            errorMessage: nil,
+            reconciliationLine: "Nessuna scrittura mobile disponibile."
+        )
+        XCTAssertEqual(presentation.phase, .offline)
+        XCTAssertTrue(presentation.title.contains("sola lettura"))
+        XCTAssertTrue(presentation.detail.contains("Nessuna scrittura"))
+    }
+
+    func testStaleCacheOverridesGenericCachedState() {
+        let presentation = MobilePairedStatusPresentation.make(
+            connectionState: .cached,
+            isWorking: false,
+            errorMessage: nil,
+            reconciliationLine: "Snapshot locale.",
+            cacheIsStale: true
+        )
+        XCTAssertEqual(presentation.phase, .stale)
+        XCTAssertEqual(presentation.actionTitle, "Ricollega")
+    }
+}


### PR DESCRIPTION
## Summary
- Introduce un pannello SwiftUI iOS-only per gli stati paired loading, error, online, cache, offline read-only, stale, session-expired e not-loaded.
- Mantiene Carta come grammatica del contenuto senza palette calda; usa superfici neutrali adattive e segnali funzionali distinti.
- Aggiunge test di presentazione, XCUITest sintetico iPhone/iPad e aggiorna la sola copertura mobile della matrice di parity.
- Consuma il manifest Mini canonico senza modificare web, scene macOS-only, AIP o Mini.

## Verification
- `scripts/native-test.sh`: 563 test, 0 failure sul commit UI `b124091e1`.
- `xcodebuild ... -destination 'generic/platform=iOS Simulator' ... build CODE_SIGNING_ALLOWED=NO`: build riuscita con Xcode 27 beta sul commit UI.
- XCUITest iPhone 17 Pro Simulator, iOS 27: status + audit accessibilità, 2/2 pass.
- XCUITest iPad Pro 13-inch (M5) Simulator, iOS 27 dark: status + audit accessibilità, 2/2 pass.
- XCUITest iPad Dynamic Type: 1/1 pass.
- `npm run check:apple-wide-qa`: 24 capability pass al commit `41d810a7e`.
- Crosswalk `jq`: 66/66 righe Apple allineate a `sourceRow`, 0 mismatch; le quattro righe WUL-556 coincidono con comandi, disposition e reason del manifest.
- `jq empty docs/apple-parity-matrix.json`, `git diff --check` e inventory Markdown: pass.
- CI di PR #188 terminale verde al precedente head `b124091e1`; il commit documentale successivo richiede il proprio stato CI.

## Risk / Notes
- Guardia su iPhone/iPad resta `PROPOSED_FOR_OWNER_REVIEW`; la decisione vincolante corrente è che Carta non è una palette.
- Manifest canonico verificato byte-identico in PR #184 head `3fd988b` e PR #190 head `1e35733`: 4/66 `available` (`6.060606%`), 61 `manual_only`, 1 `proposal_only`, 0 `unavailable`.
- Le ragioni restano esplicite: 23 `HOST_AUTHORITY_ONLY`, 38 `NOT_IN_MINI_PILOT`, 1 `SYNTHETIC_PREVIEW_ONLY`. Disponibilità Mini e gap Apple sono assi separati.
- Manifest, receipt, stato paired e token locale non sono grant agentici o clinici. Parity e promozione restano incomplete fino alla verifica manager e a WUL-564.
- Lo stato stale è coperto da presentazione/preview sintetica, ma il runtime continua a scartare snapshot oltre TTL senza metadata separati.
- Audit XCTest eseguito; una sessione VoiceOver reale su iPhone/iPad non è stata eseguita e non viene dichiarata.
- 7 file, 342 inserimenti / 9 rimozioni, divisi in due commit logici. Nessuna PHI/PII, dato paziente reale, database clinico o contenuto email.

## Ticket
Refs [WUL-556](https://linear.app/wulfgardr/issue/WUL-556/iosipados-adottare-guardia-su-carta-e-rendere-espliciti-gli-stati)