### PR TITLE
feat(ui): esplicita gli stati paired su iPhone e iPad

### DIFF
--- a/native/MediFlowAppleApp/Tests/MediFlowMobileAppUITests/MediFlowMobileAppUITests.swift
+++ b/native/MediFlowAppleApp/Tests/MediFlowMobileAppUITests/MediFlowMobileAppUITests.swift
@@ -272,6 +272,23 @@ final class MediFlowMobileAppUITests: XCTestCase {
         )
     }
 
+    /* @Codex */
+    func testPairedStatusIsVisibleAndReachableWithSyntheticPatients() throws {
+        launch(seedPatients: true)
+
+        let status = sectionView("mobile-paired-status")
+        XCTAssertTrue(status.waitForExistence(timeout: 20))
+        XCTAssertGreaterThanOrEqual(status.frame.height, 44)
+        XCTAssertFalse(status.value as? String == "")
+
+        let configure = app.buttons["Configura"]
+        XCTAssertTrue(configure.waitForExistence(timeout: 10))
+        XCTAssertGreaterThanOrEqual(configure.frame.height, 44)
+        attachScreenshot(named: UIDevice.current.userInterfaceIdiom == .pad
+            ? "WUL-556-iPad-Guardia-Carta"
+            : "WUL-556-iPhone-Guardia-Carta")
+    }
+
     // @Codex #142: AX Dynamic Type must select the existing single-column path.
     func testAccessibilityDynamicTypeUsesSinglePatientColumnOnIPad() throws {
         // Not applicable on iPhone: skipping keeps the iPhone suite meaningful

--- a/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/MobilePairedStatusView.swift
+++ b/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/MobilePairedStatusView.swift
@@ -1,0 +1,139 @@
+import SwiftUI
+
+/* @Codex */
+struct MobilePairedStatusPresentation: Equatable {
+    enum Phase: Equatable {
+        case loading, error, online, cached, offline, stale, sessionExpired, notLoaded
+    }
+
+    let phase: Phase
+    let title: String
+    let detail: String
+    let symbolName: String
+    let actionTitle: String?
+
+    static func make(
+        connectionState: PairedPatientsConnectionState,
+        isWorking: Bool,
+        errorMessage: String?,
+        reconciliationLine: String,
+        cacheIsStale: Bool = false
+    ) -> Self {
+        if isWorking {
+            return Self(phase: .loading, title: "Aggiornamento in corso", detail: "Mantieni aperto MediFlow.", symbolName: "arrow.triangle.2.circlepath", actionTitle: nil)
+        }
+        if errorMessage != nil {
+            return Self(phase: .error, title: "Aggiornamento non riuscito", detail: "I dati già visibili non vengono modificati.", symbolName: "exclamationmark.triangle.fill", actionTitle: "Riprova")
+        }
+        if cacheIsStale {
+            return Self(phase: .stale, title: "Cache scaduta", detail: "Ricollega l'home-base prima di usare questi dati.", symbolName: "clock.badge.exclamationmark", actionTitle: "Ricollega")
+        }
+        switch connectionState {
+        case .pairedOnline:
+            return Self(phase: .online, title: "Home-base collegato", detail: reconciliationLine, symbolName: "checkmark.circle.fill", actionTitle: "Aggiorna")
+        case .cached:
+            return Self(phase: .cached, title: "Cache locale", detail: reconciliationLine, symbolName: "clock.arrow.circlepath", actionTitle: "Aggiorna")
+        case .pairedOfflineDegraded:
+            return Self(phase: .offline, title: "Offline, sola lettura", detail: reconciliationLine, symbolName: "wifi.slash", actionTitle: "Riprova")
+        case .sessionExpired:
+            return Self(phase: .sessionExpired, title: "Sessione scaduta", detail: "Accedi di nuovo per leggere o modificare dati.", symbolName: "person.crop.circle.badge.exclamationmark", actionTitle: "Accedi")
+        case .notLoaded:
+            return Self(phase: .notLoaded, title: "Home-base non configurato", detail: "Collega questo dispositivo per caricare il perimetro autorizzato.", symbolName: "link.badge.plus", actionTitle: "Configura")
+        }
+    }
+}
+
+#if os(iOS)
+/* @Codex */
+struct MobilePairedStatusView: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    let presentation: MobilePairedStatusPresentation
+    let onPrimaryAction: () -> Void
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            statusSymbol
+            VStack(alignment: .leading, spacing: 4) {
+                Text(presentation.title)
+                    .font(.headline)
+                Text(presentation.detail)
+                    .font(.subheadline)
+                    .foregroundStyle(mutedColor)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 8)
+            if let actionTitle = presentation.actionTitle {
+                Button(action: onPrimaryAction) {
+                    Text(actionTitle)
+                        .foregroundStyle(colorScheme == .dark ? Color.black : Color.white)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.primary)
+                .controlSize(.large)
+                .frame(minWidth: 48, minHeight: 48)
+                .contentShape(.interaction, Rectangle())
+                .hoverEffect(.highlight)
+                .keyboardShortcut("r", modifiers: .command)
+                .accessibilityHint("Aggiorna lo stato del collegamento con l'home-base.")
+            }
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .lumeSurface(zone: .field)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Stato operativo")
+        .accessibilityValue("\(presentation.title). \(presentation.detail)")
+        .accessibilityIdentifier("mobile-paired-status")
+    }
+
+    @ViewBuilder
+    private var statusSymbol: some View {
+        if presentation.phase == .loading {
+            ProgressView()
+                .frame(width: 28, height: 28)
+        } else {
+            Image(systemName: presentation.symbolName)
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(tint)
+                .frame(width: 28, height: 28)
+        }
+    }
+
+    private var tint: Color {
+        switch presentation.phase {
+        case .online: return LumePalette.success
+        case .error, .stale: return LumePalette.critical
+        case .offline, .sessionExpired: return LumePalette.warning
+        case .loading, .cached, .notLoaded: return mutedColor
+        }
+    }
+
+    private var mutedColor: Color {
+        colorScheme == .dark
+            ? LumePalette.guardia.inkMuted
+            : LumePalette.giorno.inkMuted
+    }
+}
+
+#if DEBUG
+#Preview("iPhone, offline, light") {
+    MobilePairedStatusView(
+        presentation: .make(connectionState: .pairedOfflineDegraded, isWorking: false, errorMessage: nil, reconciliationLine: "Cache cifrata locale. Nessuna scrittura offline."),
+        onPrimaryAction: {}
+    )
+    .padding()
+    .preferredColorScheme(.light)
+}
+
+#Preview("iPad, cache scaduta, dark") {
+    MobilePairedStatusView(
+        presentation: .make(connectionState: .cached, isWorking: false, errorMessage: nil, reconciliationLine: "Snapshot locale.", cacheIsStale: true),
+        onPrimaryAction: {}
+    )
+    .padding()
+    .frame(width: 744)
+    .preferredColorScheme(.dark)
+}
+#endif
+#endif

