### PR TITLE
feat(ai): instrada binding host con lifecycle persistito

### DIFF
--- a/lib/ai-providers/fabric/candidate-router.test.ts
+++ b/lib/ai-providers/fabric/candidate-router.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { DETERMINISTIC_CAPABILITY_DESCRIPTORS } from './deterministic-catalog.ts';
 import { GENERATIVE_CAPABILITY_DESCRIPTORS } from './generative-catalog.ts';
+import { localProviderRegistry } from '../registry.ts';
 import {
     FabricPolicyError,
     type FabricCapabilityDescriptor,
@@ -10,11 +11,16 @@ import {
 } from './contract.ts';
 import { advanceOnboarding, startOnboarding, type ProviderOnboardingState } from './onboarding.ts';
 import { admitProvider, transitionProviderLifecycle } from './provider-lifecycle.ts';
-import { routeCandidateCapability, routeHostCandidateCapability } from './candidate-router.ts';
+import {
+    routeCandidateCapability,
+    routeHostCandidateCapability,
+    routeHostResolvedCandidateCapability,
+} from './candidate-router.ts';
 import { observeVenue } from './routing-observability.ts';
 
 const deterministic = DETERMINISTIC_CAPABILITY_DESCRIPTORS.icd_lookup;
 const generative = GENERATIVE_CAPABILITY_DESCRIPTORS.patient_insight;
+const smartImport = GENERATIVE_CAPABILITY_DESCRIPTORS.smart_import;
 const binding = {
     task: 'caller_value_is_ignored',
     models: { clinical: 'qwen3.5:35b-a3b', reasoning: 'reasoning-model', ocr: 'ocr-model' },
@@ -130,6 +136,88 @@ test('il router host usa il lifecycle persistito senza ricostruire onboarding', 
     }, availableLocal());
     assert.equal(result.decision.outcome, 'resolved');
     assert.equal(result.decision.receipt?.provider, 'ollama');
+});
+
+test('il router host resolved riusa la stessa resolution e adapter', () => {
+    const hostResolution = localProviderRegistry.resolve({ ...binding, task: 'clinical' });
+    const result = routeHostResolvedCandidateCapability({
+        policy: policyFor(smartImport),
+        request: {
+            descriptor: smartImport,
+            venue: 'local_process',
+            generative: hostResolution,
+        },
+        observations: [observeVenue('local_process', 'available', null)],
+    }, availableLocal());
+
+    assert.equal(result.decision.outcome, 'resolved');
+    assert.equal(result.resolution?.generative, hostResolution);
+    assert.equal(result.resolution?.generative?.adapter, hostResolution.adapter);
+    assert.equal(result.decision.receipt, result.resolution?.receipt);
+    assert.equal(Object.isFrozen(result.decision) && Object.isFrozen(result.decision.receipt), true);
+});
+
+test('snapshotta la host resolution una sola volta prima del routing', () => {
+    const hostResolution = localProviderRegistry.resolve({ ...binding, task: 'clinical' });
+    let resolutionReads = 0;
+    const result = routeHostResolvedCandidateCapability({
+        policy: policyFor(smartImport),
+        request: {
+            descriptor: smartImport,
+            venue: 'local_process',
+            get generative() {
+                resolutionReads += 1;
+                return resolutionReads === 1 ? hostResolution : null as never;
+            },
+        },
+        observations: [observeVenue('local_process', 'available', null)],
+    }, availableLocal());
+
+    assert.equal(result.decision.outcome, 'resolved');
+    assert.equal(result.resolution?.generative, hostResolution);
+    assert.equal(resolutionReads, 1);
+});
+
+test('il router host resolved nega ogni gate prima di invocare il provider', () => {
+    const available = availableLocal();
+    const base = localProviderRegistry.resolve({ ...binding, task: 'clinical' });
+    let providerInvocations = 0;
+    const guardedResolution = {
+        ...base,
+        adapter: {
+            id: base.adapter.id,
+            kind: base.adapter.kind,
+            capabilities: base.adapter.capabilities,
+            getBaseUrl: () => base.adapter.getBaseUrl(),
+            getModel: () => base.adapter.getModel(),
+            chat: async () => { providerInvocations += 1; throw new Error('not-called'); },
+            listModels: async () => { providerInvocations += 1; throw new Error('not-called'); },
+        },
+    };
+    const input = {
+        policy: policyFor(smartImport),
+        request: { descriptor: smartImport, venue: 'local_process', generative: guardedResolution },
+        observations: [observeVenue('local_process', 'available', null)],
+    } as const;
+    const cases = [
+        [{ ...input, observations: [observeVenue('local_process', 'offline', 'daemon_unreachable')] }, available, 'venue_offline'],
+        [{ ...input, observations: [observeVenue('local_process', 'unknown', 'not_probed')] }, available, 'venue_unknown'],
+        [{ ...input, observations: [observeVenue('local_process', 'degraded', 'daemon_unreachable')] }, available, 'venue_degraded'],
+        [{ ...input, request: { ...input.request, venue: 'home_base' }, observations: [observeVenue('home_base', 'available', null)], reconnection: 're_login_required' }, available, 'paired_trust_denied'],
+        [input, { ...available, extra: 'not-allowed' }, 'provider_lifecycle_invalid'],
+        [input, transitionProviderLifecycle(available, 'degrade'), 'provider_lifecycle_unavailable'],
+        [input, transitionProviderLifecycle(available, 'revoke'), 'provider_lifecycle_unavailable'],
+        [input, availableLocal('other_provider'), 'provider_receipt_mismatch'],
+        [{ ...input, request: { ...input.request, generative: { ...guardedResolution, receipt: { ...guardedResolution.receipt, task: 'reasoning' } } } }, available, 'fabric_resolution_denied'],
+    ] as const;
+
+    for (const [candidate, lifecycle, denialCode] of cases) {
+        const result = routeHostResolvedCandidateCapability(candidate as never, lifecycle as never);
+        assert.equal(result.decision.denialCode, denialCode);
+        assert.equal(result.decision.receipt, null);
+        assert.equal(result.resolution, null);
+    }
+    assert.equal(providerInvocations, 0);
 });
 
 test('il router host nega lifecycle malformed, non disponibile o incoerente', () => {

--- a/lib/ai-providers/fabric/candidate-router.ts
+++ b/lib/ai-providers/fabric/candidate-router.ts
@@ -1,5 +1,6 @@
 /* @Codex */
 import type { PairingReconnectionClass } from '../../network-pairing-lifecycle';
+import { ProviderRegistryError } from '../registry';
 import { FABRIC_CAPABILITY_DESCRIPTORS } from './catalog';
 import type { ProviderOnboardingState } from './onboarding';
 import {
@@ -23,7 +24,11 @@ import {
     observeVenue,
     type VenueObservation,
 } from './routing-observability';
-import type { FabricResolution } from './resolver';
+import {
+    resolveFabricCapabilityWithHostResolution,
+    type FabricResolution,
+    type HostResolvedFabricRequest,
+} from './resolver';
 
 type FabricResolutionRequest = Parameters<typeof observeAndResolve>[1];
 
@@ -61,6 +66,13 @@ export type CandidateRoutingInput = Readonly<{
 
 export type HostCandidateRoutingInput = Omit<CandidateRoutingInput, 'onboarding' | 'lifecycle'>;
 
+export type HostResolvedCandidateRoutingInput = Readonly<{
+    policy: FabricExecutionPolicy;
+    request: HostResolvedFabricRequest;
+    observations: readonly VenueObservation[];
+    reconnection?: PairingReconnectionClass;
+}>;
+
 export type CandidateRoutingResult = Readonly<{
     decision: CandidateRoutingDecision;
     resolution: FabricResolution | null;
@@ -68,11 +80,18 @@ export type CandidateRoutingResult = Readonly<{
 
 type CandidateDecisionContext = Readonly<{
     policy: FabricExecutionPolicy;
-    request: FabricResolutionRequest;
+    request: FabricResolutionRequest | HostResolvedFabricRequest;
     requestId: string;
     capability: FabricCapabilityId;
     requestedVenue: FabricVenue;
     descriptor: FabricCapabilityDescriptor;
+}>;
+
+type CandidateRoutingGateInput = Readonly<{
+    policy: FabricExecutionPolicy;
+    request: FabricResolutionRequest | HostResolvedFabricRequest;
+    observations: readonly VenueObservation[];
+    reconnection?: PairingReconnectionClass;
 }>;
 
 const REQUEST_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/;
@@ -98,7 +117,9 @@ function snapshotCandidateRoutingInput(input: CandidateRoutingInput): CandidateR
     });
 }
 
-function snapshotHostCandidateRoutingInput(input: HostCandidateRoutingInput): CandidateRoutingInput {
+function snapshotHostRoutingInput<
+    T extends HostCandidateRoutingInput | HostResolvedCandidateRoutingInput,
+>(input: T): T {
     if (!isRecord(input)) {
         throw new FabricPolicyError('policy_invalid');
     }
@@ -107,10 +128,10 @@ function snapshotHostCandidateRoutingInput(input: HostCandidateRoutingInput): Ca
         request: input.request,
         observations: input.observations,
         reconnection: input.reconnection,
-    });
+    }) as T;
 }
 
