### PR TITLE
feat(ai): osserva readiness provider locale host

### DIFF
--- a/lib/ai-providers/host-local-provider-readiness.test.ts
+++ b/lib/ai-providers/host-local-provider-readiness.test.ts
@@ -1,0 +1,112 @@
+/* @Codex */
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createHostLocalProviderReadinessForTest, type HostLocalProviderReadinessResult } from './host-local-provider-readiness.ts';
+import { OllamaLocalityError, type OllamaLocalAttestation } from './ollama-locality.ts';
+import { localProviderRegistry, type LocalProviderResolution } from './registry.ts';
+
+const resolution = (): LocalProviderResolution => localProviderRegistry.resolve({
+    task: 'clinical',
+    provider: 'ollama',
+    models: { clinical: 'synthetic-local-model' },
+    endpoint: 'http://127.0.0.1:11434',
+    disableThinking: true,
+    chatTimeoutMs: 1_000,
+});
+
+const attestation: OllamaLocalAttestation = {
+    authorityPlane: 'clinical_application',
+    provider: 'ollama',
+    executionMode: 'local',
+    endpointClass: 'loopback',
+    requestedModel: 'synthetic-local-model',
+    canonicalModel: 'synthetic-local-model:latest',
+    digest: 'sha256:synthetic-readiness',
+    serverVersion: '0.32.5',
+    checkedAt: '2026-08-22T00:00:00.000Z',
+};
+
+function assertDenied(result: HostLocalProviderReadinessResult, code: string, state: string): void {
+    assert.equal(result.status, 'denied');
+    if (result.status !== 'denied') return;
+    assert.equal(result.code, code);
+    assert.equal(result.observation.state, state);
+    assert.equal(Object.isFrozen(result), true);
+    assert.equal(Object.isFrozen(result.observation), true);
+}
+
+test('attesta una volta il binding clinico e restituisce solo readiness locale congelata', async () => {
+    const calls: unknown[][] = [];
+    const observer = createHostLocalProviderReadinessForTest(async (...args) => { calls.push(args); return attestation; });
+    const result = await observer.observeClinical(resolution());
+    assert.deepEqual(result, {
+        status: 'available',
+        code: null,
+        observation: { venue: 'local_process', state: 'available', reason: null },
+    });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0]?.[0], 'http://127.0.0.1:11434');
+    assert.equal(calls[0]?.[1], 'synthetic-local-model');
+    assert.equal(calls[0]?.[2] instanceof AbortSignal, true);
+    assert.equal(Object.isFrozen(result), true);
+    assert.equal(Object.isFrozen(result.observation), true);
+});
+
+test('legge una volta provider, adapter, base e modello prima della attestazione', async () => {
+    const stable = resolution();
+    const reads = { adapter: 0, provider: 0, receiptModel: 0, base: 0, model: 0 };
+    const adapter = {
+        ...stable.adapter,
+        id: 'ollama',
+        kind: 'local' as const,
+        getBaseUrl: () => (++reads.base === 1 ? 'http://127.0.0.1:11434' : ['https:', '//remote.invalid'].join('')),
+        getModel: () => (++reads.model === 1 ? 'synthetic-local-model' : 'remote:cloud'),
+    };
+    const receipt = { ...stable.receipt };
+    Object.defineProperties(receipt, {
+        provider: { enumerable: true, get: () => (++reads.provider === 1 ? 'ollama' : 'remote') },
+        model: { enumerable: true, get: () => (++reads.receiptModel === 1 ? 'synthetic-local-model' : 'remote:cloud') },
+    });
+    const stateful = { ...stable, receipt } as LocalProviderResolution;
+    Object.defineProperty(stateful, 'adapter', {
+        enumerable: true,
+        get: () => { reads.adapter += 1; return adapter; },
+    });
+
+    const result = await createHostLocalProviderReadinessForTest(async () => attestation).observeClinical(stateful);
+    assert.equal(result.status, 'available');
+    assert.deepEqual(reads, { adapter: 1, provider: 1, receiptModel: 1, base: 1, model: 1 });
+});
+
+test('mappa gli errori locality in dinieghi fissi senza dettagli raw', async () => {
+    for (const code of ['endpoint_not_loopback', 'provider_unready'] as const) {
+        const result = await createHostLocalProviderReadinessForTest(async () => { throw new OllamaLocalityError(code); })
+            .observeClinical(resolution());
+        assertDenied(result, 'provider_unready', 'offline');
+    }
+    for (const code of ['model_cloud_reference', 'model_not_local', 'model_pull_disabled', 'response_not_local'] as const) {
+        const result = await createHostLocalProviderReadinessForTest(async () => { throw new OllamaLocalityError(code); })
+            .observeClinical(resolution());
+        assertDenied(result, 'model_unavailable', 'degraded');
+    }
+    const unexpected = await createHostLocalProviderReadinessForTest(async () => { throw new Error('synthetic raw exception'); })
+        .observeClinical(resolution());
+    assertDenied(unexpected, 'provider_unready', 'offline');
+    assert.equal(JSON.stringify(unexpected).includes('synthetic raw exception'), false);
+});
+
+test('nega provider, adapter, endpoint o modello incoerenti senza attestare', async () => {
+    let calls = 0;
+    const observer = createHostLocalProviderReadinessForTest(async () => { calls += 1; return attestation; });
+    const valid = resolution();
+    const cases: LocalProviderResolution[] = [
+        { ...valid, receipt: { ...valid.receipt, provider: 'other' as never } },
+        { ...valid, adapter: { ...valid.adapter, id: 'other' } },
+        { ...valid, adapter: { ...valid.adapter, getBaseUrl: () => ['https:', '//remote.invalid'].join('') } },
+        { ...valid, adapter: { ...valid.adapter, getModel: () => 'different-local-model' } },
+    ];
+    for (const candidate of cases) {
+        assert.equal((await observer.observeClinical(candidate)).status, 'denied');
+    }
+    assert.equal(calls, 0);
+});

