### PR TITLE
feat(ai): define Smart Import Fabric admission

### DIFF
--- a/lib/domain/documents/patient-smart-import-fabric.test.ts
+++ b/lib/domain/documents/patient-smart-import-fabric.test.ts
@@ -1,0 +1,108 @@
+/* @Codex */
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { advanceOnboarding, startOnboarding } from '../../ai-providers/fabric/onboarding.ts';
+import { admitProvider, transitionProviderLifecycle } from '../../ai-providers/fabric/provider-lifecycle.ts';
+import {
+    executePatientSmartImportFabricPreview,
+    PatientSmartImportFabricDeniedError,
+    type PatientSmartImportFabricHostSnapshot,
+} from './patient-smart-import-fabric.ts';
+
+function enabledLocal() {
+    return ['configure', 'credential_declared', 'attest_local', 'enable'].reduce(
+        (state, type) => advanceOnboarding(state, { type } as Parameters<typeof advanceOnboarding>[1]),
+        startOnboarding('ollama', 'local_model'),
+    );
+}
+
+function hostSnapshot(): PatientSmartImportFabricHostSnapshot {
+    const onboarding = enabledLocal();
+    return {
+        capabilityAvailable: true,
+        onboarding,
+        lifecycle: admitProvider(onboarding),
+    };
+}
+
+const modelInfo = Object.freeze({
+    provider: 'ollama' as const,
+    model: 'synthetic-model',
+    baseUrl: 'http://127.0.0.1:11434',
+    receipt: Object.freeze({
+        schemaVersion: 'mediflow.ai.provider-selection.v1' as const,
+        authorityPlane: 'clinical_application' as const,
+        task: 'clinical' as const,
+        provider: 'ollama' as const,
+        model: 'synthetic-model',
+        execution: 'local' as const,
+        endpointClass: 'loopback' as const,
+        egress: 'none' as const,
+        runtimeReadiness: 'required' as const,
+        fallbackCount: 0 as const,
+    }),
+});
+const health = Object.freeze({ status: 'ok', models: Object.freeze(['synthetic-model']) });
+
+test('Smart Import resolves its named Fabric capability before one provider preview', async () => {
+    let invocations = 0;
+    const result = await executePatientSmartImportFabricPreview(
+        { modelInfo, health, host: hostSnapshot() },
+        async () => {
+            invocations += 1;
+            return 'synthetic-provider-output';
+        },
+    );
+
+    assert.equal(invocations, 1);
+    assert.equal(result.output, 'synthetic-provider-output');
+    assert.equal(result.metadata.routing.capability, 'smart_import');
+    assert.equal(result.metadata.provenance.receipt.capability, 'smart_import');
+    assert.equal(result.metadata.writesPerformed, 0);
+    assert.equal(JSON.stringify(result.metadata).includes('synthetic-provider-output'), false);
+});
+
+test('Smart Import denials never invoke the provider or return a reusable receipt', async () => {
+    const available = hostSnapshot();
+    const cases = [
+        { host: { ...available, capabilityAvailable: false }, health },
+        { host: available, health: { status: 'error', models: [] } },
+        { host: { ...available, lifecycle: transitionProviderLifecycle(available.lifecycle, 'degrade') }, health },
+        { host: { ...available, lifecycle: transitionProviderLifecycle(available.lifecycle, 'revoke') }, health },
+    ];
+
+    for (const candidate of cases) {
+        let invocations = 0;
+        await assert.rejects(
+            executePatientSmartImportFabricPreview({ modelInfo, ...candidate }, async () => {
+                invocations += 1;
+                return 'must-not-run';
+            }),
+            (error) => error instanceof PatientSmartImportFabricDeniedError
+                && error.denial.receipt === null,
+        );
+        assert.equal(invocations, 0);
+    }
+
+    let mismatchInvocations = 0;
+    await assert.rejects(
+        executePatientSmartImportFabricPreview(
+            { modelInfo: { ...modelInfo, model: 'mismatched-model' }, health, host: available },
+            async () => { mismatchInvocations += 1; return 'must-not-run'; },
+        ),
+        (error) => error instanceof PatientSmartImportFabricDeniedError
+            && error.denial.denialCode === 'provider_receipt_mismatch',
+    );
+    assert.equal(mismatchInvocations, 0);
+});
+
+test('Smart Import denies when health omits the selected receipt model', async () => {
+    let invocations = 0;
+    await assert.rejects(executePatientSmartImportFabricPreview({
+        modelInfo,
+        health: { status: 'ok', models: ['different-model'] },
+        host: hostSnapshot(),
+    }, async () => { invocations += 1; return 'must-not-run'; }),
+    (error) => error instanceof PatientSmartImportFabricDeniedError && error.denial.receipt === null);
+    assert.equal(invocations, 0);
+});

