### PR TITLE
feat(ai): aggiungi broker projection tipizzate

### DIFF
--- a/lib/typed-projection-broker.test.ts
+++ b/lib/typed-projection-broker.test.ts
@@ -1,0 +1,116 @@
+/* @Codex */
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { type SmartImportProjection } from './smart-import-projection.ts';
+import { createTypedProjectionBroker, ProjectionBrokerError, type TypedProjectionBrokerSources } from './typed-projection-broker.ts';
+
+const NOW = '2026-08-22T12:00:00.000Z';
+const REF = 'opaque-1234567890abcdef';
+function config() {
+    return { sessionRef: `session.${REF}`, ambulatoryRef: `ambulatory.${REF}`, patientRef: `patient.${REF}`,
+        selectionEpoch: 7, leaseRef: `lease.${REF}`, expiresAt: '2026-08-22T12:10:00.000Z' };
+}
+function sources(overrides: Partial<TypedProjectionBrokerSources> = {}): TypedProjectionBrokerSources {
+    return { clock: () => NOW, entropy: () => Uint8Array.from({ length: 16 }, (_, index) => index), ...overrides };
+}
+function projection() {
+    return { schemaVersion: 'mediflow.smart-import.projection.v1', capability: 'smart_import', patientRef: `patient.${REF}`,
+        selectionEpoch: 7, patientRevision: 3, sourceRevision: 5, capturedAt: NOW,
+        currentDiagnoses: [{ system: 'ICD-11', code: 'FAKE-1', description: 'Diagnosi sintetica' }],
+        currentActiveTherapies: [{ drugName: 'Farmaco sintetico', activePrinciple: null, dosage: '1 unita', aic: null, atc: null }],
+        therapyCandidateHints: [{ sourceId: `source.${REF}`, label: 'Fonte sintetica', excerpt: 'Indicazione sintetica.' }],
+        sources: [{ id: `source.${REF}`, kind: 'clinical-entry', label: 'Diario sintetico', date: NOW, content: 'Evidenza sintetica.' }],
+    } satisfies SmartImportProjection;
+}
+let sequence = 0;
+const requestId = () => `request.test-${REF}-${sequence += 1}`;
+const ingest = (boundary: ReturnType<typeof createTypedProjectionBroker>, value = projection()) =>
+    boundary.ingest.ingest({ projection: value, requestId: requestId() });
+const reject = (action: () => unknown, code: string) => assert.throws(action, (error) => error instanceof ProjectionBrokerError
+    && error.code === code && error.message === `Projection broker rejected: ${code}` && !/Diagnosi|Farmaco|opaque-123/u.test(error.message));
+
+test('ingests once and returns an opaque handle for one detached frozen consume', () => {
+    let clocks = 0; let entropy = 0;
+    const boundary = createTypedProjectionBroker(config(), sources({ clock: () => { clocks += 1; return NOW; },
+        entropy: () => { entropy += 1; return Uint8Array.from({ length: 16 }, (_, index) => index); } }));
+    assert.deepEqual(Object.keys(boundary), ['ingest', 'service', 'control']);
+    const input = projection();
+    const handle = boundary.ingest.ingest({ projection: input, requestId: `request.ingest-${REF}` });
+    assert.match(handle, /^prj_[0-9a-f]{32}$/u);
+    assert.doesNotMatch(handle, /patient|Diagnosi|Farmaco/u);
+    input.sources[0].content = 'Mutazione successiva';
+    const snapshot = boundary.service.consume({ handle, capability: 'smart_import', requestId: `request.consume-${REF}` });
+    assert.equal(snapshot.sources[0].content, 'Evidenza sintetica.');
+    assert.equal(Object.isFrozen(snapshot.sources[0]), true);
+    assert.deepEqual({ clocks, entropy }, { clocks: 2, entropy: 1 });
+    assert.throws(() => boundary.service.consume({ handle, capability: 'smart_import', requestId: `request.consume-${REF}` }),
+        (error) => error instanceof ProjectionBrokerError && error.code === 'request_replayed');
+});
+
+test('maps throwing or invalid clock and entropy sources to one fixed error', () => {
+    for (const source of [
+        sources({ clock: () => { throw new Error('raw clock'); } }),
+        sources({ clock: () => 'not-a-timestamp' }),
+        sources({ entropy: () => { throw new Error('raw entropy'); } }),
+        sources({ entropy: () => new Uint8Array(15) }),
+    ]) reject(() => ingest(createTypedProjectionBroker(config(), source)), 'source_invalid');
+    reject(() => createTypedProjectionBroker(config(), { ...sources(), extra: true } as never), 'source_invalid');
+});
+
+test('rejects non-exact authority, operations and opaque grammars', () => {
+    let reads = 0;
+    const accessor = config(); Object.defineProperty(accessor, 'patientRef', { get() { reads += 1; return `patient.${REF}`; } });
+    for (const value of [{ ...config(), providerId: 'caller' }, Object.create(config()), accessor])
+        reject(() => createTypedProjectionBroker(value as never, sources()), 'input_invalid');
+    assert.equal(reads, 0);
+    reject(() => createTypedProjectionBroker({ ...config(), sessionRef: 'short' }, sources()), 'input_invalid');
+    const boundary = createTypedProjectionBroker(config(), sources());
+    reject(() => boundary.ingest.ingest({ projection: projection(), requestId: 'short' }), 'input_invalid');
+    reject(() => boundary.ingest.ingest({ projection: projection(), requestId: requestId(), patientRef: `patient.${REF}` } as never), 'input_invalid');
+    reject(() => boundary.service.consume({ handle: 'prj_NOT_HEX', capability: 'smart_import', requestId: requestId() }), 'input_invalid');
+});
+
+test('denies invalid, stale, wrong-patient and wrong-epoch projections before entropy', () => {
+    let entropyCalls = 0;
+    for (const [change, code] of [
+        [(value: ReturnType<typeof projection>) => Object.assign(value, { payload: 'arbitrary' }), 'projection_invalid'],
+        [(value: ReturnType<typeof projection>) => { value.capturedAt = '2026-08-22T11:54:59.999Z'; }, 'projection_stale'],
+        [(value: ReturnType<typeof projection>) => { value.patientRef = `other.${REF}`; }, 'patient_mismatch'],
+        [(value: ReturnType<typeof projection>) => { value.selectionEpoch = 8; }, 'selection_changed'],
+    ] as const) {
+        const value = projection(); change(value);
+        reject(() => ingest(createTypedProjectionBroker(config(), sources({ entropy: () => { entropyCalls += 1; return new Uint8Array(16); } })), value), code);
+    }
+    assert.equal(entropyCalls, 0);
+});
+
+test('fails closed on wrong capability, missing handle, replay and collision', () => {
+    const boundary = createTypedProjectionBroker(config(), sources()); const handle = ingest(boundary);
+    const replay = requestId();
+    reject(() => boundary.service.consume({ handle, capability: 'other', requestId: replay } as never), 'capability_mismatch');
+    reject(() => boundary.service.consume({ handle, capability: 'smart_import', requestId: replay }), 'request_replayed');
+    reject(() => boundary.service.consume({ handle: `prj_${'f'.repeat(32)}`, capability: 'smart_import', requestId: requestId() }), 'handle_missing');
+    reject(() => ingest(boundary), 'handle_collision');
+    boundary.service.consume({ handle, capability: 'smart_import', requestId: requestId() });
+    reject(() => boundary.service.consume({ handle, capability: 'smart_import', requestId: requestId() }), 'handle_missing');
+});
+
+test('clears projections on selection change, expiry, lock and revoke', () => {
+    for (const [prepare, code] of [
+        [(boundary: ReturnType<typeof createTypedProjectionBroker>) => boundary.control.changeSelection({ patientRef: `next.${REF}`, selectionEpoch: 8 }), 'selection_changed'],
+        [(boundary: ReturnType<typeof createTypedProjectionBroker>) => boundary.control.lock(), 'broker_locked'],
+        [(boundary: ReturnType<typeof createTypedProjectionBroker>) => boundary.control.revoke(), 'broker_revoked'],
+    ] as const) {
+        const boundary = createTypedProjectionBroker(config(), sources()); const handle = ingest(boundary); prepare(boundary);
+        reject(() => boundary.service.consume({ handle, capability: 'smart_import', requestId: requestId() }), code);
+    }
+    const boundary = createTypedProjectionBroker(config(), sources());
+    reject(() => boundary.control.changeSelection({ patientRef: `next.${REF}`, selectionEpoch: 7 }), 'input_invalid');
+    reject(() => ingest(createTypedProjectionBroker(config(), sources({ clock: () => '2026-08-22T12:10:00.000Z' }))), 'lease_expired');
+});
+
+test('uses internal production clock and 128-bit entropy when sources are omitted', () => {
+    const now = new Date(); const value = projection(); value.capturedAt = now.toISOString();
+    const boundary = createTypedProjectionBroker({ ...config(), expiresAt: new Date(now.getTime() + 60_000).toISOString() });
+    assert.match(ingest(boundary, value), /^prj_[0-9a-f]{32}$/u);
+});