--- a/lib/ai-providers/host-local-provider-readiness.test.ts
+++ b/lib/ai-providers/host-local-provider-readiness.test.ts
@@ -26,11 +26,11 @@ const attestation: OllamaLocalAttestation = {
     checkedAt: '2026-08-22T00:00:00.000Z',
 };
 
-function assertDenied(result: HostLocalProviderReadinessResult, code: string, state: string): void {
-    assert.equal(result.status, 'denied');
-    if (result.status !== 'denied') return;
-    assert.equal(result.code, code);
-    assert.equal(result.observation.state, state);
+const PROVIDER_DENIED = { status: 'denied', code: 'provider_unready', observation: { venue: 'local_process', state: 'offline', reason: 'daemon_unreachable' } } as const;
+const MODEL_DENIED = { status: 'denied', code: 'model_unavailable', observation: { venue: 'local_process', state: 'degraded', reason: null } } as const;
+
+function assertDenied(result: HostLocalProviderReadinessResult, expected: typeof PROVIDER_DENIED | typeof MODEL_DENIED): void {
+    assert.deepEqual(result, expected);
     assert.equal(Object.isFrozen(result), true);
     assert.equal(Object.isFrozen(result.observation), true);
 }
@@ -82,16 +82,16 @@ test('mappa gli errori locality in dinieghi fissi senza dettagli raw', async () 
     for (const code of ['endpoint_not_loopback', 'provider_unready'] as const) {
         const result = await createHostLocalProviderReadinessForTest(async () => { throw new OllamaLocalityError(code); })
             .observeClinical(resolution());
-        assertDenied(result, 'provider_unready', 'offline');
+        assertDenied(result, PROVIDER_DENIED);
     }
     for (const code of ['model_cloud_reference', 'model_not_local', 'model_pull_disabled', 'response_not_local'] as const) {
         const result = await createHostLocalProviderReadinessForTest(async () => { throw new OllamaLocalityError(code); })
             .observeClinical(resolution());
-        assertDenied(result, 'model_unavailable', 'degraded');
+        assertDenied(result, MODEL_DENIED);
     }
     const unexpected = await createHostLocalProviderReadinessForTest(async () => { throw new Error('synthetic raw exception'); })
         .observeClinical(resolution());
-    assertDenied(unexpected, 'provider_unready', 'offline');
+    assertDenied(unexpected, PROVIDER_DENIED);
     assert.equal(JSON.stringify(unexpected).includes('synthetic raw exception'), false);
 });
 
