### PR TITLE
[WUL-568] macOS: contratto Carta neutrale e matrici

### DIFF
--- a/docs/NATIVE.md
+++ b/docs/NATIVE.md
@@ -193,11 +193,18 @@ Glass e un enhancement del chrome su OS compatibili, non un materiale da
 applicare alle card cliniche. macOS, iPhone e iPad condividono semantica e
 primitive, non la stessa navigazione o densita.
 
+La slice macOS WUL-566/WUL-567 conserva Carta come grammatica documentale, non
+come palette: nessuna resa crema, beige, avorio o parchment. L'inspector paziente usa
+colori neutrali nativi adattivi. Solo la major esatta macOS 27 usa lo sheet di
+compatibilita; macOS 28+ torna all'inspector di sistema.
+
 Gli audit XCTest e i test UI sono verdi su iPhone e iPad. VoiceOver è stato
 esercitato manualmente su macOS. La beta Xcode 27 non completa l'abilitazione
 VoiceOver nel simulatore mobile; il limite e la deroga della sola candidata
 sorgente 0.8 sono registrati in
 [docs/known-limitations.md](./known-limitations.md).
+La nuova slice inspector non aggiunge un PASS VoiceOver: nel run WUL-567 la
+sessione Mac era bloccata, quindi focus, resize e narrazione restano `PARTIAL`.
 
 ---
 

--- a/docs/apple-parity-matrix.json
+++ b/docs/apple-parity-matrix.json
@@ -367,11 +367,11 @@
       "area": "shell-globale",
       "feature": "Cockpit shell / rail navigazione globale + toolbar + deep-link",
       "web": "Kree8 cockpit shell con 5 aree, toolbar ricerca/filtri, deep-link query string, sub-area tabs (components/kree8/kree8-clinical-cockpit.tsx)",
-      "native": "partial: NavigationSplitView (macOS/iPad) / TabView (iPhone) con sezioni cliniche Pazienti/Agenda/Diario/Analytics/Scale e gruppo Progetto separato, piu master-detail pazienti (AppleFoundationViews.swift:210-292). Residuo ristretto: nessun deep-link/URL scheme nativo equivalente alla query string web ?area=&paziente=. Ricerca globale non conteggiata come residuo di parita: non esiste nemmeno come ricerca globale unica sulla web.",
-      "boundary": "n-a: chrome UI locale",
+      "native": "partial: NavigationSplitView (macOS/iPad) / TabView (iPhone) con sezioni cliniche Pazienti/Agenda/Diario/Analytics/Scale e gruppo Progetto separato. Su macOS WUL-566 isola stato e comandi per finestra; WUL-567 aggiunge un inspector paziente status-only su colori neutrali nativi adattivi. Carta resta grammatica documentale e non introduce crema, beige, avorio, parchment o skeuomorfismo. Solo la major esatta macOS 27 usa lo sheet compatibile; macOS 28+ torna all'inspector nativo. Residui: nessun deep-link/URL scheme equivalente alla query string web ?area=&paziente=; focus, resize e VoiceOver interattivi della nuova slice inspector restano partial.",
+      "boundary": "n-a: chrome UI locale. Il manifest Mini PR #184 a 3fd988bafe71a058fdd7d3c25ea569793dcba903 mantiene sourceRow 32 a manual_only, miniCommands [], reason NOT_IN_MINI_PILOT: nessun comando Mini o claim di parity.",
       "gap": "partial",
       "wave": "W3-macos-clinical-shell",
