### PR TITLE
feat(ai): route Smart Import through Fabric

### DIFF
--- a/e2e/smart-import.spec.ts
+++ b/e2e/smart-import.spec.ts
@@ -1,6 +1,18 @@
 /* @Codex */
 import { expect, test, type Locator, type Page } from '@playwright/test';
-import { bootstrapUnlockedSession } from './utils';
+import { bootstrapUnlockedSession, setAiLaneKillSwitch } from './utils';
+
+async function bootstrapSmartImportSession(page: Page, pin: string) {
+  await page.route('**/api/ai/models', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ models: [{ name: 'qwen3.5:35b-a3b' }] }),
+    });
+  });
+  await bootstrapUnlockedSession(page, pin);
+  await setAiLaneKillSwitch(page, 'aiSmartImportKillSwitch', 'enabled');
+}
 
 // WUL-274/Kree8: the cockpit patient search no longer exposes a patients-search-input
 // testid, and clicking a search result opens the Scheda (/modules) route. Tests create
@@ -43,6 +55,13 @@ async function createTherapyViaApi(page: Page, payload: Record<string, unknown>)
 async function openPatientScheda(page: Page, patientId: string) {
   await page.goto(`/patients/${patientId}/modules`);
   await expect(page).toHaveURL(new RegExp(`/patients/${patientId}/modules$`));
+}
+
+async function openDocumentiSection(page: Page) {
+  const trigger = page.locator('section#documenti > button').first();
+  await expect(trigger).toBeVisible();
+  if (await trigger.getAttribute('aria-expanded') === 'false') await trigger.click();
+  await expect(trigger).toHaveAttribute('aria-expanded', 'true');
 }
 
 function smartImportDiagnosisInputId(label: string, icdQuery: string) {
@@ -388,7 +407,7 @@ test('smart import adds ICD diagnosis chips and therapy from patient notes after
     });
   });
 
-  await bootstrapUnlockedSession(page, pin);
+  await bootstrapSmartImportSession(page, pin);
   const patientId = await createPatientViaApi(page, {
     firstName,
     lastName,
@@ -397,6 +416,7 @@ test('smart import adds ICD diagnosis chips and therapy from patient notes after
   });
 
   await openPatientScheda(page, patientId);
+  await openDocumentiSection(page);
 
   await expect(page.getByRole('button', { name: 'Analizza fonti' })).toBeVisible({ timeout: 20_000 });
   await page.getByRole('button', { name: 'Analizza fonti' }).click();
@@ -515,7 +535,7 @@ test('smart import keeps transition and uncertain therapies visible without trun
     });
   });
 
-  await bootstrapUnlockedSession(page, pin);
+  await bootstrapSmartImportSession(page, pin);
   const patientId = await createPatientViaApi(page, {
     firstName,
     lastName,
@@ -524,6 +544,7 @@ test('smart import keeps transition and uncertain therapies visible without trun
   });
 
   await openPatientScheda(page, patientId);
+  await openDocumentiSection(page);
 
   await expect(page.getByRole('button', { name: 'Analizza fonti' })).toBeVisible({ timeout: 20_000 });
   await page.getByRole('button', { name: 'Analizza fonti' }).click();
@@ -614,7 +635,7 @@ test('smart import marks therapy dosage changes as update and keeps them editabl
     });
   });
 
-  await bootstrapUnlockedSession(page, pin);
+  await bootstrapSmartImportSession(page, pin);
   const patientId = await createPatientViaApi(page, {
     firstName,
     lastName,
@@ -623,6 +644,7 @@ test('smart import marks therapy dosage changes as update and keeps them editabl
   });
 
   await openPatientScheda(page, patientId);
+  await openDocumentiSection(page);
 
   await page.evaluate(async ({ id }) => {
     const response = await fetch('/api/therapies', {
@@ -644,6 +666,7 @@ test('smart import marks therapy dosage changes as update and keeps them editabl
   }, { id: patientId });
 
   await page.reload();
+  await openDocumentiSection(page);
   await expect(page.getByRole('button', { name: 'Analizza fonti' })).toBeVisible({ timeout: 20_000 });
   await page.getByRole('button', { name: 'Analizza fonti' }).click();
 
@@ -699,7 +722,7 @@ test('smart import keeps manual-only therapy consultive and disables direct appl
     });
   });
 
-  await bootstrapUnlockedSession(page, pin);
+  await bootstrapSmartImportSession(page, pin);
   const patientId = await createPatientViaApi(page, {
     firstName,
     lastName,
@@ -708,6 +731,7 @@ test('smart import keeps manual-only therapy consultive and disables direct appl
   });
 
   await openPatientScheda(page, patientId);
+  await openDocumentiSection(page);
   await expect(page.getByRole('button', { name: 'Analizza fonti' })).toBeVisible({ timeout: 20_000 });
   await page.getByRole('button', { name: 'Analizza fonti' }).click();
 
@@ -769,7 +793,7 @@ test('smart import keeps catalog therapy without useful dosage consultive and di
     });
   });
 
