### PR TITLE
fix(ui): mantieni Carta su superfici neutrali

### DIFF
--- a/app/icon.svg
+++ b/app/icon.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
     <defs>
       <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
-        <stop offset="0" stop-color="#fbfaf7"/>
+        <stop offset="0" stop-color="#fbfcfe"/>
         <stop offset="1" stop-color="#eef0f2"/>
       </linearGradient>
     </defs>

--- a/app/lume-motion.css
+++ b/app/lume-motion.css
@@ -5,7 +5,7 @@
   initial-value: 0%;
 }
 
-@property --lume-surface-temp {
+@property --lume-surface-depth {
   syntax: '<percentage>';
   inherits: false;
   initial-value: 0%;
@@ -79,7 +79,7 @@
 
 .lume-focal {
   --lume-surface-l: 100%;
-  --lume-surface-temp: 8%;
+  --lume-surface-depth: 8%;
   --lume-focal-shadow-opacity: 1;
   position: relative;
   isolation: isolate;
@@ -90,12 +90,12 @@
       var(--lume-surface-field) calc(100% - var(--lume-surface-l)),
       var(--lume-surface-focal) var(--lume-surface-l)
     ),
-    var(--lume-surface-focal) var(--lume-surface-temp)
+    var(--lume-surface-focal) var(--lume-surface-depth)
   );
   transition:
     background-color var(--lume-dur-fuoco) var(--lume-ease),
     --lume-surface-l var(--lume-dur-fuoco) var(--lume-ease),
-    --lume-surface-temp var(--lume-dur-fuoco) var(--lume-ease);
+    --lume-surface-depth var(--lume-dur-fuoco) var(--lume-ease);
 }
 
 .lume-focal::before {

--- a/app/patients/[id]/edit/page.tsx
+++ b/app/patients/[id]/edit/page.tsx
@@ -295,7 +295,7 @@ export default function EditPatientPage() {
                     />
                 </div>
 
-                <div id="azioni" className="border-t border-[color:rgba(112,106,100,0.12)] pt-6">
+                <div id="azioni" className="border-t border-[color:color-mix(in_srgb,var(--lume-ink)_12%,transparent)] pt-6">
                     <div className="flex items-center gap-3 mb-8">
                         <div className="mf-icon-disc h-10 w-10 !text-[color:var(--lume-signal-critical)]">
                             <ShieldAlert className="w-5 h-5" />

--- a/app/patients/[id]/scales/[scaleId]/page.tsx
+++ b/app/patients/[id]/scales/[scaleId]/page.tsx
@@ -127,7 +127,7 @@ export default function ScaleRunnerPage() {
                                     'flex min-h-[54px] items-center justify-between gap-3 rounded-[16px] border px-4 text-sm font-semibold transition-[border-color,background-color,color]',
                                     setting === 'ambulatory'
                                         ? 'lume-focal border-[color:color-mix(in_srgb,var(--lume-ink)_24%,transparent)] bg-[color:var(--lume-surface-focal)] text-[color:var(--lume-ink)]'
-                                        : 'border-[color:rgba(112,106,100,0.14)] bg-white text-[color:var(--lume-ink-muted)] hover:border-[color:rgba(112,106,100,0.2)]'
+                                        : 'border-[color:color-mix(in_srgb,var(--lume-ink)_14%,transparent)] bg-white text-[color:var(--lume-ink-muted)] hover:border-[color:color-mix(in_srgb,var(--lume-ink)_20%,transparent)]'
                                 )}
                             >
                                 <span className="inline-flex items-center gap-2">
@@ -144,7 +144,7 @@ export default function ScaleRunnerPage() {
                                     'flex min-h-[54px] items-center justify-between gap-3 rounded-[16px] border px-4 text-sm font-semibold transition-[border-color,background-color,color]',
                                     setting === 'home'
                                         ? 'border-[color:rgba(182,106,60,0.24)] bg-[color:rgba(182,106,60,0.08)] text-[color:var(--lume-accent)] shadow-[0_12px_24px_rgba(182,106,60,0.08)]'
-                                        : 'border-[color:rgba(112,106,100,0.14)] bg-white text-[color:var(--lume-ink-muted)] hover:border-[color:rgba(112,106,100,0.2)]'
+                                        : 'border-[color:color-mix(in_srgb,var(--lume-ink)_14%,transparent)] bg-white text-[color:var(--lume-ink-muted)] hover:border-[color:color-mix(in_srgb,var(--lume-ink)_20%,transparent)]'
                                 )}
                             >
                                 <span className="inline-flex items-center gap-2">

