### PR TITLE
feat(auth): dispose risorse con la sessione

### DIFF
--- a/lib/security/server-session.test.ts
+++ b/lib/security/server-session.test.ts
@@ -1,0 +1,161 @@
+/* @Codex */
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { afterEach, test } from 'node:test';
+
+import {
+    clearAllSessions,
+    createSession,
+    deleteSession,
+    getSession,
+    registerServerSessionResource,
+} from './server-session';
+
+const SYNTHETIC_USERNAME = `synthetic-${randomUUID()}`;
+
+afterEach(() => clearAllSessions());
+
+function syntheticSession() {
+    return createSession({
+        id: 'user-synthetic',
+        username: SYNTHETIC_USERNAME,
+        role: 'clinician',
+    });
+}
+
+test('delete removes the session before disposing its resource exactly once', () => {
+    const session = syntheticSession();
+    const events: string[] = [];
+    const unregister = registerServerSessionResource(session.id, (reason) => {
+        assert.equal(getSession(session.id), null);
+        events.push(reason);
+    });
+
+    assert.equal(typeof unregister, 'function');
+    deleteSession(session.id);
+    deleteSession(session.id);
+
+    assert.deepEqual(events, ['session_deleted']);
+});
+
+test('expired access disposes the resource before returning null', () => {
+    const session = syntheticSession();
+    const events: string[] = [];
+    registerServerSessionResource(session.id, (reason) => events.push(reason));
+    session.expiresAt = 0;
+
+    assert.equal(getSession(session.id), null);
+    assert.equal(getSession(session.id), null);
+    assert.deepEqual(events, ['session_expired']);
+});
+
+test('live access preserves the resource and keeps sliding expiry', () => {
+    const session = syntheticSession();
+    const events: string[] = [];
+    session.expiresAt = Date.now() + 1_000;
+    const previousExpiry = session.expiresAt;
+    const unregister = registerServerSessionResource(session.id, (reason) => events.push(reason));
+
+    assert.equal(getSession(session.id), session);
+    assert.ok(session.expiresAt > previousExpiry);
+    assert.deepEqual(events, []);
+    unregister?.();
+});
+
+test('registration rejects missing and expired sessions without sliding expiry', () => {
+    let calls = 0;
+    assert.equal(registerServerSessionResource('missing-session', () => { calls += 1; }), null);
+
+    const session = syntheticSession();
+    session.expiresAt = 0;
+    assert.equal(registerServerSessionResource(session.id, () => { calls += 1; }), null);
+    assert.equal(getSession(session.id), null);
+    assert.equal(calls, 0);
+});
+
+test('unregister is synchronous and idempotent without disposing the resource', () => {
+    const session = syntheticSession();
+    let calls = 0;
+    const unregister = registerServerSessionResource(session.id, () => { calls += 1; });
+
+    unregister?.();
+    unregister?.();
+    deleteSession(session.id);
+
+    assert.equal(calls, 0);
+});
+
+test('each registration is disposed even when it reuses the same callback', () => {
+    const session = syntheticSession();
+    const reasons: string[] = [];
+    const dispose = (reason: string) => reasons.push(reason);
+    registerServerSessionResource(session.id, dispose);
+    registerServerSessionResource(session.id, dispose);
+
+    deleteSession(session.id);
+
+    assert.deepEqual(reasons, ['session_deleted', 'session_deleted']);
+});
+
+test('termination attempts every detached registration despite reentrant unregister', () => {
+    const session = syntheticSession();
+    const events: string[] = [];
+    let unregisterSecond: (() => void) | null = null;
+    registerServerSessionResource(session.id, () => {
+        events.push('first');
+        unregisterSecond?.();
+    });
+    unregisterSecond = registerServerSessionResource(session.id, () => events.push('second'));
+
+    deleteSession(session.id);
+
+    assert.deepEqual(events, ['first', 'second']);
+});
+
+test('clear removes all sessions before opaque disposal and continues after a throw', () => {
+    const first = syntheticSession();
+    const second = syntheticSession();
+    const events: string[] = [];
+    registerServerSessionResource(first.id, (reason) => {
+        events.push(`throwing:${reason}`);
+        throw new Error('synthetic cleanup detail');
+    });
+    registerServerSessionResource(first.id, (reason) => events.push(`first:${reason}`));
+    registerServerSessionResource(second.id, (reason) => {
+        assert.equal(getSession(first.id), null);
+        assert.equal(getSession(second.id), null);
+        events.push(`second:${reason}`);
+    });
+
+    clearAllSessions();
+    clearAllSessions();
+
+    assert.deepEqual(events, [
+        'throwing:sessions_cleared',
+        'first:sessions_cleared',
+        'second:sessions_cleared',
+    ]);
+});
+
+test('disposal cannot register a new resource on the terminated session', () => {
+    const session = syntheticSession();
+    let nestedRegistration: (() => void) | null | undefined;
+    registerServerSessionResource(session.id, () => {
+        nestedRegistration = registerServerSessionResource(session.id, () => undefined);
+    });
+
+    deleteSession(session.id);
+
+    assert.equal(nestedRegistration, null);
+});
+
+test('clear disposes an orphan registration left by host module drift', () => {
+    const session = syntheticSession();
+    const reasons: string[] = [];
+    registerServerSessionResource(session.id, (reason) => reasons.push(reason));
+    globalThis.__mediflowSessions?.delete(session.id);
+
+    clearAllSessions();
+
+    assert.deepEqual(reasons, ['sessions_cleared']);
+});

