### PR TITLE
docs(ai): definisci broker e servizi host per capability

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,7 @@ Approfondimenti utili:
 - Routing PDF deterministico per pagina: [ADR 0088](./adr/0088-deterministic-pdf-page-router.md)
 - Limite digest-bound della readiness AI locale: [ADR 0092](./adr/0092-limite-digest-bound-readiness-ai-locale.md)
 - Contratto Intelligence Fabric e headless 0.8.5: [ADR 0094](./adr/0094-intelligence-fabric-headless-contract-085.md)
+- Broker di projection e servizi host per capability: [ADR 0095](./adr/0095-broker-projection-e-servizi-host-per-capability.md)
 - Closeout secondario dello stack intelligente: [docs/analysis/2026-07-12-evoluzione-stack-intelligente-euristiche-scaffold-roadmap.md](./analysis/2026-07-12-evoluzione-stack-intelligente-euristiche-scaffold-roadmap.md)
 - Triage audit esterno V2: [docs/analysis/2026-07-05-audit-esterno-v2-triage.md](./analysis/2026-07-05-audit-esterno-v2-triage.md)
 
@@ -109,6 +110,7 @@ Approfondimenti utili:
 | Giunture Intelligence Fabric | [docs/adr/0090-giunture-fabric-trust-onboarding-routing-interazione.md](./adr/0090-giunture-fabric-trust-onboarding-routing-interazione.md) | `CANONICAL / ACCEPTED` | Definisce trust paired, onboarding, routing osservabile e review clinica. |
 | Candidato locale Intelligence Fabric | [docs/adr/0091-candidato-locale-fabric-admissione-continuita-status.md](./adr/0091-candidato-locale-fabric-admissione-continuita-status.md) | `CANONICAL / ACCEPTED` | Limita admissione, continuita, stato paired e harness locale senza AI paired, cloud o scritture cliniche. |
 | Intelligence Fabric e controllo headless 0.8.5 | [docs/adr/0094-intelligence-fabric-headless-contract-085.md](./adr/0094-intelligence-fabric-headless-contract-085.md) | `CANONICAL / ACCEPTED` | Definisce un Application Service Layer condiviso, separa Fabric e AIP e classifica le capability senza autorizzare runtime o apply. |
+| Broker projection e servizi host per capability | [docs/adr/0095-broker-projection-e-servizi-host-per-capability.md](./adr/0095-broker-projection-e-servizi-host-per-capability.md) | `CANONICAL / ACCEPTED` | Fissa lifecycle post-onboarding, broker plaintext minimizzato e servizi capability-specific senza autorizzare runtime o apply. |
 | FAQ pubbliche | [docs/FAQ.md](./FAQ.md) | `SECONDARY` | Sintesi rapida per capire cosa fa oggi MediFlow, quali sono i boundary dichiarati e come orientarsi nel progetto. |
 | Roadmap terminologie/FSE | [docs/FSE2-terminology-roadmap.md](./FSE2-terminology-roadmap.md) | `CANONICAL` | Evoluzione codifiche cliniche e compliance documentale (coerente con ADR 0006). |
 | Matrice baseline ufficiale GTW/FSE | [docs/fse-gtw-baseline-alignment.md](./fse-gtw-baseline-alignment.md) | `CANONICAL` | Gap analysis versionata tra artifact ministeriali `it-fse-support` e stato reale MediFlow. |

