### PR TITLE
feat(ai): persist provider lifecycle state

### DIFF
--- a/lib/ai-providers/fabric/provider-lifecycle-store.test.ts
+++ b/lib/ai-providers/fabric/provider-lifecycle-store.test.ts
@@ -1,0 +1,105 @@
+/* @Codex */
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, test } from 'node:test';
+import {
+    createProviderLifecycleStore,
+    getProviderLifecycleStorePaths,
+    ProviderLifecycleStoreError,
+} from './provider-lifecycle-store.ts';
+const roots: string[] = [];
+const lifecycle = Object.freeze({
+    schemaVersion: 'mediflow.ai.provider-lifecycle.v1' as const,
+    provider: 'ollama', credentialClass: 'local_model' as const,
+    status: 'available_unqualified' as const,
+});
+function root(): string {
+    const value = fs.mkdtempSync(path.join(os.tmpdir(), 'mediflow-fabric-lifecycle-'));
+    roots.push(value); return value;
+}
+function expectCode(code: ProviderLifecycleStoreError['code'], run: () => unknown): void {
+    assert.throws(run, (error) => error instanceof ProviderLifecycleStoreError && error.code === code); }
+afterEach(() => { for (const value of roots.splice(0)) fs.rmSync(value, { recursive: true, force: true }); });
+test('persists an exact PHI-safe snapshot across restart', () => {
+    const appDataDir = root();
+    const paths = getProviderLifecycleStorePaths(appDataDir);
+    fs.mkdirSync(paths.directory, { recursive: true, mode: 0o777 });
+    if (process.platform !== 'win32') fs.chmodSync(paths.directory, 0o777);
+    const first = createProviderLifecycleStore(appDataDir, () => new Date('2026-08-22T10:00:00.000Z'));
+    const saved = first.save({
+        kind: 'admit', expectedVersion: 0, lifecycle,
+        actorClass: 'host_service', actorRef: 'actor_1234567812345678', receiptRef: 'receipt_1234567812345678',
+    });
+    assert.equal(saved.version, 1);
+    assert.equal(saved.hostTimestamp, '2026-08-22T10:00:00.000Z');
+    assert.throws(() => ((saved.lifecycle as { status: string }).status = 'revoked'));
+    const restarted = createProviderLifecycleStore(appDataDir, () => new Date('2026-08-22T10:01:00.000Z'));
+    assert.deepEqual(restarted.load(), saved);
+    if (process.platform !== 'win32') assert.deepEqual(
+        [fs.statSync(paths.directory).mode & 0o777, fs.statSync(paths.recordPath).mode & 0o777], [0o700, 0o600]);
+    const raw = fs.readFileSync(paths.recordPath, 'utf8');
+    assert.deepEqual(Object.keys(JSON.parse(raw)).sort(), [
+        'actorClass', 'actorRef', 'hostTimestamp', 'lifecycle', 'receiptRef', 'schemaVersion', 'version',
+    ]);
+    assert.doesNotMatch(raw, /patient|clinical|prompt|token|endpoint|response/i);
+});
+test('enforces expectedVersion and terminal revocation after restart', () => {
+    const appDataDir = root();
+    const store = createProviderLifecycleStore(appDataDir, () => new Date('2026-08-22T10:00:00.000Z'));
+    store.save({
+        kind: 'admit', expectedVersion: 0, lifecycle,
+        actorClass: 'physician', actorRef: 'actor_abcdef0123456789', receiptRef: 'receipt_abcdef0123456789',
+    });
+    const degraded = store.save({
+        kind: 'transition', expectedVersion: 1, event: 'degrade',
+        actorClass: 'host_service', actorRef: 'actor_8765432187654321', receiptRef: 'receipt_8765432187654321',
+    });
+    expectCode('version_conflict', () => store.save({
+        kind: 'transition', expectedVersion: 1, event: 'recover',
+        actorClass: 'host_service', actorRef: 'actor_8765432187654321', receiptRef: 'receipt_8765432187654321',
+    }));
+    assert.equal(degraded.version, 2);
+    store.save({
+        kind: 'transition', expectedVersion: 2, event: 'revoke',
+        actorClass: 'physician', actorRef: 'actor_abcdef0123456789', receiptRef: 'receipt_deadbeef01234567',
+    });
+    const restarted = createProviderLifecycleStore(appDataDir, () => new Date('2026-08-22T10:02:00.000Z'));
+    assert.equal(restarted.load().lifecycle.status, 'revoked');
+    expectCode('transition_invalid', () => restarted.save({
+        kind: 'transition', expectedVersion: 3, event: 'recover',
+        actorClass: 'physician', actorRef: 'actor_abcdef0123456789', receiptRef: 'receipt_cafebabe01234567',
+    }));
+});
+test('fails closed on missing, corrupt, truncated, and unreadable state', () => {
+    const appDataDir = root();
+    const paths = getProviderLifecycleStorePaths(appDataDir);
+    const store = createProviderLifecycleStore(appDataDir, () => new Date());
+    expectCode('missing', () => store.load());
+    fs.mkdirSync(path.dirname(paths.recordPath), { recursive: true });
+    for (const raw of ['{', '{"schemaVersion":"wrong"}']) {
+        fs.writeFileSync(paths.recordPath, raw);
+        expectCode('corrupt', () => store.load());
+    }
+    fs.rmSync(paths.recordPath);
+    fs.mkdirSync(paths.recordPath);
+    expectCode('unreadable', () => store.load());
+});
+test('rejects secret or clinical fields and an occupied writer lock', () => {
+    const appDataDir = root();
+    const paths = getProviderLifecycleStorePaths(appDataDir);
+    const store = createProviderLifecycleStore(appDataDir, () => new Date('2026-08-22T10:00:00.000Z'));
+    expectCode('command_invalid', () => store.save({
+        kind: 'admit', expectedVersion: 0, lifecycle,
+        token: 'synthetic-secret', patientContext: 'synthetic-clinical-ref',
+        actorClass: 'host_service', actorRef: 'actor_1234567812345678', receiptRef: 'receipt_1234567812345678',
+    }));
+    assert.equal(fs.existsSync(paths.recordPath), false);
+    fs.mkdirSync(path.dirname(paths.lockPath), { recursive: true });
+    fs.writeFileSync(paths.lockPath, 'occupied');
+    expectCode('busy', () => store.save({
+        kind: 'admit', expectedVersion: 0, lifecycle,
+        actorClass: 'host_service', actorRef: 'actor_1234567812345678', receiptRef: 'receipt_1234567812345678',
+    }));
+});

