### PR TITLE
feat(ai): aggiungi binding provider locale host

### DIFF
--- a/lib/ai-providers/host-local-provider-binding.test.ts
+++ b/lib/ai-providers/host-local-provider-binding.test.ts
@@ -1,0 +1,107 @@
+/* @Codex */
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    createHostLocalProviderBindingService,
+    type HostLocalProviderBindingDenialCode,
+    type HostLocalProviderSettingsSnapshot,
+} from './host-local-provider-binding.ts';
+
+const VALID_SETTINGS = {
+    aiProvider: 'ollama',
+    aiModel_clinical: 'clinical-local:latest',
+    aiUrl: 'http://localhost:11434/v1',
+} satisfies HostLocalProviderSettingsSnapshot;
+
+async function read(snapshot: HostLocalProviderSettingsSnapshot) {
+    return createHostLocalProviderBindingService({ readSettings: async () => snapshot }).readClinical();
+}
+
+function assertDenied(
+    result: Awaited<ReturnType<ReturnType<typeof createHostLocalProviderBindingService>['readClinical']>>,
+    code: HostLocalProviderBindingDenialCode,
+) {
+    assert.deepEqual(result, { status: 'denied', code, resolution: null });
+    assert.equal(Object.isFrozen(result), true);
+}
+
+test('legge un solo snapshot e restituisce il binding clinico locale validato', async () => {
+    let reads = 0;
+    const service = createHostLocalProviderBindingService({
+        readSettings: async () => {
+            reads += 1;
+            return VALID_SETTINGS;
+        },
+    });
+
+    assert.deepEqual(Object.keys(service), ['readClinical']);
+    const result = await service.readClinical();
+
+    assert.equal(reads, 1);
+    assert.equal(result.status, 'available');
+    if (result.status !== 'available') return;
+    assert.equal(result.resolution.receipt.task, 'clinical');
+    assert.equal(result.resolution.receipt.provider, 'ollama');
+    assert.equal(result.resolution.receipt.model, 'clinical-local:latest');
+    assert.equal(result.resolution.receipt.endpointClass, 'loopback');
+    assert.equal(result.resolution.receipt.egress, 'none');
+    assert.equal(result.resolution.adapter.getBaseUrl(), 'http://127.0.0.1:11434');
+    assert.equal(Object.isFrozen(result), true);
+});
+
+test('applica le precedenze canoniche senza accettare binding dal caller', async () => {
+    for (const [snapshot, model, endpoint] of [
+        [{}, 'qwen3.5:35b-a3b', 'http://127.0.0.1:11434'],
+        [{ aiModel: 'legacy-local', ollamaUrl: 'http://localhost:11434/v1' }, 'legacy-local', 'http://127.0.0.1:11434'],
+        [{ aiModel_clinical: ' clinical-local ', aiModel: 'legacy-local', aiUrl: 'http://127.0.0.1:8080', ollamaUrl: 'http://localhost:11434' },
+            'clinical-local', 'http://127.0.0.1:11434'],
+    ] as const) {
+        const result = await read(snapshot);
+        assert.equal(result.status, 'available');
+        if (result.status !== 'available') continue;
+        assert.equal(result.resolution.receipt.provider, 'ollama');
+        assert.equal(result.resolution.receipt.model, model);
+        assert.equal(result.resolution.adapter.getBaseUrl(), endpoint);
+    }
+});
+
+test('nega provider, modello ed endpoint non validi senza fallback silenzioso', async () => {
+    for (const [snapshot, code] of [
+        [{ ...VALID_SETTINGS, aiProvider: 'remote-provider' }, 'provider_invalid'],
+        [{ ...VALID_SETTINGS, aiModel_clinical: 'qwen3.5:cloud', aiModel: 'safe-local' }, 'model_invalid'],
+        [{ ...VALID_SETTINGS, aiUrl: ['https:', '//provider.example.test'].join(''), ollamaUrl: 'http://localhost:11434' }, 'endpoint_invalid'],
+    ] as const) {
+        assertDenied(await read(snapshot), code);
+    }
+});
+
+test('nega snapshot indisponibili o corrotti con codici fissi', async () => {
+    const unavailable = await createHostLocalProviderBindingService({
+        readSettings: async () => { throw new Error('raw settings failure'); },
+    }).readClinical();
+    assertDenied(unavailable, 'settings_unavailable');
+
+    let accessorReads = 0;
+    const accessor = {};
+    Object.defineProperty(accessor, 'aiProvider', { enumerable: true, get() { accessorReads += 1; return 'ollama'; } });
+    for (const snapshot of [null, [], { ...VALID_SETTINGS, extra: 'raw' }, { aiProvider: 42 }, accessor]) {
+        const result = await createHostLocalProviderBindingService({
+            readSettings: async () => snapshot as never,
+        }).readClinical();
+        assertDenied(result, 'settings_corrupt');
+    }
+    assert.equal(accessorReads, 0);
+});
+
+test('non include valori settings o errori raw nei dinieghi', async () => {
+    const result = await read({
+        ...VALID_SETTINGS,
+        aiProvider: 'synthetic-secret-provider',
+        aiModel_clinical: 'synthetic-secret-model',
+        aiUrl: ['https:', '//synthetic-secret.example.test'].join(''),
+    });
+    const serialized = JSON.stringify(result);
+
+    assert.equal(serialized.includes('synthetic-secret'), false);
+    assert.equal(serialized.includes('raw settings failure'), false);
+});

