### PR TITLE
refactor(ai): estrai selezione modello pure

### DIFF
--- a/lib/ai-model-selection.test.ts
+++ b/lib/ai-model-selection.test.ts
@@ -1,0 +1,36 @@
+/* @Codex */
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    DEFAULT_OCR_MODEL,
+    DEFAULT_TEXT_MODEL,
+    LEGACY_MEDGEMMA_TEXT_MODEL,
+    LEGACY_QWEN_TEXT_MODEL,
+    resolveTextModel,
+} from './ai-model-selection.ts';
+
+test('espone i default e i modelli testuali legacy canonici', () => {
+    assert.equal(DEFAULT_TEXT_MODEL, 'qwen3.5:35b-a3b');
+    assert.equal(DEFAULT_OCR_MODEL, 'deepseek-ocr');
+    assert.equal(LEGACY_QWEN_TEXT_MODEL, 'qwen2.5:32b');
+    assert.equal(LEGACY_MEDGEMMA_TEXT_MODEL, 'hf.co/unsloth/medgemma-1.5-4b-it-GGUF');
+});
+
+test('preferisce il modello specifico e normalizza il whitespace esterno', () => {
+    assert.equal(resolveTextModel('  clinical-local:latest  ', 'legacy-local'), 'clinical-local:latest');
+});
+
+test('usa il modello legacy quando quello specifico contiene solo whitespace', () => {
+    assert.equal(resolveTextModel(' \n\t ', '  legacy-local:latest  '), 'legacy-local:latest');
+});
+
+test('usa il default per valori assenti, vuoti o legacy obsoleti', () => {
+    for (const [specific, legacy] of [
+        [undefined, undefined],
+        ['', '  '],
+        [null, LEGACY_QWEN_TEXT_MODEL],
+        ['  ', LEGACY_MEDGEMMA_TEXT_MODEL],
+    ] as const) {
+        assert.equal(resolveTextModel(specific, legacy), DEFAULT_TEXT_MODEL);
+    }
+});

--- a/lib/ai-model-selection.ts
+++ b/lib/ai-model-selection.ts
@@ -1,0 +1,31 @@
+/* @Codex */
+export const DEFAULT_TEXT_MODEL = 'qwen3.5:35b-a3b';
+export const DEFAULT_OCR_MODEL = 'deepseek-ocr';
+export const LEGACY_QWEN_TEXT_MODEL = 'qwen2.5:32b';
+export const LEGACY_MEDGEMMA_TEXT_MODEL = 'hf.co/unsloth/medgemma-1.5-4b-it-GGUF';
+
+const STALE_TEXT_MODELS: ReadonlySet<string> = new Set([
+    LEGACY_QWEN_TEXT_MODEL,
+    LEGACY_MEDGEMMA_TEXT_MODEL,
+]);
+
+function normalizeModelName(model?: string | null): string | null {
+    const value = model?.trim();
+    return value ? value : null;
+}
+
+export function isStaleTextModel(model: string): boolean {
+    return STALE_TEXT_MODELS.has(model);
+}
+
+export function resolveTextModel(specificModel?: string | null, legacyModel?: string | null): string {
+    const specific = normalizeModelName(specificModel);
+    if (specific) return specific;
+
+    const legacy = normalizeModelName(legacyModel);
+    if (!legacy || isStaleTextModel(legacy)) {
+        return DEFAULT_TEXT_MODEL;
+    }
+
+    return legacy;
+}

--- a/lib/ai-models.ts
+++ b/lib/ai-models.ts
@@ -1,40 +1,22 @@
 /* @Codex */
 import { db } from '@/lib/db';
-
-export const DEFAULT_TEXT_MODEL = 'qwen3.5:35b-a3b';
-export const DEFAULT_OCR_MODEL = 'deepseek-ocr';
-export const LEGACY_QWEN_TEXT_MODEL = 'qwen2.5:32b';
-export const LEGACY_MEDGEMMA_TEXT_MODEL = 'hf.co/unsloth/medgemma-1.5-4b-it-GGUF';
+import { DEFAULT_TEXT_MODEL, isStaleTextModel } from './ai-model-selection';
+export {
+    DEFAULT_OCR_MODEL,
+    DEFAULT_TEXT_MODEL,
+    LEGACY_MEDGEMMA_TEXT_MODEL,
+    LEGACY_QWEN_TEXT_MODEL,
+    resolveTextModel,
+} from './ai-model-selection';
 
 const TEXT_MODEL_MIGRATION_VERSION = 'qwen35-default-v1';
-const STALE_TEXT_MODELS = new Set([
-    LEGACY_QWEN_TEXT_MODEL,
-    LEGACY_MEDGEMMA_TEXT_MODEL,
-]);
 
 let migrationComplete = false;
 let migrationPromise: Promise<void> | null = null;
 
-function normalizeModelName(model?: string | null): string | null {
-    const value = model?.trim();
-    return value ? value : null;
-}
-
-export function resolveTextModel(specificModel?: string | null, legacyModel?: string | null): string {
-    const specific = normalizeModelName(specificModel);
-    if (specific) return specific;
-
-    const legacy = normalizeModelName(legacyModel);
-    if (!legacy || STALE_TEXT_MODELS.has(legacy)) {
-        return DEFAULT_TEXT_MODEL;
-    }
-
-    return legacy;
-}
-
 async function migrateSettingIfNeeded(key: string, nextValue: string): Promise<void> {
     const current = await db.settings.get(key);
-    if (!current?.value || !STALE_TEXT_MODELS.has(current.value)) return;
+    if (!current?.value || !isStaleTextModel(current.value)) return;
     await db.settings.put({ key, value: nextValue });
 }
 


### PR DESCRIPTION
## Summary
- Estrae default, modelli legacy e risoluzione del modello in un modulo pure e server-safe.
- Mantiene invariati API pubblica, migrazione e accesso database di `lib/ai-models.ts`.
- Aggiunge test sintetici per costanti, precedenza, whitespace e modelli obsoleti.

## Verification
- `node scripts/run-strip-types.mjs --test lib/ai-model-selection.test.ts`
- `npm run test:unit` (1113 test)
- `npm run typecheck`
- `npm run lint -- lib/ai-model-selection.ts lib/ai-model-selection.test.ts lib/ai-models.ts`
- `npm run lint`
- `npm run build`
- `npm run check:never-regress`
- `npm run check:claims`
- `git diff --check`
- Scan mirata degli import vietati sul nuovo modulo pure

## Risk / Notes
- Nessun binding provider, settings snapshot, lifecycle, rete, invocazione o route entra in questo packet.
- La build usa un data dir sintetico isolato; i warning su tabelle assenti sono baseline e la build termina con esito positivo.
- P2C0b resta bloccato fino alla verifica diretta del manager e alla CI terminale verde di questa PR.
- Nessuna PHI/PII e nessun dato clinico reale.

## Ticket
Refs WUL-522
Refs WUL-518