### PR TITLE
feat(ai): riusa binding provider validato nel resolver

### DIFF
--- a/lib/ai-providers/fabric/resolver.test.ts
+++ b/lib/ai-providers/fabric/resolver.test.ts
@@ -1,7 +1,7 @@
 /* @Codex */
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { ProviderRegistryError } from '../registry.ts';
+import { localProviderRegistry, ProviderRegistryError } from '../registry.ts';
 import {
     DETERMINISTIC_CAPABILITY_IDS, FABRIC_PREPROCESSING_LABELS,
     FABRIC_PREPROCESSING_LABEL_PATTERN, FABRIC_VENUES, GENERATIVE_CAPABILITY_IDS,
@@ -9,7 +9,11 @@ import {
 } from './contract.ts';
 import { DETERMINISTIC_CAPABILITY_DESCRIPTORS } from './deterministic-catalog.ts';
 import { GENERATIVE_CAPABILITY_DESCRIPTORS } from './generative-catalog.ts';
-import { buildProvenanceRecord, resolveFabricCapability } from './resolver.ts';
+import {
+    buildProvenanceRecord,
+    resolveFabricCapability,
+    resolveFabricCapabilityWithHostResolution,
+} from './resolver.ts';
 
 const binding = {
     task: 'caller_value_is_ignored',
@@ -46,6 +50,100 @@ test('risolve una generativa reale e deriva il task dalla capability', () => {
     assert.equal(result.receipt.model, 'qwen3.5:35b-a3b');
     assert.equal(result.receipt.providerReceipt, result.generative?.receipt);
     assert.equal(Object.isFrozen(result.receipt), true);
+});
+
+test('riusa la resolution host validata senza ricostruire adapter o binding', () => {
+    const descriptor = GENERATIVE_CAPABILITY_DESCRIPTORS.smart_import;
+    const hostResolution = localProviderRegistry.resolve({ ...binding, task: 'clinical' });
+
+    const result = resolveFabricCapabilityWithHostResolution(policyFor(descriptor), {
+        descriptor,
+        venue: 'local_process',
+        generative: hostResolution,
+    });
+
+    assert.equal(result.generative, hostResolution);
+    assert.equal(result.generative?.adapter, hostResolution.adapter);
+    assert.equal(result.receipt.providerReceipt, hostResolution.receipt);
+    assert.equal(result.receipt.model, hostResolution.receipt.model);
+});
+
+test('rifiuta una resolution host legata al task di un altro descriptor', () => {
+    const descriptor = GENERATIVE_CAPABILITY_DESCRIPTORS.smart_import;
+    const wrongTask = localProviderRegistry.resolve({ ...binding, task: 'reasoning' });
+
+    assert.throws(() => resolveFabricCapabilityWithHostResolution(policyFor(descriptor), {
+        descriptor,
+        venue: 'local_process',
+        generative: wrongTask,
+    }), (error) => error instanceof ProviderRegistryError && error.code === 'invalid_task');
+});
+
+test('rifiuta un descriptor host non canonico prima di emettere receipt', () => {
+    const descriptor = GENERATIVE_CAPABILITY_DESCRIPTORS.smart_import;
+    const hostResolution = localProviderRegistry.resolve({ ...binding, task: 'clinical' });
+    const forged = { ...descriptor } as FabricCapabilityDescriptor;
+
+    expectCode('capability_unknown', () => resolveFabricCapabilityWithHostResolution(
+        policyFor(descriptor),
+        { descriptor: forged, venue: 'local_process', generative: hostResolution },
+    ));
+});
+
+test('applica al binding host la stessa policy e le stesse venue fail-closed', () => {
+    const descriptor = GENERATIVE_CAPABILITY_DESCRIPTORS.smart_import;
+    const hostResolution = localProviderRegistry.resolve({ ...binding, task: 'clinical' });
+    const run = (policy: FabricExecutionPolicy, venue: FabricExecutionPolicy['allowedVenues'][number]) => (
+        resolveFabricCapabilityWithHostResolution(policy, { descriptor, venue, generative: hostResolution })
+    );
+
+    expectCode('policy_invalid', () => run({
+        ...policyFor(descriptor),
+        fallback: 'alternate',
+    } as unknown as FabricExecutionPolicy, 'local_process'));
+    expectCode('policy_invalid', () => run({
+        ...policyFor(descriptor),
+        operation: 'lookup',
+    }, 'local_process'));
+    expectCode('venue_not_allowed', () => run({
+        ...policyFor(descriptor),
+        allowedVenues: ['local_process'],
+    }, 'home_base'));
+    expectCode('cloud_not_authorized', () => run(policyFor(descriptor), 'cloud'));
+});
+
+test('nega mismatch host provider, modello, localita, endpoint e fallback senza invocare provider', () => {
+    const descriptor = GENERATIVE_CAPABILITY_DESCRIPTORS.smart_import;
+    const base = localProviderRegistry.resolve({ ...binding, task: 'clinical' });
+    let providerCalls = 0;
+    const adapter = (overrides: Record<string, unknown> = {}) => ({
+        id: 'ollama',
+        kind: 'local',
+        capabilities: base.adapter.capabilities,
+        getBaseUrl: () => base.adapter.getBaseUrl(),
+        getModel: () => base.adapter.getModel(),
+        chat: async () => { providerCalls += 1; throw new Error('not-called'); },
+        listModels: async () => { providerCalls += 1; throw new Error('not-called'); },
+        ...overrides,
+    });
+    const cases = [
+        [{ ...base, receipt: { ...base.receipt, provider: 'other' } }, 'provider_not_registered'],
+        [{ ...base, manifest: { ...base.manifest, provider: 'other' } }, 'provider_not_registered'],
+        [{ ...base, adapter: adapter({ id: 'other' }) }, 'provider_not_registered'],
+        [{ ...base, adapter: adapter({ getModel: () => 'other-model' }) }, 'invalid_model'],
+        [{ ...base, adapter: adapter({ kind: 'cloud' }) }, 'provider_not_local'],
+        [{ ...base, adapter: adapter({ getBaseUrl: () => 'http://localhost:11434' }) }, 'endpoint_not_local'],
+        [{ ...base, fallback: { strategy: 'none', candidates: ['other'] } }, 'provider_not_local'],
+    ] as const;
+
+    for (const [generative, code] of cases) {
+        assert.throws(() => resolveFabricCapabilityWithHostResolution(policyFor(descriptor), {
+            descriptor,
+            venue: 'local_process',
+            generative: generative as never,
+        }), (error) => error instanceof ProviderRegistryError && error.code === code);
+    }
+    assert.equal(providerCalls, 0);
 });
 
 test('risolve una deterministica in-house senza modello', () => {

--- a/lib/ai-providers/fabric/resolver.ts
+++ b/lib/ai-providers/fabric/resolver.ts
@@ -1,6 +1,15 @@
 /* @Codex */
 import { isEgressGateOpen } from '../../ai-egress-gate';
-import { localProviderRegistry, type LocalProviderBindingInput, type LocalProviderResolution } from '../registry';
+import {
+    localProviderRegistry,
+    ProviderRegistryError,
+    type LocalProviderBindingInput,
+    type LocalProviderResolution,
+} from '../registry';
+import {
+    assertLocalOllamaModelReference,
+    strictOllamaLoopbackBaseUrl,
+} from '../ollama-locality';
 import { FABRIC_CAPABILITY_DESCRIPTORS } from './catalog';
 import {
     DETERMINISTIC_CAPABILITY_IDS, EGRESS_PROFILES, FABRIC_PREPROCESSING_LABELS,
@@ -40,6 +49,107 @@ function isGenerative(id: string): id is GenerativeCapabilityId {
 
 function isDeterministic(id: string): boolean {
     return DETERMINISTIC_CAPABILITY_IDS.includes(id as typeof DETERMINISTIC_CAPABILITY_IDS[number]);
+}
+
+type HostResolutionSnapshot = Readonly<{
+    resolution: LocalProviderResolution;
+    receipt: LocalProviderResolution['receipt'];
+    task: LocalProviderResolution['receipt']['task'];
+    provider: LocalProviderResolution['receipt']['provider'];
+    model: string;
+}>;
+
+function snapshotHostResolution(value: unknown): HostResolutionSnapshot {
+    let snapshot: Record<string, unknown>;
+    try {
+        const resolution = value as LocalProviderResolution;
+        const adapter = resolution.adapter;
+        const manifest = resolution.manifest;
+        const receipt = resolution.receipt;
+        const fallback = resolution.fallback;
+        const getBaseUrl = adapter.getBaseUrl;
+        const getModel = adapter.getModel;
+        const adapterCapabilities = adapter.capabilities;
+        const manifestCapabilities = manifest.capabilities;
+        snapshot = {
+            resolution, adapter, manifest, receipt, fallback,
+            adapterId: adapter.id,
+            adapterKind: adapter.kind,
+            adapterModel: getModel.call(adapter),
+            baseUrl: getBaseUrl.call(adapter),
+            adapterCapabilities: Object.freeze({ ...adapterCapabilities }),
+            manifestCapabilities: Object.freeze({ ...manifestCapabilities }),
+            candidates: Array.isArray(fallback.candidates) ? Array.from(fallback.candidates) : null,
+        };
+    } catch {
+        throw new ProviderRegistryError('provider_not_local');
+    }
+
+    const { resolution, adapter, manifest, receipt, fallback } = snapshot as {
+        resolution: LocalProviderResolution;
+        adapter: LocalProviderResolution['adapter'];
+        manifest: LocalProviderResolution['manifest'];
+        receipt: LocalProviderResolution['receipt'];
+        fallback: LocalProviderResolution['fallback'];
+    };
+    if (
+        receipt.schemaVersion !== 'mediflow.ai.provider-selection.v1'
+        || receipt.authorityPlane !== 'clinical_application'
+        || receipt.provider !== 'ollama'
+        || manifest.provider !== receipt.provider
+        || snapshot.adapterId !== receipt.provider
+    ) {
+        throw new ProviderRegistryError('provider_not_registered');
+    }
+    if (
+        receipt.execution !== 'local'
+        || receipt.endpointClass !== 'loopback'
+        || receipt.egress !== 'none'
+        || receipt.runtimeReadiness !== 'required'
+        || receipt.fallbackCount !== 0
+        || manifest.authorityPlane !== 'clinical_application'
+        || manifest.execution !== 'local'
+        || manifest.endpointClass !== 'loopback'
+        || manifest.egress !== 'none'
+        || manifest.retention !== 'not_persisted_by_registry'
+        || manifest.capabilityEvidence !== 'provider_transport_only'
+        || manifest.modelCapabilityReadiness !== 'runtime_attestation_required'
+        || snapshot.adapterKind !== 'local'
+        || fallback.strategy !== 'none'
+        || !Array.isArray(snapshot.candidates)
+        || snapshot.candidates.length !== 0
+        || typeof adapter.chat !== 'function'
+        || typeof adapter.listModels !== 'function'
+        || JSON.stringify(snapshot.adapterCapabilities) !== JSON.stringify(snapshot.manifestCapabilities)
+    ) {
+        throw new ProviderRegistryError('provider_not_local');
+    }
+    try {
+        assertLocalOllamaModelReference(receipt.model);
+        if (receipt.model.trim() !== receipt.model || snapshot.adapterModel !== receipt.model) {
+            throw new Error('invalid');
+        }
+    } catch {
+        throw new ProviderRegistryError('invalid_model');
+    }
+    try {
+        if (
+            typeof snapshot.baseUrl !== 'string'
+            || strictOllamaLoopbackBaseUrl(snapshot.baseUrl) !== snapshot.baseUrl
+        ) {
+            throw new Error('invalid');
+        }
+    } catch {
+        throw new ProviderRegistryError('endpoint_not_local');
+    }
+
+    return Object.freeze({
+        resolution,
+        receipt,
+        task: receipt.task,
+        provider: receipt.provider,
+        model: receipt.model,
+    });
 }
 
 export function resolveFabricCapability(
@@ -146,6 +256,87 @@ export function resolveFabricCapability(
     });
 
     return { receipt, descriptor, generative };
+}
+
+export type HostResolvedFabricRequest = Readonly<{
+    descriptor: FabricCapabilityDescriptor;
+    venue: FabricVenue;
+    generative: LocalProviderResolution;
+}>;
+
+export function resolveFabricCapabilityWithHostResolution(
+    policy: FabricExecutionPolicy,
+    request: HostResolvedFabricRequest,
+): FabricResolution {
+    const descriptor = request.descriptor;
+    const rawGenerative = request.generative;
+    const allowedVenues = Array.isArray(policy.allowedVenues)
+        ? Array.from(policy.allowedVenues)
+        : null;
+    if (
+        policy.schemaVersion !== 'mediflow.ai.execution-policy.v1'
+        || policy.provenanceRequired !== true
+        || policy.fallback !== 'none'
+        || policy.authorityPlane !== 'clinical_application'
+        || typeof policy.requestId !== 'string'
+        || policy.requestId.trim().length === 0
+        || !RETENTION_VALUES.has(policy.retention)
+        || !(policy.consentRef === null
+            || (typeof policy.consentRef === 'string' && policy.consentRef.trim().length > 0))
+        || allowedVenues === null
+        || allowedVenues.length === 0
+        || !allowedVenues.every((venue) => VENUE_VALUES.has(venue))
+    ) {
+        throw new FabricPolicyError('policy_invalid');
+    }
+    if (
+        policy.capability !== descriptor.id
+        || FABRIC_CAPABILITY_DESCRIPTORS[descriptor.id] !== descriptor
+    ) {
+        throw new FabricPolicyError('capability_unknown');
+    }
+    const expectedTask = GENERATIVE_TASKS[
+        descriptor.id as Exclude<GenerativeCapabilityId, 'treatment_reasoning'>
+    ];
+    const generative = snapshotHostResolution(rawGenerative);
+    if (!expectedTask || generative.task !== expectedTask) {
+        throw new ProviderRegistryError('invalid_task');
+    }
+    if (
+        descriptor.class !== 'generative'
+        || policy.operation !== descriptor.operation
+        || policy.dataClass !== descriptor.dataClass
+        || policy.review !== descriptor.review
+        || policy.egressProfileId !== descriptor.egressProfileId
+    ) {
+        throw new FabricPolicyError('policy_invalid');
+    }
+    if (request.venue === 'cloud') throw new FabricPolicyError('cloud_not_authorized');
+    if (!descriptor.venues.includes(request.venue) || !allowedVenues.includes(request.venue)) {
+        throw new FabricPolicyError('venue_not_allowed');
+    }
+    const profile = EGRESS_PROFILES[descriptor.egressProfileId as keyof typeof EGRESS_PROFILES];
+    if (!profile) throw new FabricPolicyError('egress_profile_unknown');
+    if (profile.id !== 'local_only' || profile.egress !== 'none') {
+        throw new FabricPolicyError('egress_profile_unsatisfied');
+    }
+    const receipt: FabricResolutionReceipt = Object.freeze({
+        schemaVersion: 'mediflow.ai.fabric-resolution.v1',
+        capability: descriptor.id,
+        class: descriptor.class,
+        venue: request.venue,
+        egressProfile: Object.freeze({
+            id: profile.id,
+            version: profile.version,
+            egress: profile.egress,
+        }),
+        provider: generative.provider,
+        model: generative.model,
+        providerReceipt: generative.receipt,
+        fallbackCount: 0,
+    });
+
+    return Object.freeze({ receipt, descriptor, generative: generative.resolution });
 }
 
 export function buildProvenanceRecord(resolution: FabricResolution, preprocessing: readonly string[]): FabricProvenanceRecord {


### PR DESCRIPTION
## Summary
- aggiunge un percorso resolver host che consuma la `LocalProviderResolution` già validata
- verifica task, provider, modello, località, endpoint canonico, egress e fallback prima di emettere la receipt Fabric
- conserva la stessa resolution e lo stesso adapter, senza ricostruire il binding o invocare il provider
- mantiene invariati il resolver legacy e il candidate router

## Verification
- `node scripts/run-strip-types.mjs --test lib/ai-providers/fabric/resolver.test.ts`
- `node scripts/run-strip-types.mjs --test --glob "lib/ai-providers/fabric/**/*.test.ts"` — 80 test passati
- `npm run typecheck`
- `npx eslint --quiet lib/ai-providers/fabric/resolver.ts lib/ai-providers/fabric/resolver.test.ts`
- `npm run build` con Node 24.18.0
- `npm run check:never-regress`
- `npm run check:claims`
- `git diff --check`

## Risk / Notes
- Packet P2C1a1 limitato al resolver e ai test focali; il routing host sul lifecycle persistito resta nel packet P2C1a2 separato.
- Nessuna route, readiness, rete, invocazione provider, store, projection, prompt, parser o apply.
- Solo fixture sintetiche; nessuna PHI/PII, credenziale o provider reale.

## Ticket
Refs WUL-522
Refs WUL-518