--- a/lib/typed-projection-broker.ts
+++ b/lib/typed-projection-broker.ts
@@ -1,0 +1,118 @@
+/* @Codex */
+import 'server-only';
+import { randomBytes } from 'node:crypto';
+import { SmartImportProjectionError, snapshotSmartImportProjection, type SmartImportProjection } from './smart-import-projection.ts';
+
+export type ProjectionBrokerErrorCode =
+    | 'broker_locked' | 'broker_revoked' | 'capability_mismatch' | 'handle_collision' | 'handle_missing'
+    | 'input_invalid' | 'lease_expired' | 'patient_mismatch' | 'projection_invalid' | 'projection_stale'
+    | 'request_replayed' | 'selection_changed' | 'source_invalid';
+export class ProjectionBrokerError extends Error {
+    constructor(readonly code: ProjectionBrokerErrorCode) {
+        super(`Projection broker rejected: ${code}`);
+        this.name = 'ProjectionBrokerError';
+    }
+}
+export type TypedProjectionBrokerSources = Readonly<{ clock: () => string; entropy: () => Uint8Array }>;
+export type TypedProjectionBrokerConfig = Readonly<{
+    sessionRef: string;
+    ambulatoryRef: string;
+    patientRef: string;
+    selectionEpoch: number;
+    leaseRef: string;
+    expiresAt: string;
+}>;
+
+function fail(code: ProjectionBrokerErrorCode): never { throw new ProjectionBrokerError(code); }
+function exact(value: unknown, keys: readonly string[], code: ProjectionBrokerErrorCode) {
+    if (typeof value !== 'object' || value === null || Array.isArray(value) || Object.getPrototypeOf(value) !== Object.prototype) fail(code);
+    const ownKeys = Reflect.ownKeys(value);
+    if (ownKeys.length !== keys.length || ownKeys.some((key) => typeof key !== 'string' || !keys.includes(key))) fail(code);
+    const record: Record<string, unknown> = {};
+    for (const key of keys) {
+        const descriptor = Object.getOwnPropertyDescriptor(value, key);
+        if (!descriptor || !('value' in descriptor)) fail(code);
+        record[key] = descriptor.value;
+    }
+    return record;
+}
+function opaque(value: unknown, code: ProjectionBrokerErrorCode) {
+    if (typeof value !== 'string' || !/^[A-Za-z][A-Za-z0-9._:-]{15,159}$/u.test(value)) fail(code);
+    return value;
+}
+function positive(value: unknown) {
+    if (!Number.isSafeInteger(value) || (value as number) < 1) fail('input_invalid');
+    return value as number;
+}
+function timestamp(value: unknown, code: ProjectionBrokerErrorCode) {
+    if (typeof value !== 'string' || value.length > 32 || !Number.isFinite(Date.parse(value)) || new Date(value).toISOString() !== value) fail(code);
+    return value;
+}
+const productionSources = Object.freeze({ clock: () => new Date().toISOString(), entropy: () => randomBytes(16) });
+
+export function createTypedProjectionBroker(configValue: TypedProjectionBrokerConfig, sourceValue: TypedProjectionBrokerSources = productionSources) {
+    const config = exact(configValue, ['sessionRef', 'ambulatoryRef', 'patientRef', 'selectionEpoch', 'leaseRef', 'expiresAt'], 'input_invalid');
+    opaque(config.sessionRef, 'input_invalid'); opaque(config.ambulatoryRef, 'input_invalid'); opaque(config.leaseRef, 'input_invalid');
+    let patientRef = opaque(config.patientRef, 'input_invalid'); let selectionEpoch = positive(config.selectionEpoch);
+    const expiresMs = Date.parse(timestamp(config.expiresAt, 'input_invalid'));
+    const sourceRecord = exact(sourceValue, ['clock', 'entropy'], 'source_invalid');
+    if (typeof sourceRecord.clock !== 'function' || typeof sourceRecord.entropy !== 'function') fail('source_invalid');
+    const clock = sourceRecord.clock as () => string; const entropy = sourceRecord.entropy as () => Uint8Array;
+    const records = new Map<string, SmartImportProjection>(); const issued = new Set<string>(); const requests = new Set<string>();
+    let locked = false; let revoked = false; let selectionChanged = false;
+    const readClock = () => {
+        try { return timestamp(clock(), 'source_invalid'); } catch { return fail('source_invalid'); }
+    };
+    const readHandle = () => {
+        try {
+            const bytes = entropy();
+            if (!(bytes instanceof Uint8Array) || bytes.byteLength < 16) return fail('source_invalid');
+            let hex = ''; for (let index = 0; index < 16; index += 1) hex += bytes[index].toString(16).padStart(2, '0');
+            return `prj_${hex}`;
+        } catch { return fail('source_invalid'); }
+    };
+    const acceptRequest = (value: unknown) => {
+        const requestId = opaque(value, 'input_invalid');
+        if (requests.has(requestId)) fail('request_replayed');
+        requests.add(requestId);
+    };
+    const active = () => {
+        const now = readClock();
+        if (revoked) fail('broker_revoked');
+        if (locked) fail('broker_locked');
+        if (Date.parse(now) >= expiresMs) { records.clear(); fail('lease_expired'); }
+        return now;
+    };
+    const ingest = Object.freeze({ ingest(inputValue: Readonly<{ projection: SmartImportProjection; requestId: string }>) {
+        const input = exact(inputValue, ['projection', 'requestId'], 'input_invalid'); acceptRequest(input.requestId); const now = active();
+        let snapshot: SmartImportProjection;
+        try { snapshot = snapshotSmartImportProjection(input.projection, now); } catch (error) {
+            if (error instanceof SmartImportProjectionError) return fail(error.code);
+            return fail('projection_invalid');
+        }
+        if (snapshot.patientRef !== patientRef) fail('patient_mismatch');
+        if (snapshot.selectionEpoch !== selectionEpoch) fail('selection_changed');
+        const handle = readHandle();
+        if (issued.has(handle)) fail('handle_collision');
+        issued.add(handle); records.set(handle, snapshot); selectionChanged = false; return handle;
+    } });
+    const service = Object.freeze({ consume(inputValue: Readonly<{ handle: string; capability: 'smart_import'; requestId: string }>) {
+        const input = exact(inputValue, ['handle', 'capability', 'requestId'], 'input_invalid'); acceptRequest(input.requestId); active();
+        if (selectionChanged) fail('selection_changed');
+        if (input.capability !== 'smart_import') fail('capability_mismatch');
+        if (typeof input.handle !== 'string' || !/^prj_[0-9a-f]{32}$/u.test(input.handle)) fail('input_invalid');
+        const snapshot = records.get(input.handle);
+        if (!snapshot) fail('handle_missing');
+        records.delete(input.handle); return snapshot;
+    } });
+    const control = Object.freeze({
+        lock() { locked = true; records.clear(); },
+        revoke() { revoked = true; records.clear(); },
+        changeSelection(value: Readonly<{ patientRef: string; selectionEpoch: number }>) {
+            const next = exact(value, ['patientRef', 'selectionEpoch'], 'input_invalid'); const nextEpoch = positive(next.selectionEpoch);
+            if (nextEpoch <= selectionEpoch) fail('input_invalid');
+            patientRef = opaque(next.patientRef, 'input_invalid'); selectionEpoch = nextEpoch; selectionChanged = true; records.clear();
+        },
+    });
+    return Object.freeze({ ingest, service, control });
+}