--- a/docs/adr/0095-broker-projection-e-servizi-host-per-capability.md
+++ b/docs/adr/0095-broker-projection-e-servizi-host-per-capability.md
@@ -1,0 +1,243 @@
+# ADR 0095: broker di projection e servizi host per capability
+
+Date: 2026-08-22
+Status: Accepted
+
+Issue: WUL-522
+Baseline: PR #214, branch `codex/WUL-522-fabric-provider-lifecycle-service`
+a `b232453537bd731bd2603bddfc312fbc383c9280`
+Program line: candidato `0.8.5`
+
+Related: [ADR 0089](./0089-contratto-intelligence-fabric-e-venue-esecutive.md),
+[ADR 0090](./0090-giunture-fabric-trust-onboarding-routing-interazione.md),
+[ADR 0091](./0091-candidato-locale-fabric-admissione-continuita-status.md),
+[ADR 0094](./0094-intelligence-fabric-headless-contract-085.md), ADR 0093 in
+[PR #185](https://github.com/Wulfgardr/mediflow/pull/185), WUL-282 e WUL-564.
+
+## Problema
+
+ADR 0093 richiede un broker host-owned per sessione, selezione e projection
+plaintext minimizzate. ADR 0094 richiede un solo Application Service Layer e
+vieta a UI e Agent Interface Plane (AIP) di scegliere provider, modello, venue
+o fallback.
+
+Lo stack Fabric fino a PR #214 aggiunge uno store durevole e un servizio host
+che separa lettura e controllo del lifecycle provider. Il consumer Smart
+Import corrente resta pero client-side: ricostruisce un onboarding `enabled`,
+ammette un lifecycle sintetico e invoca il provider tramite il proxy generico.
+Il record durevole, invece, contiene gia l'esito host-owned dell'ammissione
+post-onboarding.
+
+Serve una decisione di composizione prima del runtime. La decisione deve
+preservare il plaintext nel trust domain scelto dal medico, leggere il
+lifecycle una volta sola e impedire che un adapter diventi un bypass del
+Fabric o del servizio applicativo.
+
+## Decisione
+
+### 1. Il lifecycle record e l'esito autorevole post-onboarding
+
+Un `ProviderLifecycleRecord` restituito e validato dal servizio host di sola
+lettura e l'esito autorevole dell'ammissione post-onboarding.
+
+- L'onboarding `enabled` resta obbligatorio soltanto per
+  `control.admit`.
+- Un consumer non ricostruisce l'onboarding e non lo richiede a ogni
+  invocazione.
+- Il capability service legge il lifecycle esattamente una volta per
+  operazione e riusa lo stesso snapshot validato fino alla decisione Fabric.
+- `missing`, `corrupt`, `unavailable`, `degraded` e `revoked` negano prima
+  dell'invocazione provider.
+- Un mismatch tra i binding provider o credenziale del lifecycle record e la
+  risoluzione host nega prima dell'invocazione provider.
+- Un mismatch indipendente nella policy o nella receipt host-owned per modello,
+  endpoint, venue, profilo egress o fallback nega prima dell'invocazione
+  provider.
+- Ogni denial mantiene `fallback: denied_by_contract`, `receipt: null` e zero
+  generazione.
+
+Il record non rende la readiness `qualified`, non concede una capability e non
+autorizza un consumer. Il resolver Fabric applica ancora policy, receipt e
+provenance all'operazione corrente.
+
+### 2. Il client medico consegna una projection una sola volta
+
+Dopo unlock e selezione esplicita, il client medico decifra e minimizza i soli
+dati richiesti dalla capability. Il client consegna una projection tipizzata
+al broker locale fidato tramite un canale applicativo autenticato.
+
+La projection viene acquisita una sola volta per lease e lega almeno:
+
+- schema e capability;
+- sessione medico corrente;
+- paziente selezionato tramite riferimento opaco;
+- `selectionEpoch` broker-owned;
+- provenienza, freshness, scopo e scadenza.
+
+Il broker copia e possiede la projection soltanto in memoria. Restituisce un
+handle opaco, breve e non riutilizzabile fuori dal lease. L'handle non contiene
+plaintext, identita paziente, chiavi, prompt o authority ricostruibile.
+
+Lock, logout, cambio paziente, cambio `selectionEpoch`, revoca, expiry o schema
+incompatibile invalidano projection e handle prima della richiesta successiva.
+Sessione, selezione, epoch, clock o projection equivalenti forniti dal
+chiamante non sono authority.
+
+### 3. L'host espone servizi nominati per capability
+
+L'Application Service Layer host espone soltanto comandi `read` o `preview`
+capability-specific. Per i cinque smart path sono esclusi prompt liberi e
+`generic invoke`.
+
+Ogni capability service:
+
+1. risolve l'handle nel broker e verifica sessione, paziente ed epoch;
+2. legge una volta il lifecycle tramite il servizio read-only;
+3. risolve capability, provider, modello, endpoint, venue, egress e fallback
+   tramite policy host-owned e Fabric;
+4. costruisce il prompt dalla projection tipizzata;
+5. invoca il provider soltanto dopo una decisione positiva;
+6. restituisce una proposta sanitizzata con receipt e provenance PHI-safe.
+
+UI, AIP e MediFlow Mini forniscono soltanto comando tipizzato, handle e
+argomenti applicativi ammessi. Non possono fornire lifecycle, onboarding,
+provider, modello, endpoint, venue, fallback, prompt o receipt da riusare.
+
+### 4. Il controllo lifecycle resta privilegiato e separato
+
+Il privileged lifecycle control resta host-only in una composition root
+separata. Il capability service riceve soltanto il servizio di lettura.
+
+UI, route consumer, AIP, Mini e adapter non importano, esportano o ricevono il
+control. Una receipt, un handle o un `actorRef` non sostituiscono questo
+confine.
+
+### 5. Il proxy Ollama generico e legacy per i cinque smart path
+
+`/api/proxy/ollama/chat` resta presente, ma non e conforme al contratto
+end-to-end per Patient Insight, Document Synthesis, Smart Import, OCR e
+Treatment Reasoning.
+
+Ogni path deve migrare al proprio capability service prima di un claim Fabric
+end-to-end. Questo packet non modifica o rimuove il proxy. Un header generico
+non trasforma il proxy in un servizio applicativo e non autorizza il chiamante
+a scegliere la capability.
+
+### 6. Proposal e review restano separate da apply
+
+L'output del capability service e una proposta sanitizzata e review-only. Il
+servizio non restituisce prompt o risposta provider grezzi agli adapter.
+Ne il broker ne il capability service persistono o registrano nei log la
+projection grezza o la risposta provider grezza.
+
+`apply` resta negato. Review persistente, job, conferma e applicazione sono
+packet successivi. WUL-282 resta invariato e blocca qualunque apply.
+
+### 7. Le identita restano distinte
+
+Il medico autenticato, l'agente delegato e il provider AI sono identita
+distinte. Sessione medico, mandato agentico e binding provider non si
+ereditano a vicenda.
+
+`actorClass: host_service` e il relativo `actorRef` sono metadata opachi della
+singola operazione host. Non provano l'identita del medico, dell'agente o del
+provider e non sono un grant riusabile.
+
+### 8. AIP e Mini sono adapter, non bypass
+
+AIP e Mini possono invocare soltanto capability nominate dell'Application
+Service Layer entro mandato e lease broker-owned. Non accedono direttamente
+al provider, al Fabric, al lifecycle store, al control o alla projection
+plaintext.
+
+## Topologia accettata
+
+```text
+browser medico
+  -> broker projection ingest
+  -> opaque short-lived handle
+  -> capability-specific application service
+  -> lifecycle read once
+  -> Fabric resolve
+  -> provider invoke
+  -> sanitized proposal + receipt + provenance
+```
+
+AIP e Mini si collegano come adapter al capability service. Non introducono un
+secondo percorso business e non diventano provider o bypass Fabric.
+
+## Alternative scartate
+
+### Fetch lifecycle solo client
+
+Scartata perche sposta l'admissione nel consumer, separa la decisione
+dall'invocazione e rende lifecycle o onboarding valori caller-controlled. Una
+receipt client-side non autorizza l'hop provider.
+
+### Ricostruzione sintetica dell'onboarding
+
+Scartata perche dichiara `enabled` senza un evento host. Duplica l'autorita gia
+registrata dal lifecycle record e puo ammettere un provider degradato o
+revocato.
+
+### Header capability sul proxy generico
+
+Scartato perche un header e caller-controlled. Il proxy non possiede regole
+applicative, projection, lifecycle o prompt builder capability-specific.
+
+### SQLite diretto o plaintext costruito dal server
+
+Scartati perche il server non deve ottenere la master key o leggere plaintext
+dal database. Il client medico resta il punto che decifra, minimizza e lega la
+projection alla selezione corrente.
+
+## DAG reviewable e non distruttivo
+
+```text
+Headless evidence: #185 -> #187 -> #184 -> #190 --\
+                                                   +-> broker production projection ingest
+Fabric evidence:   #207 -> #211 -> #212 -> #213 -> #214 --/
+
+broker production projection ingest
+  -> lifecycle-aware capability service
+  -> Smart Import adapter
+  -> remaining four smart-path adapters
+  -> persistent review and job
+  -> independent verification WUL-564
+
+WUL-282 -- blocks --> any apply
+```
+
+Le frecce indicano dipendenza e ordine di review, non autorizzazione al merge.
+Il manager deve scegliere e verificare ogni base esatta prima del packet
+successivo. Le PR esistenti restano draft ed evidence; questa ADR non le
+riscrive, chiude o integra automaticamente.
+
+Ogni packet modifica un solo confine, resta sotto circa 300 LOC e usa soltanto
+fixture sintetiche. Nessun packet successivo e autorizzato da questa ADR senza
+un gate manageriale esplicito.
+
+## Falsificatori e stop condition
+
+Fermare la promozione se:
+
+- il lifecycle o l'onboarding sono forniti dal consumer;
+- la stessa operazione legge il lifecycle piu di una volta;
+- un handle contiene plaintext o sopravvive a revoca, expiry o cambio epoch;
+- UI, AIP o Mini scelgono provider, modello, endpoint, venue o fallback;
+- un consumer importa o riceve il privileged control;
+- uno dei cinque smart path usa ancora il proxy generico nel claim end-to-end;
+- un adapter riceve prompt o risposta provider grezzi;
+- una denial genera output o una receipt non nulla;
+- `host_service` viene presentato come identita medica;
+- compare apply prima di WUL-282, review persistente e step-up accettato;
+- compaiono PHI/PII reali, credenziali, cloud, egress o fallback silenzioso.
+
+## Non-obiettivi e stato di delivery
+
+Questo packet non aggiunge runtime, route, store, migrazioni, UI, provider,
+credenziali, dati clinici, cloud, egress, apply, review persistente o job. Non
+modifica il proxy legacy e non esegue merge o promotion.
+
+Lo stato di delivery e `ADR0095_ACCEPTED_CI_PENDING_MANAGER_VERIFY`. Il primo
+packet runtime resta soggetto a una nuova autorizzazione manageriale.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -6,6 +6,7 @@ Questa cartella contiene le decisioni di MediFlow (web + native).
 
 ## ADR piu recente
 
+- [0095-broker-projection-e-servizi-host-per-capability.md](./0095-broker-projection-e-servizi-host-per-capability.md): fissa lifecycle post-onboarding, broker projection e servizi host capability-specific.
 - [0094-intelligence-fabric-headless-contract-085.md](./0094-intelligence-fabric-headless-contract-085.md): definisce l'Application Service Layer condiviso, separa Fabric e AIP e fissa completezza architetturale e operativa.
 - [0092-limite-digest-bound-readiness-ai-locale.md](./0092-limite-digest-bound-readiness-ai-locale.md): accetta un'annotazione distinta da `runtime`; il bracket resta detection best-effort.
 - [0089-contratto-intelligence-fabric-e-venue-esecutive.md](./0089-contratto-intelligence-fabric-e-venue-esecutive.md): contratto fabric per capability, venue esplicite, profili egress versionati e ricevute di risoluzione fail-closed.

--- a/docs/markdown-index.md
+++ b/docs/markdown-index.md
@@ -11,7 +11,7 @@ read_when:
 > GitHub mostra in alto solo alcuni file speciali (`README`, `CONTRIBUTING`, `SECURITY`, ecc.).
 > Questo file elenca invece **tutti** i `.md` tracciati nella repository con una sintesi rapida d'uso.
 
-Ultimo aggiornamento: 2026-07-29
+Ultimo aggiornamento: 2026-08-22
 
 ## 📚 Come usare questo indice
 
@@ -163,6 +163,7 @@ Ultimo aggiornamento: 2026-07-29
 | [docs/adr/0091-candidato-locale-fabric-admissione-continuita-status.md](./adr/0091-candidato-locale-fabric-admissione-continuita-status.md) | Candidato locale Fabric: admissione provider, continuita fail-closed, stato paired read-only e harness sintetico senza egress o scritture cliniche. |
 | [docs/adr/0092-limite-digest-bound-readiness-ai-locale.md](./adr/0092-limite-digest-bound-readiness-ai-locale.md) | ADR accettato: annotazione distinta da `runtime`, bracket digest best-effort e qualified readiness bloccata. |
 | [docs/adr/0094-intelligence-fabric-headless-contract-085.md](./adr/0094-intelligence-fabric-headless-contract-085.md) | ADR accettata 0.8.5 per Application Service Layer condiviso, Fabric e AIP ortogonali, catalogo 66/66, authority agentica e disposition progressive. |
+| [docs/adr/0095-broker-projection-e-servizi-host-per-capability.md](./adr/0095-broker-projection-e-servizi-host-per-capability.md) | ADR accettata per lifecycle post-onboarding, broker di projection minimizzate e servizi host capability-specific. |
 | [docs/adr/0012-operator-reviewed-smart-import-from-patient-context.md](./adr/0012-operator-reviewed-smart-import-from-patient-context.md) | Smart import reviewable da note, diario e documenti verso diagnosi ICD-11 e terapie nel profilo paziente. |
 | [docs/adr/0013-qwen35-default-text-only-medgemma-specialist.md](./adr/0013-qwen35-default-text-only-medgemma-specialist.md) | Aggiorna il default text-only a `qwen3.5:35b-a3b` e mantiene MedGemma come opzione specialistica non-default. |
 | [docs/adr/0014-native-token-bootstrap-secure-first.md](./adr/0014-native-token-bootstrap-secure-first.md) | Precedenza secure-first del token native (`Keychain -> config -> legacy`) e failure mode espliciti. |


### PR DESCRIPTION
## Summary
- Registra ADR 0095 come decisione `Accepted` per attuare ADR 0093 e ADR 0094 senza introdurre runtime.
- Definisce il lifecycle record validato come esito autorevole post-onboarding, la projection minimizzata broker-owned e i servizi host capability-specific.
- Separa il privileged lifecycle control dai consumer e classifica `/api/proxy/ollama/chat` come legacy/non conforme per i cinque smart path governati.
- Fissa la topologia e il DAG reviewable per broker, capability service, adapter e review persistente.

## Verification
- `git diff --check`: PASS.
- `rg --files -g '*.md' | sort`: PASS; ADR 0095 presente nell'inventario.
- Verifica locale dei link Markdown nei quattro documenti modificati: PASS, 359 link risolti.
- `npm run check:claims`: PASS, 493 file analizzati e 0 claim ad alto rischio.
- Diff rispetto a `b232453537bd731bd2603bddfc312fbc383c9280`: 4 file, 248 aggiunte e 1 rimozione.

## Risk / Notes
- PR docs-only stacked su #214; nessuna modifica runtime, UI, API, AIP, Mini, store o controllo lifecycle.
- L'ADR non autorizza merge, promotion, provider reale, cloud, egress, credenziali, PHI/PII, apply o packet successivi.
- `/api/proxy/ollama/chat` non viene rimosso in questo packet.
- Stato di handoff: `ADR0095_ACCEPTED_CI_PENDING_MANAGER_VERIFY`.

## Ticket
Refs WUL-522
