### PR TITLE
feat(ai): instrada dal lifecycle host persistito

### DIFF
--- a/lib/ai-providers/fabric/candidate-router.test.ts
+++ b/lib/ai-providers/fabric/candidate-router.test.ts
@@ -10,7 +10,7 @@ import {
 } from './contract.ts';
 import { advanceOnboarding, startOnboarding, type ProviderOnboardingState } from './onboarding.ts';
 import { admitProvider, transitionProviderLifecycle } from './provider-lifecycle.ts';
-import { routeCandidateCapability } from './candidate-router.ts';
+import { routeCandidateCapability, routeHostCandidateCapability } from './candidate-router.ts';
 import { observeVenue } from './routing-observability.ts';
 
 const deterministic = DETERMINISTIC_CAPABILITY_DESCRIPTORS.icd_lookup;
@@ -120,6 +120,65 @@ test('una generativa richiede onboarding enabled, lifecycle disponibile e receip
     assert.equal(result.decision.receipt?.provider, 'ollama');
     assert.equal(result.decision.receipt?.providerReceipt?.provider, 'ollama');
     assert.equal(result.decision.fallback, 'denied_by_contract');
+});
+
+test('il router host usa il lifecycle persistito senza ricostruire onboarding', () => {
+    const result = routeHostCandidateCapability({
+        policy: policyFor(generative),
+        request: { descriptor: generative, venue: 'local_process', generative: binding },
+        observations: [observeVenue('local_process', 'available', null)],
+    }, availableLocal());
+    assert.equal(result.decision.outcome, 'resolved');
+    assert.equal(result.decision.receipt?.provider, 'ollama');
+});
+
+test('il router host nega lifecycle malformed, non disponibile o incoerente', () => {
+    const available = availableLocal();
+    const cases = [
+        [{ ...available, extra: 'not-allowed' }, 'provider_lifecycle_invalid'],
+        [transitionProviderLifecycle(available, 'degrade'), 'provider_lifecycle_unavailable'],
+        [transitionProviderLifecycle(available, 'revoke'), 'provider_lifecycle_unavailable'],
+        [{ ...available, credentialClass: 'api_key' }, 'provider_lifecycle_unavailable'],
+        [availableLocal('other_provider'), 'provider_receipt_mismatch'],
+    ] as const;
+
+    for (const [lifecycle, denialCode] of cases) {
+        const result = routeHostCandidateCapability({
+            policy: policyFor(generative),
+            request: { descriptor: generative, venue: 'local_process', generative: binding },
+            observations: [observeVenue('local_process', 'available', null)],
+        }, lifecycle as never);
+
+        assert.equal(result.decision.denialCode, denialCode);
+        assert.equal(result.decision.receipt, null);
+        assert.equal(result.resolution, null);
+    }
+});
+
+test('il router host legge ogni campo lifecycle una volta e ignora onboarding caller-supplied', () => {
+    let providerReads = 0;
+    const lifecycle = {
+        ...availableLocal(),
+        get provider() {
+            providerReads += 1;
+            return providerReads === 1 ? 'ollama' : 'private-patient-value';
+        },
+    };
+    let onboardingReads = 0;
+    const result = routeHostCandidateCapability({
+        policy: policyFor(generative),
+        request: { descriptor: generative, venue: 'local_process', generative: binding },
+        observations: [observeVenue('local_process', 'available', null)],
+        get onboarding() {
+            onboardingReads += 1;
+            return enabledLocal();
+        },
+    } as never, lifecycle);
+
+    assert.equal(result.decision.outcome, 'resolved');
+    assert.equal(providerReads, 1);
+    assert.equal(onboardingReads, 0);
+    assert.equal(JSON.stringify(result).includes('private-patient-value'), false);
 });
 
 test('snapshotta onboarding e lifecycle una sola volta prima dell admissione', () => {

--- a/lib/ai-providers/fabric/candidate-router.ts
+++ b/lib/ai-providers/fabric/candidate-router.ts
@@ -59,6 +59,8 @@ export type CandidateRoutingInput = Readonly<{
     reconnection?: PairingReconnectionClass;
 }>;
 
+export type HostCandidateRoutingInput = Omit<CandidateRoutingInput, 'onboarding' | 'lifecycle'>;
+
 export type CandidateRoutingResult = Readonly<{
     decision: CandidateRoutingDecision;
     resolution: FabricResolution | null;
@@ -92,6 +94,18 @@ function snapshotCandidateRoutingInput(input: CandidateRoutingInput): CandidateR
         observations: input.observations,
         onboarding: input.onboarding,
         lifecycle: input.lifecycle,
+        reconnection: input.reconnection,
+    });
+}
+
+function snapshotHostCandidateRoutingInput(input: HostCandidateRoutingInput): CandidateRoutingInput {
+    if (!isRecord(input)) {
+        throw new FabricPolicyError('policy_invalid');
+    }
+    return Object.freeze({
+        policy: input.policy,
+        request: input.request,
+        observations: input.observations,
         reconnection: input.reconnection,
     });
 }
