### PR TITLE
feat(ai): aggiungi capability host Smart Import

### DIFF
--- a/lib/domain/documents/patient-smart-import-host-capability.test.ts
+++ b/lib/domain/documents/patient-smart-import-host-capability.test.ts
@@ -36,7 +36,8 @@ function resolution(chat: LocalProviderResolution['adapter']['chat']): LocalProv
         listModels: async () => [],
     }) };
 }
-type Stop = 'kill' | 'broker' | 'lifecycle' | 'binding' | 'readiness' | 'router' | 'chat' | 'parse' | 'source';
+type Stop = 'kill' | 'kill_unavailable' | 'broker' | 'lifecycle' | 'lifecycle_corrupt'
+    | 'lifecycle_unavailable' | 'binding' | 'readiness' | 'model' | 'router' | 'chat' | 'parse' | 'source';
 function stoppedCapability(stop: Stop, calls: string[]) {
     const binding = resolution(async () => {
         calls.push('chat');
@@ -47,26 +48,30 @@ function stoppedCapability(stop: Stop, calls: string[]) {
     const record = stop === 'router' ? { ...lifecycleRecord,
         lifecycle: { ...lifecycleRecord.lifecycle, provider: 'other_provider' } } : lifecycleRecord;
     return createPatientSmartImportHostCapability({
-        killSwitch: { read: async () => { calls.push('kill'); return stop === 'kill'
-            ? { status: 'denied', code: 'disabled' } : { status: 'enabled' }; } },
+        killSwitch: { read: async () => { calls.push('kill'); return stop === 'kill' || stop === 'kill_unavailable'
+            ? { status: 'denied', code: stop === 'kill' ? 'disabled' : 'unavailable' } : { status: 'enabled' }; } },
         broker: { consume: () => { calls.push('broker'); if (stop === 'broker') throw new Error('synthetic'); return projection; } },
-        lifecycle: { read: () => { calls.push('lifecycle'); return stop === 'lifecycle'
-            ? { status: 'denied', reason: 'missing' } : { status: 'available', record }; } },
+        lifecycle: { read: () => { calls.push('lifecycle'); return stop.startsWith('lifecycle')
+            ? { status: 'denied', reason: stop === 'lifecycle_corrupt' ? 'corrupt'
+                : stop === 'lifecycle_unavailable' ? 'unavailable' : 'missing' } : { status: 'available', record }; } },
         binding: { readClinical: async () => { calls.push('binding'); return stop === 'binding'
             ? { status: 'denied', code: 'settings_unavailable', resolution: null } : { status: 'available', resolution: binding }; } },
-        readiness: { observeClinical: async () => { calls.push('readiness'); return stop === 'readiness'
-            ? { status: 'denied', code: 'provider_unready', observation: { venue: 'local_process', state: 'offline', reason: 'daemon_unreachable' } }
+        readiness: { observeClinical: async () => { calls.push('readiness'); return stop === 'readiness' || stop === 'model'
+            ? { status: 'denied', code: stop === 'model' ? 'model_unavailable' : 'provider_unready', observation: stop === 'model'
+                ? { venue: 'local_process', state: 'degraded', reason: null }
+                : { venue: 'local_process', state: 'offline', reason: 'daemon_unreachable' } }
             : { status: 'available', code: null, observation: { venue: 'local_process', state: 'available', reason: null } }; } },
         route: (input, lifecycle) => { calls.push('router'); return routeHostResolvedCandidateCapability(input, lifecycle); },
-        sources: { clock: () => '2026-08-22T16:00:01.000Z',
-            entropy: () => stop === 'source' ? new Uint8Array(0) : new Uint8Array(16).fill(7) },
+        sources: { clock: () => { calls.push('clock'); return '2026-08-22T16:00:01.000Z'; },
+            entropy: () => { calls.push('entropy'); return stop === 'source' ? new Uint8Array(0) : new Uint8Array(16).fill(7); } },
     });
 }
 
 test('returns one frozen review-only proposal after the fixed host pipeline', async () => {
     const calls = { kill: 0, broker: 0, lifecycle: 0, binding: 0, readiness: 0, router: 0, chat: 0, clock: 0, entropy: 0 };
-    const binding = resolution(async (_messages, _signal, _maxTokens, options) => {
+    const binding = resolution(async (_messages, _signal, maxTokens, options) => {
         calls.chat += 1;
+        assert.equal(maxTokens, 1_100);
         assert.deepEqual(options, { responseFormat: 'json' });
         return { content: RESPONSE, stats: { latency: 1, tokensIn: 2, tokensOut: 3 } };
     });
@@ -98,16 +103,18 @@ test('returns one frozen review-only proposal after the fixed host pipeline', as
 });
 
 test('fails closed at every pre-invoke gate and rejects non-exact caller input', async () => {
-    const stages = [['kill', 'kill_switch_disabled'], ['broker', 'projection_unavailable'],
-        ['lifecycle', 'lifecycle_missing'], ['binding', 'provider_binding_denied'],
-        ['readiness', 'provider_unready'], ['router', 'fabric_denied']] as const;
-    const order = ['kill', 'broker', 'lifecycle', 'binding', 'readiness', 'router'];
-    for (const [stage, code] of stages) {
+    const stages = [['kill', 'kill_switch_disabled', 'kill'], ['kill_unavailable', 'kill_switch_unavailable', 'kill'],
+        ['broker', 'projection_unavailable', 'broker'], ['lifecycle', 'lifecycle_missing', 'lifecycle'],
+        ['lifecycle_corrupt', 'lifecycle_corrupt', 'lifecycle'], ['lifecycle_unavailable', 'lifecycle_unavailable', 'lifecycle'],
+        ['binding', 'provider_binding_denied', 'binding'], ['readiness', 'provider_unready', 'readiness'],
+        ['model', 'model_unavailable', 'readiness'], ['router', 'fabric_denied', 'router'], ['source', 'source_invalid', 'entropy']] as const;
+    const order = ['kill', 'broker', 'lifecycle', 'binding', 'readiness', 'router', 'clock', 'entropy'];
+    for (const [stage, code, gate] of stages) {
         const calls: string[] = [];
         const result = await stoppedCapability(stage, calls).preview({ handle: HANDLE, requestId: REQUEST_ID });
         assert.deepEqual(result, { writesPerformed: 0, apply: 'denied', status: 'denied', code,
             proposal: null, receipt: null, provenance: null, reviewRef: null });
-        assert.deepEqual(calls, order.slice(0, order.indexOf(stage) + 1));
+        assert.deepEqual(calls, order.slice(0, order.indexOf(gate) + 1));
     }
     const accessor = Object.defineProperty({ handle: HANDLE }, 'requestId', {
         enumerable: true, get: () => { throw new Error('synthetic accessor marker'); },
@@ -121,7 +128,7 @@ test('fails closed at every pre-invoke gate and rejects non-exact caller input',
 });
 
 test('uses failed only after chat and retains only PHI-safe routing evidence', async () => {
-    for (const [stage, code] of [['chat', 'provider_failed'], ['parse', 'proposal_invalid'], ['source', 'source_invalid']] as const) {
+    for (const [stage, code] of [['chat', 'provider_failed'], ['parse', 'proposal_invalid']] as const) {
         const calls: string[] = [];
         const result = await stoppedCapability(stage, calls).preview({ handle: HANDLE, requestId: REQUEST_ID });
         assert.equal(result.status, 'failed'); assert.equal(result.code, code); assert.equal(calls.at(-1), 'chat');

--- a/lib/domain/documents/patient-smart-import-host-capability.test.ts
+++ b/lib/domain/documents/patient-smart-import-host-capability.test.ts
@@ -1,0 +1,132 @@
+/* @Codex */
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { SmartImportProjection } from '../../smart-import-projection';
+import { localProviderRegistry, type LocalProviderResolution } from '../../ai-providers/registry';
+import { routeHostResolvedCandidateCapability } from '../../ai-providers/fabric/candidate-router';
+import type { ProviderLifecycleRead } from '../../ai-providers/fabric/provider-lifecycle-service';
+import { createPatientSmartImportHostCapability } from './patient-smart-import-host-capability';
+const HANDLE = `prj_${'1'.repeat(32)}`;
+const REQUEST_ID = 'request.synthetic.0001';
+const projection: SmartImportProjection = Object.freeze({
+    schemaVersion: 'mediflow.smart-import.projection.v1', capability: 'smart_import',
+    patientRef: 'patient.synthetic.0001', selectionEpoch: 2, patientRevision: 3, sourceRevision: 4,
+    capturedAt: '2026-08-22T16:00:00.000Z', currentDiagnoses: Object.freeze([]),
+    currentActiveTherapies: Object.freeze([]), therapyCandidateHints: Object.freeze([]),
+    sources: Object.freeze([{ id: 'source.synthetic.0001', kind: 'clinical-entry' as const, label: 'Fonte sintetica',
+        date: null, content: 'synthetic projection marker' }]),
+});
+const lifecycleRecord: Extract<ProviderLifecycleRead, { status: 'available' }>['record'] = Object.freeze({
+    schemaVersion: 'mediflow.ai.provider-lifecycle-record.v1',
+    lifecycle: Object.freeze({ schemaVersion: 'mediflow.ai.provider-lifecycle.v1', provider: 'ollama',
+        credentialClass: 'local_model', status: 'available_unqualified' }),
+    actorClass: 'host_service', actorRef: `actor_${'a'.repeat(32)}`, version: 1,
+    hostTimestamp: '2026-08-22T15:59:00.000Z', receiptRef: `receipt_${'b'.repeat(32)}`,
+});
+const RESPONSE = JSON.stringify({
+    schemaVersion: 'mediflow.ai.extract.v1', task: 'smart_import', summary: 'Proposta sintetica',
+    ignoredRaw: 'raw-provider-marker', data: { diagnoses: [], therapies: [], servicePrescriptions: [] },
+});
+function resolution(chat: LocalProviderResolution['adapter']['chat']): LocalProviderResolution {
+    const base = localProviderRegistry.resolve({ task: 'clinical', models: { clinical: 'synthetic-local-model' },
+        endpoint: 'http://127.0.0.1:11434', chatTimeoutMs: 1_000 });
+    return { ...base, adapter: Object.freeze({
+        id: base.adapter.id, kind: base.adapter.kind, capabilities: base.adapter.capabilities,
+        getBaseUrl: () => base.adapter.getBaseUrl(), getModel: () => base.adapter.getModel(), chat,
+        listModels: async () => [],
+    }) };
+}
+type Stop = 'kill' | 'broker' | 'lifecycle' | 'binding' | 'readiness' | 'router' | 'chat' | 'parse' | 'source';
+function stoppedCapability(stop: Stop, calls: string[]) {
+    const binding = resolution(async () => {
+        calls.push('chat');
+        if (stop === 'chat') throw new Error('synthetic provider marker');
+        return { content: stop === 'parse' ? 'synthetic invalid response' : RESPONSE,
+            stats: { latency: 1, tokensIn: 2, tokensOut: 3 } };
+    });
+    const record = stop === 'router' ? { ...lifecycleRecord,
+        lifecycle: { ...lifecycleRecord.lifecycle, provider: 'other_provider' } } : lifecycleRecord;
+    return createPatientSmartImportHostCapability({
+        killSwitch: { read: async () => { calls.push('kill'); return stop === 'kill'
+            ? { status: 'denied', code: 'disabled' } : { status: 'enabled' }; } },
+        broker: { consume: () => { calls.push('broker'); if (stop === 'broker') throw new Error('synthetic'); return projection; } },
+        lifecycle: { read: () => { calls.push('lifecycle'); return stop === 'lifecycle'
+            ? { status: 'denied', reason: 'missing' } : { status: 'available', record }; } },
+        binding: { readClinical: async () => { calls.push('binding'); return stop === 'binding'
+            ? { status: 'denied', code: 'settings_unavailable', resolution: null } : { status: 'available', resolution: binding }; } },
+        readiness: { observeClinical: async () => { calls.push('readiness'); return stop === 'readiness'
+            ? { status: 'denied', code: 'provider_unready', observation: { venue: 'local_process', state: 'offline', reason: 'daemon_unreachable' } }
+            : { status: 'available', code: null, observation: { venue: 'local_process', state: 'available', reason: null } }; } },
+        route: (input, lifecycle) => { calls.push('router'); return routeHostResolvedCandidateCapability(input, lifecycle); },
+        sources: { clock: () => '2026-08-22T16:00:01.000Z',
+            entropy: () => stop === 'source' ? new Uint8Array(0) : new Uint8Array(16).fill(7) },
+    });
+}
+
+test('returns one frozen review-only proposal after the fixed host pipeline', async () => {
+    const calls = { kill: 0, broker: 0, lifecycle: 0, binding: 0, readiness: 0, router: 0, chat: 0, clock: 0, entropy: 0 };
+    const binding = resolution(async (_messages, _signal, _maxTokens, options) => {
+        calls.chat += 1;
+        assert.deepEqual(options, { responseFormat: 'json' });
+        return { content: RESPONSE, stats: { latency: 1, tokensIn: 2, tokensOut: 3 } };
+    });
+    const capability = createPatientSmartImportHostCapability({
+        killSwitch: { read: async () => { calls.kill += 1; return { status: 'enabled' }; } },
+        broker: { consume: () => { calls.broker += 1; return projection; } },
+        lifecycle: { read: () => { calls.lifecycle += 1; return { status: 'available', record: lifecycleRecord }; } },
+        binding: { readClinical: async () => { calls.binding += 1; return { status: 'available', resolution: binding }; } },
+        readiness: { observeClinical: async () => { calls.readiness += 1; return { status: 'available', code: null,
+            observation: Object.freeze({ venue: 'local_process', state: 'available', reason: null }) }; } },
+        route: (input, lifecycle) => { calls.router += 1; return routeHostResolvedCandidateCapability(input, lifecycle); },
+        sources: {
+            clock: () => { calls.clock += 1; return '2026-08-22T16:00:01.000Z'; },
+            entropy: () => { calls.entropy += 1; return new Uint8Array(16).fill(7); },
+        },
+    });
+    const result = await capability.preview({ handle: HANDLE, requestId: REQUEST_ID });
+    assert.equal(result.status, 'available');
+    assert.equal(result.proposal?.summary, 'Proposta sintetica');
+    assert.match(result.reviewRef ?? '', /^review_[0-9a-f]{32}$/u);
+    assert.deepEqual(calls, { kill: 1, broker: 1, lifecycle: 1, binding: 1, readiness: 1, router: 1, chat: 1, clock: 1, entropy: 1 });
+    assert.equal(result.writesPerformed, 0);
+    assert.equal(result.apply, 'denied');
+    assert.equal(Object.isFrozen(result), true);
+    const serialized = JSON.stringify(result);
+    for (const forbidden of [HANDLE, projection.patientRef, 'synthetic projection marker', 'raw-provider-marker', 'tokensIn', 'actor_']) {
+        assert.equal(serialized.includes(forbidden), false);
+    }
+});
+
+test('fails closed at every pre-invoke gate and rejects non-exact caller input', async () => {
+    const stages = [['kill', 'kill_switch_disabled'], ['broker', 'projection_unavailable'],
+        ['lifecycle', 'lifecycle_missing'], ['binding', 'provider_binding_denied'],
+        ['readiness', 'provider_unready'], ['router', 'fabric_denied']] as const;
+    const order = ['kill', 'broker', 'lifecycle', 'binding', 'readiness', 'router'];
+    for (const [stage, code] of stages) {
+        const calls: string[] = [];
+        const result = await stoppedCapability(stage, calls).preview({ handle: HANDLE, requestId: REQUEST_ID });
+        assert.deepEqual(result, { writesPerformed: 0, apply: 'denied', status: 'denied', code,
+            proposal: null, receipt: null, provenance: null, reviewRef: null });
+        assert.deepEqual(calls, order.slice(0, order.indexOf(stage) + 1));
+    }
+    const accessor = Object.defineProperty({ handle: HANDLE }, 'requestId', {
+        enumerable: true, get: () => { throw new Error('synthetic accessor marker'); },
+    });
+    const inherited = Object.assign(Object.create({ inherited: true }), { handle: HANDLE, requestId: REQUEST_ID });
+    for (const caller of [{ handle: HANDLE, requestId: REQUEST_ID, model: 'caller-model' }, accessor, inherited]) {
+        const calls: string[] = [];
+        const result = await stoppedCapability('kill', calls).preview(caller as never);
+        assert.equal(result.code, 'input_invalid'); assert.deepEqual(calls, []);
+    }
+});
+
+test('uses failed only after chat and retains only PHI-safe routing evidence', async () => {
+    for (const [stage, code] of [['chat', 'provider_failed'], ['parse', 'proposal_invalid'], ['source', 'source_invalid']] as const) {
+        const calls: string[] = [];
+        const result = await stoppedCapability(stage, calls).preview({ handle: HANDLE, requestId: REQUEST_ID });
+        assert.equal(result.status, 'failed'); assert.equal(result.code, code); assert.equal(calls.at(-1), 'chat');
+        assert.equal(result.proposal, null); assert.equal(result.reviewRef, null);
+        assert.notEqual(result.receipt, null); assert.notEqual(result.provenance, null);
+        assert.equal(JSON.stringify(result).includes('synthetic provider marker'), false);
+    }
+});

--- a/lib/domain/documents/patient-smart-import-host-capability.ts
+++ b/lib/domain/documents/patient-smart-import-host-capability.ts
@@ -1,0 +1,167 @@
+/* @Codex */
+import 'server-only';
+import { randomBytes } from 'node:crypto';
+import type { SmartImportProjection } from '../../smart-import-projection';
+import type { LocalProviderResolution } from '../../ai-providers/registry';
+import type { HostLocalProviderBindingResult } from '../../ai-providers/host-local-provider-binding';
+import type { HostLocalProviderReadinessResult } from '../../ai-providers/host-local-provider-readiness';
+import type { ProviderLifecycleRead } from '../../ai-providers/fabric/provider-lifecycle-service';
+import { GENERATIVE_CAPABILITY_DESCRIPTORS } from '../../ai-providers/fabric/generative-catalog';
+import type {
+    routeHostResolvedCandidateCapability,
+    HostResolvedCandidateRoutingInput,
+} from '../../ai-providers/fabric/candidate-router';
+import { buildProvenanceRecord } from '../../ai-providers/fabric/resolver';
+import type { FabricExecutionPolicy, FabricProvenanceRecord, FabricResolutionReceipt } from '../../ai-providers/fabric/contract';
+import type { PatientSmartImportHostKillSwitchResult } from './patient-smart-import-host-kill-switch';
+import {
+    buildPatientSmartImportCapabilityPrompt,
+    parsePatientSmartImportCapabilityProposal,
+    type PatientSmartImportCapabilityProposal,
+} from './patient-smart-import-capability-contract';
+export type PatientSmartImportHostDenialCode =
+    | 'input_invalid' | 'kill_switch_disabled' | 'kill_switch_unavailable'
+    | 'projection_unavailable' | 'lifecycle_missing' | 'lifecycle_corrupt' | 'lifecycle_unavailable'
+    | 'provider_binding_denied' | 'provider_unready' | 'model_unavailable' | 'fabric_denied';
+export type PatientSmartImportHostFailureCode = 'provider_failed' | 'proposal_invalid' | 'source_invalid';
+type Common = Readonly<{ writesPerformed: 0; apply: 'denied' }>;
+export type PatientSmartImportHostCapabilityResult =
+    | (Common & Readonly<{ status: 'available'; code: null; proposal: PatientSmartImportCapabilityProposal;
+        receipt: FabricResolutionReceipt; provenance: FabricProvenanceRecord; reviewRef: string }>)
+    | (Common & Readonly<{ status: 'denied'; code: PatientSmartImportHostDenialCode; proposal: null;
+        receipt: null; provenance: null; reviewRef: null }>)
+    | (Common & Readonly<{ status: 'failed'; code: PatientSmartImportHostFailureCode; proposal: null;
+        receipt: FabricResolutionReceipt; provenance: FabricProvenanceRecord; reviewRef: null }>);
+type Sources = Readonly<{ clock: () => unknown; entropy: () => unknown }>;
+type Dependencies = Readonly<{
+    killSwitch: Readonly<{ read(): Promise<PatientSmartImportHostKillSwitchResult> }>;
+    broker: Readonly<{ consume(input: Readonly<{ handle: string; capability: 'smart_import'; requestId: string }>): SmartImportProjection }>;
+    lifecycle: Readonly<{ read(): ProviderLifecycleRead }>;
+    binding: Readonly<{ readClinical(): Promise<HostLocalProviderBindingResult> }>;
+    readiness: Readonly<{ observeClinical(resolution: LocalProviderResolution): Promise<HostLocalProviderReadinessResult> }>;
+    route: typeof routeHostResolvedCandidateCapability;
+    sources?: Sources;
+}>;
+const descriptor = GENERATIVE_CAPABILITY_DESCRIPTORS.smart_import;
+const productionSources: Sources = Object.freeze({
+    clock: () => new Date().toISOString(),
+    entropy: () => randomBytes(16),
+});
+const common = Object.freeze({ writesPerformed: 0 as const, apply: 'denied' as const });
+function deny(code: PatientSmartImportHostDenialCode): PatientSmartImportHostCapabilityResult {
+    return Object.freeze({ ...common, status: 'denied', code, proposal: null, receipt: null, provenance: null, reviewRef: null });
+}
+function failed(code: PatientSmartImportHostFailureCode, receipt: FabricResolutionReceipt,
+    provenance: FabricProvenanceRecord): PatientSmartImportHostCapabilityResult {
+    return Object.freeze({ ...common, status: 'failed', code, proposal: null, receipt, provenance, reviewRef: null });
+}
+function input(value: unknown): Readonly<{ handle: string; requestId: string }> | null {
+    if (!value || typeof value !== 'object' || Array.isArray(value) || Object.getPrototypeOf(value) !== Object.prototype) return null;
+    const keys = Reflect.ownKeys(value);
+    if (keys.length !== 2 || !keys.includes('handle') || !keys.includes('requestId')) return null;
+    const handle = Object.getOwnPropertyDescriptor(value, 'handle');
+    const requestId = Object.getOwnPropertyDescriptor(value, 'requestId');
+    if (!handle || !('value' in handle) || typeof handle.value !== 'string' || !/^prj_[0-9a-f]{32}$/u.test(handle.value)
+        || !requestId || !('value' in requestId) || typeof requestId.value !== 'string'
+        || !/^[A-Za-z][A-Za-z0-9._:-]{15,159}$/u.test(requestId.value)) return null;
+    return Object.freeze({ handle: handle.value, requestId: requestId.value });
+}
+function policy(requestId: string): FabricExecutionPolicy {
+    return Object.freeze({ schemaVersion: 'mediflow.ai.execution-policy.v1', requestId, capability: 'smart_import',
+        authorityPlane: 'clinical_application', operation: descriptor.operation, dataClass: descriptor.dataClass,
+        allowedVenues: Object.freeze(['local_process'] as const), egressProfileId: descriptor.egressProfileId,
+        consentRef: null, retention: 'not_persisted', review: descriptor.review,
+        provenanceRequired: true, fallback: 'none' });
+}
+function reviewRef(sources: Sources): string {
+    const bytes = sources.entropy();
+    if (!(bytes instanceof Uint8Array) || bytes.byteLength < 16) throw new Error('invalid');
+    return `review_${Array.from(bytes.slice(0, 16), (byte) => byte.toString(16).padStart(2, '0')).join('')}`;
+}
+function timestamp(sources: Sources): string {
+    const value = sources.clock();
+    if (typeof value !== 'string' || !Number.isFinite(Date.parse(value)) || new Date(value).toISOString() !== value) throw new Error('invalid');
+    return value;
+}
+export function createPatientSmartImportHostCapability(dependencies: Dependencies) {
+    const sources = dependencies.sources ?? productionSources;
+    return Object.freeze({
+        async preview(value: unknown): Promise<PatientSmartImportHostCapabilityResult> {
+            const request = input(value);
+            if (!request) return deny('input_invalid');
+            try {
+                const killSwitch = await dependencies.killSwitch.read();
+                if (killSwitch.status !== 'enabled') return deny(
+                    killSwitch.status === 'denied' && killSwitch.code === 'disabled'
+                        ? 'kill_switch_disabled' : 'kill_switch_unavailable');
+            } catch { return deny('kill_switch_unavailable'); }
+            let projection: SmartImportProjection;
+            try { projection = dependencies.broker.consume({ ...request, capability: 'smart_import' }); }
+            catch { return deny('projection_unavailable'); }
+            let lifecycleState: Extract<ProviderLifecycleRead, { status: 'available' }>;
+            try {
+                const lifecycle = dependencies.lifecycle.read();
+                if (lifecycle.status !== 'available') return deny(lifecycle.status === 'denied' && lifecycle.reason === 'missing'
+                    ? 'lifecycle_missing' : lifecycle.status === 'denied' && lifecycle.reason === 'corrupt'
+                        ? 'lifecycle_corrupt' : 'lifecycle_unavailable');
+                lifecycleState = lifecycle;
+            } catch { return deny('lifecycle_unavailable'); }
+            let binding: LocalProviderResolution;
+            try {
+                const result = await dependencies.binding.readClinical();
+                if (result.status !== 'available') return deny('provider_binding_denied');
+                binding = result.resolution;
+            } catch { return deny('provider_binding_denied'); }
+            let observation: HostLocalProviderReadinessResult['observation'];
+            try {
+                const readiness = await dependencies.readiness.observeClinical(binding);
+                if (readiness.status !== 'available') return deny(
+                    readiness.status === 'denied' && readiness.code === 'model_unavailable'
+                        ? 'model_unavailable' : 'provider_unready');
+                observation = readiness.observation;
+            } catch { return deny('provider_unready'); }
+            let routed: ReturnType<typeof routeHostResolvedCandidateCapability>;
+            try {
+                const routeInput: HostResolvedCandidateRoutingInput = Object.freeze({
+                    policy: policy(request.requestId),
+                    request: Object.freeze({ descriptor, venue: 'local_process', generative: binding }),
+                    observations: Object.freeze([observation]),
+                });
+                routed = dependencies.route(routeInput, lifecycleState.record.lifecycle);
+            } catch { return deny('fabric_denied'); }
+            const routedResolution = routed.resolution;
+            const routedBinding = routedResolution?.generative;
+            if (routed.decision.outcome !== 'resolved' || !routed.decision.receipt || !routedResolution
+                || routed.decision.receipt !== routedResolution.receipt || routedBinding !== binding) return deny('fabric_denied');
+            const receipt = routedResolution.receipt;
+            let provenance: FabricProvenanceRecord;
+            let prompt: string;
+            try {
+                provenance = buildProvenanceRecord(routedResolution, ['context_minimization', 'envelope_validation']);
+                prompt = buildPatientSmartImportCapabilityPrompt(projection);
+            } catch { return deny('fabric_denied'); }
+
+            let response: string;
+            try {
+                const providerResult = await routedBinding.adapter.chat(
+                    [{ role: 'user', content: prompt }], undefined, undefined, { responseFormat: 'json' },
+                );
+                response = providerResult.content;
+                if (typeof response !== 'string') throw new Error('invalid');
+            } catch { return failed('provider_failed', receipt, provenance); }
+
+            let generatedAt: string;
+            try { generatedAt = timestamp(sources); }
+            catch { return failed('source_invalid', receipt, provenance); }
+            let proposal: PatientSmartImportCapabilityProposal;
+            try { proposal = parsePatientSmartImportCapabilityProposal(response, projection, generatedAt); }
+            catch { return failed('proposal_invalid', receipt, provenance); }
+            let correlation: string;
+            try { correlation = reviewRef(sources); }
+            catch { return failed('source_invalid', receipt, provenance); }
+
+            return Object.freeze({ ...common, status: 'available', code: null, proposal, receipt, provenance,
+                reviewRef: correlation });
+        },
+    });
+}

--- a/lib/domain/documents/patient-smart-import-host-capability.ts
+++ b/lib/domain/documents/patient-smart-import-host-capability.ts
@@ -22,8 +22,8 @@ import {
 export type PatientSmartImportHostDenialCode =
     | 'input_invalid' | 'kill_switch_disabled' | 'kill_switch_unavailable'
     | 'projection_unavailable' | 'lifecycle_missing' | 'lifecycle_corrupt' | 'lifecycle_unavailable'
-    | 'provider_binding_denied' | 'provider_unready' | 'model_unavailable' | 'fabric_denied';
-export type PatientSmartImportHostFailureCode = 'provider_failed' | 'proposal_invalid' | 'source_invalid';
+    | 'provider_binding_denied' | 'provider_unready' | 'model_unavailable' | 'fabric_denied' | 'source_invalid';
+export type PatientSmartImportHostFailureCode = 'provider_failed' | 'proposal_invalid';
 type Common = Readonly<{ writesPerformed: 0; apply: 'denied' }>;
 export type PatientSmartImportHostCapabilityResult =
     | (Common & Readonly<{ status: 'available'; code: null; proposal: PatientSmartImportCapabilityProposal;
@@ -134,6 +134,10 @@ export function createPatientSmartImportHostCapability(dependencies: Dependencie
             if (routed.decision.outcome !== 'resolved' || !routed.decision.receipt || !routedResolution
                 || routed.decision.receipt !== routedResolution.receipt || routedBinding !== binding) return deny('fabric_denied');
             const receipt = routedResolution.receipt;
+            let generatedAt: string;
+            let correlation: string;
+            try { generatedAt = timestamp(sources); correlation = reviewRef(sources); }
+            catch { return deny('source_invalid'); }
             let provenance: FabricProvenanceRecord;
             let prompt: string;
             try {
@@ -144,21 +148,14 @@ export function createPatientSmartImportHostCapability(dependencies: Dependencie
             let response: string;
             try {
                 const providerResult = await routedBinding.adapter.chat(
-                    [{ role: 'user', content: prompt }], undefined, undefined, { responseFormat: 'json' },
+                    [{ role: 'user', content: prompt }], undefined, 1_100, { responseFormat: 'json' },
                 );
                 response = providerResult.content;
                 if (typeof response !== 'string') throw new Error('invalid');
             } catch { return failed('provider_failed', receipt, provenance); }
-
-            let generatedAt: string;
-            try { generatedAt = timestamp(sources); }
-            catch { return failed('source_invalid', receipt, provenance); }
             let proposal: PatientSmartImportCapabilityProposal;
             try { proposal = parsePatientSmartImportCapabilityProposal(response, projection, generatedAt); }
             catch { return failed('proposal_invalid', receipt, provenance); }
-            let correlation: string;
-            try { correlation = reviewRef(sources); }
-            catch { return failed('source_invalid', receipt, provenance); }
 
             return Object.freeze({ ...common, status: 'available', code: null, proposal, receipt, provenance,
                 reviewRef: correlation });


### PR DESCRIPTION
## Summary
- Compone kill switch, projection broker, lifecycle persistito, binding, readiness e router host in ordine fisso.
- Invoca una sola volta l adapter esatto risolto dal Fabric e passa il risultato al parser Smart Import tipizzato.
- Restituisce soltanto envelope available, denied o failed congelati, proposal-only e PHI-safe.
- Genera un reviewRef host-random di 128 bit usato solo per correlazione; apply resta negato.

## Verification
- Focused host capability: 3 test passati.
- Broker, projection e P2B: 18 test passati.
- Lifecycle, binding, readiness e router: 36 test passati.
- Fabric completo: 83 test passati.
- ai-context: 71 test passati.
- npm run typecheck.
- npm run lint.
- npm run build con Node 24.18.0.
- npm run check:never-regress.
- npm run check:claims.
- git diff --check e scansione import/rete/log.

## Risk / Notes
- PR stacked su #225; non aggiunge composizione session-scoped o route di produzione.
- Nessun singleton broker, DB, lifecycle control, UI, AIP, Mini, cloud, fallback o apply.
- Le fixture sono interamente sintetiche e non invocano provider o rete reali.
- La composizione sessione/selezione e la route di produzione restano HOLD.

## Ticket
Refs WUL-522