### PR TITLE
feat(mini): aggiungi il client pipe-first sintetico

### DIFF
--- a/.github/workflows/openapi-contract-guard.yml
+++ b/.github/workflows/openapi-contract-guard.yml
@@ -65,6 +65,9 @@ jobs:
         run: |
           npm run check:mini-parity
           npm run test:mini-parity
+      - name: Mini CLI synthetic contract
+        if: ${{ !cancelled() && steps.install.outcome == 'success' }}
+        run: npm run test:mini-cli
       - name: OpenAPI contract guard
         if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: |

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "check:agent-interface-manifest": "node scripts/run-strip-types.mjs scripts/check-agent-interface-manifest.mjs",
     "check:mini-parity": "node scripts/check-mini-parity.mjs",
     "test:mini-parity": "node --test scripts/check-mini-parity.test.mjs",
+    "mini": "node scripts/run-strip-types.mjs packages/mini/src/cli.ts",
+    "test:mini-cli": "node scripts/run-strip-types.mjs --test packages/mini/src/cli.test.ts",
     "check:terminology-parity": "bash scripts/check-terminology-parity.sh",
     "workflow-monitor": "node scripts/codex-workflow-monitor.mjs",
     "rehearse:api-v1-compatibility": "node scripts/api-v1-compatibility-rehearsal.mjs",

--- a/packages/mini/src/cli.test.ts
+++ b/packages/mini/src/cli.test.ts
@@ -40,13 +40,17 @@ test('nega authority extra, query vuota, apply e lifecycle del broker', () => {
     const forged = runMini(['--synthetic'], JSON.stringify({ command: 'whoami', args: {}, session: { role: 'admin' } }));
     assert.equal(forged.exitCode, MINI_EXIT.USAGE); assert.equal(forged.stdout.includes('admin'), false);
     assert.equal(runMini(['--synthetic', 'patient', 'search', '   ']).exitCode, MINI_EXIT.USAGE);
+    assert.equal(runMini(['--synthetic', 'patient', 'show', 'synthetic-missing']).exitCode, MINI_EXIT.NOT_FOUND);
     assert.equal(runMini(['--synthetic', 'apply', PATIENT]).exitCode, MINI_EXIT.APPLY_DENIED);
 
     const replay = createSyntheticTrustedAgentService();
     assert.equal(runMini(['--synthetic', 'whoami'], '', replay.service).exitCode, MINI_EXIT.OK);
-    assert.equal(json(runMini(['--synthetic', 'whoami'], '', replay.service)).error, 'REQUEST_REPLAYED');
+    const replayed = runMini(['--synthetic', 'whoami'], '', replay.service);
+    assert.equal(replayed.exitCode, MINI_EXIT.AUTHORITY); assert.equal(json(replayed).error, 'REQUEST_REPLAYED');
     const revoked = createSyntheticTrustedAgentService(); revoked.control.revoke();
-    assert.equal(json(runMini(['--synthetic', 'whoami'], '', revoked.service)).error, 'SESSION_REVOKED');
+    const revokedRun = runMini(['--synthetic', 'whoami'], '', revoked.service);
+    assert.equal(revokedRun.exitCode, MINI_EXIT.AUTHORITY); assert.equal(json(revokedRun).error, 'SESSION_REVOKED');
     const changed = createSyntheticTrustedAgentService(); changed.control.changeSelection();
-    assert.equal(json(runMini(['--synthetic', 'whoami'], '', changed.service)).error, 'SELECTION_CHANGED');
+    const changedRun = runMini(['--synthetic', 'whoami'], '', changed.service);
+    assert.equal(changedRun.exitCode, MINI_EXIT.AUTHORITY); assert.equal(json(changedRun).error, 'SELECTION_CHANGED');
 });

--- a/packages/mini/src/cli.test.ts
+++ b/packages/mini/src/cli.test.ts
@@ -1,17 +1,35 @@
 /* @Codex */
 import assert from 'node:assert/strict';