-  await bootstrapUnlockedSession(page, pin);
+  await bootstrapSmartImportSession(page, pin);
   const patientId = await createPatientViaApi(page, {
     firstName,
     lastName,
@@ -778,6 +802,7 @@ test('smart import keeps catalog therapy without useful dosage consultive and di
   });
 
   await openPatientScheda(page, patientId);
+  await openDocumentiSection(page);
   await expect(page.getByRole('button', { name: 'Analizza fonti' })).toBeVisible({ timeout: 20_000 });
   await page.getByRole('button', { name: 'Analizza fonti' }).click();
 
@@ -857,7 +882,7 @@ test('smart import normalizes outgoing switch therapy to transition even when mo
     });
   });
 
-  await bootstrapUnlockedSession(page, pin);
+  await bootstrapSmartImportSession(page, pin);
   const patientId = await createPatientViaApi(page, {
     firstName,
     lastName,
@@ -866,6 +891,7 @@ test('smart import normalizes outgoing switch therapy to transition even when mo
   });
 
   await openPatientScheda(page, patientId);
+  await openDocumentiSection(page);
   await expect(page.getByRole('button', { name: 'Analizza fonti' })).toBeVisible({ timeout: 20_000 });
   await page.getByRole('button', { name: 'Analizza fonti' }).click();
 
@@ -937,7 +963,7 @@ test('smart import hides already-present referral duplicates when the source has
     });
   });
 
