### PR TITLE
feat(ui): integra command center e shell Lume

### DIFF
--- a/app/mockups/kree8/page.tsx
+++ b/app/mockups/kree8/page.tsx
@@ -2,8 +2,31 @@
 
 /* @Codex */
 
+import { Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { Kree8ClinicalCockpit } from '@/components/kree8/kree8-clinical-cockpit';
 
+function Kree8KeyboardReview() {
+  const searchParams = useSearchParams();
+  const patientCountParam = searchParams.get('patientCount');
+  const requestedCount = patientCountParam === null ? undefined : Number(patientCountParam);
+  const reviewPatientCount = requestedCount !== undefined && Number.isFinite(requestedCount)
+    ? requestedCount
+    : undefined;
+
+  return (
+    <Kree8ClinicalCockpit
+      surface="review"
+      initialArea={searchParams.get('area') === 'incarico' ? 'incarico' : 'turno'}
+      reviewPatientCount={reviewPatientCount}
+    />
+  );
+}
+
 export default function Kree8ReviewPage() {
-  return <Kree8ClinicalCockpit surface="review" />;
+  return (
+    <Suspense fallback={<div className="mf-alert mf-alert-info" role="status">Preparazione review sintetica.</div>}>
+      <Kree8KeyboardReview />
+    </Suspense>
+  );
 }

--- a/components/kree8/cockpit-shared.tsx
+++ b/components/kree8/cockpit-shared.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import {
   AlertTriangle,
   CalendarClock,
+  CircleHelp,
   Cloud,
   Database,
   FileSearch,
@@ -712,6 +713,7 @@ function Toolbar({
   setFilter,
   onOpenArea,
   onSearchRequest,
+  onOpenCommand,
   operatorName,
 }: {
   activeArea: AreaId;
@@ -719,6 +721,7 @@ function Toolbar({
   setFilter: (id: StatusFilter) => void;
   onOpenArea: (area: AreaId) => void;
   onSearchRequest: () => void;
+  onOpenCommand: () => void;
   operatorName: string;
 }) {
   const operatorInitials = buildOperatorInitials(operatorName);
@@ -757,6 +760,16 @@ function Toolbar({
       <button type="button" className={shellStyles.toolChip} onClick={() => onOpenArea('revisione')}>
         <FileSearch size={13} />
         Documenti paziente
+      </button>
+      <button
+        type="button"
+        className={`${shellStyles.toolChip} ${shellStyles.commandToolChip}`}
+        onClick={onOpenCommand}
+        aria-label="Apri comandi e aiuto tastiera"
+      >
+        <CircleHelp size={13} aria-hidden="true" />
+        Comandi
+        <kbd className={shellStyles.toolChipKbd}>⌘K</kbd>
       </button>
       <span className={shellStyles.avatarPill}>
         <span className={shellStyles.avatarDot}>{operatorInitials}</span>

--- a/components/kree8/kree8-clinical-cockpit-shell.module.css
+++ b/components/kree8/kree8-clinical-cockpit-shell.module.css
@@ -536,6 +536,11 @@
 
 .toolChip:active { transform: scale(0.97); }
 
+.toolChipKbd {
+  color: var(--ink-muted);
+  font: 600 10px/1 var(--lume-font-mono);
+}
+
 .toolChipMuted {
   background: transparent;
   color: var(--ink-muted);
@@ -622,7 +627,7 @@
   }
 
   .search {
-    flex: 1 0 100%;
+    flex: 1 1 calc(100% - 52px);
     min-height: 42px;
   }
 
@@ -631,10 +636,20 @@
   }
 
   .toolChip {
+    order: 1;
     flex: 1 1 calc(50% - 4px);
     justify-content: center;
     white-space: nowrap;
   }
+
+  .commandToolChip {
+    order: 0;
+    flex: 0 0 44px;
+    padding-inline: 0;
+    font-size: 0;
+  }
+
+  .commandToolChip .toolChipKbd { display: none; }
 
   .aiButton {
     flex: 1 0 100%;

--- a/components/kree8/kree8-clinical-cockpit.tsx
+++ b/components/kree8/kree8-clinical-cockpit.tsx
@@ -40,6 +40,7 @@ import { RevisioneArea } from './areas/revisione-area';
 import { RepertoriArea } from './areas/repertori-area';
 import { HandoffArea } from './areas/handoff-area';
 import { GovernanceArea } from './areas/governance-area';
+import { Kree8CommandCenter, type CommandCenterMode } from './kree8-command-center';
 import {
   AREA_ID_VALUES,
   AREAS,
@@ -194,25 +195,54 @@ type Kree8ClinicalCockpitProps = {
   initialArea?: AreaId;
   initialPatientId?: string;
   operatorName?: string;
+  reviewPatientCount?: number;
 };
+
+/* @Codex: amplia solo la fixture di review per provare la virtualizzazione;
+   ogni riga resta sintetica e non raggiunge il database locale. */
+function buildReviewPatients(count: number): Kree8Patient[] {
+  const boundedCount = Math.min(250, Math.max(REVIEW_PATIENT_LIST.length, Math.floor(count)));
+  return Array.from({ length: boundedCount }, (_, index) => {
+    const source = REVIEW_PATIENT_LIST[index % REVIEW_PATIENT_LIST.length]!;
+    const sequence = String(index + 1).padStart(3, '0');
+    return {
+      ...source,
+      id: `review-${sequence}`,
+      name: `Caso sintetico ${sequence}`,
+      code: `SYN-${sequence}`,
+      href: `/patients/review-${sequence}`,
+      modulesHref: `/patients/review-${sequence}/modules`,
+      list: 'attivi',
+      scope: 'ambulatorio',
+    };
+  });
+}
 
 export function Kree8ClinicalCockpit({
   surface = 'live',
   initialArea = 'turno',
   initialPatientId,
   operatorName: operatorNameProp,
+  reviewPatientCount,
 }: Kree8ClinicalCockpitProps) {
   const isReview = surface === 'review';
   const operatorName = operatorNameProp || (isReview ? 'Review design' : 'Sessione locale');
-  const [area, setArea] = useState<AreaId>(() => (isReview ? 'turno' : initialArea));
+  const reviewPatients = useMemo(
+    () => reviewPatientCount === undefined
+      ? REVIEW_PATIENT_LIST
+      : buildReviewPatients(reviewPatientCount),
+    [reviewPatientCount],
+  );
+  const [area, setArea] = useState<AreaId>(() => initialArea);
   const [filter, setFilter] = useState<StatusFilter>('all');
   const [patientSearchFocusSignal, setPatientSearchFocusSignal] = useState(0);
+  const [commandCenterMode, setCommandCenterMode] = useState<CommandCenterMode>(null);
   const [agendaBridge, setAgendaBridge] = useState<ClinicalAgendaBridgeClientState>({
     status: 'idle',
   });
   const [patientState, setPatientState] = useState<Kree8PatientClientState>(() => (
     isReview
-      ? { status: 'ready', patients: REVIEW_PATIENT_LIST }
+      ? { status: 'ready', patients: reviewPatients }
       : { status: 'idle', patients: [] }
   ));
   const [agendaState, setAgendaState] = useState<Kree8AgendaClientState>(() => (
@@ -221,8 +251,30 @@ export function Kree8ClinicalCockpit({
       : { status: 'idle', rows: [] }
   ));
   const [selectedPatientId, setSelectedPatientId] = useState<string | undefined>(() => (
-    isReview ? REVIEW_PATIENT_LIST[0]?.id : initialPatientId
+    isReview ? reviewPatients[0]?.id : initialPatientId
   ));
+
+  /* @Codex: comandi globali della shell; i campi editabili conservano i propri
+     caratteri e Ctrl/Meta+K resta disponibile per aprire o chiudere la palette. */
+  useEffect(() => {
+    const handleGlobalCommand = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLocaleLowerCase('it-IT') === 'k') {
+        event.preventDefault();
+        setCommandCenterMode((current) => current === 'commands' ? null : 'commands');
+        return;
+      }
+      if (event.key !== '?' || event.metaKey || event.ctrlKey || event.altKey) return;
+      const target = event.target;
+      if (target instanceof HTMLElement) {
+        const tag = target.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || target.isContentEditable) return;
+      }
+      event.preventDefault();
+      setCommandCenterMode('help');
+    };
+    window.addEventListener('keydown', handleGlobalCommand);
+    return () => window.removeEventListener('keydown', handleGlobalCommand);
+  }, []);
 
   /* @Codex WUL-UIUX: riflette area e paziente selezionato nella query string di
      '/', cosi refresh e back del browser non perdono il punto di lavoro. Solo
@@ -404,7 +456,7 @@ export function Kree8ClinicalCockpit({
       : patientState.status === 'ready'
         ? String(patientState.patients.filter((patient) => patient.list === 'attivi').length)
         : patientState.status === 'error'
-          ? '!'
+          ? 'n.d.'
           : '…';
   const diaryNavMeta =
     isReview
@@ -492,6 +544,7 @@ export function Kree8ClinicalCockpit({
             setArea('incarico');
             setPatientSearchFocusSignal((current) => current + 1);
           }}
+          onOpenCommand={() => setCommandCenterMode('commands')}
           operatorName={operatorName}
         />
         <div
@@ -550,6 +603,17 @@ export function Kree8ClinicalCockpit({
           </main>
         </div>
       </section>
+
+      <Kree8CommandCenter
+        mode={commandCenterMode}
+        onClose={() => setCommandCenterMode(null)}
+        onOpenArea={setArea}
+        onSearchRequest={() => {
+          setArea('incarico');
+          setPatientSearchFocusSignal((current) => current + 1);
+        }}
+        onShowHelp={() => setCommandCenterMode('help')}
+      />
 
       {isReview && (
         <Link href="/" className={styles.exit} aria-label="Torna alla home MediFlow live">


### PR DESCRIPTION
## Summary
- Collega palette e aiuto a toolbar e scorciatoie globali.
- Espande la fixture solo con patientCount esplicito.
- Conserva layout responsive e un solo toggle tema per breakpoint.

## Verification
- Verificato nella stack finale con typecheck e lint.
- La suite cross-packet è isolata nella PR successiva.

## Risk / Notes
- Corregge il secondo difetto mascherato di #189: cinque righe attive invece di tre.
- Packet 121+/6−; draft, nessun merge.

## Ticket
Refs WUL-560.