--- a/lib/ai-providers/host-local-provider-binding.ts
+++ b/lib/ai-providers/host-local-provider-binding.ts
@@ -1,0 +1,125 @@
+/* @Codex */
+import 'server-only';
+import { inArray } from 'drizzle-orm';
+import { dbServer } from '@/lib/db-server';
+import { resolveTextModel } from '@/lib/ai-model-selection';
+import { settings } from '@/lib/schema';
+import { DEFAULT_OLLAMA_BASE_URL, resolveOllamaBaseUrl } from './base-url';
+import {
+    localProviderRegistry,
+    ProviderRegistryError,
+    type LocalProviderResolution,
+    type ProviderRegistryErrorCode,
+} from './registry';
+
+const HOST_LOCAL_PROVIDER_SETTING_KEYS = [
+    'aiProvider',
+    'aiModel_clinical',
+    'aiModel',
+    'aiUrl',
+    'ollamaUrl',
+] as const;
+const CLINICAL_CHAT_TIMEOUT_MS = 300_000;
+
+type HostLocalProviderSettingKey = typeof HOST_LOCAL_PROVIDER_SETTING_KEYS[number];
+export type HostLocalProviderSettingsSnapshot = Readonly<Partial<Record<HostLocalProviderSettingKey, string>>>;
+type HostLocalProviderSettingsReader = () => Promise<HostLocalProviderSettingsSnapshot>;
+
+export type HostLocalProviderBindingDenialCode =
+    | 'settings_unavailable'
+    | 'settings_corrupt'
+    | 'provider_invalid'
+    | 'model_invalid'
+    | 'endpoint_invalid';
+
+export type HostLocalProviderBindingResult =
+    | Readonly<{ status: 'available'; resolution: LocalProviderResolution }>
+    | Readonly<{ status: 'denied'; code: HostLocalProviderBindingDenialCode; resolution: null }>;
+
+function isSettingKey(value: PropertyKey): value is HostLocalProviderSettingKey {
+    return typeof value === 'string'
+        && HOST_LOCAL_PROVIDER_SETTING_KEYS.includes(value as HostLocalProviderSettingKey);
+}
+
+function snapshotSettings(value: unknown): HostLocalProviderSettingsSnapshot {
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) throw new Error('invalid');
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) throw new Error('invalid');
+
+    const snapshot: Partial<Record<HostLocalProviderSettingKey, string>> = {};
+    for (const key of Reflect.ownKeys(value)) {
+        if (!isSettingKey(key)) throw new Error('invalid');
+        const descriptor = Object.getOwnPropertyDescriptor(value, key);
+        if (!descriptor || !('value' in descriptor) || typeof descriptor.value !== 'string') {
+            throw new Error('invalid');
+        }
+        snapshot[key] = descriptor.value;
+    }
+    return Object.freeze(snapshot);
+}
+
+async function readProductionSettings(): Promise<HostLocalProviderSettingsSnapshot> {
+    const rows = await dbServer
+        .select({ key: settings.key, value: settings.value })
+        .from(settings)
+        .where(inArray(settings.key, [...HOST_LOCAL_PROVIDER_SETTING_KEYS]));
+
+    return Object.fromEntries(rows.map(({ key, value }) => [key, value]));
+}
+
+function deny(code: HostLocalProviderBindingDenialCode): HostLocalProviderBindingResult {
+    return Object.freeze({ status: 'denied', code, resolution: null });
+}
+
+function mapRegistryDenial(code: ProviderRegistryErrorCode): HostLocalProviderBindingDenialCode {
+    switch (code) {
+        case 'provider_not_registered':
+        case 'provider_not_local':
+            return 'provider_invalid';
+        case 'invalid_model':
+            return 'model_invalid';
+        case 'endpoint_not_local':
+            return 'endpoint_invalid';
+        case 'invalid_task':
+            return 'settings_corrupt';
+    }
+}
+
+export function createHostLocalProviderBindingService(options: Readonly<{
+    readSettings?: HostLocalProviderSettingsReader;
+}> = {}) {
+    const readSettings = options.readSettings ?? readProductionSettings;
+    return Object.freeze({
+        async readClinical(): Promise<HostLocalProviderBindingResult> {
+            let rawSnapshot: unknown;
+            try {
+                rawSnapshot = await readSettings();
+            } catch {
+                return deny('settings_unavailable');
+            }
+
+            let snapshot: HostLocalProviderSettingsSnapshot;
+            try {
+                snapshot = snapshotSettings(rawSnapshot);
+            } catch {
+                return deny('settings_corrupt');
+            }
+
+            try {
+                const resolution = localProviderRegistry.resolve({
+                    task: 'clinical',
+                    provider: snapshot.aiProvider ?? 'ollama',
+                    models: { clinical: resolveTextModel(snapshot.aiModel_clinical, snapshot.aiModel) },
+                    endpoint: resolveOllamaBaseUrl(snapshot.aiUrl, snapshot.ollamaUrl, DEFAULT_OLLAMA_BASE_URL),
+                    disableThinking: true,
+                    chatTimeoutMs: CLINICAL_CHAT_TIMEOUT_MS,
+                });
+                return Object.freeze({ status: 'available', resolution });
+            } catch (error) {
+                return error instanceof ProviderRegistryError
+                    ? deny(mapRegistryDenial(error.code))
+                    : deny('settings_corrupt');
+            }
+        },
+    });
+}


