### PR TITLE
feat(ui): completa tastiera, comandi e aiuto

### DIFF
--- a/app/mockups/kree8/page.tsx
+++ b/app/mockups/kree8/page.tsx
@@ -2,8 +2,28 @@
 
 /* @Codex */
 
+import { Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { Kree8ClinicalCockpit } from '@/components/kree8/kree8-clinical-cockpit';
 
+function Kree8KeyboardReview() {
+  const searchParams = useSearchParams();
+  const requestedCount = Number(searchParams.get('patientCount'));
+  const reviewPatientCount = Number.isFinite(requestedCount) ? requestedCount : undefined;
+
+  return (
+    <Kree8ClinicalCockpit
+      surface="review"
+      initialArea={searchParams.get('area') === 'incarico' ? 'incarico' : 'turno'}
+      reviewPatientCount={reviewPatientCount}
+    />
+  );
+}
+
 export default function Kree8ReviewPage() {
-  return <Kree8ClinicalCockpit surface="review" />;
+  return (
+    <Suspense fallback={<div className="mf-alert mf-alert-info" role="status">Preparazione review sintetica.</div>}>
+      <Kree8KeyboardReview />
+    </Suspense>
+  );
 }

--- a/components/kree8/areas/incarico-area.tsx
+++ b/components/kree8/areas/incarico-area.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import {
   Activity,
   Archive,
@@ -27,6 +28,7 @@ import type {
   Kree8PatientStatus,
 } from '../cockpit-shared';
 import type { InboxList, Kree8Patient } from '@/lib/patient-workspace';
+import { nextVirtualRowIndex, type VirtualListNavigationKey } from '@/lib/kree8-keyboard-navigation';
 import styles from '../kree8-clinical-cockpit-foundation.module.css';
 import patientStyles from '../kree8-clinical-cockpit-patient-inbox.module.css';
 
@@ -59,6 +61,7 @@ function IncaricoArea({
   onOpenArea: (area: AreaId) => void;
   isReview: boolean;
 }) {
+  const router = useRouter();
   const [scope, setScope] = useState<InboxScope>('ambulatorio');
   const [list, setList] = useState<InboxList>('attivi');
   const [query, setQuery] = useState('');
@@ -97,6 +100,95 @@ function IncaricoArea({
     overscan: 8,
   });
 
+  /* @Codex: il focus segue l'indice completo, non il sottoinsieme DOM prodotto
+     dalla virtualizzazione. Dopo lo scroll attende il nuovo render e porta il
+     focus sulla riga corrispondente. */
+  const focusRowAtIndex = useCallback((requestedIndex: number) => {
+    if (visible.length === 0) return;
+    const index = Math.min(visible.length - 1, Math.max(0, requestedIndex));
+    const patient = visible[index];
+    if (!patient) return;
+    onSelectPatient(patient.id);
+    patientRowVirtualizer.scrollToIndex(index, { align: 'auto' });
+
+    const focusRenderedRow = (attempts: number) => {
+      const row = patientListParentRef.current?.querySelector<HTMLButtonElement>(
+        `[data-patient-index="${index}"]`,
+      );
+      if (row) {
+        row.focus();
+        return;
+      }
+      if (attempts > 0) window.requestAnimationFrame(() => focusRenderedRow(attempts - 1));
+    };
+    window.requestAnimationFrame(() => focusRenderedRow(2));
+  }, [onSelectPatient, patientRowVirtualizer, visible]);
+
+  const currentRowIndex = useCallback((target: EventTarget | null) => {
+    const focusedRow = target instanceof HTMLElement
+      ? target.closest<HTMLElement>('[data-patient-index]')
+      : null;
+    const parsed = focusedRow ? Number(focusedRow.dataset.patientIndex) : Number.NaN;
+    if (Number.isInteger(parsed)) return parsed;
+    const selectedIndex = visible.findIndex((patient) => patient.id === selectedPatientId);
+    return selectedIndex >= 0 ? selectedIndex : 0;
+  }, [selectedPatientId, visible]);
+
+  const navigateRows = useCallback((key: VirtualListNavigationKey, target: EventTarget | null) => {
+    const viewportHeight = patientListParentRef.current?.clientHeight ?? 62;
+    const index = nextVirtualRowIndex({
+      key,
+      currentIndex: currentRowIndex(target),
+      rowCount: visible.length,
+      pageSize: Math.max(1, Math.floor(viewportHeight / 62)),
+    });
+    if (index !== null) focusRowAtIndex(index);
+  }, [currentRowIndex, focusRowAtIndex, visible.length]);
+
+  const handleListKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    const navigationKeys: VirtualListNavigationKey[] = [
+      'ArrowDown', 'ArrowUp', 'j', 'k', 'Home', 'End', 'PageDown', 'PageUp',
+    ];
+    if (navigationKeys.includes(event.key as VirtualListNavigationKey)) {
+      event.preventDefault();
+      navigateRows(event.key as VirtualListNavigationKey, event.target);
+      return;
+    }
+    if (event.key !== 'Enter') return;
+    const patient = visible[currentRowIndex(event.target)];
+    if (!patient) return;
+    event.preventDefault();
+    onSelectPatient(patient.id);
+    if (isReview) onOpenArea('scheda');
+    else router.push(patient.modulesHref);
+  };
+
+  /* @Codex: scorciatoie contestuali, disattivate nei campi editabili. */
+  useEffect(() => {
+    const handleGlobalKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.altKey) return;
+      const target = event.target;
+      if (target instanceof HTMLElement) {
+        const tag = target.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || target.isContentEditable) return;
+      }
+      if (event.key === '/') {
+        event.preventDefault();
+        searchInputRef.current?.focus();
+        searchInputRef.current?.select();
+      } else if (event.key === 'n' || event.key === 'N') {
+        event.preventDefault();
+        const patient = visible[currentRowIndex(document.activeElement)];
+        router.push(patient ? `${patient.href}/entries/new` : '/patients/new');
+      } else if (event.key === 'j' || event.key === 'k') {
+        event.preventDefault();
+        navigateRows(event.key, document.activeElement);
+      }
+    };
+    document.addEventListener('keydown', handleGlobalKeyDown);
+    return () => document.removeEventListener('keydown', handleGlobalKeyDown);
+  }, [currentRowIndex, navigateRows, router, visible]);
+
   return (
     <div className={styles.areaShell}>
       <header className={styles.areaHeader}>
@@ -107,7 +199,7 @@ function IncaricoArea({
           </h1>
           <p className={styles.areaSubtitle}>
             {patientStatus === 'ready'
-              ? 'Casi dell’ambulatorio e della rete locale, tra attivi e archivio.'
+              ? 'Casi dell’ambulatorio e della rete locale. Usa le frecce o j/k per navigare, Invio per aprire; premi ? per l’aiuto completo.'
               : patientStatus === 'error'
                 ? 'Lista pazienti non disponibile: verifica sessione e servizi locali.'
                 : 'Preparazione della lista pazienti.'}
@@ -241,9 +333,10 @@ function IncaricoArea({
               <div
                 ref={patientListParentRef}
                 className={patientStyles.patientListViewport}
-                role="list"
+                role="listbox"
                 aria-label="Elenco pazienti in carico"
                 data-testid="lume-patient-list"
+                onKeyDown={handleListKeyDown}
               >
                 <div
                   className={patientStyles.patientList}
@@ -260,7 +353,7 @@ function IncaricoArea({
                         ref={patientRowVirtualizer.measureElement}
                         data-index={virtualRow.index}
                         className={patientStyles.patientRowWrap}
-                        role="listitem"
+                        role="presentation"
                         style={{
                           position: 'absolute',
                           top: 0,
@@ -276,7 +369,10 @@ function IncaricoArea({
                             isSelected && patientStyles.patientRowSelected,
                           )}
                           onClick={() => onSelectPatient(p.id)}
-                          aria-pressed={isSelected}
+                          role="option"
+                          aria-selected={isSelected}
+                          tabIndex={isSelected ? 0 : -1}
+                          data-patient-index={virtualRow.index}
                           data-testid="lume-patient-row"
                         >
                           <span className={patientStyles.patientRowContent} data-lume-row-part="content">

--- a/components/kree8/cockpit-shared.tsx
+++ b/components/kree8/cockpit-shared.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import {
   AlertTriangle,
   CalendarClock,
+  CircleHelp,
   Cloud,
   Database,
   FileSearch,
@@ -712,6 +713,7 @@ function Toolbar({
   setFilter,
   onOpenArea,
   onSearchRequest,
+  onOpenCommand,
   operatorName,
 }: {
   activeArea: AreaId;
@@ -719,6 +721,7 @@ function Toolbar({
   setFilter: (id: StatusFilter) => void;
   onOpenArea: (area: AreaId) => void;
   onSearchRequest: () => void;
+  onOpenCommand: () => void;
   operatorName: string;
 }) {
   const operatorInitials = buildOperatorInitials(operatorName);
@@ -757,6 +760,16 @@ function Toolbar({
       <button type="button" className={shellStyles.toolChip} onClick={() => onOpenArea('revisione')}>
         <FileSearch size={13} />
         Documenti paziente
+      </button>
+      <button
+        type="button"
+        className={shellStyles.toolChip}
+        onClick={onOpenCommand}
+        aria-label="Apri comandi e aiuto tastiera"
+      >
+        <CircleHelp size={13} aria-hidden="true" />
+        Comandi
+        <kbd className={shellStyles.toolChipKbd}>⌘K</kbd>
       </button>
       <span className={shellStyles.avatarPill}>
         <span className={shellStyles.avatarDot}>{operatorInitials}</span>

--- a/components/kree8/kree8-clinical-cockpit-shell.module.css
+++ b/components/kree8/kree8-clinical-cockpit-shell.module.css
@@ -190,13 +190,7 @@
 }
 
 .brandThemeToggle {
-  display: none;
-}
-
-@media (max-width: 1024px) {
-  .brandThemeToggle {
-    display: inline-flex;
-  }
+  display: inline-flex;
 }
 
 .brandMark {

--- a/components/kree8/kree8-clinical-cockpit-shell.module.css
+++ b/components/kree8/kree8-clinical-cockpit-shell.module.css
@@ -536,6 +536,11 @@
 
 .toolChip:active { transform: scale(0.97); }
 
+.toolChipKbd {
+  color: var(--ink-muted);
+  font: 600 10px/1 var(--lume-font-mono);
+}
+
 .toolChipMuted {
   background: transparent;
   color: var(--ink-muted);

--- a/components/kree8/kree8-clinical-cockpit.tsx
+++ b/components/kree8/kree8-clinical-cockpit.tsx
@@ -40,6 +40,7 @@ import { RevisioneArea } from './areas/revisione-area';
 import { RepertoriArea } from './areas/repertori-area';
 import { HandoffArea } from './areas/handoff-area';
 import { GovernanceArea } from './areas/governance-area';
+import { Kree8CommandCenter, type CommandCenterMode } from './kree8-command-center';
 import {
   AREA_ID_VALUES,
   AREAS,
@@ -194,25 +195,49 @@ type Kree8ClinicalCockpitProps = {
   initialArea?: AreaId;
   initialPatientId?: string;
   operatorName?: string;
+  reviewPatientCount?: number;
 };
+
+/* @Codex: amplia solo la fixture di review per provare la virtualizzazione;
+   ogni riga resta sintetica e non raggiunge il database locale. */
+function buildReviewPatients(count: number): Kree8Patient[] {
+  const boundedCount = Math.min(250, Math.max(REVIEW_PATIENT_LIST.length, Math.floor(count)));
+  return Array.from({ length: boundedCount }, (_, index) => {
+    const source = REVIEW_PATIENT_LIST[index % REVIEW_PATIENT_LIST.length]!;
+    const sequence = String(index + 1).padStart(3, '0');
+    return {
+      ...source,
+      id: `review-${sequence}`,
+      name: `Caso sintetico ${sequence}`,
+      code: `SYN-${sequence}`,
+      href: `/patients/review-${sequence}`,
+      modulesHref: `/patients/review-${sequence}/modules`,
+      list: 'attivi',
+      scope: 'ambulatorio',
+    };
+  });
+}
 
 export function Kree8ClinicalCockpit({
   surface = 'live',
   initialArea = 'turno',
   initialPatientId,
   operatorName: operatorNameProp,
+  reviewPatientCount = REVIEW_PATIENT_LIST.length,
 }: Kree8ClinicalCockpitProps) {
   const isReview = surface === 'review';
   const operatorName = operatorNameProp || (isReview ? 'Review design' : 'Sessione locale');
-  const [area, setArea] = useState<AreaId>(() => (isReview ? 'turno' : initialArea));
+  const reviewPatients = useMemo(() => buildReviewPatients(reviewPatientCount), [reviewPatientCount]);
+  const [area, setArea] = useState<AreaId>(() => initialArea);
   const [filter, setFilter] = useState<StatusFilter>('all');
   const [patientSearchFocusSignal, setPatientSearchFocusSignal] = useState(0);
+  const [commandCenterMode, setCommandCenterMode] = useState<CommandCenterMode>(null);
   const [agendaBridge, setAgendaBridge] = useState<ClinicalAgendaBridgeClientState>({
     status: 'idle',
   });
   const [patientState, setPatientState] = useState<Kree8PatientClientState>(() => (
     isReview
-      ? { status: 'ready', patients: REVIEW_PATIENT_LIST }
+      ? { status: 'ready', patients: reviewPatients }
       : { status: 'idle', patients: [] }
   ));
   const [agendaState, setAgendaState] = useState<Kree8AgendaClientState>(() => (
@@ -221,8 +246,30 @@ export function Kree8ClinicalCockpit({
       : { status: 'idle', rows: [] }
   ));
   const [selectedPatientId, setSelectedPatientId] = useState<string | undefined>(() => (
-    isReview ? REVIEW_PATIENT_LIST[0]?.id : initialPatientId
+    isReview ? reviewPatients[0]?.id : initialPatientId
   ));
+
+  /* @Codex: comandi globali della shell; i campi editabili conservano i propri
+     caratteri e Ctrl/Meta+K resta disponibile per aprire o chiudere la palette. */
+  useEffect(() => {
+    const handleGlobalCommand = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLocaleLowerCase('it-IT') === 'k') {
+        event.preventDefault();
+        setCommandCenterMode((current) => current === 'commands' ? null : 'commands');
+        return;
+      }
+      if (event.key !== '?' || event.metaKey || event.ctrlKey || event.altKey) return;
+      const target = event.target;
+      if (target instanceof HTMLElement) {
+        const tag = target.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || target.isContentEditable) return;
+      }
+      event.preventDefault();
+      setCommandCenterMode('help');
+    };
+    window.addEventListener('keydown', handleGlobalCommand);
+    return () => window.removeEventListener('keydown', handleGlobalCommand);
+  }, []);
 
   /* @Codex WUL-UIUX: riflette area e paziente selezionato nella query string di
      '/', cosi refresh e back del browser non perdono il punto di lavoro. Solo
@@ -404,7 +451,7 @@ export function Kree8ClinicalCockpit({
       : patientState.status === 'ready'
         ? String(patientState.patients.filter((patient) => patient.list === 'attivi').length)
         : patientState.status === 'error'
-          ? '!'
+          ? 'n.d.'
           : '…';
   const diaryNavMeta =
     isReview
@@ -466,9 +513,8 @@ export function Kree8ClinicalCockpit({
         })}
 
         <div className={styles.railFooter}>
-          <div className={styles.railThemeToggle} aria-label="Tema interfaccia">
-            <ThemeToggle />
-          </div>
+          {/* @Codex: il tema resta nel brand; un solo controllo evita due
+              gruppi identici con stato condiviso. */}
           <span className={styles.railTag}>
             <span className={styles.railDot} />
             Mac principale
@@ -492,6 +538,7 @@ export function Kree8ClinicalCockpit({
             setArea('incarico');
             setPatientSearchFocusSignal((current) => current + 1);
           }}
+          onOpenCommand={() => setCommandCenterMode('commands')}
           operatorName={operatorName}
         />
         <div
@@ -550,6 +597,17 @@ export function Kree8ClinicalCockpit({
           </main>
         </div>
       </section>
+
+      <Kree8CommandCenter
+        mode={commandCenterMode}
+        onClose={() => setCommandCenterMode(null)}
+        onOpenArea={setArea}
+        onSearchRequest={() => {
+          setArea('incarico');
+          setPatientSearchFocusSignal((current) => current + 1);
+        }}
+        onShowHelp={() => setCommandCenterMode('help')}
+      />
 
       {isReview && (
         <Link href="/" className={styles.exit} aria-label="Torna alla home MediFlow live">

--- a/components/kree8/kree8-command-center.module.css
+++ b/components/kree8/kree8-command-center.module.css
@@ -1,0 +1,86 @@
+/* @Codex */
+
+.backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1300;
+  display: grid;
+  place-items: start center;
+  padding: min(12vh, 96px) 16px 16px;
+  background: color-mix(in srgb, var(--lume-ink) 62%, transparent);
+}
+
+.dialog {
+  width: min(600px, 100%);
+  max-height: min(720px, 76vh);
+  overflow: hidden auto;
+  border: 1px solid color-mix(in srgb, var(--lume-ink) 14%, transparent);
+  border-radius: var(--lume-radius-panel);
+  background: var(--lume-surface-focal);
+  color: var(--lume-ink);
+  box-shadow: 0 2px 8px color-mix(in srgb, var(--lume-ink) 10%, transparent);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 20px 12px;
+}
+
+.caption { margin: 0 0 4px; color: var(--lume-ink-muted); font-size: 11px; font-weight: 650; letter-spacing: .1em; text-transform: uppercase; }
+.title { margin: 0; font-size: 20px; line-height: 1.2; }
+
+.close {
+  inline-size: 44px;
+  block-size: 44px;
+  display: grid;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--lume-ink) 14%, transparent);
+  border-radius: var(--lume-radius-control);
+  background: var(--lume-surface-field);
+  color: var(--lume-ink);
+  cursor: pointer;
+}
+
+.searchField {
+  min-height: 48px;
+  margin: 0 12px 8px;
+  padding: 0 12px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border: 1px solid color-mix(in srgb, var(--lume-ink) 14%, transparent);
+  border-radius: var(--lume-radius-control);
+  background: var(--lume-surface-field);
+  color: var(--lume-ink-muted);
+}
+
+.searchField:focus-within { border-color: var(--lume-accent); box-shadow: var(--lume-focus-ring); }
+.searchField input { min-width: 0; flex: 1; border: 0; outline: 0; background: transparent; color: var(--lume-ink); font: inherit; }
+.searchField kbd, .shortcuts kbd { color: var(--lume-ink); font: 600 11px/1.2 var(--lume-font-mono); }
+
+.commandList { margin: 0; padding: 8px 12px 14px; display: grid; gap: 4px; list-style: none; }
+.command, .commandActive { min-height: 52px; display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: 12px; padding: 8px 10px; border-radius: var(--lume-radius-control); cursor: pointer; }
+.command { color: var(--lume-ink-muted); }
+.commandActive { background: var(--lume-surface-field); color: var(--lume-ink); }
+.command b, .commandActive b { display: block; font-size: 13px; }
+.command small, .commandActive small { display: block; margin-top: 2px; color: var(--lume-ink-muted); font-size: 11px; }
+.empty { margin: 0; padding: 24px; color: var(--lume-ink-muted); text-align: center; }
+
+.shortcuts { margin: 0; padding: 4px 20px 20px; display: grid; gap: 2px; }
+.shortcuts > div { min-height: 48px; display: grid; grid-template-columns: minmax(120px, .7fr) minmax(0, 1fr); align-items: center; gap: 16px; border-bottom: 1px solid color-mix(in srgb, var(--lume-ink) 10%, transparent); }
+.shortcuts > div:last-child { border-bottom: 0; }
+.shortcuts dt, .shortcuts dd { margin: 0; }
+.shortcuts dd { color: var(--lume-ink-muted); font-size: 13px; }
+
+.close:focus-visible,
+.command:focus-visible,
+.commandActive:focus-visible { outline: none; box-shadow: var(--lume-focus-ring); }
+
+@media (max-width: 480px) {
+  .backdrop { padding: 12px; place-items: center; }
+  .dialog { max-height: calc(100vh - 24px); border-radius: var(--lume-radius-card); }
+  .shortcuts > div { grid-template-columns: 1fr; gap: 4px; padding-block: 9px; }
+}

--- a/components/kree8/kree8-command-center.tsx
+++ b/components/kree8/kree8-command-center.tsx
@@ -1,0 +1,231 @@
+'use client';
+
+/* @Codex */
+
+import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  CalendarClock,
+  CircleHelp,
+  CornerDownLeft,
+  Database,
+  FileText,
+  Plus,
+  Search,
+  Settings,
+  Users,
+  X,
+} from 'lucide-react';
+
+import type { AreaId } from './cockpit-shared';
+import styles from './kree8-command-center.module.css';
+
+type CommandCenterMode = 'commands' | 'help' | null;
+
+type CommandItem = {
+  id: string;
+  label: string;
+  hint: string;
+  icon: typeof Search;
+  run: () => void;
+};
+
+const FOCUSABLE_SELECTOR =
+  'button:not([disabled]), [href], input:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+const SHORTCUTS = [
+  ['⌘/Ctrl + K', 'Apri i comandi'],
+  ['?', 'Apri questo aiuto'],
+  ['/', 'Cerca nella lista pazienti'],
+  ['↑/↓ oppure j/k', 'Naviga tutte le righe virtualizzate'],
+  ['Home / End', 'Vai alla prima o ultima riga'],
+  ['Page Up / Page Down', 'Avanza di una pagina'],
+  ['Invio', 'Apri la Scheda della riga attiva'],
+  ['n', 'Crea una nuova voce per il paziente attivo'],
+] as const;
+
+export function Kree8CommandCenter({
+  mode,
+  onClose,
+  onOpenArea,
+  onSearchRequest,
+  onShowHelp,
+}: {
+  mode: CommandCenterMode;
+  onClose: () => void;
+  onOpenArea: (area: AreaId) => void;
+  onSearchRequest: () => void;
+  onShowHelp: () => void;
+}) {
+  const router = useRouter();
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [query, setQuery] = useState('');
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const commands = useMemo<CommandItem[]>(() => {
+    const openArea = (area: AreaId) => {
+      onOpenArea(area);
+      onClose();
+    };
+    return [
+      { id: 'agenda', label: 'Apri Agenda', hint: 'Area di turno', icon: CalendarClock, run: () => openArea('turno') },
+      { id: 'patients', label: 'Apri Pazienti', hint: 'Lista e lente rapida', icon: Users, run: () => openArea('incarico') },
+      { id: 'diary', label: 'Apri Diario', hint: 'Timeline clinica', icon: FileText, run: () => openArea('diario') },
+      { id: 'catalogs', label: 'Apri Repertori', hint: 'Cataloghi locali', icon: Database, run: () => openArea('repertori') },
+      { id: 'settings', label: 'Apri Impostazioni', hint: 'Governance locale', icon: Settings, run: () => openArea('governance') },
+      {
+        id: 'search',
+        label: 'Cerca paziente',
+        hint: 'Porta il fuoco alla ricerca',
+        icon: Search,
+        run: () => {
+          onSearchRequest();
+          onClose();
+        },
+      },
+      { id: 'new', label: 'Nuova scheda', hint: 'Apri il flusso di inserimento', icon: Plus, run: () => router.push('/patients/new') },
+      { id: 'help', label: 'Aiuto tastiera', hint: 'Scorciatoie disponibili', icon: CircleHelp, run: onShowHelp },
+    ];
+  }, [onClose, onOpenArea, onSearchRequest, onShowHelp, router]);
+
+  const matches = useMemo(() => {
+    const normalized = query.trim().toLocaleLowerCase('it-IT');
+    if (!normalized) return commands;
+    return commands.filter((command) => `${command.label} ${command.hint}`.toLocaleLowerCase('it-IT').includes(normalized));
+  }, [commands, query]);
+
+  useEffect(() => {
+    if (!mode) return;
+    const previouslyFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    setQuery('');
+    setActiveIndex(0);
+    window.setTimeout(() => {
+      if (mode === 'commands') inputRef.current?.focus();
+      else dialogRef.current?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR)?.focus();
+    }, 0);
+    return () => previouslyFocused?.focus();
+  }, [mode]);
+
+  useEffect(() => setActiveIndex(0), [query]);
+
+  if (!mode) return null;
+
+  const handleDialogKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      onClose();
+      return;
+    }
+    if (event.key !== 'Tab') return;
+    const container = dialogRef.current;
+    if (!container) return;
+    const focusable = Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+    if (focusable.length === 0) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (event.shiftKey && (document.activeElement === first || !container.contains(document.activeElement))) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && (document.activeElement === last || !container.contains(document.activeElement))) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
+  const handleCommandKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setActiveIndex((current) => Math.min(matches.length - 1, current + 1));
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      setActiveIndex((current) => Math.max(0, current - 1));
+    } else if (event.key === 'Home') {
+      event.preventDefault();
+      setActiveIndex(0);
+    } else if (event.key === 'End') {
+      event.preventDefault();
+      setActiveIndex(Math.max(0, matches.length - 1));
+    } else if (event.key === 'Enter') {
+      event.preventDefault();
+      matches[activeIndex]?.run();
+    }
+  };
+
+  return (
+    <div className={styles.backdrop} role="presentation" onMouseDown={(event) => event.target === event.currentTarget && onClose()}>
+      <div
+        ref={dialogRef}
+        className={styles.dialog}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="kree8-command-title"
+        onKeyDown={handleDialogKeyDown}
+        data-testid="kree8-command-center"
+      >
+        <header className={styles.header}>
+          <div>
+            <p className={styles.caption}>{mode === 'commands' ? 'Navigazione rapida' : 'Tastiera'}</p>
+            <h2 id="kree8-command-title" className={styles.title}>
+              {mode === 'commands' ? 'Comandi MediFlow' : 'Aiuto e scorciatoie'}
+            </h2>
+          </div>
+          <button type="button" className={styles.close} onClick={onClose} aria-label="Chiudi comandi">
+            <X size={16} aria-hidden="true" />
+          </button>
+        </header>
+
+        {mode === 'commands' ? (
+          <>
+            <label className={styles.searchField}>
+              <Search size={15} aria-hidden="true" />
+              <input
+                ref={inputRef}
+                role="combobox"
+                aria-controls="kree8-command-list"
+                aria-expanded={matches.length > 0}
+                aria-activedescendant={matches[activeIndex] ? `kree8-command-${matches[activeIndex].id}` : undefined}
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                onKeyDown={handleCommandKeyDown}
+                placeholder="Cerca un comando"
+                aria-label="Cerca un comando"
+              />
+              <kbd>esc</kbd>
+            </label>
+            <ul id="kree8-command-list" className={styles.commandList} role="listbox" aria-label="Comandi disponibili">
+              {matches.map((command, index) => {
+                const Icon = command.icon;
+                return (
+                  <li
+                    key={command.id}
+                    id={`kree8-command-${command.id}`}
+                    role="option"
+                    aria-selected={index === activeIndex}
+                    className={index === activeIndex ? styles.commandActive : styles.command}
+                    onMouseDown={(event) => event.preventDefault()}
+                    onMouseEnter={() => setActiveIndex(index)}
+                    onClick={command.run}
+                  >
+                    <Icon size={16} aria-hidden="true" />
+                    <span><b>{command.label}</b><small>{command.hint}</small></span>
+                    {index === activeIndex ? <CornerDownLeft size={14} aria-hidden="true" /> : null}
+                  </li>
+                );
+              })}
+            </ul>
+            {matches.length === 0 ? <p className={styles.empty}>Nessun comando corrispondente.</p> : null}
+          </>
+        ) : (
+          <dl className={styles.shortcuts}>
+            {SHORTCUTS.map(([keys, description]) => (
+              <div key={keys}><dt><kbd>{keys}</kbd></dt><dd>{description}</dd></div>
+            ))}
+          </dl>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export type { CommandCenterMode };

--- a/e2e/kree8-keyboard.spec.ts
+++ b/e2e/kree8-keyboard.spec.ts
@@ -1,0 +1,53 @@
+/* @Codex */
+
+import { expect, test } from '@playwright/test';
+
+test('Kree8: indice virtuale, Enter, palette e aiuto restano tastierabili', async ({ page }) => {
+  await page.goto('/mockups/kree8?area=incarico&patientCount=120');
+
+  const listbox = page.getByRole('listbox', { name: 'Elenco pazienti in carico' });
+  await expect(listbox).toBeVisible();
+  await expect(page.getByText('120 risultati')).toBeVisible();
+
+  const firstRow = page.getByRole('option', { name: /Caso sintetico 001/ });
+  await firstRow.focus();
+  await firstRow.press('End');
+  const lastRow = page.getByRole('option', { name: /Caso sintetico 120/ });
+  await expect(lastRow).toBeFocused();
+  await expect(lastRow).toHaveAttribute('aria-selected', 'true');
+  await expect(page.getByRole('heading', { name: 'Caso sintetico 120', exact: true })).toBeVisible();
+
+  await lastRow.press('PageUp');
+  const pageUpIndex = await page.evaluate(() => Number(document.activeElement?.getAttribute('data-patient-index')));
+  expect(pageUpIndex).toBeGreaterThanOrEqual(0);
+  expect(pageUpIndex).toBeLessThan(119);
+
+  await page.keyboard.press('ArrowUp');
+  const arrowIndex = await page.evaluate(() => Number(document.activeElement?.getAttribute('data-patient-index')));
+  expect(arrowIndex).toBe(pageUpIndex - 1);
+  await page.keyboard.press('Enter');
+  await expect(page.getByTestId('lume-frame-canvas')).toHaveAttribute('data-lume-context', 'scheda');
+
+  await page.goto('/mockups/kree8?area=incarico&patientCount=120');
+  const commandTrigger = page.getByRole('button', { name: 'Apri comandi e aiuto tastiera' });
+  await commandTrigger.click();
+  const commandDialog = page.getByRole('dialog', { name: 'Comandi MediFlow' });
+  await expect(commandDialog).toBeVisible();
+  const commandSearch = page.getByRole('combobox', { name: 'Cerca un comando' });
+  await expect(commandSearch).toBeFocused();
+  await commandSearch.fill('Diario');
+  await expect(commandDialog.getByRole('option')).toHaveCount(1);
+  await commandSearch.press('Enter');
+  await expect(page.getByTestId('lume-frame-canvas')).toHaveAttribute('data-lume-context', 'diario');
+
+  await page.keyboard.press('?');
+  const helpDialog = page.getByRole('dialog', { name: 'Aiuto e scorciatoie' });
+  await expect(helpDialog).toBeVisible();
+  await expect(helpDialog.getByText('Apri la Scheda della riga attiva')).toBeVisible();
+  await page.keyboard.press('Escape');
+  await expect(helpDialog).toHaveCount(0);
+
+  await page.getByRole('button', { name: /Pazienti/ }).click();
+  await page.keyboard.press('/');
+  await expect(page.getByRole('searchbox', { name: 'Cerca nella lista pazienti' })).toBeFocused();
+});

--- a/lib/kree8-keyboard-navigation.test.ts
+++ b/lib/kree8-keyboard-navigation.test.ts
@@ -1,0 +1,24 @@
+/* @Codex */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { nextVirtualRowIndex } from './kree8-keyboard-navigation';
+
+test('le frecce e j/k attraversano l’intero indice con limiti stabili', () => {
+  assert.equal(nextVirtualRowIndex({ key: 'ArrowDown', currentIndex: 7, rowCount: 20, pageSize: 5 }), 8);
+  assert.equal(nextVirtualRowIndex({ key: 'j', currentIndex: 19, rowCount: 20, pageSize: 5 }), 19);
+  assert.equal(nextVirtualRowIndex({ key: 'ArrowUp', currentIndex: 0, rowCount: 20, pageSize: 5 }), 0);
+  assert.equal(nextVirtualRowIndex({ key: 'k', currentIndex: 8, rowCount: 20, pageSize: 5 }), 7);
+});
+
+test('Home, End e Page Up/Down lavorano sull’indice non renderizzato', () => {
+  assert.equal(nextVirtualRowIndex({ key: 'Home', currentIndex: 48, rowCount: 100, pageSize: 8 }), 0);
+  assert.equal(nextVirtualRowIndex({ key: 'End', currentIndex: 2, rowCount: 100, pageSize: 8 }), 99);
+  assert.equal(nextVirtualRowIndex({ key: 'PageDown', currentIndex: 48, rowCount: 100, pageSize: 8 }), 56);
+  assert.equal(nextVirtualRowIndex({ key: 'PageUp', currentIndex: 3, rowCount: 100, pageSize: 8 }), 0);
+});
+
+test('una lista vuota non produce un indice attivo', () => {
+  assert.equal(nextVirtualRowIndex({ key: 'End', currentIndex: 0, rowCount: 0, pageSize: 8 }), null);
+});

--- a/lib/kree8-keyboard-navigation.ts
+++ b/lib/kree8-keyboard-navigation.ts
@@ -1,0 +1,48 @@
+/* @Codex */
+
+export type VirtualListNavigationKey =
+  | 'ArrowDown'
+  | 'ArrowUp'
+  | 'j'
+  | 'k'
+  | 'Home'
+  | 'End'
+  | 'PageDown'
+  | 'PageUp';
+
+export function nextVirtualRowIndex({
+  key,
+  currentIndex,
+  rowCount,
+  pageSize,
+}: {
+  key: VirtualListNavigationKey;
+  currentIndex: number;
+  rowCount: number;
+  pageSize: number;
+}): number | null {
+  if (rowCount <= 0) return null;
+  const current = Math.min(rowCount - 1, Math.max(0, currentIndex));
+  const page = Math.max(1, Math.floor(pageSize));
+
+  switch (key) {
+    case 'ArrowDown':
+    case 'j':
+      return Math.min(rowCount - 1, current + 1);
+    case 'ArrowUp':
+    case 'k':
+      return Math.max(0, current - 1);
+    case 'Home':
+      return 0;
+    case 'End':
+      return rowCount - 1;
+    case 'PageDown':
+      return Math.min(rowCount - 1, current + page);
+    case 'PageUp':
+      return Math.max(0, current - page);
+    default: {
+      const exhaustive: never = key;
+      return exhaustive;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- naviga l’intero indice della lista virtualizzata con frecce, j/k, Home, End e Page Up/Down, mantenendo selezione, scroll e focus;
- assegna a Invio l’apertura della Scheda e conserva `/` e `n` fuori dai campi editabili;
- aggiunge command center accessibile con ⌘/Ctrl+K, aiuto `?`, ricerca, focus trap ed Escape;
- rende disponibile una review con 120 casi sintetici e un E2E dedicato.

## Verification
- `git diff --check`
- `npm run typecheck`
- `npm run lint`
- `npm run check:lume-tokens` — 42/42 coppie WCAG, palette Lume OK
- `node scripts/run-strip-types.mjs --test lib/kree8-keyboard-navigation.test.ts` — 3 pass
- `MEDIFLOW_E2E_DATA_DIR=/tmp/mediflow-wul560-e2e E2E_NEXT_BUNDLER=webpack E2E_SPECS='e2e/kree8-keyboard.spec.ts' bash scripts/e2e-smoke.sh` — 1 pass
- Browser su `127.0.0.1:3100`: End da riga 1 a 120 con 18 opzioni DOM, PageUp a 110, freccia a 109, Invio al contesto Scheda; palette, filtro, aiuto, Escape, focus trap e `/`; console senza warning/error.
- Browser 1440×900, 390×844 e 720×450 come equivalente sicuro al 200%; nessun overflow orizzontale, un solo `h1`, dialog mobile entro viewport, close 44×44 px.
- QA “Carta senza colore vintage” light/dark: superfici runtime neutrali `#eef0f2/#f4f6f8/#fbfcfe` e `#121417/#191c21/#22252b`; nessun valore o nome vintage nel diff.

## Risk / Notes
- La review lunga usa solo casi `SYN-*` generati in memoria; l’E2E usa un database temporaneo sintetico fuori dal repository.
- Il command center e il modello virtuale sono separati in commit logici nello stesso perimetro WUL-560.
- Questa PR non include gli stati WUL-559 né l’IA WUL-561 e non dichiara capability parity; WUL-557 resta il gate.
- Nessuna PHI/PII, nessun dato paziente reale, nessun contenuto email.
- PR in bozza: nessun merge o promozione eseguito.

## Ticket
- Refs WUL-560
- Refs WUL-562