-  await bootstrapUnlockedSession(page, pin);
+  await bootstrapSmartImportSession(page, pin);
 
   const patientId = await createPatientViaApi(page, {
     firstName: `Referral${suffix}`,
@@ -966,8 +992,8 @@ test('smart import hides already-present referral duplicates when the source has
     startDate: new Date('2026-04-01T08:00:00Z').toISOString(),
   });
 
-  // WUL-274/Kree8: the smart-import panel mounts on the primary Scheda route (/modules).
-  await page.goto(`/patients/${patientId}/modules`);
+  await openPatientScheda(page, patientId);
+  await openDocumentiSection(page);
   await expect(page.getByRole('button', { name: 'Analizza fonti' })).toBeVisible({ timeout: 20_000 });
   await page.getByRole('button', { name: 'Analizza fonti' }).click();
 

--- a/e2e/smart-import.spec.ts
+++ b/e2e/smart-import.spec.ts
@@ -60,8 +60,10 @@ async function openPatientScheda(page: Page, patientId: string) {
 async function openDocumentiSection(page: Page) {
   const trigger = page.locator('section#documenti > button').first();
   await expect(trigger).toBeVisible();
-  if (await trigger.getAttribute('aria-expanded') === 'false') await trigger.click();
-  await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  await expect.poll(async () => {
+    if (await trigger.getAttribute('aria-expanded') !== 'true') await trigger.click();
+    return await trigger.getAttribute('aria-expanded');
+  }).toBe('true');
 }
 
 function smartImportDiagnosisInputId(label: string, icdQuery: string) {

--- a/lib/ai-context.test.ts
+++ b/lib/ai-context.test.ts
@@ -2105,7 +2105,15 @@ test('smart import generation rejects an envelope with a mismatched task', async
     db.attachments.filter = (() => ({ toArray: async () => [] })) as unknown as typeof db.attachments.filter;
     db.therapies.filter = (() => ({ toArray: async () => [] })) as unknown as typeof db.therapies.filter;
     AIService.create = (async () => ({
-        getModelInfo: () => ({ provider: 'local', model: 'synthetic', baseUrl: 'http://127.0.0.1' }),
+        getModelInfo: () => ({
+            provider: 'ollama', model: 'synthetic', baseUrl: 'http://127.0.0.1:11434',
+            receipt: {
+                schemaVersion: 'mediflow.ai.provider-selection.v1', authorityPlane: 'clinical_application',
+                task: 'clinical', provider: 'ollama', model: 'synthetic', execution: 'local',
+                endpointClass: 'loopback', egress: 'none', runtimeReadiness: 'required', fallbackCount: 0,
+            },
+        }),
+        getHealth: async () => ({ status: 'ok', message: 'synthetic', models: ['synthetic'] }),
         generate: async () => JSON.stringify({
             schemaVersion: 'mediflow.ai.extract.v1',
             task: 'patient_insight',

--- a/lib/domain/documents/patient-smart-import-service.ts
+++ b/lib/domain/documents/patient-smart-import-service.ts
@@ -38,6 +38,12 @@ import {
     AI_SMART_IMPORT_KILL_SWITCH_KEY,
     assertAiSmartImportEnabledValue,
 } from '../../ai-smart-import-kill-switch';
+/* @Codex */
+import {
+    createPatientSmartImportCandidateHostSnapshot,
+    executePatientSmartImportFabricPreview,
+    PATIENT_SMART_IMPORT_FABRIC_METADATA,
+} from './patient-smart-import-fabric';
 
 export type { SmartImportConfidence, TherapySuggestionState, SmartImportReview, SmartImportReviewState };
 
@@ -841,7 +847,14 @@ export async function generatePatientSmartImportAnalysis(patientId: string): Pro
     const currentDiagnoses = parseDiagnoses(patient.diagnoses);
     const ai = await AIService.create('clinical');
     const prompt = buildStructuredPrompt(patient, currentDiagnoses, currentTherapies, sourceRecords);
-    const response = await ai.generate(prompt, undefined, SMART_IMPORT_OUTPUT_MAX_TOKENS);
+    const health = await ai.getHealth().catch(() => null);
+    const modelInfo = ai.getModelInfo();
+    const fabricPreview = await executePatientSmartImportFabricPreview({
+        modelInfo,
+        health,
+        host: createPatientSmartImportCandidateHostSnapshot(),
+    }, () => ai.generate(prompt, undefined, SMART_IMPORT_OUTPUT_MAX_TOKENS));
+    const response = fabricPreview.output;
     const parsed = parseAiPayload(response);
     const parsedData = parsed.value.data;
     const sourceMap = new Map(sourceRecords.map((source) => [source.id, source]));
@@ -919,7 +932,7 @@ export async function generatePatientSmartImportAnalysis(patientId: string): Pro
         therapy.evidence,
     )).sort(sortTherapySuggestions);
 
-    return {
+    const analysis: PatientSmartImportAnalysis = {
         generatedAt: new Date().toISOString(),
         // @Codex
         contract: {
@@ -940,6 +953,11 @@ export async function generatePatientSmartImportAnalysis(patientId: string): Pro
         diagnoses,
         therapies: therapySuggestions,
     };
+    Object.defineProperty(analysis, PATIENT_SMART_IMPORT_FABRIC_METADATA, {
+        value: fabricPreview.metadata,
+        enumerable: false,
+    });
+    return analysis;
 }
 
 function diagnosisExists(existing: Diagnosis[], suggestion: DiagnosisSmartImportSuggestion): boolean {


### PR DESCRIPTION
## Summary
- Route the existing Smart Import application generation path through the named Fabric admission helper from PR #211.
- Snapshot health and provider/model receipt once before local generation, then attach non-enumerable PHI-safe review metadata.
- Keep the existing proposal/review envelope and apply behavior unchanged.
- Make the Smart Import Playwright file standalone with one synthetic session bootstrap, exact model catalog fixture, and hydration-safe Documenti expansion.

## Verification
- `npm run test:patient-smart-import` — 24/24 pass
- `node scripts/run-strip-types.mjs --test lib/ai-providers/fabric/*.test.ts` — 64/64 pass
- `npm run test:ai-context` — 71/71 pass
- Three isolated Node 24 Smart Import Playwright runs — 7/7 each, 21/21 cumulative, zero retries (46.2s, 46.4s, 45.4s)
- `npm run typecheck`
- `npm run lint`
- `git diff --check`
- The initial stacked tree reconstructed all six corrected #210 candidate files by exact hash; the additive follow-up changes only the E2E expansion helper after CI exposed a hydration race.

## Risk / Notes
- Stacked on PR #211; own diff is 67 additions, 13 deletions across three files.
- Previous head `d292ccc07` failed E2E run 32565501938: 83 passed, 1 failed, 3 flaky, all at the pre-hydration Documenti toggle. It was not rerun unchanged.
- Synthetic fixtures only; no real clinical database, migration, new persistence, real provider, credential, network, or egress.
- Production provider lifecycle/revocation enforcement remains **NOT_VERIFIED** pending a later durable host-lifecycle packet.
- PR #210 is preserved as superseded review evidence and is not rewritten or closed. PR #211 is preserved terminal green at `6425d7936`.
- No apply, OCR, Treatment Reasoning, lifecycle storage, AIP, Mini, UI product behavior, or Apple changes.
- Draft only: not merged, promoted, or security-reviewed.

## Ticket
Refs WUL-522