@@ -99,14 +99,18 @@ test('nega provider, adapter, endpoint o modello incoerenti senza attestare', as
     let calls = 0;
     const observer = createHostLocalProviderReadinessForTest(async () => { calls += 1; return attestation; });
     const valid = resolution();
-    const cases: LocalProviderResolution[] = [
-        { ...valid, receipt: { ...valid.receipt, provider: 'other' as never } },
-        { ...valid, adapter: { ...valid.adapter, id: 'other' } },
-        { ...valid, adapter: { ...valid.adapter, getBaseUrl: () => ['https:', '//remote.invalid'].join('') } },
-        { ...valid, adapter: { ...valid.adapter, getModel: () => 'different-local-model' } },
+    const withAdapter = (override: object) => ({ ...valid, adapter: Object.assign(
+        Object.create(Object.getPrototypeOf(valid.adapter)), valid.adapter, override,
+    ) }) as LocalProviderResolution;
+    const cases: [LocalProviderResolution, typeof PROVIDER_DENIED | typeof MODEL_DENIED][] = [
+        [{ ...valid, receipt: { ...valid.receipt, provider: 'other' as never } }, PROVIDER_DENIED],
+        [withAdapter({ id: 'other' }), PROVIDER_DENIED],
+        [withAdapter({ getBaseUrl: () => ['https:', '//remote.invalid'].join('') }), PROVIDER_DENIED],
+        [withAdapter({ getModel: () => 'different-local-model' }), MODEL_DENIED],
+        [{ ...valid, receipt: { ...valid.receipt, task: 'reasoning' } }, PROVIDER_DENIED],
     ];
-    for (const candidate of cases) {
-        assert.equal((await observer.observeClinical(candidate)).status, 'denied');
+    for (const [candidate, expected] of cases) {
+        assertDenied(await observer.observeClinical(candidate), expected);
     }
     assert.equal(calls, 0);
 });

--- a/lib/ai-providers/host-local-provider-readiness.ts
+++ b/lib/ai-providers/host-local-provider-readiness.ts
@@ -1,0 +1,85 @@
+/* @Codex */
+import 'server-only';
+import {
+    assertLocalOllamaModelReference,
+    attestLocalOllamaModel,
+    OllamaLocalityError,
+    strictOllamaLoopbackBaseUrl,
+} from './ollama-locality';
+import type { LocalProviderResolution } from './registry';
+
+const READINESS_TIMEOUT_MS = 10_000;
+const AVAILABLE = Object.freeze({ venue: 'local_process', state: 'available', reason: null } as const);
+const OFFLINE = Object.freeze({ venue: 'local_process', state: 'offline', reason: 'daemon_unreachable' } as const);
+const DEGRADED = Object.freeze({ venue: 'local_process', state: 'degraded', reason: 'target_invalid' } as const);
+
+export type HostLocalProviderReadinessResult =
+    | Readonly<{ status: 'available'; code: null; observation: typeof AVAILABLE }>
+    | Readonly<{ status: 'denied'; code: 'provider_unready' | 'model_unavailable'; observation: typeof OFFLINE | typeof DEGRADED }>;
+
+type Attestor = typeof attestLocalOllamaModel;
+type Snapshot = Readonly<{ baseUrl: string; model: string }>;
+
+function deny(code: 'provider_unready' | 'model_unavailable'): HostLocalProviderReadinessResult {
+    return Object.freeze({
+        status: 'denied',
+        code,
+        observation: code === 'provider_unready' ? OFFLINE : DEGRADED,
+    });
+}
+
+function snapshotResolution(resolution: LocalProviderResolution): Snapshot | HostLocalProviderReadinessResult {
+    let provider: unknown, receiptModel: unknown, adapterId: unknown, adapterKind: unknown;
+    let baseUrl: unknown, adapterModel: unknown;
+    try {
+        const receipt = resolution.receipt;
+        const adapter = resolution.adapter;
+        provider = receipt.provider;
+        receiptModel = receipt.model;
+        adapterId = adapter.id;
+        adapterKind = adapter.kind;
+        const getBaseUrl = adapter.getBaseUrl;
+        const getModel = adapter.getModel;
+        baseUrl = getBaseUrl.call(adapter);
+        adapterModel = getModel.call(adapter);
+    } catch {
+        return deny('provider_unready');
+    }
+    if (provider !== 'ollama' || adapterId !== 'ollama' || adapterKind !== 'local'
+        || typeof baseUrl !== 'string') {
+        return deny('provider_unready');
+    }
+    try {
+        if (strictOllamaLoopbackBaseUrl(baseUrl) !== baseUrl) throw new Error();
+    } catch {
+        return deny('provider_unready');
+    }
+    try {
+        assertLocalOllamaModelReference(receiptModel);
+        if (receiptModel !== adapterModel) throw new Error();
+    } catch {
+        return deny('model_unavailable');
+    }
+    return Object.freeze({ baseUrl, model: receiptModel });
+}
+
+async function observe(resolution: LocalProviderResolution, attestor: Attestor): Promise<HostLocalProviderReadinessResult> {
+    const snapshot = snapshotResolution(resolution);
+    if ('status' in snapshot) return snapshot;
+    try {
+        await attestor(snapshot.baseUrl, snapshot.model, AbortSignal.timeout(READINESS_TIMEOUT_MS));
+    } catch (error) {
+        if (error instanceof OllamaLocalityError && !['endpoint_not_loopback', 'provider_unready'].includes(error.code)) {
+            return deny('model_unavailable');
+        }
+        return deny('provider_unready');
+    }
+    return Object.freeze({ status: 'available', code: null, observation: AVAILABLE });
+}
+
+export const observeClinical = (resolution: LocalProviderResolution): Promise<HostLocalProviderReadinessResult> =>
+    observe(resolution, attestLocalOllamaModel);
+
+export const createHostLocalProviderReadinessForTest = (attestor: Attestor) => Object.freeze({
+    observeClinical: (resolution: LocalProviderResolution) => observe(resolution, attestor),
+});

--- a/lib/ai-providers/host-local-provider-readiness.ts
+++ b/lib/ai-providers/host-local-provider-readiness.ts
@@ -8,10 +8,10 @@ import {
 } from './ollama-locality';
 import type { LocalProviderResolution } from './registry';
 
-const READINESS_TIMEOUT_MS = 10_000;
+const READINESS_TIMEOUT_MS = 300_000;
 const AVAILABLE = Object.freeze({ venue: 'local_process', state: 'available', reason: null } as const);
 const OFFLINE = Object.freeze({ venue: 'local_process', state: 'offline', reason: 'daemon_unreachable' } as const);
-const DEGRADED = Object.freeze({ venue: 'local_process', state: 'degraded', reason: 'target_invalid' } as const);
+const DEGRADED = Object.freeze({ venue: 'local_process', state: 'degraded', reason: null } as const);
 
 export type HostLocalProviderReadinessResult =
     | Readonly<{ status: 'available'; code: null; observation: typeof AVAILABLE }>
@@ -29,12 +29,13 @@ function deny(code: 'provider_unready' | 'model_unavailable'): HostLocalProvider
 }
 
 function snapshotResolution(resolution: LocalProviderResolution): Snapshot | HostLocalProviderReadinessResult {
-    let provider: unknown, receiptModel: unknown, adapterId: unknown, adapterKind: unknown;
+    let provider: unknown, task: unknown, receiptModel: unknown, adapterId: unknown, adapterKind: unknown;
     let baseUrl: unknown, adapterModel: unknown;
     try {
         const receipt = resolution.receipt;
         const adapter = resolution.adapter;
         provider = receipt.provider;
+        task = receipt.task;
         receiptModel = receipt.model;
         adapterId = adapter.id;
         adapterKind = adapter.kind;
@@ -45,7 +46,7 @@ function snapshotResolution(resolution: LocalProviderResolution): Snapshot | Hos
     } catch {
         return deny('provider_unready');
     }
-    if (provider !== 'ollama' || adapterId !== 'ollama' || adapterKind !== 'local'
+    if (provider !== 'ollama' || task !== 'clinical' || adapterId !== 'ollama' || adapterKind !== 'local'
         || typeof baseUrl !== 'string') {
         return deny('provider_unready');
     }


### PR DESCRIPTION
## Summary
- aggiunge un observer host-only per il binding clinico Ollama locale
- snapshotta provider, adapter, endpoint e modello una volta e attesta una volta con timeout host-owned
- restituisce soltanto una observation congelata oppure dinieghi PHI-safe `provider_unready` / `model_unavailable`
- mantiene l'invocazione provider, il routing Fabric e ogni route fuori da questo packet

## Verification
- `node scripts/run-strip-types.mjs --test lib/ai-providers/host-local-provider-readiness.test.ts`
- `node scripts/run-strip-types.mjs --test lib/ai-providers/host-local-provider-readiness.test.ts lib/ai-providers/ollama-locality.test.ts lib/ai-providers/registry.test.ts lib/ai-providers/host-local-provider-binding.test.ts lib/ai-providers/fabric/*.test.ts` — 109 pass
- `npm run typecheck`
- `npm run lint`
- `npm run build` con Node 24.18.0
- `npm run check:never-regress`
- `npm run check:claims`
- `git diff --cached --check`
- scan focalizzato: nessun import DB/settings/lifecycle/router/projection, nessun fetch/chat/listModels/console/child_process/fs nel nuovo servizio

## Risk / Notes
- PR stacked su #223; non autorizza provider invoke e non aggiunge una composition root, route o singleton
- l'adapter provider dovrà riattestare al momento della futura invocazione
- test solo con fixture sintetiche e attestor iniettato; nessuna rete o database reale
- la build segnala il warning NFT preesistente relativo a `next.config.ts` / ATHENA MLX, ma termina con successo

## Ticket
Refs WUL-522
Refs WUL-518
