### PR TITLE
feat(ai): aggiungi contratto capability Smart Import

### DIFF
--- a/lib/domain/documents/patient-smart-import-capability-contract.test.ts
+++ b/lib/domain/documents/patient-smart-import-capability-contract.test.ts
@@ -1,0 +1,104 @@
+/* @Codex */
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { SmartImportProjection } from '../../smart-import-projection';
+import {
+    buildPatientSmartImportCapabilityPrompt,
+    parsePatientSmartImportCapabilityProposal,
+    PatientSmartImportCapabilityError,
+} from './patient-smart-import-capability-contract';
+
+const sourceId = 'source.synthetic.0001';
+const projection: SmartImportProjection = Object.freeze({
+    schemaVersion: 'mediflow.smart-import.projection.v1',
+    capability: 'smart_import',
+    patientRef: 'patient.synthetic.0001',
+    selectionEpoch: 4,
+    patientRevision: 7,
+    sourceRevision: 9,
+    capturedAt: '2026-08-22T09:00:00.000Z',
+    currentDiagnoses: Object.freeze([{ system: 'ICD-11', code: '5A11', description: 'Diagnosi sintetica corrente' }]),
+    currentActiveTherapies: Object.freeze([{ drugName: 'Farmaco sintetico', activePrinciple: 'Principio sintetico', dosage: '1 dose/die', aic: null, atc: null }]),
+    therapyCandidateHints: Object.freeze([{ sourceId, label: 'Candidato sintetico', excerpt: 'Terapia sintetica da rivedere' }]),
+    sources: Object.freeze([{ id: sourceId, kind: 'clinical-entry' as const, label: 'Fonte sintetica', date: '2026-08-22T08:55:00.000Z', content: 'Contenuto clinico interamente sintetico.' }]),
+});
+
+type Binding = string | null | undefined;
+
+function responseWithBindings(bindings: { diagnosis?: Binding; therapy?: Binding; prescription?: Binding; item?: Binding } = {}): string {
+    const source = (value: Binding) => value === null ? {} : { sourceId: value ?? sourceId };
+    return JSON.stringify({
+        schemaVersion: 'mediflow.ai.extract.v1', task: 'smart_import', summary: 'Proposta sintetica', ignoredRaw: 'raw-provider-marker',
+        data: {
+            diagnoses: [{ label: 'Diagnosi proposta', icdQuery: 'synthetic diagnosis', confidence: 'high', evidence: 'Evidenza sintetica', ...source(bindings.diagnosis) }],
+            therapies: [{ drugMention: 'Farmaco proposto', drugQuery: 'synthetic drug', confidence: 'medium', evidence: 'Terapia sintetica', ...source(bindings.therapy) }],
+            servicePrescriptions: [{ serviceName: 'Esame sintetico', category: 'lab', confidence: 'low', evidence: 'Richiesta sintetica', ...source(bindings.prescription),
+                items: [{ serviceName: 'Analita sintetico', category: 'lab', confidence: 'low', evidence: 'Dettaglio sintetico', ...source(bindings.item) }] }],
+        },
+    });
+}
+
+test('builds the Smart Import prompt from only the typed clinical projection fields', () => {
+    const prompt = buildPatientSmartImportCapabilityPrompt(projection);
+    const payload = JSON.parse(prompt.split('CONTESTO STRUTTURATO:\n')[1] ?? 'null');
+
+    assert.deepEqual(Object.keys(payload), ['currentDiagnoses', 'currentActiveTherapies', 'therapyCandidateHints', 'sources']);
+    assert.deepEqual(payload.sources, projection.sources);
+    for (const forbidden of ['patientRef', 'selectionEpoch', 'patientRevision', 'sourceRevision', 'capturedAt', 'sessionRef', 'handle', 'model', 'endpoint', 'fabric']) {
+        assert.equal(Object.hasOwn(payload, forbidden), false);
+    }
+    assert.equal(prompt.includes(projection.patientRef), false);
+});
+
+test('returns a detached deep-frozen review-only proposal without raw provider material', () => {
+    const proposal = parsePatientSmartImportCapabilityProposal(responseWithBindings(), projection, '2026-08-22T09:00:01.000Z');
+
+    assert.equal(proposal.schemaVersion, 'mediflow.smart-import.proposal.v1');
+    assert.equal(proposal.writesPerformed, 0);
+    assert.equal(proposal.servicePrescriptions[0]?.items?.[0]?.sourceId, sourceId);
+    assert.equal(Object.isFrozen(proposal), true);
+    assert.equal(Object.isFrozen(proposal.servicePrescriptions), true);
+    assert.equal(Object.isFrozen(proposal.servicePrescriptions[0]?.items), true);
+    assert.equal(JSON.stringify(proposal).includes('raw-provider-marker'), false);
+    assert.equal('rawJson' in proposal, false);
+});
+
+test('fails closed when any suggestion source is missing or not projection-bound', () => {
+    const unbound = 'source.synthetic.unbound';
+    const cases = [
+        { diagnosis: null }, { diagnosis: unbound },
+        { therapy: null }, { therapy: unbound },
+        { prescription: null }, { prescription: unbound },
+        { item: null }, { item: unbound },
+    ];
+    for (const bindings of cases) {
+        assert.throws(
+            () => parsePatientSmartImportCapabilityProposal(responseWithBindings(bindings), projection, '2026-08-22T09:00:01.000Z'),
+            (error) => error instanceof PatientSmartImportCapabilityError
+                && error.code === 'source_binding_invalid'
+                && !error.message.includes('raw-provider-marker'),
+        );
+    }
+});
+
+test('uses fixed PHI-safe errors for invalid provider output and host inputs', () => {
+    assert.throws(
+        () => parsePatientSmartImportCapabilityProposal('raw-provider-marker', projection, '2026-08-22T09:00:01.000Z'),
+        (error) => error instanceof PatientSmartImportCapabilityError
+            && error.code === 'provider_output_invalid'
+            && error.message === 'Patient Smart Import capability rejected: provider_output_invalid',
+    );
+    assert.throws(
+        () => parsePatientSmartImportCapabilityProposal(responseWithBindings(), projection, 'not-an-iso-timestamp'),
+        (error) => error instanceof PatientSmartImportCapabilityError && error.code === 'prompt_input_invalid',
+    );
+    const throwingProjection = Object.defineProperty({}, 'currentDiagnoses', {
+        get: () => { throw new Error('raw-projection-marker'); },
+    }) as SmartImportProjection;
+    assert.throws(
+        () => buildPatientSmartImportCapabilityPrompt(throwingProjection),
+        (error) => error instanceof PatientSmartImportCapabilityError
+            && error.code === 'prompt_input_invalid'
+            && !error.message.includes('raw-projection-marker'),
+    );
+});