--- a/lib/security/server-session.ts
+++ b/lib/security/server-session.ts
@@ -9,6 +9,16 @@ const SESSION_TTL_MS = Number(process.env.MEDIFLOW_SESSION_TTL_MS || 1000 * 60 *
 declare global {
     // eslint-disable-next-line no-var
     var __mediflowSessions: Map<string, ServerSession> | undefined;
+    // eslint-disable-next-line no-var
+    var __mediflowSessionResources: Map<string, Set<ServerSessionResourceRegistration>> | undefined;
+}
+
+export type ServerSessionDisposalReason = 'session_deleted' | 'session_expired' | 'sessions_cleared';
+export type ServerSessionResourceDisposer = (reason: ServerSessionDisposalReason) => void;
+
+interface ServerSessionResourceRegistration {
+    active: boolean;
+    dispose: ServerSessionResourceDisposer;
 }
 
 export interface ServerSession {
@@ -23,6 +33,54 @@ export interface ServerSession {
 
 const sessions = globalThis.__mediflowSessions ?? new Map<string, ServerSession>();
 globalThis.__mediflowSessions = sessions;
+const sessionResources = globalThis.__mediflowSessionResources
+    ?? new Map<string, Set<ServerSessionResourceRegistration>>();
+globalThis.__mediflowSessionResources = sessionResources;
+
+function disposeSessionResources(sessionId: string, reason: ServerSessionDisposalReason): void {
+    const registrations = sessionResources.get(sessionId);
+    sessionResources.delete(sessionId);
+    if (!registrations) return;
+
+    for (const registration of registrations) {
+        if (!registration.active) continue;
+        registration.active = false;
+        try {
+            registration.dispose(reason);
+        } catch {
+            // Session authority is already removed; cleanup failures stay opaque.
+        }
+    }
+}
+
+function terminateSession(sessionId: string, reason: ServerSessionDisposalReason): void {
+    sessions.delete(sessionId);
+    disposeSessionResources(sessionId, reason);
+}
+
+export function registerServerSessionResource(
+    sessionId: string,
+    dispose: ServerSessionResourceDisposer,
+): (() => void) | null {
+    const session = sessions.get(sessionId);
+    if (!session) return null;
+    if (session.expiresAt <= Date.now()) {
+        terminateSession(sessionId, 'session_expired');
+        return null;
+    }
+
+    const registration: ServerSessionResourceRegistration = { active: true, dispose };
+    const registrations = sessionResources.get(sessionId) ?? new Set<ServerSessionResourceRegistration>();
+    registrations.add(registration);
+    sessionResources.set(sessionId, registrations);
+
+    return () => {
+        const activeRegistrations = sessionResources.get(sessionId);
+        if (!activeRegistrations?.delete(registration)) return;
+        registration.active = false;
+        if (activeRegistrations?.size === 0) sessionResources.delete(sessionId);
+    };
+}
 
 export function createSession(
     user: { id: string; username: string; role: string },
@@ -49,7 +107,7 @@ export function getSession(sessionId: string | null | undefined): ServerSession 
 
     const now = Date.now();
     if (session.expiresAt <= now) {
-        sessions.delete(sessionId);
+        terminateSession(sessionId, 'session_expired');
         return null;
     }
 
@@ -61,10 +119,14 @@ export function getSession(sessionId: string | null | undefined): ServerSession 
 
 export function deleteSession(sessionId: string | null | undefined): void {
     if (!sessionId) return;
-    sessions.delete(sessionId);
+    terminateSession(sessionId, 'session_deleted');
 }
 
 /* @Codex */
 export function clearAllSessions(): void {
+    const sessionIds = new Set([...sessions.keys(), ...sessionResources.keys()]);
     sessions.clear();
+    for (const sessionId of sessionIds) {
+        disposeSessionResources(sessionId, 'sessions_cleared');
+    }
 }


### PR DESCRIPTION
## Summary
- aggiunge una registrazione host sincrona e annullabile per risorse legate alla sessione
- centralizza la terminazione per delete, expiry e clear, rimuovendo autorità e registrazioni prima dei disposer
- mantiene opachi gli errori di cleanup e tenta ogni registrazione una sola volta, incluse quelle orfane dopo drift del modulo
- preserva lo sliding expiry delle sessioni vive e non modifica i call site esistenti

## Verification
- 10 test focali server-session
- 20 test auth/session pertinenti
- npm run test:unit: 1146 passed
- npm run lint
- npm run typecheck
- npm run check:never-regress
- npm run check:claims
- npm run check:claims -- --self-test
- npm run build con Node 24.18.0
- git diff --check e scan import/rete/log sui due file

## Risk / Notes
- draft PR stacked su #227
- lock confermato e composizione broker restano fuori scope
- nessun call site registra ancora risorse; questa PR introduce solo il seam host sincrono
- fixture esclusivamente sintetiche, nessuna PHI/PII o accesso a database reale

## Ticket
Refs WUL-522