--- a/lib/ai-providers/fabric/provider-lifecycle-store.test.ts
+++ b/lib/ai-providers/fabric/provider-lifecycle-store.test.ts
@@ -30,7 +30,7 @@ test('persists an exact PHI-safe snapshot across restart', () => {
     const first = createProviderLifecycleStore(appDataDir, () => new Date('2026-08-22T10:00:00.000Z'));
     const saved = first.save({
         kind: 'admit', expectedVersion: 0, lifecycle,
-        actorClass: 'host_service', actorRef: 'actor_1234567812345678', receiptRef: 'receipt_1234567812345678',
+        actorClass: 'host_service', actorRef: 'actor_12345678123456781234567812345678', receiptRef: 'receipt_12345678123456781234567812345678',
     });
     assert.equal(saved.version, 1);
     assert.equal(saved.hostTimestamp, '2026-08-22T10:00:00.000Z');
@@ -50,26 +50,26 @@ test('enforces expectedVersion and terminal revocation after restart', () => {
     const store = createProviderLifecycleStore(appDataDir, () => new Date('2026-08-22T10:00:00.000Z'));
     store.save({
         kind: 'admit', expectedVersion: 0, lifecycle,
-        actorClass: 'physician', actorRef: 'actor_abcdef0123456789', receiptRef: 'receipt_abcdef0123456789',
+        actorClass: 'physician', actorRef: 'actor_abcdef0123456789abcdef0123456789', receiptRef: 'receipt_abcdef0123456789abcdef0123456789',
     });
     const degraded = store.save({
         kind: 'transition', expectedVersion: 1, event: 'degrade',
-        actorClass: 'host_service', actorRef: 'actor_8765432187654321', receiptRef: 'receipt_8765432187654321',
+        actorClass: 'host_service', actorRef: 'actor_87654321876543218765432187654321', receiptRef: 'receipt_87654321876543218765432187654321',
     });
     expectCode('version_conflict', () => store.save({
         kind: 'transition', expectedVersion: 1, event: 'recover',
-        actorClass: 'host_service', actorRef: 'actor_8765432187654321', receiptRef: 'receipt_8765432187654321',
+        actorClass: 'host_service', actorRef: 'actor_87654321876543218765432187654321', receiptRef: 'receipt_87654321876543218765432187654321',
     }));
     assert.equal(degraded.version, 2);
     store.save({
         kind: 'transition', expectedVersion: 2, event: 'revoke',
-        actorClass: 'physician', actorRef: 'actor_abcdef0123456789', receiptRef: 'receipt_deadbeef01234567',
+        actorClass: 'physician', actorRef: 'actor_abcdef0123456789abcdef0123456789', receiptRef: 'receipt_deadbeef01234567deadbeef01234567',
     });
     const restarted = createProviderLifecycleStore(appDataDir, () => new Date('2026-08-22T10:02:00.000Z'));
     assert.equal(restarted.load().lifecycle.status, 'revoked');
     expectCode('transition_invalid', () => restarted.save({
         kind: 'transition', expectedVersion: 3, event: 'recover',
-        actorClass: 'physician', actorRef: 'actor_abcdef0123456789', receiptRef: 'receipt_cafebabe01234567',
+        actorClass: 'physician', actorRef: 'actor_abcdef0123456789abcdef0123456789', receiptRef: 'receipt_cafebabe01234567cafebabe01234567',
     }));
 });
 test('fails closed on missing, corrupt, truncated, and unreadable state', () => {
@@ -92,14 +92,18 @@ test('rejects secret or clinical fields and an occupied writer lock', () => {
     const store = createProviderLifecycleStore(appDataDir, () => new Date('2026-08-22T10:00:00.000Z'));
     expectCode('command_invalid', () => store.save({
         kind: 'admit', expectedVersion: 0, lifecycle,
+        actorClass: 'host_service', actorRef: 'actor_1234567812345678', receiptRef: 'receipt_12345678123456781234567812345678',
+    }));
+    expectCode('command_invalid', () => store.save({
+        kind: 'admit', expectedVersion: 0, lifecycle,
         token: 'synthetic-secret', patientContext: 'synthetic-clinical-ref',
-        actorClass: 'host_service', actorRef: 'actor_1234567812345678', receiptRef: 'receipt_1234567812345678',
+        actorClass: 'host_service', actorRef: 'actor_12345678123456781234567812345678', receiptRef: 'receipt_12345678123456781234567812345678',
     }));
     assert.equal(fs.existsSync(paths.recordPath), false);
     fs.mkdirSync(path.dirname(paths.lockPath), { recursive: true });
     fs.writeFileSync(paths.lockPath, 'occupied');
     expectCode('busy', () => store.save({
         kind: 'admit', expectedVersion: 0, lifecycle,
-        actorClass: 'host_service', actorRef: 'actor_1234567812345678', receiptRef: 'receipt_1234567812345678',
+        actorClass: 'host_service', actorRef: 'actor_12345678123456781234567812345678', receiptRef: 'receipt_12345678123456781234567812345678',
     }));
 });

--- a/lib/ai-providers/fabric/provider-lifecycle-store.ts
+++ b/lib/ai-providers/fabric/provider-lifecycle-store.ts
@@ -15,15 +15,11 @@ export type ProviderLifecycleActorClass = 'physician' | 'host_service';
 export type ProviderLifecycleRecord = Readonly<{
     schemaVersion: typeof PROVIDER_LIFECYCLE_STORE_SCHEMA_VERSION;
     lifecycle: ProviderLifecycleState;
-    actorClass: ProviderLifecycleActorClass;
-    actorRef: string;
-    version: number;
-    hostTimestamp: string;
-    receiptRef: string;
+    actorClass: ProviderLifecycleActorClass; actorRef: string;
+    version: number; hostTimestamp: string; receiptRef: string;
 }>;
 type CommonCommand = Readonly<{
-    expectedVersion: number;
-    actorClass: ProviderLifecycleActorClass;
+    expectedVersion: number; actorClass: ProviderLifecycleActorClass;
     actorRef: string;
     receiptRef: string;
 }>;
@@ -31,8 +27,8 @@ export type ProviderLifecycleStoreCommand =
     | (CommonCommand & Readonly<{ kind: 'admit'; lifecycle: ProviderLifecycleState }>)
     | (CommonCommand & Readonly<{ kind: 'transition'; event: ProviderLifecycleEvent }>);
 export type ProviderLifecycleStoreErrorCode =
-    | 'missing' | 'unreadable' | 'corrupt' | 'busy' | 'command_invalid'
-    | 'version_conflict' | 'transition_invalid' | 'clock_invalid';
+    | 'missing' | 'unreadable' | 'corrupt' | 'busy' | 'command_invalid' | 'version_conflict'
+    | 'transition_invalid' | 'clock_invalid';
 export class ProviderLifecycleStoreError extends Error {
     constructor(public readonly code: ProviderLifecycleStoreErrorCode) {
         super(`Provider lifecycle store rejected: ${code}`);
@@ -40,8 +36,8 @@ export class ProviderLifecycleStoreError extends Error {
     }
 }
 const ACTOR_CLASSES = new Set<unknown>(['physician', 'host_service']);
-const ACTOR_REF = /^actor_[0-9a-f]{16,64}$/;
-const RECEIPT_REF = /^receipt_[0-9a-f]{16,64}$/;
+const ACTOR_REF = /^actor_[0-9a-f]{32,64}$/;
+const RECEIPT_REF = /^receipt_[0-9a-f]{32,64}$/;
 function hasExactKeys(value: object, expected: readonly string[]): boolean {
     const keys = Reflect.ownKeys(value);
     return keys.length === expected.length && expected.every((key) => keys.includes(key));

--- a/lib/ai-providers/fabric/provider-lifecycle-store.ts
+++ b/lib/ai-providers/fabric/provider-lifecycle-store.ts
@@ -1,0 +1,195 @@
+/* @Codex */
+import fs from 'node:fs';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { getDataDir } from '../../data-dir';
+import {
+    ProviderLifecycleError,
+    snapshotProviderLifecycle,
+    transitionProviderLifecycle,
+    type ProviderLifecycleEvent,
+    type ProviderLifecycleState,
+} from './provider-lifecycle';
+export const PROVIDER_LIFECYCLE_STORE_SCHEMA_VERSION = 'mediflow.ai.provider-lifecycle-record.v1' as const;
+export type ProviderLifecycleActorClass = 'physician' | 'host_service';
+export type ProviderLifecycleRecord = Readonly<{
+    schemaVersion: typeof PROVIDER_LIFECYCLE_STORE_SCHEMA_VERSION;
+    lifecycle: ProviderLifecycleState;
+    actorClass: ProviderLifecycleActorClass;
+    actorRef: string;
+    version: number;
+    hostTimestamp: string;
+    receiptRef: string;
+}>;
+type CommonCommand = Readonly<{
+    expectedVersion: number;
+    actorClass: ProviderLifecycleActorClass;
+    actorRef: string;
+    receiptRef: string;
+}>;
+export type ProviderLifecycleStoreCommand =
+    | (CommonCommand & Readonly<{ kind: 'admit'; lifecycle: ProviderLifecycleState }>)
+    | (CommonCommand & Readonly<{ kind: 'transition'; event: ProviderLifecycleEvent }>);
+export type ProviderLifecycleStoreErrorCode =
+    | 'missing' | 'unreadable' | 'corrupt' | 'busy' | 'command_invalid'
+    | 'version_conflict' | 'transition_invalid' | 'clock_invalid';
+export class ProviderLifecycleStoreError extends Error {
+    constructor(public readonly code: ProviderLifecycleStoreErrorCode) {
+        super(`Provider lifecycle store rejected: ${code}`);
+        this.name = 'ProviderLifecycleStoreError';
+    }
+}
+const ACTOR_CLASSES = new Set<unknown>(['physician', 'host_service']);
+const ACTOR_REF = /^actor_[0-9a-f]{16,64}$/;
+const RECEIPT_REF = /^receipt_[0-9a-f]{16,64}$/;
+function hasExactKeys(value: object, expected: readonly string[]): boolean {
+    const keys = Reflect.ownKeys(value);
+    return keys.length === expected.length && expected.every((key) => keys.includes(key));
+}
+function freezeRecord(value: Omit<ProviderLifecycleRecord, 'schemaVersion'>): ProviderLifecycleRecord {
+    return Object.freeze({ schemaVersion: PROVIDER_LIFECYCLE_STORE_SCHEMA_VERSION, ...value });
+}
+function snapshotRecord(value: unknown): ProviderLifecycleRecord {
+    if (!value || typeof value !== 'object' || Array.isArray(value) || !hasExactKeys(value, [
+        'schemaVersion', 'lifecycle', 'actorClass', 'actorRef', 'version', 'hostTimestamp', 'receiptRef',
+    ])) throw new ProviderLifecycleStoreError('corrupt');
+    const input = value as Record<string, unknown>;
+    const schemaVersion = input.schemaVersion;
+    const lifecycle = input.lifecycle;
+    const actorClass = input.actorClass;
+    const actorRef = input.actorRef;
+    const version = input.version;
+    const hostTimestamp = input.hostTimestamp;
+    const receiptRef = input.receiptRef;
+    if (
+        schemaVersion !== PROVIDER_LIFECYCLE_STORE_SCHEMA_VERSION
+        || !ACTOR_CLASSES.has(actorClass) || typeof actorRef !== 'string' || !ACTOR_REF.test(actorRef)
+        || !Number.isSafeInteger(version) || (version as number) < 1
+        || typeof hostTimestamp !== 'string' || new Date(hostTimestamp).toISOString() !== hostTimestamp
+        || typeof receiptRef !== 'string' || !RECEIPT_REF.test(receiptRef)
+    ) throw new ProviderLifecycleStoreError('corrupt');
+    try {
+        return freezeRecord({
+            lifecycle: snapshotProviderLifecycle(lifecycle),
+            actorClass: actorClass as ProviderLifecycleActorClass,
+            actorRef, version: version as number, hostTimestamp, receiptRef,
+        });
+    } catch {
+        throw new ProviderLifecycleStoreError('corrupt');
+    }
+}
+function snapshotCommand(value: unknown): ProviderLifecycleStoreCommand {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        throw new ProviderLifecycleStoreError('command_invalid');
+    }
+    const input = value as Record<string, unknown>;
+    const kind = input.kind;
+    const expected = kind === 'admit'
+        ? ['kind', 'expectedVersion', 'lifecycle', 'actorClass', 'actorRef', 'receiptRef']
+        : ['kind', 'expectedVersion', 'event', 'actorClass', 'actorRef', 'receiptRef'];
+    const expectedVersion = input.expectedVersion;
+    const actorClass = input.actorClass;
+    const actorRef = input.actorRef;
+    const receiptRef = input.receiptRef;
+    if (
+        (kind !== 'admit' && kind !== 'transition') || !hasExactKeys(value, expected)
+        || !Number.isSafeInteger(expectedVersion) || (expectedVersion as number) < 0
+        || !ACTOR_CLASSES.has(actorClass) || typeof actorRef !== 'string' || !ACTOR_REF.test(actorRef)
+        || typeof receiptRef !== 'string' || !RECEIPT_REF.test(receiptRef)
+    ) throw new ProviderLifecycleStoreError('command_invalid');
+    if (kind === 'admit') {
+        try {
+            const lifecycle = snapshotProviderLifecycle(input.lifecycle);
+            if (lifecycle.status !== 'available_unqualified') throw new Error();
+            return Object.freeze({ kind, expectedVersion: expectedVersion as number, lifecycle,
+                actorClass: actorClass as ProviderLifecycleActorClass, actorRef, receiptRef });
+        } catch { throw new ProviderLifecycleStoreError('command_invalid'); }
+    }
+    const event = input.event;
+    if (event !== 'degrade' && event !== 'recover' && event !== 'revoke') {
+        throw new ProviderLifecycleStoreError('command_invalid');
+    }
+    return Object.freeze({ kind, expectedVersion: expectedVersion as number, event,
+        actorClass: actorClass as ProviderLifecycleActorClass, actorRef, receiptRef });
+}
+export function getProviderLifecycleStorePaths(appDataDir = getDataDir()) {
+    const directory = path.join(appDataDir, 'ai', 'fabric');
+    return {
+        directory,
+        recordPath: path.join(directory, 'provider-lifecycle.v1.json'),
+        lockPath: path.join(directory, 'provider-lifecycle.v1.lock'),
+    } as const;
+}
+export function createProviderLifecycleStore(appDataDir = getDataDir(), hostClock: () => Date = () => new Date()) {
+    const paths = getProviderLifecycleStorePaths(appDataDir);
+    function readNullable(): ProviderLifecycleRecord | null {
+        let raw: string;
+        try { raw = fs.readFileSync(paths.recordPath, 'utf8'); }
+        catch (error) {
+            if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+            throw new ProviderLifecycleStoreError('unreadable');
+        }
+        try { return snapshotRecord(JSON.parse(raw)); }
+        catch { throw new ProviderLifecycleStoreError('corrupt'); }
+    }
+    function load(): ProviderLifecycleRecord {
+        const record = readNullable();
+        if (!record) throw new ProviderLifecycleStoreError('missing');
+        return record;
+    }
+    function save(value: unknown): ProviderLifecycleRecord {
+        const command = snapshotCommand(value);
+        fs.mkdirSync(paths.directory, { recursive: true, mode: 0o700 });
+        if (process.platform !== 'win32') fs.chmodSync(paths.directory, 0o700);
+        let lock: number;
+        try { lock = fs.openSync(paths.lockPath, 'wx', 0o600); }
+        catch { throw new ProviderLifecycleStoreError('busy'); }
+        let temporaryPath: string | null = null;
+        try {
+            const current = readNullable();
+            if ((current?.version ?? 0) !== command.expectedVersion) {
+                throw new ProviderLifecycleStoreError('version_conflict');
+            }
+            if (Boolean(current) === (command.kind === 'admit')) {
+                throw new ProviderLifecycleStoreError('transition_invalid');
+            }
+            let lifecycle: ProviderLifecycleState;
+            try {
+                lifecycle = command.kind === 'admit'
+                    ? command.lifecycle
+                    : transitionProviderLifecycle(current!.lifecycle, command.event);
+            } catch (error) {
+                if (error instanceof ProviderLifecycleError) {
+                    throw new ProviderLifecycleStoreError('transition_invalid');
+                }
+                throw error;
+            }
+            let timestamp: string;
+            try { timestamp = hostClock().toISOString(); }
+            catch { throw new ProviderLifecycleStoreError('clock_invalid'); }
+            if (current && timestamp < current.hostTimestamp) {
+                throw new ProviderLifecycleStoreError('clock_invalid');
+            }
+            const record = freezeRecord({ lifecycle, actorClass: command.actorClass,
+                actorRef: command.actorRef, version: (current?.version ?? 0) + 1,
+                hostTimestamp: timestamp, receiptRef: command.receiptRef });
+            temporaryPath = `${paths.recordPath}.${process.pid}.${randomUUID()}.tmp`;
+            const file = fs.openSync(temporaryPath, 'wx', 0o600);
+            try { fs.writeFileSync(file, `${JSON.stringify(record)}\n`, 'utf8'); fs.fsyncSync(file); }
+            finally { fs.closeSync(file); }
+            fs.renameSync(temporaryPath, paths.recordPath);
+            temporaryPath = null;
+            if (process.platform !== 'win32') {
+                fs.chmodSync(paths.recordPath, 0o600);
+                const directory = fs.openSync(paths.directory, 'r');
+                try { fs.fsyncSync(directory); } finally { fs.closeSync(directory); }
+            }
+            return snapshotRecord(record);
+        } finally {
+            if (temporaryPath) fs.rmSync(temporaryPath, { force: true });
+            fs.closeSync(lock!);
+            fs.rmSync(paths.lockPath, { force: true });
+        }
+    }
+    return Object.freeze({ load, save });
+}


### PR DESCRIPTION
## Summary
- Add the canonical host-owned provider lifecycle store at `<MEDIFLOW_DATA_DIR>/ai/fabric/provider-lifecycle.v1.json`.
- Persist only an exact-schema lifecycle snapshot, actor class and opaque reference, monotonic version, host timestamp, and opaque receipt reference. Actor and receipt references require 32–64 hexadecimal digits.
- Enforce expected-version writes under an exclusive lock, terminal revocation, immutable reload snapshots, same-directory atomic replacement, POSIX directory fsync, and restrictive POSIX permissions.
- Add synthetic temp-directory coverage for restart, conflicts, corruption/truncation, unreadable state, revocation, lock contention, forbidden fields, 16-hex reference denial, and no-leak serialization.

## Verification
- `node scripts/run-strip-types.mjs --test --glob "lib/ai-providers/fabric/**/*.test.ts"` — 68/68 pass at `0d0755f5c5f0bab86056b8e84de497b32f4c19f3`.
- `npm run typecheck` — pass.
- `npm run lint` — pass.
- `git diff --check` — pass.
- Focused prohibited-import scan — no DB, SQLite, network, fetch, or child-process imports.

## Risk / Notes
- Draft stacked on #212 exact accepted head `4fd8f698d47fa9e78a475a3fea4d1d3da4c54dfa`; #207/#210/#211/#212 remain unchanged.
- This is a storage foundation only. It does not wire Smart Import or any other capability, AIP, Mini, UI, API, or clinical review persistence.
- Actor and receipt references are schema-validated opaque values; caller authenticity is not proven until a later host-only control service consumes this store.
- Crash-durability evidence is POSIX-specific because the directory fsync is intentionally skipped on Windows. Windows remains fail-closed, but this packet does not claim equivalent crash durability there.
- A stale lock remains fail-closed and requires later host lifecycle/recovery policy.
- No real clinical database, migration, or new clinical persistence; synthetic temporary fixtures only. No provider credentials, provider payloads, prompts, endpoints, clinical content, cloud, or egress.

## Ticket
Refs WUL-522.