-      "evidence": "web-global.shell query string in components/kree8/kree8-clinical-cockpit.tsx:204-219; native-ui.navigazione; W3 S5 f01346656 AppleFoundationViews.swift"
+      "evidence": "web-global.shell query string in components/kree8/kree8-clinical-cockpit.tsx:204-219; native-ui.navigazione; W3 S5 f01346656 AppleFoundationViews.swift; WUL-566 520f8b9f15a3b7f9f198c0e096aadf9cf764a6e7; WUL-567 556f06d3fa6a950bb8a6423dcdb00ef000a4f576; manifest Mini PR #184 3fd988bafe71a058fdd7d3c25ea569793dcba903 sourceRow 32"
     },
     {
       "area": "turno",

--- a/docs/design/lume/06-macos-apple-contract.md
+++ b/docs/design/lume/06-macos-apple-contract.md
@@ -12,6 +12,28 @@ Questo documento applica [ADR 0078](../../adr/0078-lume-lingua-di-design-di-dest
 alla app reale `MediFlowMacApp`. Non governa la feature parity, che resta in un
 workstream separato, e non attiva le lane Windows/Linux.
 
+## Decisione corrente: Carta neutrale
+
+ADR 0078 registra gia il rifiuto della direzione calda/carta "Referto". Nella
+slice WUL-566/WUL-567, **Carta** indica quindi la grammatica documentale del
+contenuto clinico: gerarchia tipografica, continuita, spazio, hairline e poca
+elevazione. Non indica crema, beige, avorio, parchment, texture o ombre da
+foglio. L'inspector usa `controlBackgroundColor` e `separatorColor`, entrambi
+neutrali, nativi e adattivi a light/dark mode.
+
+La shell mantiene un modello per finestra e instrada toolbar, menu Vista e
+`⌥⌘I` tramite la scena focalizzata. L'inspector di sistema e il percorso
+predefinito; solo la major esatta macOS 27 usa uno sheet per evitare il loop di
+layout osservato nel runtime beta. macOS 28 e successive tornano
+all'inspector nativo finche una nuova prova non richiede un'altra eccezione.
+
+Il pannello e status-only. Il manifest Mini di PR #184, SHA
+`3fd988bafe71a058fdd7d3c25ea569793dcba903`, conserva la shell a
+`sourceRow: 32`, `miniDisposition: manual_only`, `miniCommands: []` e motivo
+`NOT_IN_MINI_PILOT`. Il consumo di questo contratto non abilita comandi Mini,
+azioni headless o parity macOS. Una futura azione inspector Mini o headless
+richiede una modifica esplicita del manifest e dell'autorita.
+
 ## 1. Outcome e confini
 
 L'app macOS deve diventare la superficie primaria di lavoro MediFlow senza
@@ -44,7 +66,7 @@ Matrice operativa:
 | Livello | Contratto |
 | --- | --- |
 | Package condiviso | `MediFlowMac/Package.swift` conserva macOS 13 per il codice condiviso. |
-| App prodotto | `MediFlowMacApp` ha deployment target macOS 14. `.inspector()` e quindi ammesso senza fallback nel target app. |
+| App prodotto | `MediFlowMacApp` ha deployment target macOS 14. Usa `.inspector()` per default; soltanto la major esatta macOS 27 usa lo sheet compatibile. macOS 28+ torna al percorso nativo. |
 | Enhancement recente | Liquid Glass e le API geometriche/toolbar 26+ stanno dietro `#available(macOS 26, *)`; la struttura e la gerarchia non dipendono da esse. |
 | Evidenza del ramo card opaca | La correzione delle card cliniche opache e il suo test sono poi atterrati su `main` (PR #46). Un run storico WUL-55 del 2026-07-12 sul vecchio head PR #40 (`DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer xcodebuild -project native/MediFlowAppleApp/MediFlowAppleApp.xcodeproj -scheme MediFlowMacApp -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build`) aveva dato `BUILD SUCCEEDED` con SDK macOS 27 e target macOS 14; questo packet docs-only non riesegue la build. |
 
@@ -108,7 +130,7 @@ Confermato localmente e contro-rivisto da Opus 4.8 max:
 | --- | --- | --- |
 | Le card cliniche usano `glassEffect` su OS 26+ | Risolto (PR #46): `clinicalCardStyle()` rende opaca la card clinica su ogni OS, `cardStyle()` è alias di compatibilità e `GlassCard` è deprecata e resa opaca | Consolidare le primitive Lume (`LumeSurface`/`LumeCard`) resta lavoro separato. |
 | Il workspace pazienti interno è un `HStack` con colonna fissa 360pt | Risolto nella slice M2a (#74) | `NavigationSplitView` + `List(selection:)` usano l'ID paziente stabile; la visibilità `.all` ripristina la worklist quando si rientra dalla sidebar clinica e il dettaglio resta opaco. |
-| Non esiste `.inspector()` nel workspace | Confermato | Introdurlo dopo lo split, per contesto e drill-down. |
+| Non esiste `.inspector()` nel workspace | Risolto nella slice WUL-566/WUL-567 con inspector status-only neutrale e stato per finestra | Test focalizzati, suite nativa, build Xcode e screenshot sintetici light/dark passano. Focus, resize e VoiceOver interattivi della slice restano `PARTIAL` perche la sessione del run era bloccata. |
 | Identità paziente scorre via e non esiste `safeAreaInset` | Implementato nella slice M2b (#106): testata `focal` persistente con nome, codice abbreviato, età se nota e aggiornamento; heading AX autonomo. Il probe interattivo finale resta un gate separato | Le allergie restano escluse finché il contratto dati non espone un valore strutturato affidabile. |
 | Il Registro non e applicato a dose/valore/codice/data | Confermato | Modifier `.registro()` e audit dei call-site. |
 | La storia osservazioni e una sparkline senza assi o banda | Confermato | Non promuoverla come `RigaLaboratorio`; sostituirla solo con dati e fonti disponibili. |
@@ -132,7 +154,9 @@ simulate con dati inventati.
    Spostare il pairing fuori dalla worklist resta una slice distinta.
 4. **M3, sicurezza di contesto avanzata**: allergie e altri segnali invariabili
    entrano solo dopo un contratto dati strutturato; nessuna inferenza dalla prosa.
-5. **M4, densita a strati**: inspector e provenienza senza perdere la selezione.
+5. **M4, densita a strati**: WUL-566/WUL-567 consegnano la prima slice
+   status-only di inspector e provenienza senza perdere la selezione. M4 non e
+   chiusa: focus, resize e VoiceOver interattivi restano da esercitare.
 6. **M5, firma Lume**: filo, fuoco e motion sobri, dopo la prova della struttura.
 
 La prima slice, atterrata con PR #46, e la correzione delle card cliniche opache
@@ -142,9 +166,9 @@ sintetico light/dark (`ClinicalCardStyleTests`) e build del bundle macOS
 non una QA manuale completa dei gate qui sotto.
 
 Le slice M2a e M2b restano separate: #74/#94 possiedono lo split desktop, #106
-possiede la testata persistente. Inspector, spostamento del pairing e segnali
-clinici senza contratto dati restano esplicitamente aperti; il debito documentale
-sulle primitive M1 viene riconciliato nel follow-up docs finale di #68.
+possiede la testata persistente; WUL-566/WUL-567 possiedono la prima slice
+inspector status-only. Spostamento del pairing, azioni inspector e segnali
+clinici senza contratto dati restano esplicitamente aperti.
 
 ## 8. Gate di verifica
 

--- a/docs/parity-matrix.md
+++ b/docs/parity-matrix.md
@@ -196,6 +196,7 @@ La mappa registra i controlli esercitati nel closeout.
 | macOS | Agenda sidebar | `clinical-workspace-section-agenda-button` | Seleziona riga `List` | Click-map e probe AX PASS |
 | macOS | Riga paziente | `patient-cell-*` | Seleziona e carica dettaglio | Click-map e probe AX PASS |
 | macOS | Focus | focus system | Avanza con `Tab` e freccia | Interazione reale PASS |
+| macOS | Inspector paziente | `clinical-workspace-inspector-toggle` | Toolbar o `⌥⌘I` mostra/nasconde il contesto della finestra focalizzata | WUL-566/WUL-567: test focalizzati, 2 finestre simultanee osservate nello stesso PID, suite nativa, build Xcode e screenshot light/dark PASS; focus, resize e VoiceOver interattivi della slice `PARTIAL` per sessione bloccata. Il manifest Mini PR #184 mantiene `sourceRow: 32` a `manual_only`, senza comandi Mini. |
 
 ### AXPress
 


### PR DESCRIPTION
## Outcome

Definisce il contratto documentale macOS per Carta neutrale e riconcilia le matrici dopo WUL-566/WUL-567.

- Carta resta grammatica clinica: gerarchia, continuita, spazio, hairline e poca elevazione.
- Nessuna resa crema, beige, avorio/parchment o skeuomorfica.
- Inspector nativo per default; fallback sheet limitato alla sola major macOS 27; macOS 28+ torna nativo.
- Stato/comandi per finestra e shortcut `Option-Command-I` documentati senza ampliare autorita.

## Mini boundary

Consuma come vincolo il manifest di #184 a `3fd988bafe71a058fdd7d3c25ea569793dcba903`:

- `sourceRow: 32`
- `miniDisposition: manual_only`
- `miniCommands: []`
- `reason: NOT_IN_MINI_PILOT`

Nessun comando Mini e nessun claim di parity Mini.

## Stack ed evidenze

- Linear: WUL-568
- Base funzionale: #205 / WUL-567
- Dipendenza: #194 / WUL-566
- Evidenza storica immutata: #191 / WUL-565
- Manifest vincolante: #184

## Verifica

- `npm run check:apple-wide-qa` - PASS, 24 capability
- `npm run check:claims` - PASS, 496 file, 0 claim high-risk
- `jq empty docs/apple-parity-matrix.json` - PASS
- `git diff --check` - PASS
- manifest row 32 verificato direttamente allo SHA vincolante - PASS
- scope: 4 file sotto `docs/`, +41/-9

## Gap residui

La matrice resta `partial`: focus, resize e VoiceOver interattivi della nuova slice inspector non sono promossi a PASS perche la sessione runtime era bloccata. Nessun merge o promotion in questa PR.

Closes WUL-568