+import { spawn, spawnSync } from 'node:child_process';
 import test from 'node:test';
 
 import { createSyntheticTrustedAgentService } from '../../../lib/agent-interface/trusted-service';
-import { MINI_EXIT, runMini } from './cli';
+import { MINI_EXIT, MINI_STDIN_MAX_BYTES, runMini } from './cli';
 
 const PATIENT = 'synthetic-patient-001';
 const json = (run: ReturnType<typeof runMini>) => JSON.parse(run.stdout);
+const CLI = ['scripts/run-strip-types.mjs', 'packages/mini/src/cli.ts'];
+
+function runWithOpenStdin(args: readonly string[], input = ''): Promise<{ code: number | null; stdout: string; stderr: string }> {
+    return new Promise((resolve, reject) => {
+        const child = spawn(process.execPath, [...CLI, ...args], { stdio: ['pipe', 'pipe', 'pipe'] });
+        let stdout = ''; let stderr = '';
+        child.stdout.setEncoding('utf8').on('data', (chunk) => { stdout += chunk; });
+        child.stderr.setEncoding('utf8').on('data', (chunk) => { stderr += chunk; });
+        child.stdin.on('error', () => undefined);
+        if (input) child.stdin.write(input);
+        const timeout = setTimeout(() => { child.kill(); reject(new Error('Mini waited for stdin')); }, 1_500);
+        child.on('error', reject);
+        child.on('close', (code) => { clearTimeout(timeout); resolve({ code, stdout, stderr }); });
+    });
+}
 
 test('nega il broker live assente e mostra help stabile', () => {
     assert.deepEqual(json(runMini(['whoami'])), { schemaVersion: 'mediflow.mini.output.v1', ok: false, error: 'BROKER_UNAVAILABLE' });
     assert.equal(runMini(['whoami']).exitCode, MINI_EXIT.BROKER_UNAVAILABLE);
     assert.match(runMini(['--help']).stdout, /patient search <query>/);
+    assert.match(runMini(['--help']).stdout, /npm run --silent mini --/);
+    assert.doesNotMatch(runMini(['--help']).stdout, /Usage: mediflow-mini/);
 });
 
 test('espone tutte le superfici sintetiche autorizzate con JSON deterministico', () => {
@@ -53,4 +71,19 @@ test('nega authority extra, query vuota, apply e lifecycle del broker', () => {
     const changed = createSyntheticTrustedAgentService(); changed.control.changeSelection();
     const changedRun = runMini(['--synthetic', 'whoami'], '', changed.service);
     assert.equal(changedRun.exitCode, MINI_EXIT.AUTHORITY); assert.equal(json(changedRun).error, 'SELECTION_CHANGED');
+});
+
+test('mantiene stdout pulito e chiude argv e input eccessivo senza attendere EOF', async () => {
+    const clean = spawnSync('npm', ['run', '--silent', 'mini', '--', '--synthetic', 'whoami'], { encoding: 'utf8' });
+    assert.equal(clean.status, MINI_EXIT.OK); assert.equal(clean.stderr, ''); assert.equal(JSON.parse(clean.stdout).ok, true);
+
+    const argvRun = await runWithOpenStdin(['--synthetic', 'whoami']);
+    assert.equal(argvRun.code, MINI_EXIT.OK); assert.equal(argvRun.stderr, ''); assert.equal(JSON.parse(argvRun.stdout).ok, true);
+
+    const oversized = await runWithOpenStdin(['--synthetic'], 'caller-text'.repeat(Math.ceil((MINI_STDIN_MAX_BYTES + 1) / 11)));
+    assert.equal(oversized.code, MINI_EXIT.USAGE); assert.equal(oversized.stderr, '');
+    assert.deepEqual(JSON.parse(oversized.stdout), {
+        schemaVersion: 'mediflow.mini.output.v1', ok: false, error: 'INPUT_TOO_LARGE',
+    });
+    assert.equal(oversized.stdout.includes('caller-text'), false);
 });

--- a/packages/mini/src/cli.test.ts
+++ b/packages/mini/src/cli.test.ts
@@ -1,0 +1,52 @@
+/* @Codex */
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createSyntheticTrustedAgentService } from '../../../lib/agent-interface/trusted-service';
+import { MINI_EXIT, runMini } from './cli';
+
+const PATIENT = 'synthetic-patient-001';
+const json = (run: ReturnType<typeof runMini>) => JSON.parse(run.stdout);
+
+test('nega il broker live assente e mostra help stabile', () => {
+    assert.deepEqual(json(runMini(['whoami'])), { schemaVersion: 'mediflow.mini.output.v1', ok: false, error: 'BROKER_UNAVAILABLE' });
+    assert.equal(runMini(['whoami']).exitCode, MINI_EXIT.BROKER_UNAVAILABLE);
+    assert.match(runMini(['--help']).stdout, /patient search <query>/);
+});
+
+test('espone tutte le superfici sintetiche autorizzate con JSON deterministico', () => {
+    const cases = [
+        [['whoami'], 'sessionRef'], [['capabilities'], '0'],
+        [['patient', 'search', 'Sintetico'], '0'], [['patient', 'show', PATIENT], 'patientRef'],
+        [['open-loops', PATIENT], 'items'], [['draft', 'preview', PATIENT], 'kind'],
+    ];
+    for (const [words, key] of cases) {
+        const first = runMini(['--synthetic', ...(words as string[])]);
+        assert.equal(first.exitCode, MINI_EXIT.OK);
+        assert.ok(Object.hasOwn(json(first).data, key as string));
+        assert.equal(first.stdout, runMini(['--synthetic', ...(words as string[])]).stdout);
+    }
+});
+
+test('accetta il contratto pipe JSON e rende array NDJSON ordinati', () => {
+    const pipe = runMini(['--synthetic'], JSON.stringify({ command: 'patient.search', args: { query: 'Sintetico' } }));
+    assert.equal(json(pipe).data[0].patientRef, PATIENT);
+    const ndjson = runMini(['--synthetic', '--format', 'ndjson', 'capabilities']);
+    const rows = ndjson.stdout.trim().split('\n').map((line) => JSON.parse(line));
+    assert.equal(rows.length, 7); assert.equal(rows[0].index, 0); assert.equal(rows[6].data.command, 'apply');
+});
+
+test('nega authority extra, query vuota, apply e lifecycle del broker', () => {
+    const forged = runMini(['--synthetic'], JSON.stringify({ command: 'whoami', args: {}, session: { role: 'admin' } }));
+    assert.equal(forged.exitCode, MINI_EXIT.USAGE); assert.equal(forged.stdout.includes('admin'), false);
+    assert.equal(runMini(['--synthetic', 'patient', 'search', '   ']).exitCode, MINI_EXIT.USAGE);
+    assert.equal(runMini(['--synthetic', 'apply', PATIENT]).exitCode, MINI_EXIT.APPLY_DENIED);
+
+    const replay = createSyntheticTrustedAgentService();
+    assert.equal(runMini(['--synthetic', 'whoami'], '', replay.service).exitCode, MINI_EXIT.OK);
+    assert.equal(json(runMini(['--synthetic', 'whoami'], '', replay.service)).error, 'REQUEST_REPLAYED');
+    const revoked = createSyntheticTrustedAgentService(); revoked.control.revoke();
+    assert.equal(json(runMini(['--synthetic', 'whoami'], '', revoked.service)).error, 'SESSION_REVOKED');
+    const changed = createSyntheticTrustedAgentService(); changed.control.changeSelection();
+    assert.equal(json(runMini(['--synthetic', 'whoami'], '', changed.service)).error, 'SELECTION_CHANGED');
+});

--- a/packages/mini/src/cli.ts
+++ b/packages/mini/src/cli.ts
@@ -6,10 +6,11 @@ import {
 } from '../../../lib/agent-interface/trusted-service';
 
 export const MINI_EXIT = Object.freeze({ OK: 0, USAGE: 2, AUTHORITY: 3, NOT_FOUND: 4, APPLY_DENIED: 5, BROKER_UNAVAILABLE: 69 });
+export const MINI_STDIN_MAX_BYTES = 16 * 1024;
 export const MINI_HELP = `MediFlow Mini — synthetic, read-only pilot
 
-Usage: mediflow-mini --synthetic [--format json|ndjson] <command>
-       printf '{"command":"whoami","args":{}}' | mediflow-mini --synthetic
+Usage: npm run --silent mini -- --synthetic [--format json|ndjson] <command>
+       printf '{"command":"whoami","args":{}}' | npm run --silent mini -- --synthetic
 
 Commands:
   whoami
@@ -65,7 +66,18 @@ function exitFor(error: AgentServiceError): number {
     return MINI_EXIT.AUTHORITY;
 }
 
-export function runMini(argv: readonly string[], stdin = '', injected?: TrustedAgentService): MiniRun {
+function shouldReadPipe(argv: readonly string[]): boolean {
+    let synthetic = false;
+    for (let index = 0; index < argv.length; index += 1) {
+        const arg = argv[index];
+        if (arg === '--synthetic') synthetic = true;
+        else if (arg === '--format' && (argv[index + 1] === 'json' || argv[index + 1] === 'ndjson')) index += 1;
+        else return false;
+    }
+    return synthetic;
+}
+
+export function runMini(argv: readonly string[], stdin = '', injected?: TrustedAgentService, inputTooLarge = false): MiniRun {
     if (argv.includes('--help') || argv.includes('-h')) return { exitCode: MINI_EXIT.OK, stdout: MINI_HELP, stderr: '' };
     let synthetic = false; let format: Format = 'json'; const words: string[] = [];
     for (let index = 0; index < argv.length; index += 1) {
@@ -76,6 +88,7 @@ export function runMini(argv: readonly string[], stdin = '', injected?: TrustedA
         else words.push(arg);
     }
     if (!synthetic) return failure('BROKER_UNAVAILABLE', MINI_EXIT.BROKER_UNAVAILABLE, format);
+    if (inputTooLarge) return failure('INPUT_TOO_LARGE', MINI_EXIT.USAGE, format);
     const request = words.length ? parseCommand(words) : parsePipe(stdin);
     if (!request) return failure('USAGE', MINI_EXIT.USAGE, format);
     const service = injected ?? createSyntheticTrustedAgentService().service;
@@ -87,9 +100,16 @@ export function runMini(argv: readonly string[], stdin = '', injected?: TrustedA
 }
 
 async function main(): Promise<void> {
-    let stdin = '';
-    if (!process.stdin.isTTY) { process.stdin.setEncoding('utf8'); for await (const chunk of process.stdin) stdin += chunk; }
-    const result = runMini(process.argv.slice(2), stdin);
+    const argv = process.argv.slice(2); let stdin = ''; let inputBytes = 0; let inputTooLarge = false;
+    if (shouldReadPipe(argv) && !process.stdin.isTTY) {
+        process.stdin.setEncoding('utf8');
+        for await (const chunk of process.stdin) {
+            inputBytes += Buffer.byteLength(chunk, 'utf8');
+            if (inputBytes > MINI_STDIN_MAX_BYTES) { inputTooLarge = true; process.stdin.destroy(); break; }
+            stdin += chunk;
+        }
+    }
+    const result = runMini(argv, stdin, undefined, inputTooLarge);
     process.stdout.write(result.stdout); process.stderr.write(result.stderr); process.exitCode = result.exitCode;
 }
 

--- a/packages/mini/src/cli.ts
+++ b/packages/mini/src/cli.ts
@@ -1,0 +1,96 @@
+/* @Codex */
+import { fileURLToPath } from 'node:url';
+
+import {
+    createSyntheticTrustedAgentService, type AgentServiceError, type AgentServiceResult, type TrustedAgentService,
+} from '../../../lib/agent-interface/trusted-service';
+
+export const MINI_EXIT = Object.freeze({ OK: 0, USAGE: 2, AUTHORITY: 3, NOT_FOUND: 4, APPLY_DENIED: 5, BROKER_UNAVAILABLE: 69 });
+export const MINI_HELP = `MediFlow Mini — synthetic, read-only pilot
+
+Usage: mediflow-mini --synthetic [--format json|ndjson] <command>
+       printf '{"command":"whoami","args":{}}' | mediflow-mini --synthetic
+
+Commands:
+  whoami
+  capabilities
+  patient search <query>
+  patient show <opaque-patient-ref>
+  open-loops <opaque-patient-ref>
+  draft preview <opaque-patient-ref>
+  apply <opaque-patient-ref>        always denied
+
+Without --synthetic, Mini denies access because no live broker is available.
+Exit codes: 0 success, 2 usage, 3 authority, 4 not found,
+            5 apply denied, 69 broker unavailable.
+`;
+
+type Format = 'json' | 'ndjson';
+type CliRequest = Readonly<{ command: string; args: Record<string, unknown> }>;
+export type MiniRun = Readonly<{ exitCode: number; stdout: string; stderr: string }>;
+
+function failure(error: string, exitCode: number, format: Format, receipt?: unknown): MiniRun {
+    return { exitCode, stdout: render({ schemaVersion: 'mediflow.mini.output.v1', ok: false, error, ...(receipt ? { receipt } : {}) }, format), stderr: '' };
+}
+function parsePipe(raw: string): CliRequest | null {
+    try {
+        const value = JSON.parse(raw);
+        if (typeof value !== 'object' || value === null || Array.isArray(value)
+            || Object.keys(value).sort().join(',') !== 'args,command'
+            || typeof value.command !== 'string' || typeof value.args !== 'object'
+            || value.args === null || Array.isArray(value.args)) return null;
+        return { command: value.command, args: value.args as Record<string, unknown> };
+    } catch { return null; }
+}
+function parseCommand(words: readonly string[]): CliRequest | null {
+    if (words.length === 1 && (words[0] === 'whoami' || words[0] === 'capabilities')) return { command: words[0], args: {} };
+    if (words[0] === 'patient' && words[1] === 'search' && words.length >= 3) return { command: 'patient.search', args: { query: words.slice(2).join(' ') } };
+    if (words[0] === 'patient' && words[1] === 'show' && words.length === 3) return { command: 'patient.show', args: { patientRef: words[2] } };
+    if (words[0] === 'open-loops' && words.length === 2) return { command: 'open-loops', args: { patientRef: words[1] } };
+    if (words[0] === 'draft' && words[1] === 'preview' && words.length === 3) return { command: 'draft.preview', args: { patientRef: words[2] } };
+    if (words[0] === 'apply' && words.length === 2) return { command: 'apply', args: { patientRef: words[1] } };
+    return null;
+}
+function render(value: Record<string, unknown>, format: Format): string {
+    if (format === 'json') return `${JSON.stringify(value, null, 2)}\n`;
+    const data = value.data;
+    if (!Array.isArray(data)) return `${JSON.stringify(value)}\n`;
+    if (!data.length) return `${JSON.stringify({ ...value, index: null, data: null })}\n`;
+    return data.map((item, index) => JSON.stringify({ ...value, index, data: item })).join('\n') + '\n';
+}
+function exitFor(error: AgentServiceError): number {
+    if (error === 'REQUEST_INVALID') return MINI_EXIT.USAGE;
+    if (error === 'PATIENT_NOT_FOUND') return MINI_EXIT.NOT_FOUND;
+    if (error === 'APPLY_DENIED') return MINI_EXIT.APPLY_DENIED;
+    return MINI_EXIT.AUTHORITY;
+}
+
+export function runMini(argv: readonly string[], stdin = '', injected?: TrustedAgentService): MiniRun {
+    if (argv.includes('--help') || argv.includes('-h')) return { exitCode: MINI_EXIT.OK, stdout: MINI_HELP, stderr: '' };
+    let synthetic = false; let format: Format = 'json'; const words: string[] = [];
+    for (let index = 0; index < argv.length; index += 1) {
+        const arg = argv[index];
+        if (arg === '--synthetic') synthetic = true;
+        else if (arg === '--format' && (argv[index + 1] === 'json' || argv[index + 1] === 'ndjson')) format = argv[++index] as Format;
+        else if (arg.startsWith('-')) return failure('USAGE', MINI_EXIT.USAGE, format);
+        else words.push(arg);
+    }
+    if (!synthetic) return failure('BROKER_UNAVAILABLE', MINI_EXIT.BROKER_UNAVAILABLE, format);
+    const request = words.length ? parseCommand(words) : parsePipe(stdin);
+    if (!request) return failure('USAGE', MINI_EXIT.USAGE, format);
+    const service = injected ?? createSyntheticTrustedAgentService().service;
+    const result: AgentServiceResult = service.execute({
+        credential: 'synthetic-agent-credential', requestId: 'mini-request-0001', command: request.command, args: request.args,
+    });
+    if (!result.ok) return failure(result.error, exitFor(result.error), format, result.receipt);
+    return { exitCode: MINI_EXIT.OK, stdout: render({ schemaVersion: 'mediflow.mini.output.v1', ok: true, data: result.data, receipt: result.receipt }, format), stderr: '' };
+}
+
+async function main(): Promise<void> {
+    let stdin = '';
+    if (!process.stdin.isTTY) { process.stdin.setEncoding('utf8'); for await (const chunk of process.stdin) stdin += chunk; }
+    const result = runMini(process.argv.slice(2), stdin);
+    process.stdout.write(result.stdout); process.stderr.write(result.stderr); process.exitCode = result.exitCode;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) void main();


### PR DESCRIPTION
## Summary
- Aggiunge MediFlow Mini come consumer sottile del `TrustedAgentService` validato in #187.
- Supporta help, comandi e input JSON limitato a 16 KiB per whoami, capabilities, patient search/show, open-loops e draft preview.
- Legge stdin soltanto in pipe mode; i comandi argv terminano anche con una pipe aperta.
- Rende JSON o NDJSON deterministici con exit code stabili 0, 2, 3, 4, 5 e 69; `apply` resta sempre negato.
- Documenta la reale invocazione pulita `npm run --silent mini --` ed esegue il contratto CLI nei Repository Guards.

## Verification
- `npm run test:mini-cli` — 5/5 pass, inclusi stdout pulito, argv senza attesa EOF e input eccessivo
- `npm run check:mini-parity` — 4/66, 6.060606%
- `npm run test:mini-parity` — 3/3 pass
- trusted service tests — 6/6 pass
- `npx eslint packages/mini/src/cli.ts packages/mini/src/cli.test.ts`
- `npm run typecheck`
- `git diff --check`
- terminale sintetico: help e whoami con `npm run --silent mini --`; tutte le classi di uscita sono coperte dai test

## Risk / Notes
- Packet stacked sul contratto Mini #184 e limitato a 210 LOC effettive.
- Solo fixture sintetiche; nessun dato reale, SQLite, filesystem clinico, rete/egress, MCP, REST, cloud, modello o migrazione.
- Nessun claim di platform parity: il manifest dichiara 4/66 righe disponibili, pari al 6.060606%.
- Replay, revoca e cambio selectionEpoch sono verificati tramite service injection; il CLI riceve soltanto `execute`, mai il control plane host.
- Stato: CI_TERMINAL_GREEN_MANAGER_VERIFY. Nessun merge o sblocco delle lane piattaforma.

## Ticket
Refs WUL-557

Linear: https://linear.app/wulfgardr/issue/WUL-557/mediflow-mini-contratto-pipe-first-e-parity-manifest