--- a/lib/domain/documents/patient-smart-import-capability-contract.ts
+++ b/lib/domain/documents/patient-smart-import-capability-contract.ts
@@ -1,0 +1,121 @@
+/* @Codex */
+import type { SmartImportProjection } from '../../smart-import-projection';
+import {
+    buildSmartImportExtractionPrompt,
+    isEnvelopeUsable,
+    parseSmartImportExtractionResponse,
+    type SmartImportDiagnosisExtraction,
+    type SmartImportServicePrescriptionExtraction,
+    type SmartImportServicePrescriptionItemExtraction,
+    type SmartImportTherapyExtraction,
+} from '../../ai-task-contracts';
+
+export type PatientSmartImportCapabilityErrorCode =
+    | 'prompt_input_invalid'
+    | 'provider_output_invalid'
+    | 'source_binding_invalid';
+
+export class PatientSmartImportCapabilityError extends Error {
+    constructor(readonly code: PatientSmartImportCapabilityErrorCode) {
+        super(`Patient Smart Import capability rejected: ${code}`);
+        this.name = 'PatientSmartImportCapabilityError';
+    }
+}
+
+function fail(code: PatientSmartImportCapabilityErrorCode): never {
+    throw new PatientSmartImportCapabilityError(code);
+}
+
+type Bound<T> = Readonly<T & { sourceId: string }>;
+type BoundService = Bound<Omit<SmartImportServicePrescriptionExtraction, 'items'> & {
+    items?: ReadonlyArray<Bound<SmartImportServicePrescriptionItemExtraction>>;
+}>;
+
+export type PatientSmartImportCapabilityProposal = Readonly<{
+    schemaVersion: 'mediflow.smart-import.proposal.v1';
+    generatedAt: string;
+    contract: Readonly<{ validJson: true; validTask: true; legacyContract: boolean }>;
+    summary: string;
+    diagnoses: ReadonlyArray<Bound<SmartImportDiagnosisExtraction>>;
+    therapies: ReadonlyArray<Bound<SmartImportTherapyExtraction>>;
+    servicePrescriptions: ReadonlyArray<BoundService>;
+    writesPerformed: 0;
+}>;
+
+export function buildPatientSmartImportCapabilityPrompt(projection: SmartImportProjection): string {
+    try {
+        return buildSmartImportExtractionPrompt({
+            currentDiagnoses: projection.currentDiagnoses.map((item) => ({ ...item })),
+            currentActiveTherapies: projection.currentActiveTherapies.map((item) => ({ ...item })),
+            therapyCandidateHints: projection.therapyCandidateHints.map((item) => ({ ...item })),
+            sources: projection.sources.map((item) => ({ ...item })),
+        });
+    } catch {
+        return fail('prompt_input_invalid');
+    }
+}
+
+function validIso(value: string): boolean {
+    return Number.isFinite(Date.parse(value)) && new Date(value).toISOString() === value;
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+    return typeof value === 'object' && value !== null && !Array.isArray(value)
+        ? value as Record<string, unknown>
+        : null;
+}
+
+function requireSource(value: unknown, sourceIds: ReadonlySet<string>): string {
+    if (typeof value !== 'string' || !sourceIds.has(value)) return fail('source_binding_invalid');
+    return value;
+}
+
+function validateRawSourceBindings(rawJson: string | null, sourceIds: ReadonlySet<string>): void {
+    if (!rawJson) return fail('provider_output_invalid');
+    const root = record(JSON.parse(rawJson));
+    const data = record(root?.data);
+    if (!data) return fail('provider_output_invalid');
+    for (const key of ['diagnoses', 'therapies', 'servicePrescriptions'] as const) {
+        const values = data[key];
+        if (!Array.isArray(values)) continue;
+        for (const value of values) {
+            const item = record(value);
+            if (!item) continue;
+            requireSource(item.sourceId, sourceIds);
+            if (key !== 'servicePrescriptions' || !Array.isArray(item.items)) continue;
+            for (const nested of item.items) {
+                const nestedItem = record(nested);
+                if (nestedItem) requireSource(nestedItem.sourceId, sourceIds);
+            }
+        }
+    }
+}
+
+export function parsePatientSmartImportCapabilityProposal(
+    response: string,
+    projection: SmartImportProjection,
+    generatedAt: string,
+): PatientSmartImportCapabilityProposal {
+    try {
+        if (!validIso(generatedAt)) return fail('prompt_input_invalid');
+        const parsed = parseSmartImportExtractionResponse(response);
+        if (!isEnvelopeUsable(parsed)) return fail('provider_output_invalid');
+        const sourceIds = new Set(projection.sources.map(({ id }) => id));
+        validateRawSourceBindings(parsed.rawJson, sourceIds);
+        const diagnoses = Object.freeze(parsed.value.data.diagnoses.map((item) => Object.freeze({ ...item, sourceId: requireSource(item.sourceId, sourceIds) })));
+        const therapies = Object.freeze(parsed.value.data.therapies.map((item) => Object.freeze({ ...item, sourceId: requireSource(item.sourceId, sourceIds) })));
+        const servicePrescriptions = Object.freeze(parsed.value.data.servicePrescriptions.map((item) => {
+            const { items: rawItems, ...service } = item;
+            const items = rawItems?.map((nested) => Object.freeze({ ...nested, sourceId: requireSource(nested.sourceId, sourceIds) }));
+            return Object.freeze({ ...service, sourceId: requireSource(service.sourceId, sourceIds), ...(items ? { items: Object.freeze(items) } : {}) });
+        }));
+        return Object.freeze({
+            schemaVersion: 'mediflow.smart-import.proposal.v1', generatedAt,
+            contract: Object.freeze({ validJson: true, validTask: true, legacyContract: parsed.legacyContract }),
+            summary: parsed.value.summary, diagnoses, therapies, servicePrescriptions, writesPerformed: 0,
+        });
+    } catch (error) {
+        if (error instanceof PatientSmartImportCapabilityError) throw error;
+        return fail('provider_output_invalid');
+    }
+}


