### PR TITLE
feat(ai): isolate provider lifecycle control

### DIFF
--- a/lib/ai-providers/fabric/provider-lifecycle-service.test.ts
+++ b/lib/ai-providers/fabric/provider-lifecycle-service.test.ts
@@ -58,6 +58,8 @@ test('separates read service from host control and generates operation metadata'
 });
 
 test('rejects caller authority extras and snapshots host sources once', () => {
+    expectCode('input_invalid', () => createHostProviderLifecycleService({ appDataDir: '' }));
+    expectCode('input_invalid', () => createHostProviderLifecycleService({ appDataDir: 'relative/app-data' }));
     const appDataDir = root();
     let entropyReads = 0; let clockReads = 0;
     const boundary = createHostProviderLifecycleService({ appDataDir, sources: {

--- a/lib/ai-providers/fabric/provider-lifecycle-service.test.ts
+++ b/lib/ai-providers/fabric/provider-lifecycle-service.test.ts
@@ -1,0 +1,115 @@
+/* @Codex */
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, test } from 'node:test';
+import { advanceOnboarding, startOnboarding } from './onboarding.ts';
+import {
+    createHostProviderLifecycleService,
+    ProviderLifecycleServiceError,
+} from './provider-lifecycle-service.ts';
+import { getProviderLifecycleStorePaths, ProviderLifecycleStoreError } from './provider-lifecycle-store.ts';
+
+const roots: string[] = [];
+function root(): string {
+    const value = fs.mkdtempSync(path.join(os.tmpdir(), 'mediflow-lifecycle-service-'));
+    roots.push(value); return value;
+}
+function enabledLocal() {
+    let state = startOnboarding('ollama', 'local_model');
+    for (const type of ['configure', 'credential_declared', 'attest_local', 'enable'] as const) {
+        state = advanceOnboarding(state, { type });
+    }
+    return state;
+}
+function expectCode(code: string, run: () => unknown): void {
+    assert.throws(run, (error) => (
+        (error instanceof ProviderLifecycleServiceError || error instanceof ProviderLifecycleStoreError)
+        && error.code === code
+    ));
+}
+afterEach(() => { for (const value of roots.splice(0)) fs.rmSync(value, { recursive: true, force: true }); });
+
+test('separates read service from host control and generates operation metadata', () => {
+    const boundary = createHostProviderLifecycleService({
+        appDataDir: root(),
+        sources: {
+            entropy: () => `${'1'.repeat(32)}${'2'.repeat(32)}`,
+            now: () => '2026-08-22T11:00:00.000Z',
+        },
+    });
+    assert.deepEqual(Object.keys(boundary), ['service', 'control']);
+    assert.deepEqual(Object.keys(boundary.service), ['read']);
+    assert.deepEqual(Object.keys(boundary.control), ['admit', 'degrade', 'recover', 'revoke']);
+    assert.equal('admit' in boundary.service, false);
+
+    const admitted = boundary.control.admit({ expectedVersion: 0, onboarding: enabledLocal() });
+    assert.equal(admitted.actorRef, `actor_${'1'.repeat(32)}`);
+    assert.equal(admitted.receiptRef, `receipt_${'2'.repeat(32)}`);
+    assert.equal(admitted.hostTimestamp, '2026-08-22T11:00:00.000Z');
+    const read = boundary.service.read();
+    assert.equal(read.status, 'available');
+    if (read.status === 'available') {
+        assert.deepEqual(read.record, admitted);
+        assert.notEqual(read.record, admitted);
+        assert.equal(Object.isFrozen(read.record), true);
+    }
+});
+
+test('rejects caller authority extras and snapshots host sources once', () => {
+    const appDataDir = root();
+    let entropyReads = 0; let clockReads = 0;
+    const boundary = createHostProviderLifecycleService({ appDataDir, sources: {
+        entropy: () => { entropyReads += 1; return 'a'.repeat(64); },
+        now: () => { clockReads += 1; return '2026-08-22T11:01:00.000Z'; },
+    } });
+    expectCode('input_invalid', () => boundary.control.admit({
+        expectedVersion: 0, onboarding: enabledLocal(), actorRef: 'actor_caller',
+    }));
+    expectCode('input_invalid', () => boundary.control.admit({
+        expectedVersion: 0, onboarding: { ...enabledLocal(), token: 'synthetic-secret' },
+    }));
+    assert.deepEqual([entropyReads, clockReads], [0, 0]);
+    boundary.control.admit({ expectedVersion: 0, onboarding: enabledLocal() });
+    assert.deepEqual([entropyReads, clockReads], [1, 1]);
+
+    const accessor = { now: () => '2026-08-22T11:01:00.000Z' } as Record<string, unknown>;
+    Object.defineProperty(accessor, 'entropy', { enumerable: true, get: () => () => 'b'.repeat(64) });
+    expectCode('source_invalid', () => createHostProviderLifecycleService({ appDataDir: root(), sources: accessor }));
+    const malformed = createHostProviderLifecycleService({ appDataDir: root(), sources: {
+        entropy: () => Object.defineProperty({}, 'value', { get: () => 'c'.repeat(64) }),
+        now: () => '2026-08-22T11:01:00.000Z',
+    } });
+    expectCode('source_invalid', () => malformed.control.admit({ expectedVersion: 0, onboarding: enabledLocal() }));
+});
+
+test('keeps CAS stable and revocation terminal across restart', () => {
+    const appDataDir = root();
+    const options = { appDataDir, sources: {
+        entropy: () => 'd'.repeat(64), now: () => '2026-08-22T11:02:00.000Z',
+    } };
+    const first = createHostProviderLifecycleService(options);
+    first.control.admit({ expectedVersion: 0, onboarding: enabledLocal() });
+    first.control.degrade({ expectedVersion: 1 });
+    expectCode('version_conflict', () => first.control.recover({ expectedVersion: 1 }));
+    first.control.revoke({ expectedVersion: 2 });
+    const restarted = createHostProviderLifecycleService(options);
+    const read = restarted.service.read();
+    assert.equal(read.status === 'available' && read.record.lifecycle.status, 'revoked');
+    expectCode('transition_invalid', () => restarted.control.recover({ expectedVersion: 3 }));
+    const raw = fs.readFileSync(getProviderLifecycleStorePaths(appDataDir).recordPath, 'utf8');
+    assert.doesNotMatch(raw, /patient|clinical|prompt|token|endpoint|response/i);
+});
+
+test('returns explicit fail-closed read dispositions', () => {
+    const appDataDir = root();
+    const boundary = createHostProviderLifecycleService({ appDataDir });
+    assert.deepEqual(boundary.service.read(), { status: 'denied', reason: 'missing' });
+    const paths = getProviderLifecycleStorePaths(appDataDir);
+    fs.mkdirSync(paths.directory, { recursive: true });
+    fs.writeFileSync(paths.recordPath, '{');
+    assert.deepEqual(boundary.service.read(), { status: 'denied', reason: 'corrupt' });
+    fs.rmSync(paths.recordPath); fs.mkdirSync(paths.recordPath);
+    assert.deepEqual(boundary.service.read(), { status: 'denied', reason: 'unavailable' });
+});

--- a/lib/ai-providers/fabric/provider-lifecycle-service.ts
+++ b/lib/ai-providers/fabric/provider-lifecycle-service.ts
@@ -1,5 +1,6 @@
 /* @Codex */
 import { randomBytes } from 'node:crypto';
+import path from 'node:path';
 import { admitProvider, type ProviderLifecycleEvent, type ProviderLifecycleState } from './provider-lifecycle';
 import {
     createProviderLifecycleStore,
@@ -87,7 +88,8 @@ function snapshotOnboarding(value: unknown): ProviderOnboardingState {
 
 export function createHostProviderLifecycleService(options: FactoryOptions = {}) {
     const config = dataRecord(options, [], ['appDataDir', 'sources']);
-    if (config.appDataDir !== undefined && typeof config.appDataDir !== 'string') {
+    if (config.appDataDir !== undefined
+        && (typeof config.appDataDir !== 'string' || !path.isAbsolute(config.appDataDir))) {
         throw new ProviderLifecycleServiceError('input_invalid');
     }
     const appDataDir = config.appDataDir as string | undefined;

--- a/lib/ai-providers/fabric/provider-lifecycle-service.ts
+++ b/lib/ai-providers/fabric/provider-lifecycle-service.ts
@@ -1,0 +1,126 @@
+/* @Codex */
+import { randomBytes } from 'node:crypto';
+import { admitProvider, type ProviderLifecycleEvent, type ProviderLifecycleState } from './provider-lifecycle';
+import {
+    createProviderLifecycleStore,
+    ProviderLifecycleStoreError,
+    type ProviderLifecycleRecord,
+} from './provider-lifecycle-store';
+import type { ProviderOnboardingState } from './onboarding';
+
+export type ProviderLifecycleRead =
+    | Readonly<{ status: 'available'; record: ProviderLifecycleRecord }>
+    | Readonly<{ status: 'denied'; reason: 'missing' | 'corrupt' | 'unavailable' }>;
+export type ProviderLifecycleServiceErrorCode = 'input_invalid' | 'source_invalid';
+export class ProviderLifecycleServiceError extends Error {
+    constructor(public readonly code: ProviderLifecycleServiceErrorCode) {
+        super(`Provider lifecycle service rejected: ${code}`);
+        this.name = 'ProviderLifecycleServiceError';
+    }
+}
+
+type HostSources = Readonly<{ entropy: () => unknown; now: () => unknown }>;
+type FactoryOptions = Readonly<{ appDataDir?: string; sources?: unknown }>;
+const PRODUCTION_SOURCES: HostSources = Object.freeze({
+    entropy: () => randomBytes(32).toString('hex'),
+    now: () => new Date().toISOString(),
+});
+
+function dataRecord(value: unknown, required: readonly string[], optional: readonly string[] = []): Record<string, unknown> {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        throw new ProviderLifecycleServiceError('input_invalid');
+    }
+    const keys = Reflect.ownKeys(value);
+    if (!keys.every((key) => typeof key === 'string' && (required.includes(key) || optional.includes(key)))
+        || !required.every((key) => keys.includes(key))) {
+        throw new ProviderLifecycleServiceError('input_invalid');
+    }
+    const result: Record<string, unknown> = {};
+    for (const key of keys as string[]) {
+        const descriptor = Object.getOwnPropertyDescriptor(value, key);
+        if (!descriptor || !('value' in descriptor)) throw new ProviderLifecycleServiceError('input_invalid');
+        result[key] = descriptor.value;
+    }
+    return result;
+}
+
+function snapshotSources(value: unknown): HostSources {
+    if (value === undefined) return PRODUCTION_SOURCES;
+    let record: Record<string, unknown>;
+    try { record = dataRecord(value, ['entropy', 'now']); }
+    catch { throw new ProviderLifecycleServiceError('source_invalid'); }
+    if (typeof record.entropy !== 'function' || typeof record.now !== 'function') {
+        throw new ProviderLifecycleServiceError('source_invalid');
+    }
+    return Object.freeze({ entropy: record.entropy as () => unknown, now: record.now as () => unknown });
+}
+
+function operationMetadata(sources: HostSources) {
+    let entropy: unknown;
+    let timestamp: unknown;
+    try { entropy = sources.entropy(); timestamp = sources.now(); }
+    catch { throw new ProviderLifecycleServiceError('source_invalid'); }
+    try {
+        if (typeof entropy !== 'string' || !/^[0-9a-f]{64}$/.test(entropy)
+            || typeof timestamp !== 'string' || new Date(timestamp).toISOString() !== timestamp) throw new Error();
+    } catch { throw new ProviderLifecycleServiceError('source_invalid'); }
+    return Object.freeze({
+        actorRef: `actor_${entropy.slice(0, 32)}`,
+        receiptRef: `receipt_${entropy.slice(32)}`,
+        timestamp,
+    });
+}
+
+function expectedVersion(value: unknown, extraKey?: string) {
+    const keys = extraKey ? ['expectedVersion', extraKey] : ['expectedVersion'];
+    const input = dataRecord(value, keys);
+    if (!Number.isSafeInteger(input.expectedVersion) || (input.expectedVersion as number) < 0) {
+        throw new ProviderLifecycleServiceError('input_invalid');
+    }
+    return input;
+}
+
+function snapshotOnboarding(value: unknown): ProviderOnboardingState {
+    const input = dataRecord(value, ['schemaVersion', 'provider', 'credentialClass', 'step', 'attestation']);
+    return Object.freeze({ ...input }) as ProviderOnboardingState;
+}
+
+export function createHostProviderLifecycleService(options: FactoryOptions = {}) {
+    const config = dataRecord(options, [], ['appDataDir', 'sources']);
+    if (config.appDataDir !== undefined && typeof config.appDataDir !== 'string') {
+        throw new ProviderLifecycleServiceError('input_invalid');
+    }
+    const appDataDir = config.appDataDir as string | undefined;
+    const sources = snapshotSources(config.sources);
+    const read = (): ProviderLifecycleRead => {
+        try {
+            return Object.freeze({ status: 'available', record: createProviderLifecycleStore(appDataDir).load() });
+        } catch (error) {
+            const reason = error instanceof ProviderLifecycleStoreError && error.code === 'missing'
+                ? 'missing' : error instanceof ProviderLifecycleStoreError && error.code === 'corrupt'
+                    ? 'corrupt' : 'unavailable';
+            return Object.freeze({ status: 'denied', reason });
+        }
+    };
+    const save = (expected: number, lifecycle: ProviderLifecycleState | ProviderLifecycleEvent) => {
+        const metadata = operationMetadata(sources);
+        const store = createProviderLifecycleStore(appDataDir, () => new Date(metadata.timestamp));
+        return typeof lifecycle === 'string'
+            ? store.save({ kind: 'transition', expectedVersion: expected, event: lifecycle,
+                actorClass: 'host_service', actorRef: metadata.actorRef, receiptRef: metadata.receiptRef })
+            : store.save({ kind: 'admit', expectedVersion: expected, lifecycle,
+                actorClass: 'host_service', actorRef: metadata.actorRef, receiptRef: metadata.receiptRef });
+    };
+    const admit = (value: unknown) => {
+        const input = expectedVersion(value, 'onboarding');
+        return save(input.expectedVersion as number, admitProvider(snapshotOnboarding(input.onboarding)));
+    };
+    const transition = (event: ProviderLifecycleEvent) => (value: unknown) => {
+        const input = expectedVersion(value);
+        return save(input.expectedVersion as number, event);
+    };
+    const service = Object.freeze({ read });
+    const control = Object.freeze({ admit, degrade: transition('degrade'), recover: transition('recover'),
+        revoke: transition('revoke') });
+    return Object.freeze({ service, control });
+}


### PR DESCRIPTION
## Summary
- Wrap the accepted provider lifecycle store in separate read-only service and privileged host-control handles.
- Generate 128-bit operation actor and receipt references plus host timestamps inside the factory boundary.
- Admit only exact enabled-onboarding inputs and expose named degrade, recover, and revoke transitions with expected-version CAS.
- Return explicit fail-closed read dispositions for missing, corrupt, or unavailable durable state.

## Verification
- `node scripts/run-strip-types.mjs --test lib/ai-providers/fabric/provider-lifecycle-service.test.ts` — 4/4 pass, including empty and relative app-data path denial.
- All `lib/ai-providers/fabric/*.test.ts` — 72/72 pass.
- `npm run lint` — pass.
- `npm run typecheck` — pass.
- `git diff --check` — pass.

## Risk / Notes
- Stacked on PR #213 exact accepted store head `0d0755f5c5f0bab86056b8e84de497b32f4c19f3`.
- The factory is a privileged composition boundary. Explicit app-data overrides must be absolute; the production default remains host-owned. Deterministic entropy and clock injection is reserved for synthetic tests.
- Control methods do not accept actor references, receipt references, clocks, stored state, versions, or authority extras.
- The per-operation `host_service` actor reference is opaque operation metadata. It is not a stable physician or host identity. Stable authenticated principal binding remains a later composition packet.
- Records use the existing non-clinical app-data store. No clinical database, migration, real provider, credential, network, egress, UI, API, AIP, Mini, or capability wiring is added.
- Synthetic fixtures only. No PHI/PII or real credentials.

## Ticket
Refs WUL-522