-function snapshotCandidateDecisionContext(input: CandidateRoutingInput): CandidateDecisionContext {
+function snapshotCandidateDecisionContext(input: CandidateRoutingGateInput): CandidateDecisionContext {
     // Copy each caller-owned input before inspecting it. This denies getters
     // that change identifiers after validation and keeps invalid values out of
     // the observable decision shape.
@@ -231,10 +252,26 @@ function snapshotPersistedGenerativeAdmission(value: unknown): ProviderLifecycle
         : null;
 }
 
+function resolveObservedCandidate(
+    context: CandidateDecisionContext,
+    observations: readonly VenueObservation[],
+): FabricResolution | null {
+    const routed = observeAndResolve(
+        context.policy,
+        context.request as FabricResolutionRequest,
+        observations,
+    );
+    return routed.resolution && routed.decision.receipt ? routed.resolution : null;
+}
+
 function routeCandidateCapabilityWithAdmission(
-    inputSnapshot: CandidateRoutingInput,
+    inputSnapshot: CandidateRoutingGateInput,
     snapshotAdmission: () => ProviderLifecycleState | null,
     mapsOnboardingErrors: boolean,
+    resolve: (
+        context: CandidateDecisionContext,
+        observations: readonly VenueObservation[],
+    ) => FabricResolution | null,
 ): CandidateRoutingResult {
     const context = snapshotCandidateDecisionContext(inputSnapshot);
     const observations = observationsFor(context.requestedVenue, inputSnapshot.observations);
@@ -283,18 +320,14 @@ function routeCandidateCapabilityWithAdmission(
         }
     }
 
-    const routed = observeAndResolve(
-        context.policy,
-        context.request,
-        observations,
-    );
-    if (!routed.resolution || !routed.decision.receipt) {
+    const resolution = resolve(context, observations);
+    if (!resolution) {
         return denied(context, observations, 'fabric_resolution_denied');
     }
 
     if (context.descriptor.class === 'generative') {
         const lifecycle = admittedLifecycle;
-        const receipt = routed.decision.receipt;
+        const receipt = resolution.receipt;
         if (
             !lifecycle
             || receipt.provider !== lifecycle.provider
@@ -311,9 +344,9 @@ function routeCandidateCapabilityWithAdmission(
             observations,
             'resolved',
             null,
-            routed.decision.receipt,
+            resolution.receipt,
         ),
-        resolution: routed.resolution,
+        resolution,
     });
 }
 
@@ -330,6 +363,7 @@ export function routeCandidateCapability(
         inputSnapshot,
         () => snapshotGenerativeAdmission(inputSnapshot),
         true,
+        resolveObservedCandidate,
     );
 }
 
