### PR TITLE
[WUL-567] macOS: inspector Carta neutrale e nativo

### DIFF
--- a/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/MacPatientContextInspector.swift
+++ b/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/MacPatientContextInspector.swift
@@ -1,0 +1,124 @@
+#if os(macOS)
+import AppKit
+import SwiftUI
+
+/* @Codex */
+enum MacInspectorPresentationMode: Equatable {
+    case nativeInspector
+    case sheetFallback
+
+    static func resolve(forMajorVersion majorVersion: Int) -> Self {
+        majorVersion == 27 ? .sheetFallback : .nativeInspector
+    }
+
+    static var current: Self {
+        resolve(forMajorVersion: ProcessInfo.processInfo.operatingSystemVersion.majorVersion)
+    }
+}
+
+/* @Codex */
+enum MacClinicalContentSurfaceStyle {
+    static var backgroundColor: NSColor { .controlBackgroundColor }
+    static var separatorColor: NSColor { .separatorColor }
+}
+
+/* @Codex */
+struct MacPatientInspectorSnapshot: Equatable {
+    let displayName: String
+    let taxCode: String
+    let birthYear: String
+    let recordState: String
+    let connectionState: String
+
+    init(patient: HomeBasePatientDetail, connectionState: PairedPatientsConnectionState) {
+        displayName = "\(patient.lastName) \(patient.firstName)"
+        taxCode = PairedPatientsWorkspaceSupport.compactTaxCode(patient.taxCode)
+        birthYear = patient.birthDate.map {
+            String(Calendar(identifier: .gregorian).component(.year, from: $0))
+        } ?? "Non disponibile"
+        recordState = patient.isArchived == true ? "Archiviata" : "Attiva"
+        self.connectionState = connectionState.title
+    }
+}
+
+/* @Codex */
+struct MacPatientInspectorContent: View {
+    let snapshot: MacPatientInspectorSnapshot
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Contesto paziente")
+                .font(.title3.weight(.semibold))
+                .accessibilityHeading(.h1)
+                .accessibilityIdentifier("clinical-workspace-patient-inspector")
+
+            Grid(alignment: .leading, horizontalSpacing: 12, verticalSpacing: 10) {
+                row("Paziente", snapshot.displayName, identifier: "clinical-workspace-inspector-patient-name")
+                row("Codice", snapshot.taxCode)
+                row("Anno", snapshot.birthYear)
+                row("Cartella", snapshot.recordState)
+                row("Origine", snapshot.connectionState)
+            }
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color(nsColor: MacClinicalContentSurfaceStyle.backgroundColor), in: surfaceShape)
+            .overlay {
+                surfaceShape.stroke(Color(nsColor: MacClinicalContentSurfaceStyle.separatorColor), lineWidth: 0.5)
+            }
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+    }
+
+    private var surfaceShape: RoundedRectangle {
+        RoundedRectangle(cornerRadius: 10, style: .continuous)
+    }
+
+    private func row(_ label: String, _ value: String, identifier: String? = nil) -> some View {
+        GridRow {
+            Text(label).foregroundStyle(.secondary)
+            Text(value).fontWeight(.medium).textSelection(.enabled)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(label): \(value)")
+        .accessibilityIdentifier(identifier ?? "")
+    }
+}
+
+/* @Codex */
+struct MacPatientInspectorPresentationModifier: ViewModifier {
+    let workspaceModel: PairedPatientsWorkspaceModel?
+    @Binding var isPresented: Bool
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if MacInspectorPresentationMode.current == .sheetFallback {
+            content.sheet(isPresented: $isPresented) {
+                inspectorContent.frame(width: 320, height: 520)
+            }
+        } else if #available(macOS 14.0, *) {
+            content.inspector(isPresented: $isPresented) {
+                inspectorContent.inspectorColumnWidth(min: 270, ideal: 320, max: 420)
+            }
+        } else {
+            content.sheet(isPresented: $isPresented) {
+                inspectorContent.frame(width: 320, height: 520)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var inspectorContent: some View {
+        if let patient = workspaceModel?.selectedPatient {
+            MacPatientInspectorContent(snapshot: MacPatientInspectorSnapshot(
+                patient: patient,
+                connectionState: workspaceModel?.connectionState ?? .notLoaded
+            ))
+        } else {
+            Text("Seleziona un paziente per mostrare il contesto.")
+                .foregroundStyle(.secondary)
+                .padding(20)
+        }
+    }
+}
+#endif

--- a/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/MacWorkspaceRootView.swift
+++ b/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/MacWorkspaceRootView.swift
@@ -170,6 +170,10 @@ public struct MediFlowMacRootView: View {
                 }
             }
         }