--- a/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/PairedPatientsWorkspaceView.swift
+++ b/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/PairedPatientsWorkspaceView.swift
@@ -4,6 +4,7 @@ import PhotosUI
 struct PairedPatientsWorkspaceView: View {
     @Environment(\.scenePhase) private var scenePhase
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.colorScheme) private var colorScheme
     @ObservedObject private var model: PairedPatientsWorkspaceModel
     // S6 (D7-bis): gates the new document surfaces on the effective capability
     // matrix returned for this pairing. The server downgrades host-supported but
@@ -75,7 +76,7 @@ struct PairedPatientsWorkspaceView: View {
         )
         .modifier(MinimizedSearchToolbarBehavior())
         #else
-        .background(PlatformColors.groupedBackground)
+        .background(mobileCanvasColor)
         // Creating a patient is the home's primary action, so it belongs in the
         // navigation bar. Inline it consumed the first viewport at accessibility
         // text sizes and pushed the first patient off screen.
@@ -341,7 +342,7 @@ struct PairedPatientsWorkspaceView: View {
             HStack(spacing: 0) {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 12) {
-                        connectionSetupBanner
+                        mobilePairedStatus
                         workspaceFeedbackLine
                         patientsListContent
                             .padding(16)
@@ -401,12 +402,12 @@ struct PairedPatientsWorkspaceView: View {
                         selectedPatientSections(detail)
                             .compactContainerWidth(inset: 40)
                     } else {
-                        connectionSetupBanner
+                        mobilePairedStatus
                         workspaceFeedbackLine
                         patientsCard
                     }
                     #else
-                    connectionSetupBanner
+                    mobilePairedStatus
                     workspaceFeedbackLine
                     patientsCard
                     #endif
@@ -418,6 +419,32 @@ struct PairedPatientsWorkspaceView: View {
                 if let detail = model.selectedPatient {
                     compactPatientHeader(detail)
                 }
+            }
+        }
+    }
+
+    /* @Codex */
+    private var mobileCanvasColor: Color {
+        colorScheme == .dark
+            ? LumePalette.guardia.canvas
+            : PlatformColors.groupedBackground
+    }
+
+    /* @Codex */
+    private var mobilePairedStatus: some View {
+        MobilePairedStatusView(
+            presentation: .make(
+                connectionState: model.connectionState,
+                isWorking: model.isWorking,
+                errorMessage: model.errorMessage,
+                reconciliationLine: model.reconciliationLine
+            )
+        ) {
+            switch model.connectionState {
+            case .notLoaded, .sessionExpired:
+                showsConnectionSetup = true
+            case .cached, .pairedOnline, .pairedOfflineDegraded:
+                Task { await model.loadPatients() }
             }
         }
     }