### PR DESCRIPTION
## Summary
- Costruisce il prompt Smart Import dai soli campi clinici della projection tipizzata.
- Valida il binding di fonte per diagnosi, terapie, prescrizioni e item annidati senza fallback.
- Restituisce una proposal detached e deep-frozen senza prompt, raw JSON o risposta provider.
- Mantiene il packet puro e limitato a due nuovi file, stacked su #218.

## Verification
- `node scripts/run-strip-types.mjs --test lib/domain/documents/patient-smart-import-capability-contract.test.ts`
- `npm run test:ai-task-contracts`
- `npm run test:patient-smart-import`
- `npm run typecheck`
- `npx eslint --quiet lib/domain/documents/patient-smart-import-capability-contract.ts lib/domain/documents/patient-smart-import-capability-contract.test.ts`
- `npm run check:never-regress`
- `npm run check:claims`
- `git diff --check a34316930643ba48f9956cece8d1dc5caa46e1cf..HEAD`
- Node 24 `next build --webpack`: compilazione, TypeScript e 108 pagine completati; il postbuild standalone si ferma perché il `node_modules` condiviso risolve `better-sqlite3` fuori dal worktree.

## Risk / Notes
- Nessuna route, UI, database, catalogo, apply, Fabric o invocazione provider cambia in questo packet.
- Fixture esclusivamente sintetiche; nessun PHI/PII, credenziale, cloud o egress.
- Il parser usa gli export puri del contratto AI esistente e non importa il servizio Smart Import client-side.
- Draft PR di verifica; nessun merge o promotion autorizzato.

## Ticket
Refs WUL-522