@@ -209,15 +223,19 @@ function snapshotGenerativeAdmission(input: CandidateRoutingInput): ProviderLife
     return lifecycle;
 }
 
-/**
- * Candidate-only admission layer for ADR 0091. It composes the pure resolver
- * with provider lifecycle and paired trust, but introduces no provider call,
- * persistence, credential handling, or fallback selection.
- */
-export function routeCandidateCapability(
-    input: CandidateRoutingInput,
+function snapshotPersistedGenerativeAdmission(value: unknown): ProviderLifecycleState | null {
+    const lifecycle = snapshotProviderLifecycle(value);
+    return lifecycle.credentialClass === 'local_model'
+        && lifecycle.status === 'available_unqualified'
+        ? lifecycle
+        : null;
+}
+
+function routeCandidateCapabilityWithAdmission(
+    inputSnapshot: CandidateRoutingInput,
+    snapshotAdmission: () => ProviderLifecycleState | null,
+    mapsOnboardingErrors: boolean,
 ): CandidateRoutingResult {
-    const inputSnapshot = snapshotCandidateRoutingInput(input);
     const context = snapshotCandidateDecisionContext(inputSnapshot);
     const observations = observationsFor(context.requestedVenue, inputSnapshot.observations);
     const requestedObservation = observations.find(
@@ -245,7 +263,7 @@ export function routeCandidateCapability(
     let admittedLifecycle: ProviderLifecycleState | null = null;
     if (context.descriptor.class === 'generative') {
         try {
-            admittedLifecycle = snapshotGenerativeAdmission(inputSnapshot);
+            admittedLifecycle = snapshotAdmission();
             if (!admittedLifecycle) {
                 return denied(context, observations, 'provider_lifecycle_unavailable');
             }
@@ -254,9 +272,9 @@ export function routeCandidateCapability(
                 return denied(
                     context,
                     observations,
-                    error.code === 'onboarding_not_enabled'
+                    mapsOnboardingErrors && (error.code === 'onboarding_not_enabled'
                         || error.code === 'credential_class_forbidden'
-                        || error.code === 'egress_profile_unsatisfied'
+                        || error.code === 'egress_profile_unsatisfied')
                         ? 'provider_onboarding_required'
                         : 'provider_lifecycle_invalid',
                 );
@@ -297,4 +315,32 @@ export function routeCandidateCapability(
         ),
         resolution: routed.resolution,
     });
+}
+
+/**
+ * Candidate-only admission layer for ADR 0091. It composes the pure resolver
+ * with provider lifecycle and paired trust, but introduces no provider call,
+ * persistence, credential handling, or fallback selection.
+ */
+export function routeCandidateCapability(
+    input: CandidateRoutingInput,
+): CandidateRoutingResult {
+    const inputSnapshot = snapshotCandidateRoutingInput(input);
+    return routeCandidateCapabilityWithAdmission(
+        inputSnapshot,
+        () => snapshotGenerativeAdmission(inputSnapshot),
+        true,
+    );
+}
+
+export function routeHostCandidateCapability(
+    input: HostCandidateRoutingInput,
+    lifecycle: ProviderLifecycleState,
+): CandidateRoutingResult {
+    const inputSnapshot = snapshotHostCandidateRoutingInput(input);
+    return routeCandidateCapabilityWithAdmission(
+        inputSnapshot,
+        () => snapshotPersistedGenerativeAdmission(lifecycle),
+        false,
+    );
 }


### PR DESCRIPTION
## Summary
- aggiunge `routeHostCandidateCapability` per usare un lifecycle post-onboarding validato senza ricostruire onboarding
- riusa il percorso Fabric esistente e mantiene invariata la API legacy
- nega lifecycle malformed, degraded, revoked o con credenziale incoerente e mismatch provider/receipt con receipt nulla
- limita il diff al router candidato e ai relativi test sintetici

## Verification
- `candidate-router.test.ts`: 11 test passati
- suite Fabric completa: 81 test passati
- `npm run typecheck`
- ESLint focalizzato sui due file
- `npm run check:never-regress`
- `npm run check:claims`
- `git diff --check`
- build Webpack: compilazione production, TypeScript e 108 pagine statiche completati

## Risk / Notes
- PR draft stacked su #217
- nessun consumer, route, UI, AIP, Mini, store o lifecycle control modificato
- `npm run build` con Turbopack non parte perché il worktree usa un symlink `node_modules` esterno; il retry Webpack completa la build ma il postbuild standalone rifiuta correttamente `better-sqlite3` risolto fuori dal bundle
- nessuna PHI/PII, credenziale, provider reale, cloud o egress

## Ticket
Refs WUL-522