--- a/native/MediFlowMac/Tests/MediFlowAppleSharedTests/MobilePairedStatusPresentationTests.swift
+++ b/native/MediFlowMac/Tests/MediFlowAppleSharedTests/MobilePairedStatusPresentationTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import MediFlowAppleShared
+
+/* @Codex */
+final class MobilePairedStatusPresentationTests: XCTestCase {
+    func testLoadingAndErrorTakePrecedenceOverConnectionState() {
+        let loading = MobilePairedStatusPresentation.make(
+            connectionState: .pairedOnline,
+            isWorking: true,
+            errorMessage: "errore sintetico",
+            reconciliationLine: "online"
+        )
+        XCTAssertEqual(loading.phase, .loading)
+
+        let error = MobilePairedStatusPresentation.make(
+            connectionState: .pairedOnline,
+            isWorking: false,
+            errorMessage: "errore sintetico",
+            reconciliationLine: "online"
+        )
+        XCTAssertEqual(error.phase, .error)
+        XCTAssertEqual(error.actionTitle, "Riprova")
+    }
+
+    func testOfflineIsExplicitlyReadOnly() {
+        let presentation = MobilePairedStatusPresentation.make(
+            connectionState: .pairedOfflineDegraded,
+            isWorking: false,
+            errorMessage: nil,
+            reconciliationLine: "Nessuna scrittura mobile disponibile."
+        )
+        XCTAssertEqual(presentation.phase, .offline)
+        XCTAssertTrue(presentation.title.contains("sola lettura"))
+        XCTAssertTrue(presentation.detail.contains("Nessuna scrittura"))
+    }
+
+    func testStaleCacheOverridesGenericCachedState() {
+        let presentation = MobilePairedStatusPresentation.make(
+            connectionState: .cached,
+            isWorking: false,
+            errorMessage: nil,
+            reconciliationLine: "Snapshot locale.",
+            cacheIsStale: true
+        )
+        XCTAssertEqual(presentation.phase, .stale)
+        XCTAssertEqual(presentation.actionTitle, "Ricollega")
+    }
+}


### PR DESCRIPTION
## Summary
- Isola il solo packet runtime SwiftUI iPhone/iPadOS già valutato in PR #188.
- Rende espliciti loading, error, online, cache, offline read-only, stale, session-expired e not-loaded.
- Include i relativi test di presentazione e XCUITest sintetici, senza documentazione o matrici.
- Non modifica web, scene macOS-only, AIP o Mini.

## Verification
- Patch dei 4 file nativi byte-identica al sottoinsieme runtime di `b124091e1`: SHA-256 `f6afeb3e1737c6b50c505f483441ce9b0e9031a00c51f22a443bbf915d78548b`.
- `scripts/native-test.sh`: 563 test, 0 failure.
- Xcode 27.0 beta `27A5194q`, build generica iOS Simulator con signing disabilitato: `BUILD SUCCEEDED`.
- `scripts/check-apple-structure.sh`: pass.
- `scripts/check-apple-network-entitlements.sh`: pass.
- GitHub CI terminale verde sullo SHA; il primo `web-core` ha avuto un flake estraneo in `pdf-inspector-router` (1079/1080), poi il rerun selettivo è passato.
- Le prove sintetiche iPhone/iPad, Dynamic Type e audit XCTest già registrate su PR #188 restano evidence dello stesso packet byte-identico; non sono state rieseguite in questo split.

## Risk / Notes
- Guardia resta `PROPOSED_FOR_OWNER_REVIEW`; Carta resta grammatica del contenuto, non palette.
- Lo stato stale resta di presentazione: metadata live, dettaglio offline e write queue non sono aggiunti.
- Audit XCTest non equivale a una sessione VoiceOver reale.
- PR #188 e SHA `41d810a7e` restano evidence e non vengono riscritti.
- Nessuna PHI/PII, dato paziente reale, database clinico o contenuto email.
- Draft soltanto: nessun merge o promozione.

## Ticket
Refs [WUL-556](https://linear.app/wulfgardr/issue/WUL-556/iosipados-adottare-guardia-su-carta-e-rendere-espliciti-gli-stati)