+        .modifier(MacPatientInspectorPresentationModifier(
+            workspaceModel: scene.workspaceModel,
+            isPresented: $isInspectorPresented
+        ))
         .focusedSceneValue(\.clinicalWorkspaceNavigationAction, navigationAction)
         .task {
             // Keeps the paired-snapshot read out of the scene initialiser, which

--- a/native/MediFlowMac/Tests/MediFlowAppleSharedTests/MacPatientContextInspectorTests.swift
+++ b/native/MediFlowMac/Tests/MediFlowAppleSharedTests/MacPatientContextInspectorTests.swift
@@ -1,0 +1,88 @@
+// @Codex
+#if os(macOS)
+import AppKit
+import SwiftUI
+import XCTest
+@testable import MediFlowAppleShared
+
+@MainActor
+final class MacPatientContextInspectorTests: XCTestCase {
+    func testSnapshotExposesOnlyBoundedContext() {
+        let snapshot = MacPatientInspectorSnapshot(
+            patient: syntheticPatient(isArchived: true),
+            connectionState: .cached
+        )
+
+        XCTAssertEqual(snapshot.displayName, "Paziente Esempio")
+        XCTAssertEqual(snapshot.taxCode, "…CF-001")
+        XCTAssertEqual(snapshot.birthYear, "1972")
+        XCTAssertEqual(snapshot.recordState, "Archiviata")
+        XCTAssertEqual(snapshot.connectionState, "Cache locale")
+    }
+
+    func testMissingBirthDateIsReportedInsteadOfInferred() {
+        let snapshot = MacPatientInspectorSnapshot(
+            patient: syntheticPatient(birthDate: nil),
+            connectionState: .pairedOfflineDegraded
+        )
+        XCTAssertEqual(snapshot.birthYear, "Non disponibile")
+        XCTAssertEqual(snapshot.connectionState, "Offline degradato")
+    }
+
+    func testSheetWorkaroundIsLimitedToOperatingSystemMajorVersion27() {
+        XCTAssertEqual(MacInspectorPresentationMode.resolve(forMajorVersion: 26), .nativeInspector)
+        XCTAssertEqual(MacInspectorPresentationMode.resolve(forMajorVersion: 27), .sheetFallback)
+        XCTAssertEqual(MacInspectorPresentationMode.resolve(forMajorVersion: 28), .nativeInspector)
+    }
+
+    func testNeutralSurfaceAndSyntheticRenderInLightAndDark() throws {
+        for (name, scheme, appearanceName) in [
+            ("light", ColorScheme.light, NSAppearance.Name.aqua),
+            ("dark", ColorScheme.dark, NSAppearance.Name.darkAqua)
+        ] {
+            let appearance = try XCTUnwrap(NSAppearance(named: appearanceName))
+            var background: NSColor?
+            appearance.performAsCurrentDrawingAppearance {
+                background = MacClinicalContentSurfaceStyle.backgroundColor.usingColorSpace(.sRGB)
+            }
+            let color = try XCTUnwrap(background)
+            XCTAssertEqual(color.redComponent, color.greenComponent, accuracy: 0.001)
+            XCTAssertEqual(color.greenComponent, color.blueComponent, accuracy: 0.001)
+
+            let content = MacPatientInspectorContent(snapshot: MacPatientInspectorSnapshot(
+                patient: syntheticPatient(), connectionState: .cached
+            ))
+            .frame(width: 320, height: 520)
+            .background(Color(nsColor: .windowBackgroundColor))
+            .environment(\.colorScheme, scheme)
+            let renderer = ImageRenderer(content: content)
+            renderer.scale = 2
+            let image = try XCTUnwrap(renderer.cgImage)
+            XCTAssertEqual(image.width, 640)
+            XCTAssertEqual(image.height, 1_040)
+            try writeEvidence(image, name: name)
+        }
+    }
+
+    private func syntheticPatient(birthDate: Date? = Calendar(identifier: .gregorian).date(
+        from: DateComponents(year: 1972, month: 4, day: 12)
+    ), isArchived: Bool = false) -> HomeBasePatientDetail {
+        HomeBasePatientDetail(
+            id: "synthetic-patient-001", firstName: "Esempio", lastName: "Paziente",
+            birthDate: birthDate, taxCode: "SYNTHETIC-CF-001",
+            address: nil, phone: nil, caregiver: nil, exemptions: nil, diagnoses: nil,
+            monitoringProfile: nil, statusReason: nil, notes: nil, aiSummary: nil,
+            documentInsights: nil, isAdi: false, isArchived: isArchived, version: 1,
+            ambulatoryId: "synthetic-ambulatory", createdAt: nil, updatedAt: nil
+        )
+    }
+
+    private func writeEvidence(_ image: CGImage, name: String) throws {
+        guard let directory = ProcessInfo.processInfo.environment["MEDIFLOW_MAC_INSPECTOR_EVIDENCE_DIR"] else { return }
+        let output = URL(fileURLWithPath: directory).appendingPathComponent("mac-patient-inspector-\(name).png")
+        try FileManager.default.createDirectory(at: output.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let png = try XCTUnwrap(NSBitmapImageRep(cgImage: image).representation(using: .png, properties: [:]))
+        try png.write(to: output, options: .atomic)
+    }
+}
+#endif


### PR DESCRIPTION
## Outcome

Aggiunge l'inspector paziente macOS come superficie clinica neutrale e adattiva. Carta resta una grammatica documentale: gerarchia, continuità, spazio e hairline. Non è una palette crema o beige.

- superficie `controlBackgroundColor` con hairline `separatorColor`;
- testo e stati bounded, con fixture solo sintetiche;
- inspector nativo per le versioni supportate;
- workaround sheet limitato alla major esatta 27;
- 28+ torna automaticamente all'inspector nativo.

## Stack e tracciabilità

- Issue: [WUL-567](https://linear.app/wulfgardr/issue/WUL-567/macos-inspector-clinico-neutrale-carta-e-test)
- Base/dependency: PR #194, WUL-566.
- Blocca WUL-568.
- PR #191 resta evidenza immutata.
- Nessun web, iOS/iPad-only, AIP, Mini o impatto API.

## Verifica

- Test inspector focalizzati: 4/4.
- `npm run test:native`: 566/566.
- Generazione progetto e guard struttura/entitlement: PASS.
- Build `MediFlowMacApp` con `CODE_SIGNING_ALLOWED=NO`: PASS.
- Test policy: major 26 → native, 27 → sheet, 28 → native.
- Test colore light/dark: canali sRGB uguali per la superficie neutrale.
- Screenshot sintetici light/dark rigenerati dopo l'ultimo diff e ispezionati.
- Ricerca negativa su nomi e valori comuni crema/beige/avorio/parchment: nessun match nella slice.
- VoiceOver/focus/resize live: PARTIAL, perché la sessione Mac è bloccata. Nessun claim di PASS.

Diff: 3 file, +216/−0. Solo fixture sintetiche. Nessun merge o force-push.