--- a/lib/domain/documents/patient-smart-import-fabric.ts
+++ b/lib/domain/documents/patient-smart-import-fabric.ts
@@ -1,0 +1,177 @@
+/* @Codex */
+import { getFabricCapabilityDescriptor } from '../../ai-providers/fabric/catalog';
+import {
+    routeCandidateCapability,
+    type CandidateRoutingDecision,
+} from '../../ai-providers/fabric/candidate-router';
+import type { FabricProvenanceRecord } from '../../ai-providers/fabric/contract';
+import { advanceOnboarding, startOnboarding, type ProviderOnboardingState } from '../../ai-providers/fabric/onboarding';
+import { admitProvider, type ProviderLifecycleState } from '../../ai-providers/fabric/provider-lifecycle';
+import type { ProviderSelectionReceipt } from '../../ai-providers/registry';
+import { observeVenue } from '../../ai-providers/fabric/routing-observability';
+import { buildProvenanceRecord } from '../../ai-providers/fabric/resolver';
+
+export const PATIENT_SMART_IMPORT_FABRIC_METADATA = Symbol('patient-smart-import-fabric-metadata');
+
+export type PatientSmartImportFabricHostSnapshot = Readonly<{
+    capabilityAvailable: boolean;
+    onboarding: ProviderOnboardingState;
+    lifecycle: ProviderLifecycleState;
+}>;
+
+export type PatientSmartImportFabricMetadata = Readonly<{
+    routing: CandidateRoutingDecision; provenance: FabricProvenanceRecord; reviewRef: string; writesPerformed: 0;
+}>;
+
+export class PatientSmartImportFabricDeniedError extends Error {
+    constructor(public readonly denial: CandidateRoutingDecision) {
+        super(`Smart Import denied by Fabric: ${denial.denialCode ?? 'unknown'}`);
+        this.name = 'PatientSmartImportFabricDeniedError';
+    }
+}
+
+export function createPatientSmartImportCandidateHostSnapshot(): PatientSmartImportFabricHostSnapshot {
+    const onboarding = ['configure', 'credential_declared', 'attest_local', 'enable'].reduce(
+        (state, type) => advanceOnboarding(state, { type } as Parameters<typeof advanceOnboarding>[1]),
+        startOnboarding('ollama', 'local_model'),
+    );
+    return Object.freeze({
+        capabilityAvailable: true,
+        onboarding,
+        lifecycle: admitProvider(onboarding),
+    });
+}
+
+type SmartImportModelInfo = Readonly<{
+    provider: 'ollama'; model: string; baseUrl: string; receipt: ProviderSelectionReceipt;
+}>;
+
+function snapshotModelInfo(value: unknown): SmartImportModelInfo | null {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+    const { provider, model, baseUrl, receipt } = value as Record<string, unknown>;
+    if (!receipt || typeof receipt !== 'object' || Array.isArray(receipt)) return null;
+    const snapshot = { ...receipt } as ProviderSelectionReceipt;
+    if (
+        provider !== 'ollama'
+        || typeof model !== 'string'
+        || typeof baseUrl !== 'string'
+        || snapshot.schemaVersion !== 'mediflow.ai.provider-selection.v1'
+        || snapshot.authorityPlane !== 'clinical_application'
+        || snapshot.task !== 'clinical'
+        || snapshot.provider !== provider
+        || snapshot.model !== model
+        || snapshot.execution !== 'local'
+        || snapshot.endpointClass !== 'loopback'
+        || snapshot.egress !== 'none'
+        || snapshot.runtimeReadiness !== 'required'
+        || snapshot.fallbackCount !== 0
+    ) return null;
+    return Object.freeze({ provider, model, baseUrl, receipt: Object.freeze(snapshot) });
+}
+
+function denied(
+    requestId: string,
+    code: NonNullable<CandidateRoutingDecision['denialCode']>,
+): CandidateRoutingDecision {
+    return Object.freeze({
+        schemaVersion: 'mediflow.ai.candidate-routing.v1',
+        requestId,
+        capability: 'smart_import',
+        requestedVenue: 'local_process',
+        outcome: 'denied',
+        denialCode: code,
+        fallback: 'denied_by_contract',
+        observations: Object.freeze([]),
+        receipt: null,
+    });
+}
+
+function receiptMatchesModel(
+    receipt: NonNullable<CandidateRoutingDecision['receipt']>,
+    modelInfo: SmartImportModelInfo,
+): boolean {
+    const providerReceipt = receipt.providerReceipt;
+    return receipt.capability === 'smart_import'
+        && receipt.class === 'generative'
+        && receipt.venue === 'local_process'
+        && receipt.egressProfile.id === 'local_only'
+        && receipt.egressProfile.egress === 'none'
+        && receipt.provider === modelInfo.provider
+        && receipt.model === modelInfo.model
+        && providerReceipt !== null
+        && providerReceipt.schemaVersion === modelInfo.receipt.schemaVersion
+        && providerReceipt.task === modelInfo.receipt.task
+        && providerReceipt.provider === modelInfo.receipt.provider
+        && providerReceipt.model === modelInfo.receipt.model
+        && providerReceipt.egress === modelInfo.receipt.egress
+        && providerReceipt.fallbackCount === 0
+        && receipt.fallbackCount === 0;
+}
+
+function observeSelectedModel(health: unknown, selectedModel: string) {
+    if (!health || typeof health !== 'object' || Array.isArray(health)) {
+        return observeVenue('local_process', 'offline', 'daemon_unreachable');
+    }
+    const { status, models: rawModels } = health as Record<string, unknown>;
+    const models = Array.isArray(rawModels) ? Array.from(rawModels) : null;
+    if (status !== 'ok') return observeVenue('local_process', 'offline', 'daemon_unreachable');
+    if (!models || !models.every((model) => typeof model === 'string') || !models.includes(selectedModel)) {
+        return observeVenue('local_process', 'degraded', 'not_probed');
+    }
+    return observeVenue('local_process', 'available', null);
+}
+
+export async function executePatientSmartImportFabricPreview<T>(
+    input: Readonly<{ modelInfo: unknown; health: unknown; host: PatientSmartImportFabricHostSnapshot }>,
+    invokeProvider: () => Promise<T>,
+): Promise<Readonly<{ output: T; metadata: PatientSmartImportFabricMetadata }>> {
+    const requestId = globalThis.crypto.randomUUID();
+    const modelInfo = snapshotModelInfo(input.modelInfo);
+    const host = input.host;
+    if (!modelInfo) throw new PatientSmartImportFabricDeniedError(denied(requestId, 'provider_receipt_mismatch'));
+    if (host.capabilityAvailable !== true) {
+        throw new PatientSmartImportFabricDeniedError(denied(requestId, 'fabric_resolution_denied'));
+    }
+
+    const descriptor = getFabricCapabilityDescriptor('smart_import');
+    const routed = routeCandidateCapability({
+        policy: Object.freeze({
+            schemaVersion: 'mediflow.ai.execution-policy.v1', requestId, capability: descriptor.id,
+            authorityPlane: 'clinical_application', operation: descriptor.operation, dataClass: descriptor.dataClass,
+            allowedVenues: Object.freeze(['local_process'] as const), egressProfileId: descriptor.egressProfileId,
+            consentRef: null, retention: 'not_persisted', review: descriptor.review,
+            provenanceRequired: true, fallback: 'none',
+        }),
+        request: { descriptor, venue: 'local_process', generative: {
+            task: 'clinical', provider: modelInfo.provider, models: { clinical: modelInfo.model },
+            endpoint: modelInfo.baseUrl, chatTimeoutMs: 1_000,
+        } },
+        observations: [observeSelectedModel(input.health, modelInfo.model)],
+        onboarding: host.onboarding,
+        lifecycle: host.lifecycle,
+    });
+    const receipt = routed.decision.receipt;
+    if (!routed.resolution || !receipt) {
+        throw new PatientSmartImportFabricDeniedError(routed.decision);
+    }
+    if (receipt !== routed.resolution.receipt || !receiptMatchesModel(receipt, modelInfo)) {
+        throw new PatientSmartImportFabricDeniedError(denied(requestId, 'provider_receipt_mismatch'));
+    }
+
+    const metadata = Object.freeze({
+        routing: routed.decision,
+        provenance: buildProvenanceRecord(routed.resolution, ['context_minimization', 'envelope_validation']),
+        reviewRef: `mediflow.smart-import.review.v1:${requestId}`,
+        writesPerformed: 0 as const,
+    });
+    const output = await invokeProvider();
+    return Object.freeze({ output, metadata });
+}
+
+export function getPatientSmartImportFabricMetadata(
+    result: object,
+): PatientSmartImportFabricMetadata | undefined {
+    return (result as { [PATIENT_SMART_IMPORT_FABRIC_METADATA]?: PatientSmartImportFabricMetadata })[
+        PATIENT_SMART_IMPORT_FABRIC_METADATA
+    ];
+}

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "test:pdf-service": "node scripts/run-strip-types.mjs --test lib/pdf-service.test.ts",
     "test:patient-document-import": "node scripts/run-strip-types.mjs --test lib/domain/documents/patient-import-decision.test.ts lib/domain/documents/patient-document-import-service.test.ts lib/domain/documents/patient-document-review.test.ts",
     "test:patient-document-decision": "node scripts/run-strip-types.mjs --test lib/domain/documents/patient-document-decision.test.ts",