--- a/lib/typed-projection-broker.ts
+++ b/lib/typed-projection-broker.ts
@@ -1,7 +1,7 @@
 /* @Codex */
 import 'server-only';
 import { randomBytes } from 'node:crypto';
-import { SmartImportProjectionError, snapshotSmartImportProjection, type SmartImportProjection } from './smart-import-projection.ts';
+import { SmartImportProjectionError, snapshotSmartImportProjection, type SmartImportProjection } from './smart-import-projection';
 
 export type ProjectionBrokerErrorCode =
     | 'broker_locked' | 'broker_revoked' | 'capability_mismatch' | 'handle_collision' | 'handle_missing'


### PR DESCRIPTION
## Summary
- aggiunge un broker server-only, in-memory e capability-specific per `smart_import`
- separa le superfici ingest, consume e controllo host-only con handle opaco one-shot
- usa clock ed entropy production interni; la source seam exact-key resta confinata ai test sintetici
- nega replay, collisioni, mismatch, expiry, lock, revoca e cambio selezione con errori fissi

## Verification
- `scripts/run-strip-types.mjs --test lib/typed-projection-broker.test.ts` (7 test)
- validator P1a + suite Fabric completa + Smart Import Fabric + ai-context (157 test)
- `npm run test:patient-smart-import` (24 test)
- `npm run typecheck`
- ESLint focalizzato sui due file P1b
- `git diff --cached --check`
- scan focalizzato: nessun fs, db, network, fetch, child_process o console

## Risk / Notes
- PR stacked su #216; importa il validator senza cambiarne la semantica
- nessuna route, UI, lifecycle control/store, AIP/Mini adapter o invocazione provider/Fabric
- `node:crypto` genera soltanto handle opachi da almeno 128 bit; nessuna PHI/PII, credenziale o egress

## Ticket
Refs WUL-522