### PR TITLE
feat(ai): aggiungi kill switch host per Smart Import

### DIFF
--- a/lib/domain/documents/patient-smart-import-host-kill-switch.test.ts
+++ b/lib/domain/documents/patient-smart-import-host-kill-switch.test.ts
@@ -1,0 +1,45 @@
+/* @Codex */
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createPatientSmartImportHostKillSwitch } from './patient-smart-import-host-kill-switch';
+
+test('reads the host Smart Import kill switch once and enables only an explicit enabled value', async () => {
+    let reads = 0;
+    const killSwitch = createPatientSmartImportHostKillSwitch({
+        readSetting: async () => {
+            reads += 1;
+            return 'enabled';
+        },
+    });
+
+    const result = await killSwitch.read();
+
+    assert.deepEqual(result, { status: 'enabled' });
+    assert.equal(reads, 1);
+    assert.equal(Object.isFrozen(result), true);
+});
+
+test('fails closed for absent, false, and malformed settings', async () => {
+    const throwingAccessor = Object.defineProperty({}, 'raw', {
+        get: () => { throw new Error('synthetic accessor marker'); },
+    });
+
+    for (const value of [undefined, null, false, 'false', 'disabled', '', 'malformed', throwingAccessor]) {
+        const result = await createPatientSmartImportHostKillSwitch({
+            readSetting: async () => value,
+        }).read();
+
+        assert.deepEqual(result, { status: 'denied', code: 'disabled' });
+        assert.equal(Object.isFrozen(result), true);
+    }
+});
+
+test('maps an unavailable setting read to a fixed PHI-safe denial', async () => {
+    const result = await createPatientSmartImportHostKillSwitch({
+        readSetting: async () => { throw new Error('synthetic raw database marker'); },
+    }).read();
+
+    assert.deepEqual(result, { status: 'denied', code: 'unavailable' });
+    assert.equal(Object.isFrozen(result), true);
+    assert.equal(JSON.stringify(result).includes('synthetic raw database marker'), false);
+});

--- a/lib/domain/documents/patient-smart-import-host-kill-switch.ts
+++ b/lib/domain/documents/patient-smart-import-host-kill-switch.ts
@@ -1,0 +1,48 @@
+/* @Codex */
+import 'server-only';
+import { eq } from 'drizzle-orm';
+import { dbServer } from '@/lib/db-server';
+import {
+    AI_SMART_IMPORT_KILL_SWITCH_KEY,
+    isAiSmartImportEnabledValue,
+} from '@/lib/ai-smart-import-kill-switch';
+import { settings } from '@/lib/schema';
+
+type HostKillSwitchSettingReader = () => Promise<unknown>;
+
+export type PatientSmartImportHostKillSwitchResult =
+    | Readonly<{ status: 'enabled' }>
+    | Readonly<{ status: 'denied'; code: 'disabled' | 'unavailable' }>;
+
+async function readProductionSetting(): Promise<unknown> {
+    const row = await dbServer
+        .select({ value: settings.value })
+        .from(settings)
+        .where(eq(settings.key, AI_SMART_IMPORT_KILL_SWITCH_KEY))
+        .get();
+
+    return row?.value;
+}
+
+const ENABLED = Object.freeze({ status: 'enabled' as const });
+const DISABLED = Object.freeze({ status: 'denied' as const, code: 'disabled' as const });
+const UNAVAILABLE = Object.freeze({ status: 'denied' as const, code: 'unavailable' as const });
+
+export function createPatientSmartImportHostKillSwitch(options: Readonly<{
+    readSetting?: HostKillSwitchSettingReader;
+}> = {}) {
+    const readSetting = options.readSetting ?? readProductionSetting;
+
+    return Object.freeze({
+        async read(): Promise<PatientSmartImportHostKillSwitchResult> {
+            let value: unknown;
+            try {
+                value = await readSetting();
+            } catch {
+                return UNAVAILABLE;
+            }
+
+            return isAiSmartImportEnabledValue(value) ? ENABLED : DISABLED;
+        },
+    });
+}


### PR DESCRIPTION
## Summary
- Aggiunge un reader host-only del kill switch canonico Smart Import.
- Legge aiSmartImportKillSwitch una volta per operazione e abilita solo valori canonici espliciti.
- Nega setting assente, falsa, malformata o indisponibile con risultati fissi e senza valori o errori grezzi.

## Verification
- Focused kill-switch test: 3 test passati.
- Smart Import contract/service regressions: 28 test passati.
- Fabric regressions: 83 test passati.
- ai-context: 71 test passati.
- AI rollout readiness: 37 test passati.
- npm run typecheck.
- npm run lint.
- npm run build con Node 24.18.0.
- npm run check:never-regress.
- npm run check:claims.
- git diff --check e scansione import/rete/log.

## Risk / Notes
- PR stacked su #224; non aggiunge route o composizione runtime.
- Il reader iniettato serve solo alle fixture sintetiche.
- Nessun provider, rete, lifecycle, Fabric, UI, AIP, Mini o apply in questo packet.

## Ticket
Refs WUL-522