### PR TITLE
refactor(ui): separa Quadro e Scheda clinica

### DIFF
--- a/app/mockups/scheda/page.tsx
+++ b/app/mockups/scheda/page.tsx
@@ -63,16 +63,16 @@ const signals: ClinicalSignal[] = [
 ];
 
 const navItems: Kree8WorkspaceNavItem[] = [
-    { href: '#quadro', label: 'Quadro' },
-    { href: '#insight', label: 'Sintesi AI' },
-    { href: '#timeline', label: 'Timeline', meta: '23' },
-    { href: '#diario', label: 'Diario', meta: '17' },
-    { href: '#parametri', label: 'Parametri', meta: '24' },
-    { href: '#terapie', label: 'Terapie', meta: '8' },
-    { href: '#prestazioni', label: 'Prestazioni', meta: '5' },
-    { href: '#protesica', label: 'Protesica', meta: '2' },
-    { href: '#siss', label: 'SISS/FSE' },
-    { href: '#follow-up', label: 'Follow-up', meta: '3' },
+    { group: 'Quadro e decisioni', href: '#quadro', label: 'Quadro' },
+    { group: 'Quadro e decisioni', href: '#insight', label: 'Sintesi AI' },
+    { group: 'Quadro e decisioni', href: '#parametri', label: 'Parametri', meta: '24' },
+    { group: 'Terapie e prescrizioni', href: '#terapie', label: 'Terapie', meta: '8' },
+    { group: 'Terapie e prescrizioni', href: '#prestazioni', label: 'Prestazioni', meta: '5' },
+    { group: 'Terapie e prescrizioni', href: '#protesica', label: 'Protesica', meta: '2' },
+    { group: 'Terapie e prescrizioni', href: '#siss', label: 'SISS/FSE' },
+    { group: 'Documenti e prove', href: '#documenti', label: 'Documenti', meta: '14' },
+    { group: 'Diario e follow-up', href: '#diario', label: 'Diario', meta: '23' },
+    { group: 'Diario e follow-up', href: '#follow-up', label: 'Follow-up', meta: '3' },
 ];
 
 function PlaceholderBody({ lines }: { lines: number }) {
@@ -81,7 +81,7 @@ function PlaceholderBody({ lines }: { lines: number }) {
             {Array.from({ length: lines }).map((_, index) => (
                 <div
                     key={index}
-                    className="rounded-[16px] border border-[color:rgba(112,106,100,0.12)] bg-white/60 px-4 py-3 text-sm text-[color:var(--lume-ink-muted)] dark:border-white/10 dark:bg-white/5"
+                    className="rounded-[16px] border border-[color:color-mix(in_srgb,var(--lume-ink)_12%,transparent)] bg-white/60 px-4 py-3 text-sm text-[color:var(--lume-ink-muted)] dark:border-white/10 dark:bg-white/5"
                 >
                     Contenuto del gestore reale (placeholder di prova).
                 </div>
@@ -92,7 +92,7 @@ function PlaceholderBody({ lines }: { lines: number }) {
 
 export default function MockSchedaPage() {
     const actionsDock = (
-        <div className="patient-actions-dock rounded-[14px] border border-[color:rgba(112,106,100,0.12)] bg-white/82 p-4 dark:bg-white/4">
+        <div className="patient-actions-dock rounded-[14px] border border-[color:color-mix(in_srgb,var(--lume-ink)_12%,transparent)] bg-white/82 p-4 dark:bg-white/4">
             <button className="ui-btn-primary flex h-11 w-full items-center justify-center gap-2 px-4 text-sm font-semibold">
                 <Plus className="h-4 w-4" />
                 Nuova voce
@@ -146,29 +146,16 @@ export default function MockSchedaPage() {
                         </p>
                     </section>
 
-                    <section id="timeline" className="patient-detail-section border p-5 md:p-6 scroll-mt-28">
+                    <section id="diario" className="patient-detail-section border p-5 md:p-6 scroll-mt-28">
+                        <span id="timeline" aria-hidden="true" />
                         <div className="mb-5 flex items-center justify-between gap-3">
                             <div>
-                                <p className="section-kicker">Timeline</p>
-                                <h2 className="mt-1 text-xl font-semibold text-[color:var(--lume-ink)]">Timeline clinica</h2>
+                                <p className="section-kicker">Diario</p>
+                                <h2 className="mt-1 text-xl font-semibold text-[color:var(--lume-ink)]">Diario clinico</h2>
                             </div>
                             <span className="apple-chip">23 eventi in totale</span>
                         </div>
                         <PlaceholderBody lines={3} />
-                    </section>
-
-                    <section id="diario" className="patient-detail-section border p-5 md:p-6 scroll-mt-28">
-                        <div className="mb-5 flex items-center justify-between gap-3">
-                            <div>
-                                <p className="section-kicker">Diario</p>
-                                <h2 className="mt-1 flex items-center gap-2 text-xl font-semibold text-[color:var(--lume-ink)]">
-                                    <FileText className="h-5 w-5 text-[color:var(--lume-ink-muted)]" />
-                                    Diario clinico
-                                </h2>
-                            </div>
-                            <span className="apple-chip">17 voci attive</span>
-                        </div>
-                        <PlaceholderBody lines={2} />
                     </section>
 
                     {/* Gestori operativi: collassati di default (progressive disclosure). */}
@@ -225,7 +212,7 @@ export default function MockSchedaPage() {
                 </div>
 
                 <div className={workspaceStyles.secondaryStack}>
-                    <section className="patient-detail-side-section border p-5 scroll-mt-28">
+                    <section id="documenti" className="patient-detail-side-section border p-5 scroll-mt-28">
                         <p className="section-kicker">Evidenze documentali</p>
                         <h3 className="mt-1 text-lg font-semibold text-[color:var(--lume-ink)]">Referti recenti</h3>
                         <div className="mt-4">
@@ -240,7 +227,7 @@ export default function MockSchedaPage() {
                             Follow-up
                         </h3>
                         <div className="mt-4 space-y-2">
-                            <div className="rounded-[12px] border border-[color:rgba(112,106,100,0.12)] bg-white/82 px-4 py-3 dark:bg-white/5">
+                            <div className="rounded-[12px] border border-[color:color-mix(in_srgb,var(--lume-ink)_12%,transparent)] bg-white/82 px-4 py-3 dark:bg-white/5">
                                 <p className="text-sm font-semibold text-[color:var(--lume-ink)]">Controllo cardiologico</p>
                                 <span className="apple-chip">22/06/2026</span>
                             </div>

--- a/app/patients/[id]/modules/page.tsx
+++ b/app/patients/[id]/modules/page.tsx
@@ -26,7 +26,6 @@ import SissHandoffDiary from '@/components/siss-handoff-diary';
 import SissPatientContextPanel from '@/components/siss-patient-context-panel';
 import TherapyManager from '@/components/therapy-manager';
 import TreatmentReasoningPanel from '@/components/treatment-reasoning-panel';
-import Timeline from '@/components/timeline';
 import { Kree8WorkspaceShell, type Kree8WorkspaceNavItem } from '@/components/kree8/kree8-workspace-shell';
 import workspaceStyles from '@/components/kree8/kree8-workspace-shell.module.css';
 import { AI_DOCUMENT_SYNTHESIS_KILL_SWITCH_KEY, isAiDocumentSynthesisEnabledValue } from '@/lib/ai-document-synthesis-kill-switch';
@@ -335,10 +334,6 @@ export default function PatientDetailPage() {
     const activeEntries = (entries ?? []).filter((entry) => !entry.deletedAt);
     const nonScaleEntries = activeEntries.filter((entry) => entry.type !== 'scale');
     const scaleEntries = activeEntries.filter((entry) => entry.type === 'scale');
-    /* @Codex WUL-UIUX: il Diario non deve mostrare le compilazioni scala (hanno
-       la loro sezione). Manteniamo le voci cancellate per il toggle audit interno
-       di Timeline; filtriamo solo il tipo scala, cosi il conteggio del chip torna. */
-    const timelineEntries = (entries ?? []).filter((entry) => entry.type !== 'scale');
     const recentEvidence = documentInsights.slice(0, 4);
     const leadDiagnosis = diagnosisItems[0];
     const nextCheckup = (checkups ?? [])[0];
@@ -505,19 +500,18 @@ export default function PatientDetailPage() {
         + openLoopProjection.standaloneLoops.length;
     /* @Codex LUME-104/68: il rail segue l'ordine clinico della superficie unica. */
     const workspaceNavItems: Kree8WorkspaceNavItem[] = [
-        { href: '#attenzione', label: 'Attenzione', meta: String(reviewQueueSummary.attentionCount + openLoopCount) },
-        { href: '#quadro', label: 'Quadro' },
-        { href: '#identita', label: 'Identità' },
-        { href: '#timeline', label: 'Timeline', meta: String(nonScaleEntries.length + (checkups ?? []).length + documentInsights.length) },
-        { href: '#diario', label: 'Diario', meta: String(nonScaleEntries.length) },
-        { href: '#terapie', label: 'Terapie', meta: workspace ? String(workspace.activeTherapiesCount) : undefined },
-        { href: '#prestazioni', label: 'Prestazioni', meta: prestazioniCount !== undefined ? String(prestazioniCount) : undefined },
-        { href: '#parametri', label: 'Parametri', meta: workspace ? String(workspace.observationsCount) : undefined },
-        { href: '#protesica', label: 'Protesica', meta: protesicaCount !== undefined ? String(protesicaCount) : undefined },
-        { href: '#siss', label: 'SISS/FSE' },
-        { href: '#documenti', label: 'Documenti', meta: String(attachmentItems.length) },
-        { href: '#scale', label: 'Scale' },
-        { href: '#follow-up', label: 'Follow-up', meta: workspace ? String(workspace.pendingCheckupsCount) : undefined },
+        { group: 'Quadro e decisioni', href: '#attenzione', label: 'Attenzione', meta: String(reviewQueueSummary.attentionCount + openLoopCount) },
+        { group: 'Quadro e decisioni', href: '#quadro', label: 'Quadro' },
+        { group: 'Quadro e decisioni', href: '#identita', label: 'Identità' },
+        { group: 'Quadro e decisioni', href: '#parametri', label: 'Parametri', meta: workspace ? String(workspace.observationsCount) : undefined },
+        { group: 'Terapie e prescrizioni', href: '#terapie', label: 'Terapie', meta: workspace ? String(workspace.activeTherapiesCount) : undefined },
+        { group: 'Terapie e prescrizioni', href: '#prestazioni', label: 'Prestazioni', meta: prestazioniCount !== undefined ? String(prestazioniCount) : undefined },
+        { group: 'Terapie e prescrizioni', href: '#protesica', label: 'Protesica', meta: protesicaCount !== undefined ? String(protesicaCount) : undefined },
+        { group: 'Terapie e prescrizioni', href: '#siss', label: 'SISS/FSE' },
+        { group: 'Documenti e prove', href: '#documenti', label: 'Documenti', meta: String(attachmentItems.length) },
+        { group: 'Documenti e prove', href: '#scale', label: 'Scale' },
+        { group: 'Diario e follow-up', href: '#diario', label: 'Diario', meta: String(nonScaleEntries.length + (checkups ?? []).length + documentInsights.length) },
+        { group: 'Diario e follow-up', href: '#follow-up', label: 'Follow-up', meta: workspace ? String(workspace.pendingCheckupsCount) : undefined },
     ];
 
     /* @Codex Validates against the FSE and builds the bundle, or returns null
@@ -719,27 +713,16 @@ export default function PatientDetailPage() {
                 </CollapsibleSection>
 
                 <CollapsibleSection
-                    id="timeline"
-                    kicker="Timeline"
-                    title="Timeline clinica"
-                    count={`${nonScaleEntries.length + (checkups ?? []).length + documentInsights.length} eventi`}
-                    summary="Diario, controlli e referti in ordine cronologico."
-                    surfaceClassName={workspaceStyles.clinicalSection}
-                >
-                    <ClinicalRiverTimeline entries={nonScaleEntries} checkups={checkups ?? []} documentInsights={documentInsights} />
-                </CollapsibleSection>
-
-                <CollapsibleSection
                     id="diario"
                     kicker="Diario"
                     title="Diario clinico"
-                    icon={FileText}
-                    count={`${nonScaleEntries.length} voci`}
-                    summary={nonScaleEntries.length === 0 ? 'Nessuna voce clinica registrata.' : 'Apri le voci attive del diario.'}
+                    count={`${nonScaleEntries.length + (checkups ?? []).length + documentInsights.length} eventi`}
+                    summary="Timeline unica di voci, controlli e referti in ordine cronologico."
                     surfaceClassName={workspaceStyles.clinicalSection}
                     keepMounted
                 >
-                    {entries ? <Timeline entries={timelineEntries} /> : <p className={workspaceStyles.mutedText}>Diario in caricamento.</p>}
+                    <span id="timeline" aria-hidden="true" />
+                    <ClinicalRiverTimeline entries={nonScaleEntries} checkups={checkups ?? []} documentInsights={documentInsights} />
                 </CollapsibleSection>
 
                     <CollapsibleSection

--- a/components/kree8/areas/real-patient-area.tsx
+++ b/components/kree8/areas/real-patient-area.tsx
@@ -22,7 +22,6 @@ type QuadroSignal = 'warning' | 'critical';
 
 type QuadroMetric = { label: string; value: string | number; note: string; signal?: QuadroSignal };
 type QuadroDiagnosis = { code: string; description: string };
-type QuadroTherapy = { name: string; dose: string };
 type QuadroRow = { title: string; value?: string; note?: string; signal?: QuadroSignal };
 type QuadroAction = { label: string; icon: ReactNode; href?: string; onClick?: () => void };
 
@@ -35,12 +34,8 @@ type PatientQuadroProps = {
   diagnoses: QuadroDiagnosis[];
   summary: string;
   metrics: QuadroMetric[];
-  therapies: QuadroTherapy[];
-  therapiesEmpty: string;
   nextRows: QuadroRow[];
   nextEmpty: string;
-  documentRows: QuadroRow[];
-  documentsEmpty: string;
   primaryAction: QuadroAction;
   quietActions: QuadroAction[];
 };
@@ -54,11 +49,6 @@ function splitDiagnosis(diagnosis: string): QuadroDiagnosis {
     return { code: 'non codificata', description: diagnosis };
   }
   return { code: diagnosis.slice(0, separatorIndex), description: diagnosis.slice(separatorIndex + 3) };
-}
-
-function splitTherapy(therapy: string): QuadroTherapy {
-  const [name, ...doseParts] = therapy.split(' · ');
-  return { name, dose: doseParts.join(' · ') || 'Dose non registrata' };
 }
 
 function QuadroActionControl({
@@ -130,12 +120,8 @@ function PatientQuadro({
   diagnoses,
   summary,
   metrics,
-  therapies,
-  therapiesEmpty,
   nextRows,
   nextEmpty,
-  documentRows,
-  documentsEmpty,
   primaryAction,
   quietActions,
 }: PatientQuadroProps) {
@@ -189,7 +175,7 @@ function PatientQuadro({
         ))}
       </div>
 
-      <div className={patientStyles.quadroSectionGrid}>
+      <div className={patientStyles.quadroSectionGrid} data-testid="lume-quadro-lens">
         <div className={patientStyles.quadroSection} data-testid="lume-quadro-section">
           <p className={patientStyles.quadroSectionLabel}>Diagnosi e sintesi</p>
           <ul className={patientStyles.quadroDiagnoses} aria-label="Diagnosi">
@@ -213,32 +199,8 @@ function PatientQuadro({
         </div>
 
         <div className={patientStyles.quadroSection} data-testid="lume-quadro-section">
-          <p className={patientStyles.quadroSectionLabel}>Terapie attive</p>
-          {therapies.length ? (
-            <div className={patientStyles.quadroTherapies}>
-              {therapies.map((therapy) => (
-                <div key={`${therapy.name}-${therapy.dose}`} className={patientStyles.quadroTherapy}>
-                  <span className={patientStyles.quadroTherapyName}>{therapy.name}</span>
-                  <span className={classNames(patientStyles.quadroTherapyDose, 'lume-registro')}>
-                    {therapy.dose}
-                  </span>
-                </div>
-              ))}
-            </div>
-          ) : (
-            <p className={patientStyles.quadroEmpty}>{therapiesEmpty}</p>
-          )}
-        </div>
-      </div>
-
-      <div className={patientStyles.quadroSectionGrid}>
-        <div className={patientStyles.quadroSection} data-testid="lume-quadro-section">
-          <p className={patientStyles.quadroSectionLabel}>Cosa fare ora</p>
+          <p className={patientStyles.quadroSectionLabel}>Prossima azione</p>
           <QuadroRows rows={nextRows} empty={nextEmpty} />
-        </div>
-        <div className={patientStyles.quadroSection} data-testid="lume-quadro-section">
-          <p className={patientStyles.quadroSectionLabel}>Documenti e codifiche</p>
-          <QuadroRows rows={documentRows} empty={documentsEmpty} />
         </div>
       </div>
 
@@ -261,7 +223,6 @@ function RealPatientArea({
   const nextCheckup = workspace?.nextCheckup;
   const latestObservation = workspace?.latestObservation;
   const codingHints = workspace?.codingHints ?? [];
-  const therapies = workspace?.therapyLabels.map(splitTherapy) ?? [];
 
   const metrics: QuadroMetric[] = [
     {
@@ -272,7 +233,7 @@ function RealPatientArea({
     {
       label: 'Terapie attive',
       value: isWorkspaceLoading ? 'in attesa' : workspace?.activeTherapiesCount ?? 0,
-      note: isWorkspaceLoading ? 'Caricamento del piano terapeutico in corso.' : therapies[0]?.name ?? 'Nessun piano attivo.',
+      note: isWorkspaceLoading ? 'Caricamento del piano terapeutico in corso.' : workspace?.therapyLabels[0] ?? 'Nessun piano attivo.',
     },
     {
       label: 'Follow-up',
@@ -297,10 +258,9 @@ function RealPatientArea({
     ...(latestObservation ? [{ title: latestObservation.label, value: latestObservation.date, note: 'Ultima osservazione registrata' }] : []),
   ];
 
-  const documentRows: QuadroRow[] = [
-    ...codingHints.map((hint) => ({ title: hint, note: 'Da rivedere prima di applicare.' })),
-    ...(workspace?.recentAttachmentNames ?? []).map((name) => ({ title: name, note: 'Documento recente agganciato.' })),
-  ];
+  if (codingHints.length > 0 && nextRows.length < 3) {
+    nextRows.push({ title: codingHints[0], note: 'Codifica da rivedere prima di applicare.' });
+  }
 
   return (
     <div className={styles.areaShell}>
@@ -318,12 +278,8 @@ function RealPatientArea({
         diagnoses={patient.diagnoses.map(splitDiagnosis)}
         summary={patient.summary}
         metrics={metrics}
-        therapies={therapies}
-        therapiesEmpty={isWorkspaceLoading ? 'Caricamento delle terapie locali in corso.' : 'Nessuna terapia attiva registrata.'}
         nextRows={nextRows}
         nextEmpty={isWorkspaceLoading ? 'Caricamento dei prossimi passaggi in corso.' : 'Nessun passaggio clinico aperto.'}
-        documentRows={documentRows}
-        documentsEmpty={isWorkspaceLoading ? 'Caricamento di documenti e codifiche in corso.' : 'Nessun documento o codice sospeso.'}
         primaryAction={{
           label: 'Apri scheda paziente',
           icon: <UserSquare2 size={13} />,
@@ -331,12 +287,8 @@ function RealPatientArea({
         }}
         quietActions={[
           { label: 'Nuova voce', icon: <Plus size={12} />, href: `${patient.href}/entries/new` },
-          { label: 'Anagrafica', icon: <Edit3 size={12} />, href: `${patient.href}/edit` },
-          { label: 'Agenda', icon: <CalendarClock size={12} />, onClick: () => onOpenArea('turno') },
           { label: 'Rivedi documenti', icon: <Sparkles size={13} />, href: `${patient.modulesHref}#documenti` },
-          { label: 'Scale cliniche', icon: <ListChecks size={12} />, href: `${patient.modulesHref}#scale` },
-          { label: 'Contesto SISS', icon: <Workflow size={12} />, href: `${patient.modulesHref}#contesto` },
-          { label: 'Apri moduli', icon: <ArrowUpRight size={12} />, href: patient.modulesHref },
+          { label: 'Agenda', icon: <CalendarClock size={12} />, onClick: () => onOpenArea('turno') },
         ]}
       />
     </div>
@@ -344,4 +296,4 @@ function RealPatientArea({
 }
 
 export { PatientQuadro, RealPatientArea };
-export type { QuadroAction, QuadroDiagnosis, QuadroMetric, QuadroRow, QuadroTherapy };
+export type { QuadroAction, QuadroDiagnosis, QuadroMetric, QuadroRow };

--- a/components/kree8/areas/scheda-area.tsx
+++ b/components/kree8/areas/scheda-area.tsx
@@ -1,18 +1,15 @@
 import {
   CalendarClock,
-  FileSignature,
-  FileText,
-  ListChecks,
   Paperclip,
   Plus,
   Sparkles,
-  Workflow,
+  UserSquare2,
 } from 'lucide-react';
 
 import type { AreaId } from '../cockpit-shared';
 import type { Kree8Patient, Kree8PatientWorkspace } from '@/lib/patient-workspace';
 import { PatientQuadro, RealPatientArea } from './real-patient-area';
-import type { QuadroAction, QuadroDiagnosis, QuadroMetric, QuadroRow, QuadroTherapy } from './real-patient-area';
+import type { QuadroAction, QuadroDiagnosis, QuadroMetric, QuadroRow } from './real-patient-area';
 import styles from '../kree8-clinical-cockpit-foundation.module.css';
 import patientStyles from '../kree8-clinical-cockpit-patient-inbox.module.css';
 
@@ -35,22 +32,10 @@ const REVIEW_METRICS: QuadroMetric[] = [
   },
 ];
 
-const REVIEW_THERAPIES: QuadroTherapy[] = [
-  { name: 'Ramipril', dose: '5 mg · 1 cpr/die' },
-  { name: 'Atorvastatina', dose: '20 mg · 1 cpr/sera' },
-  { name: 'Salbutamolo', dose: 'al bisogno' },
-];
-
 const REVIEW_NEXT_ROWS: QuadroRow[] = [
   { title: 'Controllo cardiologico', value: '18/07', note: 'Finestra di follow-up clinico vicina.', signal: 'warning' },
   { title: 'Rinnovo esenzione 031', value: '27 gg', note: 'Azione amministrativa MMG.' },
   { title: 'Tinetti e MMSE', value: 'da rivedere', note: 'Scale nella finestra di rivalutazione.' },
-];
-
-const REVIEW_DOCUMENT_ROWS: QuadroRow[] = [
-  { title: 'Referto cardiologico ASL', value: '02/05', note: 'Holter 24h nella norma, fonte sintetica.' },
-  { title: 'Codifica I10', value: 'da confermare', note: 'Revisione documentale richiesta prima di applicare.' },
-  { title: 'Posologia estratta', value: 'incerta', note: 'Il dato resta sospeso e non viene applicato.' },
 ];
 
 function SchedaArea({
@@ -81,8 +66,7 @@ function SchedaArea({
             </div>
           </header>
           <p className={patientStyles.quadroEmpty}>
-            Apri un paziente dalla lista in carico per vedere sintesi, azioni,
-            documenti e follow-up del caso.
+            Apri un paziente dalla lista in carico per vedere stato e prossima azione.
           </p>
         </section>
       </div>
@@ -93,10 +77,6 @@ function SchedaArea({
     { label: 'Nuova voce diario', icon: <Plus size={12} />, onClick: () => onOpenArea('diario') },
     { label: 'Allega documento', icon: <Paperclip size={12} />, onClick: () => onOpenArea('revisione') },
     { label: 'Pianifica visita', icon: <CalendarClock size={12} />, onClick: () => onOpenArea('turno') },
-    { label: 'Smart Import', icon: <Sparkles size={12} />, onClick: () => onOpenArea('revisione') },
-    { label: 'Apri documenti', icon: <FileText size={12} />, onClick: () => onOpenArea('revisione') },
-    { label: 'Scale cliniche', icon: <ListChecks size={12} />, onClick: () => onOpenArea('scheda') },
-    { label: 'Firma e handoff', icon: <FileSignature size={12} />, onClick: () => onOpenArea('handoff') },
   ];
 
   return (
@@ -110,13 +90,9 @@ function SchedaArea({
         diagnoses={REVIEW_DIAGNOSES}
         summary="Aderenza terapeutica buona negli ultimi 90 giorni. Vitali nell’ultima rilevazione entro la baseline del caso. Il follow-up cardiologico è vicino e la codifica dell’ultimo documento resta da confermare."
         metrics={REVIEW_METRICS}
-        therapies={REVIEW_THERAPIES}
-        therapiesEmpty="Nessuna terapia attiva registrata."
         nextRows={REVIEW_NEXT_ROWS}
         nextEmpty="Nessun passaggio clinico aperto."
-        documentRows={REVIEW_DOCUMENT_ROWS}
-        documentsEmpty="Nessun documento o codice sospeso."
-        primaryAction={{ label: 'Prepara SISS', icon: <Workflow size={13} />, onClick: () => onOpenArea('handoff') }}
+        primaryAction={{ label: 'Apri Scheda completa', icon: <UserSquare2 size={13} />, href: '/mockups/scheda' }}
         quietActions={quietActions}
       />
     </div>

--- a/components/kree8/kree8-clinical-cockpit-patient-inbox.module.css
+++ b/components/kree8/kree8-clinical-cockpit-patient-inbox.module.css
@@ -545,7 +545,7 @@
   gap: 10px; align-items: baseline; padding: 7px 0; color: var(--lume-ink); font-size: 13px;
   border-bottom: 1px solid color-mix(in srgb, var(--lume-ink) 9%, transparent);
 }
-.quadroDiagnosis:last-child, .quadroTherapy:last-child, .quadroRow:last-child { border-bottom: 0; }
+.quadroDiagnosis:last-child, .quadroRow:last-child { border-bottom: 0; }
 .quadroDiagnosisCode { color: var(--lume-ink-muted); font-size: 12px; overflow-wrap: anywhere; }
 .quadroStatus {
   margin: 10px 0 0; display: flex; align-items: baseline;
@@ -556,14 +556,7 @@
   margin: 8px 0 0; max-width: 70ch; color: var(--lume-ink-muted);
   font-size: 13px; line-height: 1.6; text-wrap: pretty;
 }
-.quadroTherapies, .quadroRows { display: flex; flex-direction: column; }
-.quadroTherapy {
-  min-width: 0; min-height: 40px; padding: 7px 0; display: flex;
-  align-items: center; justify-content: space-between; gap: 12px;
-  border-bottom: 1px solid color-mix(in srgb, var(--lume-ink) 9%, transparent);
-}
-.quadroTherapyName { min-width: 0; color: var(--lume-ink); font-size: 13px; font-weight: 540; }
-.quadroTherapyDose { flex: none; color: var(--lume-ink-muted); font-size: 12px; text-align: right; }
+.quadroRows { display: flex; flex-direction: column; }
 .quadroRow {
   min-width: 0; display: grid; grid-template-columns: 9px minmax(0, 1fr) auto;
   gap: 9px; align-items: start; padding: 8px 0;
@@ -619,8 +612,6 @@
   .quadroPrimaryAction { width: 100%; align-self: stretch; }
   .quadroMetrics { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .quadroSectionGrid { grid-template-columns: minmax(0, 1fr); }
-  .quadroTherapy { align-items: flex-start; flex-direction: column; gap: 3px; }
-  .quadroTherapyDose { text-align: left; }
   .quadroRow { grid-template-columns: 9px minmax(0, 1fr); }
   .quadroRowValue { grid-column: 2; max-width: none; text-align: left; }
   .quadroActions > * { flex: 1 1 142px; }

--- a/components/kree8/kree8-workspace-shell.module.css
+++ b/components/kree8/kree8-workspace-shell.module.css
@@ -361,13 +361,14 @@
    each section remains visible and reachable without a hidden scrollbar. */
 @media (max-width: 480px) {
   .sectionRail {
-    display: flex;
-    flex-direction: column;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     align-items: stretch;
     overflow: visible;
     scroll-snap-type: none;
   }
 
+  .sectionGroup { grid-column: 1 / -1; }
   .sectionGroupLinks { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); }
 
   .sectionLink {

--- a/components/kree8/kree8-workspace-shell.module.css
+++ b/components/kree8/kree8-workspace-shell.module.css
@@ -331,6 +331,13 @@
 
 .sectionRail::-webkit-scrollbar { display: none; }
 
+.sectionGroup { flex: 0 0 auto; min-width: 0; }
+.sectionGroupLabel {
+  display: block; margin: 0 0 3px 4px; color: var(--k8-subtle);
+  font-size: 9px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase;
+}
+.sectionGroupLinks { display: flex; align-items: center; gap: 6px; }
+
 .sectionLink {
   flex: 0 0 auto;
   scroll-snap-align: start;
@@ -354,12 +361,14 @@
    each section remains visible and reachable without a hidden scrollbar. */
 @media (max-width: 480px) {
   .sectionRail {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    display: flex;
+    flex-direction: column;
     align-items: stretch;
     overflow: visible;
     scroll-snap-type: none;
   }
+
+  .sectionGroupLinks { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); }
 
   .sectionLink {
     min-width: 0;

--- a/components/kree8/kree8-workspace-shell.tsx
+++ b/components/kree8/kree8-workspace-shell.tsx
@@ -15,6 +15,7 @@ export type Kree8WorkspaceNavItem = {
   href: string;
   label: string;
   meta?: string;
+  group?: string;
 };
 
 type Kree8WorkspaceShellProps = {
@@ -58,6 +59,15 @@ export function Kree8WorkspaceShell({
   const activeHrefRef = useRef<string | null>(null);
   const rootRef = useRef<HTMLDivElement>(null);
   const navKey = navItems.map((item) => item.href).join('|');
+  const navGroups = navItems.reduce<Array<{ label?: string; items: Kree8WorkspaceNavItem[] }>>((groups, item) => {
+    const previous = groups.at(-1);
+    if (previous && previous.label === item.group) {
+      previous.items.push(item);
+    } else {
+      groups.push({ label: item.group, items: [item] });
+    }
+    return groups;
+  }, []);
   const PrimaryActionIcon = primaryAction?.icon;
 
   /* Lume focal locus + scrollspy (WUL-55, F2c). Un solo effetto governa la vita
@@ -270,16 +280,28 @@ export function Kree8WorkspaceShell({
 
         {navItems.length > 0 ? (
           <nav className={styles.sectionRail} aria-label="Sezioni della vista">
-            {navItems.map((item) => (
-              <a
-                key={item.href}
-                href={item.href}
-                className={styles.sectionLink}
-                aria-current={item.href === activeHref ? 'location' : undefined}
+            {navGroups.map((group, index) => (
+              <div
+                key={`${group.label ?? 'navigation'}-${index}`}
+                className={styles.sectionGroup}
+                role={group.label ? 'group' : undefined}
+                aria-label={group.label}
               >
-                <span>{item.label}</span>
-                {item.meta ? <small>{item.meta}</small> : null}
-              </a>
+                {group.label ? <span className={styles.sectionGroupLabel}>{group.label}</span> : null}
+                <div className={styles.sectionGroupLinks}>
+                  {group.items.map((item) => (
+                    <a
+                      key={item.href}
+                      href={item.href}
+                      className={styles.sectionLink}
+                      aria-current={item.href === activeHref ? 'location' : undefined}
+                    >
+                      <span>{item.label}</span>
+                      {item.meta ? <small>{item.meta}</small> : null}
+                    </a>
+                  ))}
+                </div>
+              </div>
             ))}
           </nav>
         ) : null}

--- a/components/patient-identity-lens.tsx
+++ b/components/patient-identity-lens.tsx
@@ -102,9 +102,9 @@ export function PatientIdentityLens({
                                 <p className="text-[10px] font-medium uppercase tracking-[0.12em] text-[color:var(--lume-ink-muted)]">
                                     Scheda paziente
                                 </p>
-                                <h1 className="mt-2 text-2xl font-semibold tracking-tight text-[color:var(--lume-ink)] md:text-[28px]">
+                                <h2 className="mt-2 text-2xl font-semibold tracking-tight text-[color:var(--lume-ink)] md:text-[28px]">
                                     <PrivacyBlur>{patient.lastName} {patient.firstName}</PrivacyBlur>
-                                </h1>
+                                </h2>
                                 <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-[color:var(--lume-ink-muted)]">
                                     <span className="lume-registro text-[12px] tracking-tight">
                                         <PrivacyBlur intensity="sm">{patient.taxCode}</PrivacyBlur>

--- a/e2e/lume-quadro.spec.ts
+++ b/e2e/lume-quadro.spec.ts
@@ -161,7 +161,7 @@ async function assertQuadroContract(page: Page, quadro: Locator): Promise<void> 
   const primary = quadro.locator('[data-lume-action="primary"]');
   const quiet = quadro.locator('[data-lume-action="quiet"]');
   await expect(primary).toHaveCount(1);
-  await expect(quiet).toHaveCount(7);
+  await expect(quiet).toHaveCount(3);
   await expect(primary).toHaveCSS('background-color', await resolveColor(page, '--lume-ink'));
   await expect(primary).toHaveCSS('color', await resolveColor(page, '--lume-surface-focal'));
 
@@ -177,8 +177,10 @@ async function assertReflowStack(quadro: Locator): Promise<void> {
       return { top: box.top, bottom: box.bottom };
     }),
   );
-  expect(sections[1].top).toBeGreaterThanOrEqual(sections[0].bottom - 1);
-  expect(sections[3].top).toBeGreaterThanOrEqual(sections[2].bottom - 1);
+  expect(sections).toHaveLength(2);
+  for (let index = 1; index < sections.length; index += 1) {
+    expect(sections[index].top).toBeGreaterThanOrEqual(sections[index - 1].bottom - 1);
+  }
 }
 
 test('quadro live usa il paziente selezionato dal database sintetico', async ({ page }) => {

--- a/e2e/lume-scheda.spec.ts
+++ b/e2e/lume-scheda.spec.ts
@@ -155,7 +155,13 @@ for (const schedaCase of CASES) {
     const scroll = page.getByTestId('lume-scheda-scroll');
     const header = page.getByTestId('lume-scheda-header');
     const surface = page.getByTestId('lume-scheda-surface');
+    const sectionRail = page.getByRole('navigation', { name: 'Sezioni della vista' });
     await expect(header.getByRole('heading', { name: patient.name, level: 1 })).toBeVisible();
+    await expect(page.locator('h1')).toHaveCount(1);
+    await expect(sectionRail.getByRole('group')).toHaveCount(4);
+    await expect(sectionRail.getByRole('link', { name: /Timeline/ })).toHaveCount(0);
+    await expect(page.locator('#diario')).toHaveCount(1);
+    await expect(page.locator('#timeline')).toHaveCount(1);
     await expect(page.getByRole('button', { name: /Archivio documenti ed evidenze/ }))
       .toHaveAttribute('aria-expanded', 'false');
     await expectInViewport(header);

--- a/scripts/check-lume-tokens.mjs
+++ b/scripts/check-lume-tokens.mjs
@@ -30,7 +30,7 @@ const FUNCTION_COLOR = /\b(?:rgba?|hsla?)\((?:[^()]*)\)/gi;
 // letterali legacy e le loro ripetizioni. La baseline deve combaciare
 // esattamente: una voce che copre meno letterali di quelli dichiarati fallisce.
 export const PALETTE_ALLOWLIST = [
-  {"path":"app/mockups/scheda/page.tsx","reason":"Debito storico su superficie non clinica: migrazione Lume da completare.","occurrences":10,"fingerprint":"0b532d8493c010f98eba790c6cca032e0c871be43eccd5bb743d13b514892219"},
+  {"path":"app/mockups/scheda/page.tsx","reason":"Debito storico su superficie non clinica: migrazione Lume da completare.","occurrences":7,"fingerprint":"a9261e48fe9ddbbcaa3ca087ea795d3f6cce439f8d8c67d20aa3849fce5a16c9"},
   {"path":"app/patients/[id]/edit/page.tsx","reason":"Debito storico su superficie clinica: migrazione Lume da completare.","occurrences":2,"fingerprint":"c465f2f78534069d2c5091795196bb3c49d4428b0c2aaa3a488617f7bc16d9a4"},
   {"path":"app/patients/[id]/scales/[scaleId]/page.tsx","reason":"Debito storico su superficie clinica: migrazione Lume da completare.","occurrences":8,"fingerprint":"2aa3c828cc9648c78578de11157a552e6a94dd15d7437c7e8b86d847a1024582"},
   {"path":"app/patients/[id]/scales/page.tsx","reason":"Debito storico su superficie clinica: migrazione Lume da completare.","occurrences":3,"fingerprint":"d5ff14dc1c75592ec7919d22cb7374120b0c3834bea183ea6fffd36e2e4fa75b"},


### PR DESCRIPTION
## Summary
- Mantiene Quadro come lente rapida e Scheda come workspace completo.
- Fonde Diario e Timeline in una capability con alias compatibile.
- Raggruppa la rail della Scheda in quattro gruppi clinici.

## Verification
- Typecheck e lint: pass sulla stack WUL-561.
- E2E Quadro/Scheda: 13 pass sulla stack.

## Risk / Notes
- Nessun AIP/Mini/Apple; fixture sintetiche.
- Draft; WUL-564 resta gate finale.

## Ticket
Refs WUL-561.