-    "test:patient-smart-import": "node scripts/run-strip-types.mjs --test lib/domain/documents/patient-smart-import-service.test.ts",
+    "test:patient-smart-import": "node scripts/run-strip-types.mjs --test lib/domain/documents/patient-smart-import-fabric.test.ts lib/domain/documents/patient-smart-import-service.test.ts",
     "test:patient-structured-fields": "node scripts/run-strip-types.mjs --test lib/patient-structured-fields.test.ts",
     "test:locked-field-guard": "node scripts/run-strip-types.mjs --test lib/locked-field-guard.test.ts",
     "test:attachment-payload": "node scripts/run-strip-types.mjs --test lib/attachment-payload.test.ts",


### PR DESCRIPTION
## Summary
- Add the named `smart_import` Fabric admission helper on the accepted ADR 0094 base.
- Bind one validated provider receipt to one health/model snapshot before generation.
- Return PHI-safe routing/provenance metadata and deny unavailable, offline, degraded, revoked, or mismatched candidates before provider invocation.
- Add focused positive and negative helper tests plus the Smart Import test script binding.

## Verification
- `npm run test:patient-smart-import` — 24/24 pass
- `node scripts/run-strip-types.mjs --test lib/ai-providers/fabric/*.test.ts` — 64/64 pass
- `npm run typecheck`
- `npm run lint`
- `git diff --check`

## Risk / Notes
- 286 additions, 1 deletion; one Fabric admission boundary.
- Synthetic fixtures only; no real clinical database, migration, new persistence, real provider, credential, network, or egress.
- Production provider lifecycle/revocation enforcement is **NOT_VERIFIED**: no canonical durable host-owned lifecycle source exists in the accepted base, and this packet does not invent one. Injected lifecycle tests are candidate-level evidence only.
- PR #210 is preserved as superseded review evidence; this replacement tranche contains only its contract/helper boundary.
- Draft only: not merged, promoted, or security-reviewed.

## Ticket
Refs WUL-522