### PR TITLE
feat(ui): isola la tastiera della lista virtuale

### DIFF
--- a/components/kree8/areas/incarico-area.tsx
+++ b/components/kree8/areas/incarico-area.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import {
   Activity,
   Archive,
@@ -27,6 +28,7 @@ import type {
   Kree8PatientStatus,
 } from '../cockpit-shared';
 import type { InboxList, Kree8Patient } from '@/lib/patient-workspace';
+import { nextVirtualRowIndex, type VirtualListNavigationKey } from '@/lib/kree8-keyboard-navigation';
 import styles from '../kree8-clinical-cockpit-foundation.module.css';
 import patientStyles from '../kree8-clinical-cockpit-patient-inbox.module.css';
 
@@ -59,6 +61,7 @@ function IncaricoArea({
   onOpenArea: (area: AreaId) => void;
   isReview: boolean;
 }) {
+  const router = useRouter();
   const [scope, setScope] = useState<InboxScope>('ambulatorio');
   const [list, setList] = useState<InboxList>('attivi');
   const [query, setQuery] = useState('');
@@ -97,6 +100,95 @@ function IncaricoArea({
     overscan: 8,
   });
 
+  /* @Codex: il focus segue l'indice completo, non il sottoinsieme DOM prodotto
+     dalla virtualizzazione. Dopo lo scroll attende il nuovo render e porta il
+     focus sulla riga corrispondente. */
+  const focusRowAtIndex = useCallback((requestedIndex: number) => {
+    if (visible.length === 0) return;
+    const index = Math.min(visible.length - 1, Math.max(0, requestedIndex));
+    const patient = visible[index];
+    if (!patient) return;
+    onSelectPatient(patient.id);
+    patientRowVirtualizer.scrollToIndex(index, { align: 'auto' });
+
+    const focusRenderedRow = (attempts: number) => {
+      const row = patientListParentRef.current?.querySelector<HTMLButtonElement>(
+        `[data-patient-index="${index}"]`,
+      );
+      if (row) {
+        row.focus();
+        return;
+      }
+      if (attempts > 0) window.requestAnimationFrame(() => focusRenderedRow(attempts - 1));
+    };
+    window.requestAnimationFrame(() => focusRenderedRow(2));
+  }, [onSelectPatient, patientRowVirtualizer, visible]);
+
+  const currentRowIndex = useCallback((target: EventTarget | null) => {
+    const focusedRow = target instanceof HTMLElement
+      ? target.closest<HTMLElement>('[data-patient-index]')
+      : null;
+    const parsed = focusedRow ? Number(focusedRow.dataset.patientIndex) : Number.NaN;
+    if (Number.isInteger(parsed)) return parsed;
+    const selectedIndex = visible.findIndex((patient) => patient.id === selectedPatientId);
+    return selectedIndex >= 0 ? selectedIndex : 0;
+  }, [selectedPatientId, visible]);
+
+  const navigateRows = useCallback((key: VirtualListNavigationKey, target: EventTarget | null) => {
+    const viewportHeight = patientListParentRef.current?.clientHeight ?? 62;
+    const index = nextVirtualRowIndex({
+      key,
+      currentIndex: currentRowIndex(target),
+      rowCount: visible.length,
+      pageSize: Math.max(1, Math.floor(viewportHeight / 62)),
+    });
+    if (index !== null) focusRowAtIndex(index);
+  }, [currentRowIndex, focusRowAtIndex, visible.length]);
+
+  const handleListKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    const navigationKeys: VirtualListNavigationKey[] = [
+      'ArrowDown', 'ArrowUp', 'j', 'k', 'Home', 'End', 'PageDown', 'PageUp',
+    ];
+    if (navigationKeys.includes(event.key as VirtualListNavigationKey)) {
+      event.preventDefault();
+      navigateRows(event.key as VirtualListNavigationKey, event.target);
+      return;
+    }
+    if (event.key !== 'Enter') return;
+    const patient = visible[currentRowIndex(event.target)];
+    if (!patient) return;
+    event.preventDefault();
+    onSelectPatient(patient.id);
+    if (isReview) onOpenArea('scheda');
+    else router.push(patient.modulesHref);
+  };
+
+  /* @Codex: scorciatoie contestuali, disattivate nei campi editabili. */
+  useEffect(() => {
+    const handleGlobalKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || event.metaKey || event.ctrlKey || event.altKey) return;
+      const target = event.target;
+      if (target instanceof HTMLElement) {
+        const tag = target.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || target.isContentEditable) return;
+      }
+      if (event.key === '/') {
+        event.preventDefault();
+        searchInputRef.current?.focus();
+        searchInputRef.current?.select();
+      } else if (event.key === 'n' || event.key === 'N') {
+        event.preventDefault();
+        const patient = visible[currentRowIndex(document.activeElement)];
+        router.push(patient ? `${patient.href}/entries/new` : '/patients/new');
+      } else if (event.key === 'j' || event.key === 'k') {
+        event.preventDefault();
+        navigateRows(event.key, document.activeElement);
+      }
+    };
+    document.addEventListener('keydown', handleGlobalKeyDown);
+    return () => document.removeEventListener('keydown', handleGlobalKeyDown);
+  }, [currentRowIndex, navigateRows, router, visible]);
+
   return (
     <div className={styles.areaShell}>
       <header className={styles.areaHeader}>
@@ -107,7 +199,7 @@ function IncaricoArea({
           </h1>
           <p className={styles.areaSubtitle}>
             {patientStatus === 'ready'
-              ? 'Casi dell’ambulatorio e della rete locale, tra attivi e archivio.'
+              ? 'Casi dell’ambulatorio e della rete locale. Usa le frecce o j/k per navigare, Invio per aprire; premi ? per l’aiuto completo.'
               : patientStatus === 'error'
                 ? 'Lista pazienti non disponibile: verifica sessione e servizi locali.'
                 : 'Preparazione della lista pazienti.'}
@@ -241,9 +333,10 @@ function IncaricoArea({
               <div
                 ref={patientListParentRef}
                 className={patientStyles.patientListViewport}
-                role="list"
+                role="listbox"
                 aria-label="Elenco pazienti in carico"
                 data-testid="lume-patient-list"
+                onKeyDown={handleListKeyDown}
               >
                 <div
                   className={patientStyles.patientList}
@@ -260,7 +353,7 @@ function IncaricoArea({
                         ref={patientRowVirtualizer.measureElement}
                         data-index={virtualRow.index}
                         className={patientStyles.patientRowWrap}
-                        role="listitem"
+                        role="presentation"
                         style={{
                           position: 'absolute',
                           top: 0,
@@ -276,7 +369,10 @@ function IncaricoArea({
                             isSelected && patientStyles.patientRowSelected,
                           )}
                           onClick={() => onSelectPatient(p.id)}
-                          aria-pressed={isSelected}
+                          role="option"
+                          aria-selected={isSelected}
+                          tabIndex={isSelected ? 0 : -1}
+                          data-patient-index={virtualRow.index}
                           data-testid="lume-patient-row"
                         >
                           <span className={patientStyles.patientRowContent} data-lume-row-part="content">

--- a/e2e/lume-worklist.spec.ts
+++ b/e2e/lume-worklist.spec.ts
@@ -64,8 +64,8 @@ async function resolvedFontFamily(locator: Locator): Promise<string> {
 }
 
 async function assertWorklistContract(page: Page): Promise<void> {
-  const list = page.getByRole('list', { name: 'Elenco pazienti in carico', exact: true });
-  const listItems = list.getByRole('listitem');
+  const list = page.getByRole('listbox', { name: 'Elenco pazienti in carico', exact: true });
+  const listItems = list.getByRole('option');
   const rows = list.getByTestId('lume-patient-row');
   await expect(list).toBeVisible();
   await expect(listItems).toHaveCount(3);
@@ -91,11 +91,11 @@ async function assertWorklistContract(page: Page): Promise<void> {
   expect(new Set(codeFamilies)).toEqual(new Set([registerFamily]));
   expect(new Set(whenFamilies)).toEqual(new Set([registerFamily]));
 
-  await expect(firstRow).toHaveAttribute('aria-pressed', 'true');
-  await expect(secondRow).toHaveAttribute('aria-pressed', 'false');
+  await expect(firstRow).toHaveAttribute('aria-selected', 'true');
+  await expect(secondRow).toHaveAttribute('aria-selected', 'false');
   await secondRow.click();
-  await expect(firstRow).toHaveAttribute('aria-pressed', 'false');
-  await expect(secondRow).toHaveAttribute('aria-pressed', 'true');
+  await expect(firstRow).toHaveAttribute('aria-selected', 'false');
+  await expect(secondRow).toHaveAttribute('aria-selected', 'true');
 
   const rowSurfaces = await Promise.all([firstRow, secondRow].map((row) => row.evaluate((element) => {
     const style = getComputedStyle(element);

--- a/lib/kree8-keyboard-navigation.test.ts
+++ b/lib/kree8-keyboard-navigation.test.ts
@@ -1,0 +1,24 @@
+/* @Codex */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { nextVirtualRowIndex } from './kree8-keyboard-navigation';
+
+test('le frecce e j/k attraversano l’intero indice con limiti stabili', () => {
+  assert.equal(nextVirtualRowIndex({ key: 'ArrowDown', currentIndex: 7, rowCount: 20, pageSize: 5 }), 8);
+  assert.equal(nextVirtualRowIndex({ key: 'j', currentIndex: 19, rowCount: 20, pageSize: 5 }), 19);
+  assert.equal(nextVirtualRowIndex({ key: 'ArrowUp', currentIndex: 0, rowCount: 20, pageSize: 5 }), 0);
+  assert.equal(nextVirtualRowIndex({ key: 'k', currentIndex: 8, rowCount: 20, pageSize: 5 }), 7);
+});
+
+test('Home, End e Page Up/Down lavorano sull’indice non renderizzato', () => {
+  assert.equal(nextVirtualRowIndex({ key: 'Home', currentIndex: 48, rowCount: 100, pageSize: 8 }), 0);
+  assert.equal(nextVirtualRowIndex({ key: 'End', currentIndex: 2, rowCount: 100, pageSize: 8 }), 99);
+  assert.equal(nextVirtualRowIndex({ key: 'PageDown', currentIndex: 48, rowCount: 100, pageSize: 8 }), 56);
+  assert.equal(nextVirtualRowIndex({ key: 'PageUp', currentIndex: 3, rowCount: 100, pageSize: 8 }), 0);
+});
+
+test('una lista vuota non produce un indice attivo', () => {
+  assert.equal(nextVirtualRowIndex({ key: 'End', currentIndex: 0, rowCount: 0, pageSize: 8 }), null);
+});

--- a/lib/kree8-keyboard-navigation.ts
+++ b/lib/kree8-keyboard-navigation.ts
@@ -1,0 +1,48 @@
+/* @Codex */
+
+export type VirtualListNavigationKey =
+  | 'ArrowDown'
+  | 'ArrowUp'
+  | 'j'
+  | 'k'
+  | 'Home'
+  | 'End'
+  | 'PageDown'
+  | 'PageUp';
+
+export function nextVirtualRowIndex({
+  key,
+  currentIndex,
+  rowCount,
+  pageSize,
+}: {
+  key: VirtualListNavigationKey;
+  currentIndex: number;
+  rowCount: number;
+  pageSize: number;
+}): number | null {
+  if (rowCount <= 0) return null;
+  const current = Math.min(rowCount - 1, Math.max(0, currentIndex));
+  const page = Math.max(1, Math.floor(pageSize));
+
+  switch (key) {
+    case 'ArrowDown':
+    case 'j':
+      return Math.min(rowCount - 1, current + 1);
+    case 'ArrowUp':
+    case 'k':
+      return Math.max(0, current - 1);
+    case 'Home':
+      return 0;
+    case 'End':
+      return rowCount - 1;
+    case 'PageDown':
+      return Math.min(rowCount - 1, current + page);
+    case 'PageUp':
+      return Math.max(0, current - page);
+    default: {
+      const exhaustive: never = key;
+      return exhaustive;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Isola Arrow/j/k/Home/End/Page e Invio sull’indice virtualizzato.
- Allinea il test storico al contratto accessibile listbox/option e aria-selected.
- Corregge la prima causa deterministica del CI red di #189.

## Verification
- Unit navigation: 3 pass nella stack finale.
- `e2e/lume-worklist.spec.ts`: 12 pass su giorno/grafite e sei viewport.

## Risk / Notes
- PR #189 e SHA 5d9c90b5205167f5918b4ac96ef6cd36b35ba4ca restano evidence immutabile.
- Draft; nessun merge.

## Ticket
Refs WUL-572.