--- a/components/kree8/kree8-clinical-cockpit-shell.module.css
+++ b/components/kree8/kree8-clinical-cockpit-shell.module.css
@@ -361,7 +361,7 @@
  * on the border. */
 .canvas {
   --lume-surface-l: 0%;
-  --lume-surface-temp: 0%;
+  --lume-surface-depth: 0%;
   background: var(--lume-surface-canvas);
   padding: 14px;
   min-width: 0;
@@ -378,7 +378,7 @@
 
 .canvas[data-lume-context='turno'] {
   --lume-surface-l: 3.5%;
-  --lume-surface-temp: 1.1%;
+  --lume-surface-depth: 1.1%;
 }
 
 .framePanel {
@@ -422,14 +422,14 @@
 
 .canvas[data-lume-context='incarico'] {
   --lume-surface-l: 5.5%;
-  --lume-surface-temp: 1.8%;
+  --lume-surface-depth: 1.8%;
 }
 
 .canvas[data-lume-context='incarico'] .focusSurface { --k8-focus-wash: 2.5%; }
 
 .canvas[data-lume-context='scheda'] {
   --lume-surface-l: 7%;
-  --lume-surface-temp: 2.4%;
+  --lume-surface-depth: 2.4%;
   background: color-mix(in srgb, var(--lume-surface-canvas) 99%, var(--lume-surface-focal));
 }
 
@@ -437,7 +437,7 @@
 
 .canvas[data-lume-context='diario'] {
   --lume-surface-l: 4.5%;
-  --lume-surface-temp: 1.4%;
+  --lume-surface-depth: 1.4%;
 }
 
 .canvas[data-lume-context='diario'] .focusSurface { --k8-focus-wash: 1.5%; }

--- a/components/patient-clinical-signals.tsx
+++ b/components/patient-clinical-signals.tsx
@@ -37,7 +37,7 @@ export function PatientClinicalSignals({ signals }: { signals: ClinicalSignal[] 
                 return (
                     <div
                         key={signal.label}
-                        className="rounded-[18px] border border-[color:rgba(112,106,100,0.12)] bg-white/72 px-4 py-3 dark:border-[color:rgba(255,247,240,0.1)] dark:bg-white/5"
+                        className="rounded-[18px] border border-[color:color-mix(in_srgb,var(--lume-ink)_12%,transparent)] bg-white/72 px-4 py-3 dark:border-[color:color-mix(in_srgb,var(--lume-ink)_10%,transparent)] dark:bg-white/5"
                     >
                         <p className="flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-[0.08em] text-[color:var(--lume-ink-muted)]">
                             {Icon ? <Icon className="h-3.5 w-3.5" /> : null}

--- a/components/scale-engine.tsx
+++ b/components/scale-engine.tsx
@@ -84,7 +84,7 @@ export default function ScaleEngine({ scale, onComplete, onCancel }: ScaleEngine
     return (
         // @Codex WUL-273: scale engine can live inside the Kree8 workspace without the old page chrome.
         <div className="patient-detail-section mx-auto flex min-h-[500px] w-full max-w-3xl flex-col overflow-hidden border !p-0">
-            <div className="border-b border-[color:rgba(112,106,100,0.12)] p-6">
+            <div className="border-b border-[color:color-mix(in_srgb,var(--lume-ink)_12%,transparent)] p-6">
                 <h2 className="text-2xl font-semibold tracking-tight text-[color:var(--lume-ink)]">{scale.title}</h2>
                 <p className="mt-1 text-sm text-[color:var(--lume-ink-muted)]">{scale.description}</p>
 
@@ -147,7 +147,7 @@ export default function ScaleEngine({ scale, onComplete, onCancel }: ScaleEngine
                 </div>
             </div>
 
-            <div className="flex flex-wrap items-center justify-between gap-3 border-t border-[color:rgba(112,106,100,0.12)] p-5 md:p-6">
+            <div className="flex flex-wrap items-center justify-between gap-3 border-t border-[color:color-mix(in_srgb,var(--lume-ink)_12%,transparent)] p-5 md:p-6">
                 <button
                     onClick={onCancel}
                     className="mf-btn-secondary"

--- a/components/settings/ai-model-selector.tsx
+++ b/components/settings/ai-model-selector.tsx
@@ -185,7 +185,7 @@ export function ModelSelector({ selectorId, label, description, icon, value, onC
                                             className="flex h-4 w-4 shrink-0 items-center justify-center rounded-full border"
                                             style={selected
                                                 ? { borderColor: 'var(--lume-ink)', background: 'var(--lume-ink)' }
-                                                : { borderColor: 'rgba(112,106,100,0.28)' }}
+                                                : { borderColor: 'color-mix(in srgb, var(--lume-ink) 28%, transparent)' }}
                                         >
                                             {selected && <div className={`h-1.5 w-1.5 rounded-full ${c.selectedDot}`} />}
                                         </div>

--- a/components/siss-patient-context-panel.tsx
+++ b/components/siss-patient-context-panel.tsx
@@ -935,7 +935,7 @@ export default function SissPatientContextPanel({ patientId, patientTaxCode, emb
             </div>
 
             <details className="group mt-4">
-                <summary className="flex cursor-pointer list-none items-center justify-between gap-2 rounded-[10px] border border-[color:rgba(112,106,100,0.12)] bg-[color:rgba(255,252,247,0.78)] px-3 py-2 text-[12.5px] font-semibold text-[color:var(--lume-ink)] transition-colors hover:border-[color:color-mix(in_srgb,var(--lume-accent)_26%,transparent)] dark:border-[color:rgba(255,247,240,0.08)] dark:bg-white/4">
+                <summary className="flex cursor-pointer list-none items-center justify-between gap-2 rounded-[10px] border border-[color:color-mix(in_srgb,var(--lume-ink)_12%,transparent)] bg-[color:color-mix(in_srgb,var(--lume-surface-focal)_78%,transparent)] px-3 py-2 text-[12.5px] font-semibold text-[color:var(--lume-ink)] transition-colors hover:border-[color:color-mix(in_srgb,var(--lume-accent)_26%,transparent)] dark:border-[color:color-mix(in_srgb,var(--lume-ink)_8%,transparent)] dark:bg-white/4">
                     <span className="flex items-center gap-2">
                         <ShieldAlert className="h-4 w-4 text-[color:var(--lume-signal-warning)]" />
                         Funzioni non automatiche

--- a/docs/design/lume/01-lingua.md
+++ b/docs/design/lume/01-lingua.md
@@ -13,14 +13,14 @@ In ogni istante l'interfaccia ha un solo **fuoco**: l'oggetto clinico in lavoraz
 
 | Zona | Cosa contiene | Resa |
 | --- | --- | --- |
-| **Fuoco** | L'oggetto in lavorazione | Superficie più chiara e leggermente più calda, contrasto pieno, ombra corta che la solleva |
+| **Fuoco** | L'oggetto in lavorazione | Superficie neutra più chiara, contrasto pieno, ombra corta che la solleva |
 | **Penombra** | Il contesto di lavoro (worklist, pannelli vicini) | Superficie neutra, contrasto pieno del testo ma cromatismo trattenuto, nessuna ombra |
 | **Buio operativo** | Il telaio (rail, barre, chrome) | Superficie leggermente più scura e più fredda, contenuti attenuati, zero ornamento |
 
 Regole:
 
 - Il fuoco è UNO. Se due zone sembrano fuoco, la gerarchia è rotta.
-- Il fuoco non si assegna con il colore ma con la luce: luminanza, temperatura, ombra. Il colore resta ai segnali clinici.
+- Il fuoco non si assegna con il colore ma con la luce: luminanza, ombra e spazio. Il colore resta ai segnali clinici.
 - Il buio operativo non è nascosto: è presente e raggiungibile, ma non chiede attenzione (la lezione Linear: il chrome recede, il lavoro avanza).
 - La densità (comoda/densa) e il modello focale sono assi indipendenti: lo strumento denso ha comunque un fuoco.
 
@@ -35,14 +35,16 @@ Tre registri di luce, non tre temi (giorno/grafite seguono il chiaro/scuro di si
 | Token | Giorno | Grafite | Guardia |
 | --- | --- | --- | --- |
 | `surface.canvas` (periferia) | `#eef0f2` | `#121417` | `#0c0e12` |
-| `surface.field` (penombra) | `#f5f5f4` | `#191c21` | `#14171d` |
-| `surface.focal` (fuoco) | `#fbfaf7` | `#22252b` | `#1a1e26` |
+| `surface.field` (penombra) | `#f4f6f8` | `#191c21` | `#14171d` |
+| `surface.focal` (fuoco) | `#fbfcfe` | `#22252b` | `#1a1e26` |
 | `surface.chrome` (buio operativo) | `#e6e8eb` | `#0e1013` | `#090b0e` |
 | `ink.primary` | `#1a1c1e` | `#e9ecef` | `#e3e8ee` |
 | `ink.muted` | `#5c6772` | `#8f9aa6` | `#8792a3` |
 | `accent.minerale` (interattivo) | `#33506b` | `#8fb0cc` | `#7fa0bc` |
 
-Il gradiente di temperatura è la novità: il fuoco è appena più caldo (avorio), la periferia appena più fredda (minerale). Sotto la soglia del dichiarabile a parole, sopra la soglia del percepibile: è la lampada, non un tema.
+Le superfici restano neutrali. Il fuoco emerge per luminanza, contrasto, hairline,
+ombra corta e spazio; la metafora Carta non introduce crema, beige, avorio o
+altri toni vintage. Guardia e Strumento non implicano tinte proprie.
 
 I valori sono formalizzati nel sorgente token DTCG `tokens/lume.tokens.json` e misurati da `scripts/check-lume-tokens.mjs` (L1a). Il mirror CSS `app/lume-tokens.css`, importato dal layout insieme al marker fisso `data-lume="true"`, li porta nel runtime web con giorno su `:root` e grafite su `.dark` (L1b); il marker non governa la cascata e la guardia resta nel sorgente ma non è ancora un tema attivo. In `giorno` `ink.muted` è stato scurito da `#5f6b76` a `#5c6772`: il valore originale misurava 4,44:1 su `surface.chrome` (la superficie chiara più scura, quindi la coppia vincolante), sotto la soglia 4,5:1; ora misura 4,70:1. Le altre coppie erano già sopra soglia.
 
@@ -110,7 +112,7 @@ Il layout di Lume non presenta dati: presenta decisioni.
 
 ## 7. Motion: la luce si sposta
 
-- Quando il fuoco cambia, si muove la luce, non le superfici: cross-fade di luminanza e temperatura (150-200ms, ease-out) dal vecchio al nuovo fuoco. Il fuoco è la luce, non un filo sul bordo; i connettori (spina, provenienza) si ridisegnano come geometria SVG (vedi [07-gesto-e-movimento.md](./07-gesto-e-movimento.md)).
+- Quando il fuoco cambia, si muove la luce, non le superfici: cross-fade di luminanza e ombra (150-200ms, ease-out) dal vecchio al nuovo fuoco. Il fuoco è la luce, non un filo sul bordo; i connettori (spina, provenienza) si ridisegnano come geometria SVG (vedi [07-gesto-e-movimento.md](./07-gesto-e-movimento.md)).
 - Il filo può estendersi (una linea che si allunga, 200ms) per esprimere continuità: Quadro -> Scheda è il filo che prosegue, non una pagina che vola.
 - La manipolazione diretta (drag, riordino) mantiene le spring interrompibili di Vetro Clinico ([../vetro-clinico/04-interazione.md](../vetro-clinico/04-interazione.md)): la fisica resta dove c'è un gesto.
 - Niente parallasse, niente morphing di superfici, niente blur animato. Reduce Motion è quasi già soddisfatto per costruzione: il cross-fade è il comportamento di default, non il fallback.

--- a/docs/design/lume/02-derivazione.md
+++ b/docs/design/lume/02-derivazione.md
@@ -27,7 +27,7 @@ Pattern emergenti: progressive disclosure con home calma; baseline personale pri
 
 Temi: post-glass (le critiche di leggibilità a Liquid Glass documentate da [WIRED](https://www.wired.com/story/designers-react-to-apple-liquid-glass/) e la correzione di Apple nelle beta), la luce come sistema (la HIG spaziale Apple: [Spatial layout](https://developer.apple.com/design/human-interface-guidelines/spatial-layout/): profondità per importanza, temperatura e ombre come grammatica), texture e grana controllata ([Creative Bloq 2026](https://www.creativebloq.com/design/graphic-design/texture-warmth-and-tactile-rebellion-the-big-graphic-design-trends-for-2026)), estetica e-ink ([Mudita](https://mudita.com/community/blog/introducing-mudita-mindful-design/)), tipografia variabile e optical sizing ([Monotype](https://guillaume-rondet.com/wp-content/uploads/2025/12/Monotype_Revision_2025_Report_EN.pdf)), data-ink alla Tufte nelle interfacce dense, dark grafite (non nero puro) con contratto di contrasto ([Android AEP](https://developer.android.com/distribute/aep/aep-req-dark-theme)), interfacce che compongono viste per task con provenienza e revisione ([OpenAI Canvas](https://help.openai.com/en/articles/9930697-what-is-the-canvas-featue-in-chatgpt-and-how-do-i-use-it)). Chi definisce il gusto: Apple (materia e luce), Nothing (luce come linguaggio funzionale), BUCK, COLLINS, Pentagram (rigore editoriale-scientifico).
 
-Gli otto ingredienti ad alto potenziale indicati dalla lane: profondità semantica, superfici opache intelligenti, palette da materiale (grafite, avorio freddo, blu minerale, un accento diagnostico), grana sub-percettiva, tipografia variabile con optical sizing, mono funzionale, densità Tufte, composizione di viste verificabili.
+Gli otto ingredienti ad alto potenziale indicati dalla lane: profondità semantica, superfici opache intelligenti, scala neutra con blu minerale e un accento diagnostico, grana sub-percettiva, tipografia variabile con optical sizing, mono funzionale, densità Tufte, composizione di viste verificabili.
 
 ## 2. Le decisioni di Lume, una per una
 
@@ -35,7 +35,7 @@ Gli otto ingredienti ad alto potenziale indicati dalla lane: profondità semanti
 | --- | --- |
 | La luce come sistema di gerarchia (fuoco/penombra/buio operativo) | R3: la lezione spaziale Apple e Nothing; R1: la sidebar dimmer di Linear elevata a legge; il post-glass che chiede profondità selettiva senza blur |
 | Superfici opache, vetro solo negli overlay | R1: il soft flat è il materiale del premium; R3: le critiche di leggibilità al vetro e la ritirata di Apple; R2: il dato clinico non tollera fondi instabili |
-| Palette avorio/grafite/minerale con gradiente di temperatura | R3: palette da materiale + temperatura come grammatica di profondità; distintiva senza decorazione |
+| Scala neutra giorno/grafite con accento minerale | La profondità usa luminanza, hairline e spazio; Carta resta grammatica documentale e non una palette |
 | Il filo come firma, con tratto = stato epistemico | R2: la provenienza visibile (Abridge, Heidi) trasformata da badge a segno grafico; R1: l'identità ownable dei prodotti premium ottenuta con un solo gesto, non con effetti |
 | Due voci (Voce + Registro mono per gli atomi verificabili) | R3: mono funzionale + variable type; R2: fiducia = dato distinguibile dal discorso; R1: i numeri ben composti di Mercury/Ramp |
 | Grammatica dell'attenzione (testata, colonna, baseline, riga di laboratorio canonica) | R2, quasi integralmente: è il consenso della frontiera clinica |

--- a/docs/design/lume/03-migrazione.md
+++ b/docs/design/lume/03-migrazione.md
@@ -27,7 +27,7 @@ Principio: Lume non butta niente di ciò che vale. Il consolidamento di Vetro Cl
 | (nessuno) | `surface.chrome` | Nuovo: il buio operativo |
 | `material.vitreous` (vetro strutturale) | RITIRATO | Il telaio diventa chrome opaco |
 | `material.specular` (vetro transitorio) | `overlay` (ombra+scrim; blur opzionale di piattaforma) | Il vetro resta solo qui |
-| `material.paper` | `surface.focal`/`surface.field` | La carta si fonde nel modello focale |
+| `material.paper` | `surface.focal`/`surface.field` | Carta descrive continuità documentale; le superfici restano neutrali |
 | `--glass-*` | RITIRATI | Dopo la migrazione degli overlay |
 | `radius.panel/card/control` 30/24/16 | 20/14/10 | Curva più asciutta |
 | `--mf-font-sans` | `font.voce` (variabile impacchettata; SF su Apple) | Richiede decisione sul font e bundling locale |
@@ -56,8 +56,8 @@ Aggiornamento mirato 2026-07-16, issue #71 e #75: il layer page-owned in `app/pa
 
 ## 4. Rischi
 
-- **Il gradiente di temperatura è sottile**: su monitor scadenti può sparire. Mitigazione: la gerarchia non dipende MAI dalla sola temperatura (c'è sempre luminanza + ombra + filo); la temperatura è rifinitura.
+- **La gerarchia neutra può appiattirsi**: su monitor scadenti i gradini possono convergere. Mitigazione: luminanza, hairline, spazio e ombra corta restano sempre osservabili.
 - **Fatica da doppio sistema** durante la convivenza L1-L5: `data-lume` è un marker tecnico fisso, non un gate né un selettore utente (ADR 0047 rispettato); la condizione di uscita già formalizzata in ADR 0078 resta il criterio vincolante e ogni slice deve ridurre, non ampliare, i consumatori legacy.
 - **Il font impacchettato** aggiunge peso al bundle e una scelta di licenza: candidati open (Inter, IBM Plex) con licenza OFL; su Apple si resta su SF (zero costo).
 - **Il filo tratteggiato come stato**: convenzione nuova da insegnare; mitigazione: legenda nella vista di aiuto `?` e coerenza assoluta (mai tratteggio decorativo).
-- **Regressione di identità**: togliendo il vetro, MediFlow deve restare riconoscibile; l'identità passa al filo, alla temperatura e alle due voci. Il dimostratore serve esattamente a giudicare questo prima di scrivere codice.
+- **Regressione di identità**: togliendo il vetro, MediFlow deve restare riconoscibile; l'identità passa al filo, alla gerarchia neutra e alle due voci. Il dimostratore serve esattamente a giudicare questo prima di scrivere codice.

--- a/docs/design/lume/07-gesto-e-movimento.md
+++ b/docs/design/lume/07-gesto-e-movimento.md
@@ -18,7 +18,7 @@ Lume ha tre modi di dire le cose in movimento, e non si sovrappongono mai.
 
 | Portatore | Lavoro | Resa |
 | --- | --- | --- |
-| **La luce** | Il fuoco (cosa e in lavorazione adesso) | La superficie sale nella luce: luminanza e temperatura appena piu alte, ombra corta. Nessuna linea. |
+| **La luce** | Il fuoco (cosa e in lavorazione adesso) | La superficie sale nella luce: luminanza, spazio e ombra corta. Nessuna linea. |
 | **L'inchiostro** | Lo stato epistemico (bozza o firmato) | Il tono del testo: la bozza e a contrasto piu basso con una micro-etichetta onesta; il firmato e a contrasto pieno. La firma e il gesto che asciuga l'inchiostro. |
 | **Il filo** | La connessione, dove e reale | Una hairline continua resa come geometria SVG che si disegna: la spina della timeline, il connettore di provenienza, la storia di un valore. Mai sul lato di un riquadro. |
 
@@ -27,7 +27,7 @@ La regola che tiene tutto: **il fuoco non porta mai una linea, e la linea non ma
 ## 2. Leggi di movimento
 
 1. **La vitalita risponde al gesto, non va in loop.** Nessuna animazione ambientale, nessun respiro perenne, nessuno shimmer di attesa: sono proprio i movimenti che-vanno-avanti-da-soli a leggere come procedurali e da intelligenza artificiale. Il movimento nasce quando l'utente agisce (sposta il fuoco, firma, preme, trascina) e finisce.
-2. **La luce si sposta, non le superfici.** Quando il fuoco cambia, la luce fa un cross-fade di luminanza e temperatura (150-200ms, ease-out). La velocita e proporzionale alla scala del salto: riga vicina, breve; Quadro verso Scheda, piu lungo ma entro 250ms. Le variabili di luce si registrano via `@property` cosi da interpolare in modo pulito, oppure scattano; non si "trascinano" a caso.
+2. **La luce si sposta, non le superfici.** Quando il fuoco cambia, la luce fa un cross-fade di luminanza e ombra (150-200ms, ease-out). La velocita e proporzionale alla scala del salto: riga vicina, breve; Quadro verso Scheda, piu lungo ma entro 250ms. Le variabili di luce si registrano via `@property` cosi da interpolare in modo pulito, oppure scattano; non si "trascinano" a caso.
 3. **La conferma e transiente.** L'accento non resta come peso persistente: lampeggia brevemente per dare sicurezza e si spegne (una pulsazione di ombra e di alone minerale, ~300ms). E l'opposto della stanghetta fissa.
 4. **Il filo si disegna.** I connettori sono `stroke` SVG che entrano con `stroke-dashoffset` (draw-on), non `border-left`. "Il filo che prosegue" da Quadro a Scheda e una linea che si allunga, non una pagina che vola. Nota: draw-on non vuol dire aspetto tratteggiato; la linea a riposo e continua e piena.
 5. **I controlli sono materia reattiva.** Press `scale(0.97)` ~150ms su `:active`; l'azione emette un anello che parte dal punto del tocco e si spegne; hover = un lift sottile. La fisica (spring interrompibili) resta dove c'e un gesto diretto (riordino, drag).
@@ -64,7 +64,7 @@ L'interfaccia deve sembrare orchestrata da un modello che serve la cosa giusta a
 
 Queste primitive derivano dalla review di design del 2026-07-13, riconciliate alla direzione luce+inchiostro: quello che era pensato per far vivere la linea qui fa vivere la luce, l'inchiostro e il connettore.
 
-- **Variabili di luce registrate.** Le variabili di zona (`--surface-l` luminanza, `--surface-temp` temperatura) si dichiarano con `@property` a syntax tipata, cosi interpolano davvero durante il cross-fade; senza registrazione scattano invece di transire. Il cross-fade del fuoco anima queste, non un `translate` di superfici.
+- **Variabili di luce registrate.** Le variabili di zona (`--lume-surface-l` e `--lume-surface-depth`) si dichiarano con `@property` a syntax tipata, cosi interpolano davvero durante il cross-fade; senza registrazione scattano invece di transire. Il cross-fade del fuoco anima queste, non un `translate` di superfici.
 - **L'ombra non si anima.** Il sollevamento del fuoco (profondita 0 verso 1) anima l'`opacity` di uno strato-ombra pre-renderizzato (pseudo-elemento), non `box-shadow` diretto, che e paint-bound.
 - **Il filo e geometria vettoriale.** Un `<line>` o `<rect>` SVG (o `Path.trim` sul nativo), mai un bordo animato. Crescita lungo un asse dritto (la spina del diario che si allunga) uguale `transform: scaleY`, compositor-friendly; percorso non lineare (la provenienza) uguale `stroke-dashoffset`. Mai `opacity` da 0 a 1 su un filo: un filo che sfuma tradisce il suo significato di continuita.
 - **`--filo-fill` per il connettore che si completa.** Proprieta registrata `@property --filo-fill { syntax: '<percentage>'; inherits: false; initial-value: 0% }`, da 0 a 100% in ~200ms ease-out. In luce+inchiostro serve al FILO-CONNETTORE (la provenienza che si riempie fonte per fonte, 33/66/100, man mano che il medico conferma ciascuna; la spina che si completa), NON allo stato epistemico: lo stato resta inchiostro che asciuga (par. 1 e 3). Il riempimento e legato al gesto, mai temporizzato.

--- a/docs/design/lume/08-matrice-viste.md
+++ b/docs/design/lume/08-matrice-viste.md
@@ -100,7 +100,7 @@ parte della coppia minima di screenshot web.
 
 ### Motion, reduce motion e contrasto
 
-- Fuoco: cross-fade di luminanza e temperatura in 150-200 ms, ease-out. Filo:
+- Fuoco: cross-fade di luminanza e ombra in 150-200 ms, ease-out. Filo:
   disegno SVG o `Path`, non bordo animato. Pressione diretta: scala 0,97 circa
   100 ms. I tempi e i portatori sono definiti in
   `docs/design/lume/07-gesto-e-movimento.md`.

--- a/docs/design/lume/09-icona.md
+++ b/docs/design/lume/09-icona.md
@@ -19,8 +19,8 @@ medico. Non c'è testo. La forma resta leggibile a 16 pixel.
 
 | Variante | Sfondo | Filo | Nodo |
 | --- | --- | --- | --- |
-| Default (giorno) | gradiente carta `#fbfaf7 -> #eef0f2` | minerale profondo `#33506b` | core bianco, anello d'inchiostro |
-| Dark (grafite) | gradiente `#191c21 -> #121417` | minerale chiaro `#8fb0cc` | core `#fbfaf7`, anello minerale |
+| Default (giorno) | gradiente neutro `#fbfcfe -> #eef0f2` | minerale profondo `#33506b` | core neutro, anello d'inchiostro |
+| Dark (grafite) | gradiente `#191c21 -> #121417` | minerale chiaro `#8fb0cc` | core `#fbfcfe`, anello minerale |
 
 I valori provengono dai token Lume (`docs/design/lume/tokens/lume.tokens.json`).
 La variante tinted la deriva il sistema.

--- a/docs/design/lume/10-superficie-e-materiale.md
+++ b/docs/design/lume/10-superficie-e-materiale.md
@@ -8,7 +8,7 @@ decisione di Leonardo.
 
 Lume e' gia' condiviso piu' di quanto sembrasse. `LumePalette` nel pacchetto
 Apple contiene gli stessi esadecimali di `docs/design/lume/tokens/lume.tokens.json`,
-byte per byte: `#eef0f2`, `#f5f5f4`, `#fbfaf7`, `#e6e8eb` e i tre registri
+byte per byte: `#eef0f2`, `#f4f6f8`, `#fbfcfe`, `#e6e8eb` e i tre registri
 giorno, grafite, guardia. Web, iPhone e iPad disegnavano gia' da quella stessa
 sorgente.
 

--- a/docs/design/lume/icona/mediflow-icon-giorno.svg
+++ b/docs/design/lume/icona/mediflow-icon-giorno.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
     <defs>
       <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
-        <stop offset="0" stop-color="#fbfaf7"/>
+        <stop offset="0" stop-color="#fbfcfe"/>
         <stop offset="1" stop-color="#eef0f2"/>
       </linearGradient>
     </defs>

--- a/docs/design/lume/icona/mediflow-icon-grafite-fg.svg
+++ b/docs/design/lume/icona/mediflow-icon-grafite-fg.svg
@@ -2,5 +2,5 @@
     <line x1="512" y1="150" x2="512" y2="870" stroke="#8fb0cc" stroke-width="76" stroke-linecap="round"/>
     <circle cx="512" cy="150" r="54.72" fill="#8fb0cc"/>
     <circle cx="512" cy="870" r="54.72" fill="#8fb0cc"/>
-    <circle cx="512" cy="510" r="129.2" fill="#fbfaf7" stroke="#8fb0cc" stroke-width="28.12"/>
+    <circle cx="512" cy="510" r="129.2" fill="#fbfcfe" stroke="#8fb0cc" stroke-width="28.12"/>
   </svg>

--- a/docs/design/lume/icona/mediflow-icon-grafite.svg
+++ b/docs/design/lume/icona/mediflow-icon-grafite.svg
@@ -9,5 +9,5 @@
     <line x1="512" y1="150" x2="512" y2="870" stroke="#8fb0cc" stroke-width="76" stroke-linecap="round"/>
     <circle cx="512" cy="150" r="54.72" fill="#8fb0cc"/>
     <circle cx="512" cy="870" r="54.72" fill="#8fb0cc"/>
-    <circle cx="512" cy="510" r="129.2" fill="#fbfaf7" stroke="#8fb0cc" stroke-width="28.12"/>
+    <circle cx="512" cy="510" r="129.2" fill="#fbfcfe" stroke="#8fb0cc" stroke-width="28.12"/>
   </svg>

--- a/docs/design/lume/mockups/lume-campi.html
+++ b/docs/design/lume/mockups/lume-campi.html
@@ -22,7 +22,7 @@
    ============================================================ */
 
 :root {
-  --canvas:#eef0f2; --field:#f5f5f4; --focal:#fbfaf7; --chrome:#e6e8eb;
+  --canvas:#eef0f2; --field:#f4f6f8; --focal:#fbfcfe; --chrome:#e6e8eb;
   --ink:#1a1c1e; --ink-muted:#5c6772; --minerale:#33506b;
   --warning:#9a6a2f; --critical:#a33a2f; --success:#4b6354; --plum:#555161;
   --warning-tint:rgba(154,106,47,0.10); --critical-tint:rgba(163,58,47,0.10); --success-tint:rgba(75,99,84,0.12);

--- a/docs/design/lume/mockups/lume-cockpit-vivo.html
+++ b/docs/design/lume/mockups/lume-cockpit-vivo.html
@@ -22,7 +22,7 @@
    ============================================================ */
 
 :root {
-  --canvas:#eef0f2; --field:#f5f5f4; --focal:#fbfaf7; --chrome:#e6e8eb;
+  --canvas:#eef0f2; --field:#f4f6f8; --focal:#fbfcfe; --chrome:#e6e8eb;
   --ink:#1a1c1e; --ink-muted:#5c6772; --minerale:#33506b;
   --warning:#9a6a2f; --critical:#a33a2f; --success:#4b6354; --plum:#555161;
   --warning-tint:rgba(154,106,47,0.10); --critical-tint:rgba(163,58,47,0.10); --success-tint:rgba(75,99,84,0.12);
@@ -122,7 +122,7 @@ body {
 @media (max-width:1180px){ .attn { flex:1 1 100%; min-height:auto; } }
 @media (max-width:900px){ .worklist { flex:1 1 100%; } .rail { flex:1 1 100%; flex-direction:row; align-items:center; min-height:auto; flex-wrap:wrap; } .rail .foot { display:none; } .roomswitch { flex-direction:row; } }
 
-/* Il fuoco: solo luce (luminanza+temperatura appena piu alte, ombra breve).
+/* Il fuoco: solo luce (luminanza e ombra breve).
    Mai una linea, mai una stanghetta sul bordo. */
 .pan[data-fuoco="true"] { background:linear-gradient(var(--warm),var(--warm)),var(--focal); box-shadow:var(--shadow-focal); }
 

--- a/docs/design/lume/mockups/lume-dinamica.html
+++ b/docs/design/lume/mockups/lume-dinamica.html
@@ -17,7 +17,7 @@
    ============================================================ */
 
 :root {
-  --canvas:#eef0f2; --field:#f5f5f4; --focal:#fbfaf7; --chrome:#e6e8eb;
+  --canvas:#eef0f2; --field:#f4f6f8; --focal:#fbfcfe; --chrome:#e6e8eb;
   --ink:#1a1c1e; --ink-muted:#5c6772; --minerale:#33506b;
   --warning:#9a6a2f; --critical:#a33a2f; --success:#4b6354; --plum:#555161;
   --warning-tint:rgba(154,106,47,0.10); --critical-tint:rgba(163,58,47,0.10); --success-tint:rgba(75,99,84,0.12);
@@ -29,7 +29,7 @@
   --voce:-apple-system,BlinkMacSystemFont,"SF Pro Text","Segoe UI","Inter",sans-serif;
   --registro:ui-monospace,"SF Mono","IBM Plex Mono","Cascadia Mono",Menlo,monospace;
   --focus-ring:0 0 0 2px var(--canvas),0 0 0 4px var(--minerale);
-  /* la temperatura del fuoco: appena piu calda della penombra */
+  /* il fuoco resta neutro: emerge per luminanza e ombra */
   --warm:rgba(154,106,47,0.05);
 }
 .grafite {

--- a/docs/design/lume/mockups/lume-voce.html
+++ b/docs/design/lume/mockups/lume-voce.html
@@ -25,7 +25,7 @@
    ============================================================ */
 
 :root {
-  --canvas:#eef0f2; --field:#f5f5f4; --focal:#fbfaf7; --chrome:#e6e8eb;
+  --canvas:#eef0f2; --field:#f4f6f8; --focal:#fbfcfe; --chrome:#e6e8eb;
   --ink:#1a1c1e; --ink-muted:#5c6772; --minerale:#33506b;
   --warning:#9a6a2f; --critical:#a33a2f; --success:#4b6354; --plum:#555161;
   --warning-tint:rgba(154,106,47,0.10); --critical-tint:rgba(163,58,47,0.10); --success-tint:rgba(75,99,84,0.12);

--- a/docs/design/lume/mockups/lume.html
+++ b/docs/design/lume/mockups/lume.html
@@ -15,8 +15,8 @@
 :root {
   /* Registro Giorno */
   --canvas: #eef0f2;
-  --field: #f5f5f4;
-  --focal: #fbfaf7;
+  --field: #f4f6f8;
+  --focal: #fbfcfe;
   --chrome: #e6e8eb;
   --ink: #1a1c1e;
   --ink-muted: #5f6b76;

--- a/e2e/lume-runtime.spec.ts
+++ b/e2e/lume-runtime.spec.ts
@@ -70,7 +70,7 @@ test('lume runtime tokens are the live default across theme changes, reload and 
   expect(await resolveActiveVar(page, '--lume-surface-canvas')).toBe(GRAFITE_CANVAS_RGB);
 });
 
-test('lume registered properties drive canvas light and SVG filo fill', async ({ page }) => {
+test('lume registered properties drive neutral canvas depth and SVG filo fill', async ({ page }) => {
   await bootstrapUnlockedSession(page, process.env.E2E_PIN || '1234');
 
   const canvas = page.locator('[data-lume-context]').first();
@@ -81,6 +81,7 @@ test('lume registered properties drive canvas light and SVG filo fill', async ({
       const style = getComputedStyle(element);
       return {
         light: style.getPropertyValue('--lume-surface-l').trim(),
+        depth: style.getPropertyValue('--lume-surface-depth').trim(),
         temperature: style.getPropertyValue('--lume-surface-temp').trim(),
         background: style.backgroundColor,
       };
@@ -92,9 +93,11 @@ test('lume registered properties drive canvas light and SVG filo fill', async ({
     return { incarico, scheda };
   });
   expect(lightSamples.incarico.light).toBe('5.5%');
-  expect(lightSamples.incarico.temperature).toBe('1.8%');
+  expect(lightSamples.incarico.depth).toBe('1.8%');
+  expect(lightSamples.incarico.temperature).toBe('');
   expect(lightSamples.scheda.light).toBe('7%');
-  expect(lightSamples.scheda.temperature).toBe('2.4%');
+  expect(lightSamples.scheda.depth).toBe('2.4%');
+  expect(lightSamples.scheda.temperature).toBe('');
   expect(lightSamples.scheda.background).not.toBe(lightSamples.incarico.background);
 
   const filoSamples = await page.evaluate(() => {

--- a/scripts/check-lume-tokens.mjs
+++ b/scripts/check-lume-tokens.mjs
@@ -30,9 +30,9 @@ const FUNCTION_COLOR = /\b(?:rgba?|hsla?)\((?:[^()]*)\)/gi;
 // letterali legacy e le loro ripetizioni. La baseline deve combaciare
 // esattamente: una voce che copre meno letterali di quelli dichiarati fallisce.
 export const PALETTE_ALLOWLIST = [
-  {"path":"app/mockups/scheda/page.tsx","reason":"Debito storico su superficie non clinica: migrazione Lume da completare.","occurrences":10,"fingerprint":"0b532d8493c010f98eba790c6cca032e0c871be43eccd5bb743d13b514892219"},
-  {"path":"app/patients/[id]/edit/page.tsx","reason":"Debito storico su superficie clinica: migrazione Lume da completare.","occurrences":2,"fingerprint":"c465f2f78534069d2c5091795196bb3c49d4428b0c2aaa3a488617f7bc16d9a4"},
-  {"path":"app/patients/[id]/scales/[scaleId]/page.tsx","reason":"Debito storico su superficie clinica: migrazione Lume da completare.","occurrences":8,"fingerprint":"2aa3c828cc9648c78578de11157a552e6a94dd15d7437c7e8b86d847a1024582"},
+  {"path":"app/mockups/scheda/page.tsx","reason":"Debito storico su superficie non clinica: migrazione Lume da completare.","occurrences":7,"fingerprint":"a9261e48fe9ddbbcaa3ca087ea795d3f6cce439f8d8c67d20aa3849fce5a16c9"},
+  {"path":"app/patients/[id]/edit/page.tsx","reason":"Debito storico su superficie clinica: migrazione Lume da completare.","occurrences":1,"fingerprint":"adef65828ad647ade4a039b1e0340556537ad51ca66ceda9e9f4b49d9cc44452"},
+  {"path":"app/patients/[id]/scales/[scaleId]/page.tsx","reason":"Debito storico su superficie clinica: migrazione Lume da completare.","occurrences":4,"fingerprint":"ea7660a2d7e5f71406626810382882a731b5f5b7e69e8aa8dfe24286c211a616"},
   {"path":"app/patients/[id]/scales/page.tsx","reason":"Debito storico su superficie clinica: migrazione Lume da completare.","occurrences":3,"fingerprint":"d5ff14dc1c75592ec7919d22cb7374120b0c3834bea183ea6fffd36e2e4fa75b"},
   {"path":"app/patients/new/page.tsx","reason":"Debito storico su superficie clinica: migrazione Lume da completare.","occurrences":4,"fingerprint":"0aa269a73f2eb260a9c4dbd49759a327de47595518ab671274424fe5aeb2af8d"},
   {"path":"app/settings/ai/funzioni/page.tsx","reason":"Debito storico su superficie non clinica: migrazione Lume da completare.","occurrences":5,"fingerprint":"9f63101a17e633701731cbc5a283831e8a96df52452becbaeab278c198c93faa"},
@@ -51,13 +51,12 @@ export const PALETTE_ALLOWLIST = [
   {"path":"components/followup-suggestions.tsx","reason":"Debito storico su superficie clinica: migrazione Lume da completare.","occurrences":1,"fingerprint":"a9ea794b338ca05d36f1aeb6c13712161214b7f3a9cedf5b258350d65177799c"},
   {"path":"components/kree8/kree8-workspace-shell.module.css","reason":"Debito storico su superficie clinica: migrazione Lume da completare.","occurrences":15,"fingerprint":"fa250e7b6f53574872e76a36673a80ee388f84d80626e55d761b82975aeb5dc7"},
   {"path":"components/observation-manager.tsx","reason":"Debito storico su superficie clinica: migrazione Lume da completare.","occurrences":2,"fingerprint":"316c0591b2c775a3511f7e3dfd261710a3cfa928cfe22a488d81aba90bc9ef38"},
-  {"path":"components/patient-clinical-signals.tsx","reason":"Debito storico su superficie clinica: migrazione Lume da completare.","occurrences":7,"fingerprint":"16ced9b1b6a637581983755058a65c6dd29d74703fb442d488e1b88f01bbb2c7"},
+  {"path":"components/patient-clinical-signals.tsx","reason":"Debito storico su superficie clinica: migrazione Lume da completare.","occurrences":5,"fingerprint":"99e4ef12c1042743f5213ac45cb734990354919e80478e88a5102219e30570c5"},
   {"path":"components/patient-document-import-review.tsx","reason":"Debito storico su superficie clinica: migrazione Lume da completare.","occurrences":4,"fingerprint":"dde9d41cdd6acf1b150e71385a5734c7892bf07682c496287eb136aaf3feb179"},
   {"path":"components/patient-form.tsx","reason":"Debito storico su superficie clinica: migrazione Lume da completare.","occurrences":6,"fingerprint":"d951c75dec7e4f2efc7a68b2c81e7b9a472660d00422e24dbc9c7012f696d22e"},
-  {"path":"components/scale-engine.tsx","reason":"Debito storico su superficie clinica: migrazione Lume da completare.","occurrences":3,"fingerprint":"81a39fe2423dffcee6aef072f8ad23aa371607578aeab5d494686b8363031e1a"},
+  {"path":"components/scale-engine.tsx","reason":"Debito storico su superficie clinica: migrazione Lume da completare.","occurrences":1,"fingerprint":"70a62af7b293204bcc777fc284904b19fc006f635c5b7b713cafb2cb8d703750"},
   {"path":"components/service-architecture-panel.tsx","reason":"Debito storico su superficie non clinica: migrazione Lume da completare.","occurrences":55,"fingerprint":"8c544348e9f098417d6c6e44839928d4c6c0897c2cbcde1279e9eeca631de15f"},
   {"path":"components/settings/ai-model-parliament-panel.tsx","reason":"Debito storico su superficie non clinica: migrazione Lume da completare.","occurrences":142,"fingerprint":"418913b2d5d845cf4298742a705d626c3b756b37ad6a31fc55051abb995ba1ab"},
-  {"path":"components/settings/ai-model-selector.tsx","reason":"Debito storico su superficie non clinica: migrazione Lume da completare.","occurrences":1,"fingerprint":"df13a493dbddcbcc063e8c184254da292afd6f96485dc9ecfd49b7dd53ad05a1"},
   {"path":"components/settings/ai-rollout-guard-notice.tsx","reason":"Debito storico su superficie non clinica: migrazione Lume da completare.","occurrences":58,"fingerprint":"e6730ba7ad92f247c44235f36108c9a0253f266df5b441eeeec76eb68d0ca25d"},
   {"path":"components/settings/ai-rollout-readiness-panel.tsx","reason":"Debito storico su superficie non clinica: migrazione Lume da completare.","occurrences":164,"fingerprint":"b9e478ca6bf287186726e9eeec945f50335f9fe6e098fda65644a91340879e9b"},
   {"path":"components/settings/drug-db-manager.tsx","reason":"Debito storico su superficie non clinica: migrazione Lume da completare.","occurrences":49,"fingerprint":"bde1223c75bcc9eb4db5ceb3b284bf4a03d431c39f1ae9a8bdd0f17c923b590d"},
@@ -65,7 +64,7 @@ export const PALETTE_ALLOWLIST = [
   {"path":"components/settings/network-operating-mode-panel.tsx","reason":"Debito storico su superficie non clinica: migrazione Lume da completare.","occurrences":232,"fingerprint":"e7ad7ca7e5b04731b2e1024468b383c4d345082b21c3a8e01dc7c538e408d0d6"},
   {"path":"components/settings/settings-search.tsx","reason":"Debito storico su superficie non clinica: migrazione Lume da completare.","occurrences":1,"fingerprint":"30b66e71736711489accadafb52c1196a07501b44cbe3da7eac0cb30824ac0b6"},
   {"path":"components/settings/update-awareness-panel.tsx","reason":"Debito storico su superficie non clinica: migrazione Lume da completare.","occurrences":14,"fingerprint":"90bf901f29bf2adcbaa9e4642612d6af651bb684d5b8c0c70deee31f4f15b1fa"},
-  {"path":"components/siss-patient-context-panel.tsx","reason":"Debito storico su superficie clinica: migrazione Lume da completare.","occurrences":4,"fingerprint":"dc1abc5bf03e92d3a95f90b3d3cea35b86b946c46faa6df73b3fa8e426f5db0b"},
+  {"path":"components/siss-patient-context-panel.tsx","reason":"Debito storico su superficie clinica: migrazione Lume da completare.","occurrences":1,"fingerprint":"512c3afe21e33b4928114c0466141ada4d00aca45da3739104bfd72c47dee1e4"},
   {"path":"components/ui/button.tsx","reason":"Debito storico su superficie non clinica: migrazione Lume da completare.","occurrences":1,"fingerprint":"a9ea794b338ca05d36f1aeb6c13712161214b7f3a9cedf5b258350d65177799c"},
   {"path":"components/ui/toast-provider.tsx","reason":"Debito storico su superficie non clinica: migrazione Lume da completare.","occurrences":1,"fingerprint":"7d5a19cd0a4184d467eea48394d1bd77a823ec405266a9858031ba0dac8b3620"},
 ];


### PR DESCRIPTION
## Summary
- Rimuove valori caldi da token, mockup e asset Web toccati.
- Mantiene Carta come grammatica documentale, non palette.
- Usa superfici neutrali coerenti in giorno e grafite.

## Verification
- `npm run check:lume-tokens`: 42/42, palette OK.
- `npm run test:lume-tokens`: 30 pass.
- QA Browser light/dark sulla stack.

## Risk / Notes
- Icone binarie non rigenerate: il generatore condiviso toccherebbe sorgenti native fuori scope.
- Draft; nessun merge.

## Ticket
Refs WUL-561.