### PR TITLE
[WUL-566] macOS: stato inspector per finestra e comandi focalizzati

### DIFF
--- a/native/MediFlowAppleApp/Sources/MediFlowMacApp/MediFlowMacShellApp.swift
+++ b/native/MediFlowAppleApp/Sources/MediFlowMacApp/MediFlowMacShellApp.swift
@@ -10,19 +10,18 @@ import SwiftUI
 @main
 struct MediFlowMacShellApp: App {
     @StateObject private var appearance = AppleAppearanceStore()
-    @StateObject private var scene = MediFlowMacSceneModel()
 
     var body: some Scene {
         WindowGroup {
-            MediFlowMacRootView(snapshot: .live, scene: scene, appearance: appearance)
-                // Measured, not guessed: below ~1100pt the three panes (sections,
-                // worklist, chart) can no longer all be laid out and the chart
-                // starts to clip at the window edge.
-                .frame(minWidth: 1100, minHeight: 680)
-                .preferredColorScheme(appearance.theme.preferredColorScheme)
+            MediFlowMacWindow(appearance: appearance)
         }
         .defaultSize(width: 1280, height: 840)
-        .commands { MediFlowMacCommands(scene: scene) }
+        .commands { MediFlowMacCommands() }
+
+        WindowGroup("MediFlow", id: "clinical-workspace-secondary") {
+            MediFlowMacWindow(appearance: appearance)
+        }
+        .defaultSize(width: 1280, height: 840)
 
         Settings {
             HomeBaseRuntimeStatusView()
@@ -32,5 +31,20 @@ struct MediFlowMacShellApp: App {
                 .respectsAppleMotionPreference()
                 .preferredColorScheme(appearance.theme.preferredColorScheme)
         }
+    }
+}
+
+/* @Codex */
+private struct MediFlowMacWindow: View {
+    @StateObject private var scene = MediFlowMacSceneModel()
+    @ObservedObject var appearance: AppleAppearanceStore
+
+    var body: some View {
+        MediFlowMacRootView(snapshot: .live, scene: scene, appearance: appearance)
+            // Measured, not guessed: below ~1100pt the three panes (sections,
+            // worklist, chart) can no longer all be laid out and the chart
+            // starts to clip at the window edge.
+            .frame(minWidth: 1100, minHeight: 680)
+            .preferredColorScheme(appearance.theme.preferredColorScheme)
     }
 }

--- a/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/MacWorkspaceRootView.swift
+++ b/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/MacWorkspaceRootView.swift
@@ -1,6 +1,33 @@
 #if os(macOS)
 import SwiftUI
 
+/* @Codex */
+@MainActor
+struct ClinicalWorkspaceNavigationAction {
+    let section: ClinicalWorkspaceSection
+    let canCreatePatient: Bool
+    let select: (ClinicalWorkspaceSection) -> Void
+    let createPatient: () -> Void
+}
+
+struct ClinicalWorkspaceNavigationActionKey: FocusedValueKey {
+    typealias Value = ClinicalWorkspaceNavigationAction?
+    static var defaultValue: ClinicalWorkspaceNavigationAction? { nil }
+}
+
+/* @Codex */
+@MainActor
+struct ClinicalWorkspaceInspectorAction {
+    let isEnabled: Bool
+    let isPresented: Bool
+    let toggle: () -> Void
+}
+
+struct ClinicalWorkspaceInspectorActionKey: FocusedValueKey {
+    typealias Value = ClinicalWorkspaceInspectorAction?
+    static var defaultValue: ClinicalWorkspaceInspectorAction? { nil }
+}
+
 /// The current detail section exposes its own refresh semantics to the menu
 /// bar. This keeps ⌘R aligned with the visible workspace instead of treating
 /// every section as the patient list.
@@ -16,6 +43,16 @@ struct ClinicalWorkspaceRefreshActionKey: FocusedValueKey {
 }
 
 extension FocusedValues {
+    var clinicalWorkspaceNavigationAction: ClinicalWorkspaceNavigationAction? {
+        get { self[ClinicalWorkspaceNavigationActionKey.self] ?? nil }
+        set { self[ClinicalWorkspaceNavigationActionKey.self] = newValue }
+    }
+
+    var clinicalWorkspaceInspectorAction: ClinicalWorkspaceInspectorAction? {
+        get { self[ClinicalWorkspaceInspectorActionKey.self] ?? nil }
+        set { self[ClinicalWorkspaceInspectorActionKey.self] = newValue }
+    }
+
     var clinicalWorkspaceRefreshAction: ClinicalWorkspaceRefreshAction? {
         get { self[ClinicalWorkspaceRefreshActionKey.self] ?? nil }
         set { self[ClinicalWorkspaceRefreshActionKey.self] = newValue }
@@ -24,10 +61,8 @@ extension FocusedValues {
 
 /// Scene-level state of the macOS app.
 ///
-/// The Mac window and the menu bar are two separate SwiftUI scenes: commands
-/// cannot reach `@State` that lives inside the window's view tree. Holding the
-/// section and the workspace model here is what lets ⌘N, ⌘R and the Vai menu
-/// act on the same workspace the window is showing.
+/// One instance belongs to one window. Commands reach it through focused
+/// values, so a second window never inherits the first window's selection.
 @MainActor
 public final class MediFlowMacSceneModel: ObservableObject {
     @Published public var section: ClinicalWorkspaceSection = .patients
@@ -97,6 +132,7 @@ public struct MediFlowMacRootView: View {
     @ObservedObject private var scene: MediFlowMacSceneModel
     @ObservedObject private var appearance: AppleAppearanceStore
     @Environment(\.dynamicTypeSize) private var inheritedDynamicTypeSize
+    @SceneStorage("mediflow.mac.patientInspector.isPresented") private var isInspectorPresented = false
 
     public init(
         snapshot: AppleFoundationSnapshot,
@@ -118,8 +154,14 @@ public struct MediFlowMacRootView: View {
                     // tracks it. Read straight from this view the subtitle went
                     // stale: this view observes the scene, not the workspace, so
                     // twenty loaded patients still read "Non caricato".
-                    MacDetailChrome(workspaceModel: workspaceModel, section: scene.section) {
-                        detailView(for: scene.section, workspaceModel: workspaceModel)
+                    MacInspectorCommandBridge(
+                        workspaceModel: workspaceModel,
+                        section: scene.section,
+                        isPresented: $isInspectorPresented
+                    ) {
+                        MacDetailChrome(workspaceModel: workspaceModel, section: scene.section) {
+                            detailView(for: scene.section, workspaceModel: workspaceModel)
+                        }
                     }
                 } else {
                     startupState
@@ -128,6 +170,7 @@ public struct MediFlowMacRootView: View {
                 }
             }
         }
+        .focusedSceneValue(\.clinicalWorkspaceNavigationAction, navigationAction)
         .task {
             // Keeps the paired-snapshot read out of the scene initialiser, which
             // is the right place for it not to be: a scene initialiser should not
@@ -152,6 +195,16 @@ public struct MediFlowMacRootView: View {
         .environment(\.dynamicTypeSize, scene.launchDynamicTypeSizeOverride ?? inheritedDynamicTypeSize)
         .respectsAppleMotionPreference()
         .privacyShield(appearance: appearance)
+    }
+
+    /* @Codex */
+    private var navigationAction: ClinicalWorkspaceNavigationAction {
+        ClinicalWorkspaceNavigationAction(
+            section: scene.section,
+            canCreatePatient: scene.canCreatePatient,
+            select: scene.select,
+            createPatient: scene.createPatient
+        )
     }
 
     // MARK: - Sidebar
@@ -303,53 +356,106 @@ private struct MacDetailChrome<Content: View>: View {
 /// a shortcut, which is what makes the app usable from the keyboard and what
 /// VoiceOver users navigate first.
 public struct MediFlowMacCommands: Commands {
-    @ObservedObject private var scene: MediFlowMacSceneModel
+    @Environment(\.openWindow) private var openWindow
+    @FocusedValue(\.clinicalWorkspaceNavigationAction) private var navigation
+    @FocusedValue(\.clinicalWorkspaceInspectorAction) private var inspector
     @FocusedValue(\.clinicalWorkspaceRefreshAction) private var workspaceRefresh
 
-    public init(scene: MediFlowMacSceneModel) {
-        _scene = ObservedObject(wrappedValue: scene)
-    }
+    public init() {}
 
     public var body: some Commands {
+        CommandGroup(after: .windowList) {
+            Button("Nuova finestra MediFlow") {
+                openWindow(id: "clinical-workspace-secondary")
+            }
+        }
+
         // Replaces "New" wholesale: this app has one creatable thing, and a
         // File > New that opened a second empty window would be a lie.
         CommandGroup(replacing: .newItem) {
             Button("Nuovo paziente") {
-                scene.select(.patients)
-                scene.createPatient()
+                navigation?.select(.patients)
+                navigation?.createPatient()
             }
             .keyboardShortcut("n", modifiers: .command)
-            .disabled(scene.section == .patients && !scene.canCreatePatient)
+            .disabled(navigation == nil || (navigation?.section == .patients && navigation?.canCreatePatient == false))
         }
 
         CommandMenu("Vai") {
             ForEach(Array(ClinicalWorkspaceSection.clinicalSections.enumerated()), id: \.element) { index, item in
-                Button(item.title) { scene.select(item) }
+                Button(item.title) { navigation?.select(item) }
                     .keyboardShortcut(shortcutKey(for: index), modifiers: .command)
             }
             Divider()
             ForEach(MediFlowMacRootView.referenceSections + MediFlowMacRootView.systemSections) { item in
-                Button(item.title) { scene.select(item) }
+                Button(item.title) { navigation?.select(item) }
             }
             Divider()
             ForEach(MediFlowMacRootView.projectSections) { item in
-                Button(item.title) { scene.select(item) }
+                Button(item.title) { navigation?.select(item) }
             }
             Divider()
             Button("Aggiorna") {
                 if let workspaceRefresh {
                     workspaceRefresh.perform()
-                } else {
-                    scene.refresh()
                 }
             }
                 .keyboardShortcut("r", modifiers: .command)
-                .disabled(!(workspaceRefresh?.isEnabled ?? scene.canRefresh))
+                .disabled(!(workspaceRefresh?.isEnabled ?? false))
+        }
+
+        CommandMenu("Vista") {
+            Button(inspector?.isPresented == true ? "Nascondi dettagli paziente" : "Mostra dettagli paziente") {
+                inspector?.toggle()
+            }
+            .keyboardShortcut("i", modifiers: [.command, .option])
+            .disabled(!(inspector?.isEnabled ?? false))
         }
     }
 
     private func shortcutKey(for index: Int) -> KeyEquivalent {
         KeyEquivalent(Character("\(index + 1)"))
+    }
+}
+
+/* @Codex */
+private struct MacInspectorCommandBridge<Content: View>: View {
+    @ObservedObject var workspaceModel: PairedPatientsWorkspaceModel
+    let section: ClinicalWorkspaceSection
+    @Binding var isPresented: Bool
+    @ViewBuilder let content: Content
+
+    private var isEnabled: Bool {
+        section == .patients && workspaceModel.selectedPatient != nil
+    }
+
+    var body: some View {
+        content
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button {
+                        guard isEnabled else { return }
+                        isPresented.toggle()
+                    } label: {
+                        Label("Dettagli paziente", systemImage: "sidebar.trailing")
+                    }
+                    .help("Mostra o nascondi i dettagli del paziente")
+                    .disabled(!isEnabled)
+                    .accessibilityValue(isPresented ? "Mostrato" : "Nascosto")
+                    .accessibilityIdentifier("clinical-workspace-inspector-toggle")
+                }
+            }
+            .focusedSceneValue(\.clinicalWorkspaceInspectorAction, ClinicalWorkspaceInspectorAction(
+                isEnabled: isEnabled,
+                isPresented: isPresented,
+                toggle: {
+                    guard isEnabled else { return }
+                    isPresented.toggle()
+                }
+            ))
+            .onChange(of: section) { nextSection in
+                if nextSection != .patients { isPresented = false }
+            }
     }
 }
 #endif

--- a/native/MediFlowMac/Tests/MediFlowAppleSharedTests/MacWindowInspectorCommandTests.swift
+++ b/native/MediFlowMac/Tests/MediFlowAppleSharedTests/MacWindowInspectorCommandTests.swift
@@ -1,0 +1,40 @@
+// @Codex
+#if os(macOS)
+import XCTest
+@testable import MediFlowAppleShared
+
+@MainActor
+final class MacWindowInspectorCommandTests: XCTestCase {
+    func testWindowSceneModelsDoNotShareSelection() {
+        let firstWindow = MediFlowMacSceneModel()
+        let secondWindow = MediFlowMacSceneModel()
+
+        firstWindow.select(.agenda)
+
+        XCTAssertEqual(firstWindow.section, .agenda)
+        XCTAssertEqual(secondWindow.section, .patients)
+    }
+
+    func testFocusedInspectorActionChangesOnlyItsWindow() {
+        var firstWindowPresented = false
+        var secondWindowPresented = false
+        let firstWindow = ClinicalWorkspaceInspectorAction(
+            isEnabled: true,
+            isPresented: firstWindowPresented,
+            toggle: { firstWindowPresented.toggle() }
+        )
+        let secondWindow = ClinicalWorkspaceInspectorAction(
+            isEnabled: true,
+            isPresented: secondWindowPresented,
+            toggle: { secondWindowPresented.toggle() }
+        )
+
+        firstWindow.toggle()
+
+        XCTAssertTrue(firstWindowPresented)
+        XCTAssertFalse(secondWindowPresented)
+        XCTAssertFalse(secondWindow.isPresented)
+    }
+
+}
+#endif


### PR DESCRIPTION
## Outcome

Isola lo stato del workspace macOS per finestra e instrada toolbar/menu sulla scena focalizzata.

- una istanza di `MediFlowMacSceneModel` per finestra;
- stato inspector in `SceneStorage`;
- menu Vista e shortcut Option-Command-I via `FocusedValues`;
- comando Window per aprire una seconda finestra MediFlow;
- nessun contenuto Carta, documento parity, web, iOS/iPad-only, AIP o Mini.

## Stack e tracciabilità

- Issue: [WUL-566](https://linear.app/wulfgardr/issue/WUL-566/macos-stato-inspector-per-finestra-e-comandi-focalizzati)
- Base: `main@0d55c6d0f29a86c3333efc49bc0159563d9518b9`
- Blocca WUL-567.
- PR #191 resta evidenza immutata e non è stata riscritta.
- Nessun impatto sui contratti API.

## Verifica

- `swift test --package-path native/MediFlowMac --filter MacWindowInspectorCommandTests`: 2/2.
- `npm run test:native`: 562/562.
- Generazione progetto e guard struttura/entitlement: PASS.
- Build `MediFlowMacApp` con `CODE_SIGNING_ALLOWED=NO`: PASS.
- Prova sintetica runtime: CoreGraphics ha osservato 2 finestre simultanee dello stesso PID dopo “Nuova finestra MediFlow”.
- Menu AX: `Mostra dettagli paziente`, carattere `I`, modificatori `2` (Option; Command implicito).
- Il probe AX interattivo si è fermato correttamente perché la sessione Mac era bloccata. Focus/VoiceOver reali restano un limite dichiarato, non un PASS.

Solo fixture sintetiche. Nessun merge o force-push.