### PR TITLE
fix(ui): isola gli stati degradati Lume

### DIFF
--- a/app/mockups/kree8/page.tsx
+++ b/app/mockups/kree8/page.tsx
@@ -14,10 +14,12 @@ function Kree8SyntheticReviewSurface() {
     || requestedState === 'error'
     ? requestedState
     : 'ready';
+  const initialArea = searchParams.get('area') === 'incarico' ? 'incarico' : 'turno';
 
   return (
     <Kree8ClinicalCockpit
       surface="review"
+      initialArea={initialArea}
       reviewPatientStatus={reviewPatientStatus}
       reviewNetworkOffline={searchParams.get('network') === 'offline'}
     />

--- a/app/mockups/kree8/page.tsx
+++ b/app/mockups/kree8/page.tsx
@@ -2,8 +2,32 @@
 
 /* @Codex */
 
+import { Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { Kree8ClinicalCockpit } from '@/components/kree8/kree8-clinical-cockpit';
 
+function Kree8SyntheticReviewSurface() {
+  const searchParams = useSearchParams();
+  const requestedState = searchParams.get('patientState');
+  const reviewPatientStatus = requestedState === 'loading'
+    || requestedState === 'stale'
+    || requestedState === 'error'
+    ? requestedState
+    : 'ready';
+
+  return (
+    <Kree8ClinicalCockpit
+      surface="review"
+      reviewPatientStatus={reviewPatientStatus}
+      reviewNetworkOffline={searchParams.get('network') === 'offline'}
+    />
+  );
+}
+
 export default function Kree8ReviewPage() {
-  return <Kree8ClinicalCockpit surface="review" />;
+  return (
+    <Suspense fallback={<div className="mf-alert mf-alert-info" role="status">Preparazione review sintetica.</div>}>
+      <Kree8SyntheticReviewSurface />
+    </Suspense>
+  );
 }

--- a/components/kree8/areas/incarico-area.tsx
+++ b/components/kree8/areas/incarico-area.tsx
@@ -49,6 +49,7 @@ function IncaricoArea({
   searchFocusSignal,
   onSelectPatient,
   onOpenArea,
+  onRetryPatients,
   isReview,
 }: {
   patients: Kree8Patient[];
@@ -57,6 +58,7 @@ function IncaricoArea({
   searchFocusSignal: number;
   onSelectPatient: (patientId: string) => void;
   onOpenArea: (area: AreaId) => void;
+  onRetryPatients?: () => void;
   isReview: boolean;
 }) {
   const [scope, setScope] = useState<InboxScope>('ambulatorio');
@@ -90,6 +92,7 @@ function IncaricoArea({
   const selected = visible.find((p) => p.id === selectedPatientId) ?? visible[0] ?? null;
 
   const patientListParentRef = useRef<HTMLDivElement>(null);
+
   const patientRowVirtualizer = useVirtualizer({
     count: visible.length,
     getScrollElement: () => patientListParentRef.current,
@@ -224,13 +227,22 @@ function IncaricoArea({
           <div style={{ marginTop: 8 }}>
             {/* @Codex */}
             {patientStatus === 'idle' || patientStatus === 'loading' ? (
-              <p className={styles.emptyState} role="status" aria-live="polite">
-                Caricamento pazienti…
-              </p>
+              <div className={styles.emptyState} role="status" aria-live="polite" aria-label="Caricamento pazienti">
+                <div className="mf-skeleton h-12" />
+                <div className="mf-skeleton h-12 mt-2" />
+                <div className="mf-skeleton h-12 mt-2" />
+              </div>
             ) : patientStatus === 'error' ? (
-              <p className={styles.emptyState} role="alert">
-                Lista pazienti non disponibile. Verifica sessione e servizi locali.
-              </p>
+              <div className={styles.emptyState} role="alert">
+                {/* @Codex WUL-UIUX: l'errore dichiara cosa è successo e offre
+                    l'azione di recupero, come chiede il contratto PRODUCT.md. */}
+                <p>Lista pazienti non disponibile. Verifica sessione e servizi locali.</p>
+                {onRetryPatients ? (
+                  <button type="button" className={styles.ghostBtnSm} onClick={onRetryPatients}>
+                    Riprova
+                  </button>
+                ) : null}
+              </div>
             ) : visible.length === 0 ? (
               <p className={styles.emptyState}>
                 {normalizedQuery

--- a/components/kree8/areas/incarico-area.tsx
+++ b/components/kree8/areas/incarico-area.tsx
@@ -111,6 +111,8 @@ function IncaricoArea({
           <p className={styles.areaSubtitle}>
             {patientStatus === 'ready'
               ? 'Casi dell’ambulatorio e della rete locale, tra attivi e archivio.'
+              : patientStatus === 'stale'
+                ? 'Ultimo snapshot locale disponibile: il refresh non è riuscito.'
               : patientStatus === 'error'
                 ? 'Lista pazienti non disponibile: verifica sessione e servizi locali.'
                 : 'Preparazione della lista pazienti.'}
@@ -225,6 +227,16 @@ function IncaricoArea({
           </header>
 
           <div style={{ marginTop: 8 }}>
+            {patientStatus === 'stale' ? (
+              <div className="mf-alert mf-alert-warning" role="status">
+                <span>Dati precedenti: l’ultimo aggiornamento non è riuscito.</span>
+                {onRetryPatients ? (
+                  <button type="button" className={styles.ghostBtnSm} onClick={onRetryPatients}>
+                    Riprova aggiornamento
+                  </button>
+                ) : null}
+              </div>
+            ) : null}
             {/* @Codex */}
             {patientStatus === 'idle' || patientStatus === 'loading' ? (
               <div className={styles.emptyState} role="status" aria-live="polite" aria-label="Caricamento pazienti">

--- a/components/kree8/areas/real-patient-area.tsx
+++ b/components/kree8/areas/real-patient-area.tsx
@@ -20,7 +20,7 @@ import patientStyles from '../kree8-clinical-cockpit-patient-inbox.module.css';
 /* @Codex #98, #68 */
 type QuadroSignal = 'warning' | 'critical';
 
-type QuadroMetric = { label: string; value: string | number; note: string; signal?: QuadroSignal };
+type QuadroMetric = { label: string; value: string | number; note: string; signal?: QuadroSignal; loading?: boolean };
 type QuadroDiagnosis = { code: string; description: string };
 type QuadroTherapy = { name: string; dose: string };
 type QuadroRow = { title: string; value?: string; note?: string; signal?: QuadroSignal };
@@ -168,23 +168,39 @@ function PatientQuadro({
 
       <div className={patientStyles.quadroMetrics} data-testid="lume-quadro-metrics">
         {metrics.map((metric) => (
-          <div key={metric.label} className={patientStyles.quadroMetric} data-lume-surface="field">
+          <div
+            key={metric.label}
+            className={patientStyles.quadroMetric}
+            data-lume-surface="field"
+            aria-busy={metric.loading || undefined}
+          >
             <p className={patientStyles.quadroMetricLabel} data-testid="lume-quadro-metric-label">
               {metric.label}
             </p>
-            <p
-              className={classNames(
-                patientStyles.quadroMetricValue,
-                'lume-registro',
-                metric.signal && SIGNAL_VALUE_CLASSES[metric.signal],
-              )}
-              data-testid="lume-quadro-metric-value"
-              data-lume-signal={metric.signal}
-              data-lume-clinical-state={metric.signal}
-            >
-              {metric.value}
-            </p>
-            <p className={patientStyles.quadroMetricNote}>{metric.note}</p>
+            {/* @Codex WUL-UIUX: il caricamento è una linea in attesa, non un
+                valore finto «in attesa» che sembra un dato. */}
+            {metric.loading ? (
+              <div aria-hidden="true">
+                <div className="mf-skeleton h-5 w-16 mt-2" />
+                <div className="mf-skeleton h-3 w-28 mt-2" />
+              </div>
+            ) : (
+              <>
+                <p
+                  className={classNames(
+                    patientStyles.quadroMetricValue,
+                    'lume-registro',
+                    metric.signal && SIGNAL_VALUE_CLASSES[metric.signal],
+                  )}
+                  data-testid="lume-quadro-metric-value"
+                  data-lume-signal={metric.signal}
+                  data-lume-clinical-state={metric.signal}
+                >
+                  {metric.value}
+                </p>
+                <p className={patientStyles.quadroMetricNote}>{metric.note}</p>
+              </>
+            )}
           </div>
         ))}
       </div>
@@ -266,23 +282,27 @@ function RealPatientArea({
   const metrics: QuadroMetric[] = [
     {
       label: 'Diario',
-      value: isWorkspaceLoading ? 'in attesa' : workspace?.entriesCount ?? 0,
-      note: isWorkspaceLoading ? 'Caricamento del diario locale in corso.' : latestEntry ? `${latestEntry.type} · ${latestEntry.date}` : 'Nessuna voce recente.',
+      value: workspace?.entriesCount ?? 0,
+      note: latestEntry ? `${latestEntry.type} · ${latestEntry.date}` : 'Nessuna voce recente.',
+      loading: isWorkspaceLoading,
     },
     {
       label: 'Terapie attive',
-      value: isWorkspaceLoading ? 'in attesa' : workspace?.activeTherapiesCount ?? 0,
-      note: isWorkspaceLoading ? 'Caricamento del piano terapeutico in corso.' : therapies[0]?.name ?? 'Nessun piano attivo.',
+      value: workspace?.activeTherapiesCount ?? 0,
+      note: therapies[0]?.name ?? 'Nessun piano attivo.',
+      loading: isWorkspaceLoading,
     },
     {
       label: 'Follow-up',
-      value: isWorkspaceLoading ? 'in attesa' : workspace?.pendingCheckupsCount ?? 0,
-      note: isWorkspaceLoading ? 'Caricamento dell’agenda locale in corso.' : nextCheckup ? `${nextCheckup.title} · ${nextCheckup.date}` : 'Nessun passaggio aperto.',
+      value: workspace?.pendingCheckupsCount ?? 0,
+      note: nextCheckup ? `${nextCheckup.title} · ${nextCheckup.date}` : 'Nessun passaggio aperto.',
+      loading: isWorkspaceLoading,
     },
     {
       label: 'Documenti',
-      value: isWorkspaceLoading ? 'in attesa' : workspace?.attachmentsCount ?? 0,
-      note: isWorkspaceLoading ? 'Caricamento dell’archivio locale in corso.' : workspace?.documentInsightCount ? `${workspace.documentInsightCount} sintesi disponibili.` : 'Nessuna sintesi disponibile.',
+      value: workspace?.attachmentsCount ?? 0,
+      note: workspace?.documentInsightCount ? `${workspace.documentInsightCount} sintesi disponibili.` : 'Nessuna sintesi disponibile.',
+      loading: isWorkspaceLoading,
     },
   ];
 

--- a/components/kree8/areas/turno-area.tsx
+++ b/components/kree8/areas/turno-area.tsx
@@ -84,6 +84,8 @@ function TurnoArea({
   const patientTrendLabel =
     patientState.status === 'ready'
       ? `${formatCountLabel(patientState.patients.length, 'scheda', 'schede')} in carico`
+      : patientState.status === 'stale'
+        ? `${formatCountLabel(patientState.patients.length, 'scheda', 'schede')} da snapshot locale`
       : patientState.status === 'error'
         ? 'pazienti non disponibili'
         : 'aggiornamento in corso';
@@ -116,11 +118,11 @@ function TurnoArea({
     : [
       {
         title: 'Pazienti in carico',
-        body: patientState.status === 'ready'
+        body: patientState.status === 'ready' || patientState.status === 'stale'
           ? `${formatCountLabel(patientState.patients.length, 'scheda pronta', 'schede pronte')} nell’archivio locale.`
           : 'Preparazione della lista pazienti.',
-        pill: patientState.status === 'error' ? 'Errore' : 'In carico',
-        pillVariant: patientState.status === 'error' ? 'critical' : 'neutral',
+        pill: patientState.status === 'error' ? 'Errore' : patientState.status === 'stale' ? 'Dati precedenti' : 'In carico',
+        pillVariant: patientState.status === 'error' ? 'critical' : patientState.status === 'stale' ? 'warning' : 'neutral',
         action: 'Vai ai pazienti',
         target: 'incarico',
       },
@@ -157,6 +159,8 @@ function TurnoArea({
           <p className={styles.areaSubtitle}>
             {patientState.status === 'ready'
               ? 'Rivedi i passaggi della giornata: i filtri in alto ordinano l’agenda per urgenze, suggerimenti AI e passaggi manuali.'
+              : patientState.status === 'stale'
+                ? 'Rivedi lo snapshot locale disponibile; l’ultimo aggiornamento non è riuscito.'
               : 'Preparazione della giornata dopo sblocco PIN.'}
           </p>
         </div>

--- a/components/kree8/cockpit-shared.tsx
+++ b/components/kree8/cockpit-shared.tsx
@@ -96,7 +96,7 @@ type ClinicalAgendaBridgeClientState = {
   data?: ClinicalAgendaBridgePreview;
 };
 
-type Kree8PatientStatus = 'idle' | 'loading' | 'ready' | 'error';
+type Kree8PatientStatus = 'idle' | 'loading' | 'ready' | 'stale' | 'error';
 
 type Kree8PatientClientState = {
   status: Kree8PatientStatus;

--- a/components/kree8/kree8-clinical-cockpit-shell.module.css
+++ b/components/kree8/kree8-clinical-cockpit-shell.module.css
@@ -420,6 +420,32 @@
   z-index: 1;
 }
 
+/* @Codex: avviso degradato azionabile, distinto dal contenuto locale. */
+.degradedState {
+  position: relative;
+  z-index: 1;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  margin-block-end: 12px;
+}
+
+.degradedStateAction {
+  min-block-size: 44px;
+  padding-inline: 14px;
+  border: 1px solid currentColor;
+  border-radius: var(--lume-radius-control);
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+@media (max-width: 640px) {
+  .degradedState { grid-template-columns: 1fr; }
+  .degradedStateAction { justify-self: stretch; }
+}
+
 .canvas[data-lume-context='incarico'] {
   --lume-surface-l: 5.5%;
   --lume-surface-temp: 1.8%;

--- a/components/kree8/kree8-clinical-cockpit.tsx
+++ b/components/kree8/kree8-clinical-cockpit.tsx
@@ -213,7 +213,7 @@ export function Kree8ClinicalCockpit({
 }: Kree8ClinicalCockpitProps) {
   const isReview = surface === 'review';
   const operatorName = operatorNameProp || (isReview ? 'Review design' : 'Sessione locale');
-  const [area, setArea] = useState<AreaId>(() => (isReview ? 'turno' : initialArea));
+  const [area, setArea] = useState<AreaId>(() => initialArea);
   const [filter, setFilter] = useState<StatusFilter>('all');
   const [patientSearchFocusSignal, setPatientSearchFocusSignal] = useState(0);
   const [agendaBridge, setAgendaBridge] = useState<ClinicalAgendaBridgeClientState>({

--- a/components/kree8/kree8-clinical-cockpit.tsx
+++ b/components/kree8/kree8-clinical-cockpit.tsx
@@ -197,6 +197,10 @@ type Kree8ClinicalCockpitProps = {
   initialArea?: AreaId;
   initialPatientId?: string;
   operatorName?: string;
+  /* @Codex: controlli limitati alla review sintetica per verificare gli stati
+     degradati senza dipendere da database o dati clinici reali. */
+  reviewPatientStatus?: Extract<Kree8PatientClientState['status'], 'ready' | 'loading' | 'stale' | 'error'>;
+  reviewNetworkOffline?: boolean;
 };
 
 export function Kree8ClinicalCockpit({
@@ -204,6 +208,8 @@ export function Kree8ClinicalCockpit({
   initialArea = 'turno',
   initialPatientId,
   operatorName: operatorNameProp,
+  reviewPatientStatus = 'ready',
+  reviewNetworkOffline = false,
 }: Kree8ClinicalCockpitProps) {
   const isReview = surface === 'review';
   const operatorName = operatorNameProp || (isReview ? 'Review design' : 'Sessione locale');
@@ -215,7 +221,12 @@ export function Kree8ClinicalCockpit({
   });
   const [patientState, setPatientState] = useState<Kree8PatientClientState>(() => (
     isReview
-      ? { status: 'ready', patients: REVIEW_PATIENT_LIST }
+      ? {
+        status: reviewPatientStatus,
+        patients: reviewPatientStatus === 'ready' || reviewPatientStatus === 'stale'
+          ? REVIEW_PATIENT_LIST
+          : [],
+      }
       : { status: 'idle', patients: [] }
   ));
   const [agendaState, setAgendaState] = useState<Kree8AgendaClientState>(() => (
@@ -226,6 +237,36 @@ export function Kree8ClinicalCockpit({
   const [selectedPatientId, setSelectedPatientId] = useState<string | undefined>(() => (
     isReview ? REVIEW_PATIENT_LIST[0]?.id : initialPatientId
   ));
+  const [networkOffline, setNetworkOffline] = useState(reviewNetworkOffline);
+
+  /* @Codex: l'assenza di rete non equivale all'indisponibilita del database
+     locale. L'avviso resta quindi non bloccante e descrive solo le funzioni che
+     possono dipendere da servizi esterni. */
+  useEffect(() => {
+    if (isReview) {
+      setNetworkOffline(reviewNetworkOffline);
+      return;
+    }
+
+    const readNetworkState = () => setNetworkOffline(!window.navigator.onLine);
+    readNetworkState();
+    window.addEventListener('online', readNetworkState);
+    window.addEventListener('offline', readNetworkState);
+    return () => {
+      window.removeEventListener('online', readNetworkState);
+      window.removeEventListener('offline', readNetworkState);
+    };
+  }, [isReview, reviewNetworkOffline]);
+
+  useEffect(() => {
+    if (!isReview) return;
+    setPatientState({
+      status: reviewPatientStatus,
+      patients: reviewPatientStatus === 'ready' || reviewPatientStatus === 'stale'
+        ? REVIEW_PATIENT_LIST
+        : [],
+    });
+  }, [isReview, reviewPatientStatus]);
 
   /* @Codex WUL-UIUX: riflette area e paziente selezionato nella query string di
      '/', cosi refresh e back del browser non perdono il punto di lavoro. Solo
@@ -286,7 +327,7 @@ export function Kree8ClinicalCockpit({
   /* @Codex */
   const diaryState = useMemo<Kree8DiaryClientState>(() => {
     if (isReview) return REVIEW_DIARY_STATE;
-    if (!liveDiaryRows || patientState.status !== 'ready') {
+    if (!liveDiaryRows || (patientState.status !== 'ready' && patientState.status !== 'stale')) {
       return {
         status: 'loading',
         entries: [],
@@ -358,13 +399,13 @@ export function Kree8ClinicalCockpit({
   useEffect(() => {
     if (isReview) return;
 
-    if (livePatientLoading) {
+    if (livePatientLoading && !livePatientRows) {
       setPatientState({ status: 'loading', patients: [] });
       setAgendaState({ status: 'loading', rows: [] });
       return;
     }
 
-    if (livePatientError) {
+    if (livePatientError && !livePatientRows) {
       setPatientState({ status: 'error', patients: [] });
       setAgendaState({ status: 'loading', rows: [] });
       return;
@@ -381,7 +422,7 @@ export function Kree8ClinicalCockpit({
       })
       .map(mapPatientForKree8);
     const checkups = liveCheckupRows ?? [];
-    setPatientState({ status: 'ready', patients });
+    setPatientState({ status: livePatientError ? 'stale' : 'ready', patients });
     setAgendaState({
       status: liveCheckupRows ? 'ready' : 'loading',
       rows: mapCheckupsForKree8(checkups, patients),
@@ -405,7 +446,7 @@ export function Kree8ClinicalCockpit({
   const patientNavMeta =
     isReview
       ? '312'
-      : patientState.status === 'ready'
+      : patientState.status === 'ready' || patientState.status === 'stale'
         ? String(patientState.patients.filter((patient) => patient.list === 'attivi').length)
         : patientState.status === 'error'
           ? '!'
@@ -509,6 +550,21 @@ export function Kree8ClinicalCockpit({
             data-testid="lume-frame-focus"
             data-lume-frame-element="focus"
           >
+            {networkOffline ? (
+              <div className={`mf-alert mf-alert-warning ${styles.degradedState}`} role="status">
+                <span>
+                  Rete non disponibile. I dati locali restano consultabili; invii e passaggi che
+                  richiedono servizi esterni possono restare in attesa.
+                </span>
+                <button
+                  type="button"
+                  className={styles.degradedStateAction}
+                  onClick={() => setNetworkOffline(isReview ? reviewNetworkOffline : !window.navigator.onLine)}
+                >
+                  Controlla connessione
+                </button>
+              </div>
+            ) : null}
             {/* @Codex WUL-UIUX: where-am-i persistente nelle sotto-aree paziente
                 (il rail le colora come Pazienti): tab Quadro / Documenti / SISS con
                 aria-current e nome del paziente attivo. */}

--- a/components/kree8/kree8-clinical-cockpit.tsx
+++ b/components/kree8/kree8-clinical-cockpit.tsx
@@ -110,6 +110,7 @@ function AreaContent({
   isReview,
   onSelectPatient,
   onOpenArea,
+  onRetryPatients,
 }: {
   area: AreaId;
   filter: StatusFilter;
@@ -124,6 +125,7 @@ function AreaContent({
   isReview: boolean;
   onSelectPatient: (patientId: string) => void;
   onOpenArea: (area: AreaId) => void;
+  onRetryPatients: () => void;
 }) {
   switch (area) {
     case 'turno':
@@ -146,6 +148,7 @@ function AreaContent({
           searchFocusSignal={patientSearchFocusSignal}
           onSelectPatient={onSelectPatient}
           onOpenArea={onOpenArea}
+          onRetryPatients={onRetryPatients}
           isReview={isReview}
         />
       );
@@ -256,6 +259,7 @@ export function Kree8ClinicalCockpit({
     data: livePatientRows,
     error: livePatientError,
     loading: livePatientLoading,
+    refresh: refreshPatients,
   } = useLiveQueryState<Patient[]>(
     async () => (isReview ? [] : db.patients.toArray()),
     [isReview],
@@ -545,6 +549,7 @@ export function Kree8ClinicalCockpit({
                 isReview={isReview}
                 onSelectPatient={setSelectedPatientId}
                 onOpenArea={setArea}
+                onRetryPatients={refreshPatients}
               />
             </div>
           </main>

--- a/lib/live-query-scoped-invalidation.test.ts
+++ b/lib/live-query-scoped-invalidation.test.ts
@@ -83,7 +83,7 @@ test('both React hooks retain dynamic scope resolver wiring', () => {
     const source = readFileSync('lib/live-query.ts', 'utf8');
     const hookBlocks = [
         sourceBetween(source, 'export function useLiveQuery<', 'export type LiveQueryState'),
-        sourceBetween(source, 'export function useLiveQueryState<', '    return { data, error, loading };'),
+        sourceBetween(source, 'export function useLiveQueryState<', '    return { data, error, loading, refresh };'),
     ];
     for (const hookBlock of hookBlocks) {
         assert.match(hookBlock, /const tablesRef = useRef\(tables\);\s*tablesRef\.current = tables;/);

--- a/lib/live-query.ts
+++ b/lib/live-query.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { DependencyList, useEffect, useRef, useState } from 'react';
+import { DependencyList, useCallback, useEffect, useRef, useState } from 'react';
 import { createDbChangeBus } from './live-query-scope';
 import type { DbChangeScope } from './live-query-scope';
 
@@ -63,6 +63,9 @@ export type LiveQueryState<T, TDefault = undefined> = {
     data: T | TDefault | undefined;
     error: unknown;
     loading: boolean;
+    /* @Codex WUL-UIUX: riesegue la query adesso (es. azione «Riprova» su errore).
+       Additivo: i chiamanti che non lo destrutturano non cambiano. */
+    refresh: () => void;
 };
 
 export function useLiveQueryState<T, TDefault = undefined>(
@@ -76,6 +79,7 @@ export function useLiveQueryState<T, TDefault = undefined>(
     const [error, setError] = useState<unknown>(null);
     const [loading, setLoading] = useState(true);
     const [revision, setRevision] = useState(0);
+    const refresh = useCallback(() => setRevision((previous) => previous + 1), []);
     /* @Codex */
     const tablesRef = useRef(tables);
     tablesRef.current = tables;
@@ -115,5 +119,5 @@ export function useLiveQueryState<T, TDefault = undefined>(
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [revision, ...(deps ?? [])]);
 
-    return { data, error, loading };
+    return { data, error, loading, refresh };
 }


### PR DESCRIPTION
## Summary
- Isola loading, error, offline e stale con azioni di recupero.
- Mantiene data-plane locale e fixture esclusivamente sintetiche.
- Sostituisce in modo non distruttivo la porzione stati della PR #186.

## Verification
- Verificata nella stack composta: typecheck e lint.
- `node scripts/run-strip-types.mjs --test lib/live-query-scoped-invalidation.test.ts`: 5 pass.

## Risk / Notes
- PR #186 e SHA 784423913be1488ce90141b84407276b608a1178 restano evidence immutabile.
- Nessuna PHI/PII, dato reale, AIP/Mini o sorgente Apple.
- Draft; nessuna promozione o merge.

## Ticket
Refs WUL-570.