@@ -337,10 +371,36 @@ export function routeHostCandidateCapability(
     input: HostCandidateRoutingInput,
     lifecycle: ProviderLifecycleState,
 ): CandidateRoutingResult {
-    const inputSnapshot = snapshotHostCandidateRoutingInput(input);
+    const inputSnapshot = snapshotHostRoutingInput(input);
     return routeCandidateCapabilityWithAdmission(
         inputSnapshot,
         () => snapshotPersistedGenerativeAdmission(lifecycle),
         false,
+        resolveObservedCandidate,
+    );
+}
+
+export function routeHostResolvedCandidateCapability(
+    input: HostResolvedCandidateRoutingInput,
+    lifecycle: ProviderLifecycleState,
+): CandidateRoutingResult {
+    const inputSnapshot = snapshotHostRoutingInput(input);
+    return routeCandidateCapabilityWithAdmission(
+        inputSnapshot,
+        () => snapshotPersistedGenerativeAdmission(lifecycle),
+        false,
+        (context) => {
+            try {
+                return resolveFabricCapabilityWithHostResolution(
+                    context.policy,
+                    context.request as HostResolvedFabricRequest,
+                );
+            } catch (error) {
+                if (error instanceof FabricPolicyError || error instanceof ProviderRegistryError) {
+                    return null;
+                }
+                throw error;
+            }
+        },
     );
 }


### PR DESCRIPTION
## Summary
- Adds `routeHostResolvedCandidateCapability` for a canonical host provider resolution plus persisted lifecycle state.
- Reuses existing observation, paired-trust, lifecycle, and receipt-coherence gates before the host resolver.
- Preserves the exact host resolution and adapter on success; every denial returns null resolution and receipt without `chat` or `listModels` calls.
- Keeps legacy candidate-router APIs unchanged.

## Verification
- `node scripts/run-strip-types.mjs --test lib/ai-providers/fabric/candidate-router.test.ts` (14/14)
- `node scripts/run-strip-types.mjs --test lib/ai-providers/fabric/*.test.ts` (83/83)
- `npm run typecheck`
- `npx eslint --quiet lib/ai-providers/fabric/candidate-router.ts lib/ai-providers/fabric/candidate-router.test.ts`
- `npm run build` with Node 24.18.0
- `npm run check:never-regress`
- `npm run check:claims`
- `git diff --check`
- Focused forbidden-boundary scan

## Risk / Notes
- Scope is limited to `candidate-router.ts` and its synthetic tests; no route, store, provider invocation, UI, AIP, Mini, or apply path is added.
- Production build completed with the existing Turbopack NFT trace warning pattern outside this diff.
- P2C1b remains blocked and is not part of this PR.
- This draft PR is stacked on #222 and is not a merge or promotion claim.

## Ticket
Refs WUL-522
Refs WUL-518