### PR DESCRIPTION
## Summary
- Aggiunge un servizio host-only e read-only che legge un solo snapshot delle cinque impostazioni AI locali.
- Applica le precedenze canoniche per provider, modello clinico ed endpoint e valida il risultato tramite `LocalProviderRegistry`.
- Restituisce una resolution validata oppure un diniego fisso PHI-safe, senza valori settings o errori raw.
- Mantiene timeout e thinking come policy interna host; l’unico seam iniettabile è il settings reader sintetico dei test.

## Verification
- `node scripts/run-strip-types.mjs --test lib/ai-model-selection.test.ts lib/ai-providers/registry.test.ts lib/ai-providers/host-local-provider-binding.test.ts` (21 test)
- `npm run test:unit` (1118 test)
- `npm run typecheck`
- `npm run lint -- lib/ai-providers/host-local-provider-binding.ts lib/ai-providers/host-local-provider-binding.test.ts`
- `npm run lint`
- `npm run build`
- `npm run check:never-regress`
- `npm run check:claims`
- `git diff --check`
- Scan mirata per write, migrazione, lifecycle, readiness, rete, invoke, route ed egress

## Risk / Notes
- Nessun settings write, migrazione, lifecycle, readiness, fetch, invoke, route, UI, AIP, Mini, apply o cloud entra in questo packet.
- I test sostituiscono il reader production e usano un data dir sintetico isolato; nessun database clinico viene letto.
- I warning build sulle tabelle assenti nel data dir sintetico sono baseline; build e standalone check terminano con esito positivo.
- P2C1 resta bloccato fino alla verifica diretta del manager e alla CI terminale verde.
- Nessuna PHI/PII e nessun dato clinico reale.

## Ticket
Refs WUL-522
Refs WUL-518