### PR TITLE
feat(ai): separa projection input dall'authority host

### DIFF
--- a/lib/smart-import-projection-attachment-host.test.ts
+++ b/lib/smart-import-projection-attachment-host.test.ts
@@ -1,0 +1,90 @@
+/* @Codex */
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+    createHostSmartImportProjectionAttacher,
+    SmartImportProjectionAttachmentHostError,
+} from './smart-import-projection-attachment-host.ts';
+import { SmartImportProjectionError } from './smart-import-projection.ts';
+
+const NOW = '2026-08-22T12:00:00.000Z';
+const PATIENT_REF = 'patient.canonical-1234567890';
+const SOURCE_REF = 'source.synthetic-1234567890';
+function attachment() {
+    return {
+        schemaVersion: 'mediflow.smart-import.projection-attachment.v1', capability: 'smart_import',
+        patientRevision: 3, sourceRevision: 5, capturedAt: NOW,
+        currentDiagnoses: [{ system: 'ICD-11', code: 'FAKE-1', description: 'Diagnosi sintetica' }],
+        currentActiveTherapies: [{ drugName: 'Farmaco sintetico', activePrinciple: null, dosage: '1 unita', aic: null, atc: null }],
+        therapyCandidateHints: [{ sourceId: SOURCE_REF, label: 'Fonte sintetica', excerpt: 'Indicazione sintetica.' }],
+        sources: [{ id: SOURCE_REF, kind: 'clinical-entry', label: 'Diario sintetico', date: NOW, content: 'Evidenza sintetica.' }],
+    };
+}
+const rejectHost = (action: () => unknown, code: 'authority_invalid' | 'source_invalid') => assert.throws(
+    action,
+    (error) => error instanceof SmartImportProjectionAttachmentHostError && error.code === code
+        && error.message === `Smart Import projection attachment host rejected: ${code}`
+        && !/canonical|Diagnosi|raw source/u.test(error.message),
+);
+
+test('applies one canonical authority snapshot with one host clock read', () => {
+    let clocks = 0;
+    const authority = { patientRef: PATIENT_REF, selectionEpoch: 7 };
+    const attacher = createHostSmartImportProjectionAttacher(authority, { clock: () => { clocks += 1; return NOW; } });
+    authority.patientRef = 'patient.changed-1234567890'; authority.selectionEpoch = 8;
+    const input = attachment();
+    const value = attacher.attach(input);
+    input.sources[0].content = 'Mutazione successiva';
+
+    assert.equal(value.patientRef, PATIENT_REF);
+    assert.equal(value.selectionEpoch, 7);
+    assert.equal(value.sources[0].content, 'Evidenza sintetica.');
+    assert.deepEqual({ clocks, frozen: Object.isFrozen(value) && Object.isFrozen(value.sources[0]) }, { clocks: 1, frozen: true });
+});
+
+test('rejects malformed authority and clock sources with fixed non-echoing errors', () => {
+    let authorityReads = 0;
+    const accessorAuthority = { selectionEpoch: 7 } as { patientRef: string; selectionEpoch: number };
+    Object.defineProperty(accessorAuthority, 'patientRef', { get() { authorityReads += 1; return PATIENT_REF; } });
+    const symbolAuthority = { patientRef: PATIENT_REF, selectionEpoch: 7 };
+    Object.defineProperty(symbolAuthority, Symbol('authority'), { value: true });
+    for (const authority of [
+        { patientRef: 'short', selectionEpoch: 7 },
+        { patientRef: PATIENT_REF, selectionEpoch: 0 },
+        { patientRef: PATIENT_REF, selectionEpoch: 7, sessionRef: 'caller-authority' },
+        Object.create({ patientRef: PATIENT_REF, selectionEpoch: 7 }),
+        accessorAuthority,
+        symbolAuthority,
+    ]) rejectHost(() => createHostSmartImportProjectionAttacher(authority as never), 'authority_invalid');
+    assert.equal(authorityReads, 0);
+
+    for (const clock of [() => { throw new Error('raw source detail'); }, () => 'invalid']) {
+        const attacher = createHostSmartImportProjectionAttacher(
+            { patientRef: PATIENT_REF, selectionEpoch: 7 }, { clock },
+        );
+        rejectHost(() => attacher.attach(attachment()), 'source_invalid');
+    }
+    rejectHost(() => createHostSmartImportProjectionAttacher(
+        { patientRef: PATIENT_REF, selectionEpoch: 7 }, { clock: () => NOW, extra: true } as never,
+    ), 'source_invalid');
+});
+
+test('rejects caller authority overrides before returning an internal projection', () => {
+    const attacher = createHostSmartImportProjectionAttacher(
+        { patientRef: PATIENT_REF, selectionEpoch: 7 }, { clock: () => NOW },
+    );
+    assert.throws(
+        () => attacher.attach({ ...attachment(), patientRef: 'patient.caller-1234567890', selectionEpoch: 99 }),
+        (error) => error instanceof SmartImportProjectionError && error.code === 'projection_invalid'
+            && !/caller-123|Diagnosi/u.test(error.message),
+    );
+});
+
+test('maps hostile authority and source objects to fixed errors', () => {
+    const hostile = new Proxy({}, { getPrototypeOf() { throw new Error('raw proxy detail'); } });
+    rejectHost(() => createHostSmartImportProjectionAttacher(hostile as never), 'authority_invalid');
+    rejectHost(() => createHostSmartImportProjectionAttacher(
+        { patientRef: PATIENT_REF, selectionEpoch: 7 }, hostile as never,
+    ), 'source_invalid');
+});

--- a/lib/smart-import-projection-attachment-host.ts
+++ b/lib/smart-import-projection-attachment-host.ts
@@ -1,0 +1,77 @@
+/* @Codex */
+import 'server-only';
+
+import {
+    snapshotSmartImportProjectionAttachment,
+    type SmartImportProjection,
+} from './smart-import-projection';
+
+export type SmartImportProjectionAttachmentHostErrorCode = 'authority_invalid' | 'source_invalid';
+export class SmartImportProjectionAttachmentHostError extends Error {
+    constructor(readonly code: SmartImportProjectionAttachmentHostErrorCode) {
+        super(`Smart Import projection attachment host rejected: ${code}`);
+        this.name = 'SmartImportProjectionAttachmentHostError';
+    }
+}
+export type HostSmartImportProjectionAuthority = Readonly<{ patientRef: string; selectionEpoch: number }>;
+export type HostSmartImportProjectionAttacherSources = Readonly<{ clock: () => unknown }>;
+
+const productionSources: HostSmartImportProjectionAttacherSources = Object.freeze({ clock: () => new Date().toISOString() });
+function fail(code: SmartImportProjectionAttachmentHostErrorCode): never {
+    throw new SmartImportProjectionAttachmentHostError(code);
+}
+function exact(value: unknown, keys: readonly string[], code: SmartImportProjectionAttachmentHostErrorCode) {
+    if (typeof value !== 'object' || value === null || Array.isArray(value) || Object.getPrototypeOf(value) !== Object.prototype) fail(code);
+    const ownKeys = Reflect.ownKeys(value);
+    if (ownKeys.length !== keys.length || ownKeys.some((key) => typeof key !== 'string' || !keys.includes(key))) fail(code);
+    const record: Record<string, unknown> = {};
+    for (const key of keys) {
+        const descriptor = Object.getOwnPropertyDescriptor(value, key);
+        if (!descriptor || !('value' in descriptor)) fail(code);
+        record[key] = descriptor.value;
+    }
+    return record;
+}
+function safeExact(value: unknown, keys: readonly string[], code: SmartImportProjectionAttachmentHostErrorCode) {
+    try { return exact(value, keys, code); } catch (error) {
+        if (error instanceof SmartImportProjectionAttachmentHostError) throw error;
+        return fail(code);
+    }
+}
+function authority(value: unknown): HostSmartImportProjectionAuthority {
+    const record = safeExact(value, ['patientRef', 'selectionEpoch'], 'authority_invalid');
+    if (typeof record.patientRef !== 'string' || !/^[A-Za-z][A-Za-z0-9._:-]{15,159}$/u.test(record.patientRef)
+        || !Number.isSafeInteger(record.selectionEpoch) || (record.selectionEpoch as number) < 1) fail('authority_invalid');
+    return Object.freeze({ patientRef: record.patientRef, selectionEpoch: record.selectionEpoch as number });
+}
+function readClock(clock: () => unknown): string {
+    try {
+        const value = clock();
+        if (typeof value !== 'string' || value.length > 32 || !Number.isFinite(Date.parse(value))
+            || new Date(value).toISOString() !== value) return fail('source_invalid');
+        return value;
+    } catch { return fail('source_invalid'); }
+}
+
+export function createHostSmartImportProjectionAttacher(
+    authorityValue: HostSmartImportProjectionAuthority,
+    sourceValue: HostSmartImportProjectionAttacherSources = productionSources,
+) {
+    const canonical = authority(authorityValue);
+    const source = safeExact(sourceValue, ['clock'], 'source_invalid');
+    if (typeof source.clock !== 'function') fail('source_invalid');
+    const clock = source.clock as () => unknown;
+    return Object.freeze({
+        attach(value: unknown): SmartImportProjection {
+            const attachment = snapshotSmartImportProjectionAttachment(value, readClock(clock));
+            return Object.freeze({
+                schemaVersion: 'mediflow.smart-import.projection.v1', capability: 'smart_import',
+                patientRef: canonical.patientRef, selectionEpoch: canonical.selectionEpoch,
+                patientRevision: attachment.patientRevision, sourceRevision: attachment.sourceRevision,
+                capturedAt: attachment.capturedAt, currentDiagnoses: attachment.currentDiagnoses,
+                currentActiveTherapies: attachment.currentActiveTherapies,
+                therapyCandidateHints: attachment.therapyCandidateHints, sources: attachment.sources,
+            });
+        },
+    });
+}

--- a/lib/smart-import-projection.test.ts
+++ b/lib/smart-import-projection.test.ts
@@ -1,7 +1,11 @@
 /* @Codex */
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { SmartImportProjectionError, snapshotSmartImportProjection } from './smart-import-projection.ts';
+import {
+    SmartImportProjectionError,
+    snapshotSmartImportProjection,
+    snapshotSmartImportProjectionAttachment,
+} from './smart-import-projection.ts';
 
 const NOW = '2026-08-22T12:00:00.000Z';
 const PATIENT_REF = 'patient.opaque-1234567890';
@@ -16,8 +20,23 @@ function projection() {
         sources: [{ id: SOURCE_REF, kind: 'clinical-entry', label: 'Diario sintetico', date: NOW, content: 'Evidenza sintetica.' }],
     };
 }
+function attachment() {
+    return {
+        schemaVersion: 'mediflow.smart-import.projection-attachment.v1', capability: 'smart_import',
+        patientRevision: 3, sourceRevision: 5, capturedAt: NOW,
+        currentDiagnoses: [{ system: 'ICD-11', code: 'FAKE-1', description: 'Diagnosi sintetica' }],
+        currentActiveTherapies: [{ drugName: 'Farmaco sintetico', activePrinciple: null, dosage: '1 unita', aic: null, atc: null }],
+        therapyCandidateHints: [{ sourceId: SOURCE_REF, label: 'Fonte sintetica', excerpt: 'Indicazione sintetica.' }],
+        sources: [{ id: SOURCE_REF, kind: 'clinical-entry', label: 'Diario sintetico', date: NOW, content: 'Evidenza sintetica.' }],
+    };
+}
 const reject = (value: unknown, code = 'projection_invalid') => assert.throws(
     () => snapshotSmartImportProjection(value, NOW),
+    (error) => error instanceof SmartImportProjectionError && error.code === code
+        && error.message === `Smart Import projection rejected: ${code}` && !/Diagnosi|Farmaco|opaque-123/u.test(error.message),
+);
+const rejectAttachment = (value: unknown, code = 'projection_invalid') => assert.throws(
+    () => snapshotSmartImportProjectionAttachment(value, NOW),
     (error) => error instanceof SmartImportProjectionError && error.code === code
         && error.message === `Smart Import projection rejected: ${code}` && !/Diagnosi|Farmaco|opaque-123/u.test(error.message),
 );
@@ -30,6 +49,46 @@ test('copies a valid closed projection into a deeply frozen snapshot', () => {
     assert.equal(Object.isFrozen(snapshot), true);
     assert.equal(Object.isFrozen(snapshot.sources), true);
     assert.equal(Object.isFrozen(snapshot.sources[0]), true);
+});
+
+test('copies a valid authority-free attachment into a deeply frozen snapshot', () => {
+    const input = attachment();
+    const value = snapshotSmartImportProjectionAttachment(input, NOW);
+    input.sources[0].content = 'Mutazione successiva';
+
+    assert.deepEqual(Reflect.ownKeys(value), [
+        'schemaVersion', 'capability', 'patientRevision', 'sourceRevision', 'capturedAt',
+        'currentDiagnoses', 'currentActiveTherapies', 'therapyCandidateHints', 'sources',
+    ]);
+    assert.equal(value.sources[0].content, 'Evidenza sintetica.');
+    assert.equal(Object.isFrozen(value.sources[0]), true);
+});
+
+test('rejects caller authority and malformed attachment structures without reading accessors', () => {
+    for (const key of ['patientRef', 'selectionEpoch', 'sessionRef', 'ambulatoryRef', 'leaseRef', 'actorRef',
+        'handle', 'requestId', 'provider', 'model', 'endpoint', 'receipt']) {
+        rejectAttachment({ ...attachment(), [key]: 'caller-authority' });
+    }
+    let reads = 0;
+    const accessor = attachment();
+    Object.defineProperty(accessor.sources[0], 'content', { get() { reads += 1; return 'Non leggere'; } });
+    const sparse = attachment(); sparse.sources = new Array(1) as typeof sparse.sources;
+    const symbol = attachment(); Object.defineProperty(symbol, Symbol('authority'), { value: true });
+    for (const value of [Object.create(attachment()), accessor, sparse, symbol]) rejectAttachment(value);
+    assert.equal(reads, 0);
+});
+
+test('enforces attachment freshness, revisions, bounds and source bindings', () => {
+    const cases = [
+        [(value: ReturnType<typeof attachment>) => { value.capturedAt = '2026-08-22T11:54:59.999Z'; }, 'projection_stale'],
+        [(value: ReturnType<typeof attachment>) => { value.patientRevision = 0; }, 'projection_invalid'],
+        [(value: ReturnType<typeof attachment>) => { value.sourceRevision = 0; }, 'projection_invalid'],
+        [(value: ReturnType<typeof attachment>) => { value.sources[0].kind = 'unknown'; }, 'projection_invalid'],
+        [(value: ReturnType<typeof attachment>) => { value.sources[0].content = 'x'.repeat(901); }, 'projection_invalid'],
+        [(value: ReturnType<typeof attachment>) => { value.sources.push({ ...value.sources[0] }); }, 'projection_invalid'],
+        [(value: ReturnType<typeof attachment>) => { value.therapyCandidateHints[0].sourceId = 'source.unbound-1234567890'; }, 'projection_invalid'],
+    ] as const;
+    for (const [change, code] of cases) { const value = attachment(); change(value); rejectAttachment(value, code); }
 });
 
 test('rejects extra, inherited, accessor and sparse structures without reading accessors', () => {

--- a/lib/smart-import-projection.ts
+++ b/lib/smart-import-projection.ts
@@ -24,11 +24,7 @@ export type SmartImportProjectionSource = Readonly<{
     date: string | null;
     content: string;
 }>;
-export type SmartImportProjection = Readonly<{
-    schemaVersion: 'mediflow.smart-import.projection.v1';
-    capability: 'smart_import';
-    patientRef: string;
-    selectionEpoch: number;
+type SmartImportProjectionContent = Readonly<{
     patientRevision: number;
     sourceRevision: number;
     capturedAt: string;
@@ -36,6 +32,16 @@ export type SmartImportProjection = Readonly<{
     currentActiveTherapies: ReadonlyArray<ActiveTherapy>;
     therapyCandidateHints: ReadonlyArray<TherapyCandidateHint>;
     sources: ReadonlyArray<SmartImportProjectionSource>;
+}>;
+export type SmartImportProjectionAttachment = SmartImportProjectionContent & Readonly<{
+    schemaVersion: 'mediflow.smart-import.projection-attachment.v1';
+    capability: 'smart_import';
+}>;
+export type SmartImportProjection = SmartImportProjectionContent & Readonly<{
+    schemaVersion: 'mediflow.smart-import.projection.v1';
+    capability: 'smart_import';
+    patientRef: string;
+    selectionEpoch: number;
 }>;
 
 function fail(code: SmartImportProjectionErrorCode): never { throw new SmartImportProjectionError(code); }
@@ -84,10 +90,7 @@ function list<T>(value: unknown, max: number, snapshot: (entry: unknown) => T): 
     return Object.freeze(output);
 }
 
-function snapshot(value: unknown, now: string): SmartImportProjection {
-    const root = exact(value, ['schemaVersion', 'capability', 'patientRef', 'selectionEpoch', 'patientRevision', 'sourceRevision', 'capturedAt',
-        'currentDiagnoses', 'currentActiveTherapies', 'therapyCandidateHints', 'sources']);
-    if (root.schemaVersion !== 'mediflow.smart-import.projection.v1' || root.capability !== 'smart_import') fail('projection_invalid');
+function snapshotContent(root: Record<string, unknown>, now: string): SmartImportProjectionContent {
     const capturedAt = iso(root.capturedAt) as string;
     const nowMs = Date.parse(iso(now) as string); const capturedMs = Date.parse(capturedAt);
     if (capturedMs > nowMs || nowMs - capturedMs > 300_000) fail('projection_stale');
@@ -114,13 +117,33 @@ function snapshot(value: unknown, now: string): SmartImportProjection {
     if (sources.length === 0) fail('projection_invalid');
     const sourceIds = new Set(sources.map(({ id }) => id));
     if (sourceIds.size !== sources.length || therapyCandidateHints.some(({ sourceId }) => !sourceIds.has(sourceId))) fail('projection_invalid');
-    return Object.freeze({ schemaVersion: 'mediflow.smart-import.projection.v1', capability: 'smart_import', patientRef: opaque(root.patientRef),
-        selectionEpoch: positive(root.selectionEpoch), patientRevision: positive(root.patientRevision), sourceRevision: positive(root.sourceRevision), capturedAt,
+    return Object.freeze({ patientRevision: positive(root.patientRevision), sourceRevision: positive(root.sourceRevision), capturedAt,
         currentDiagnoses, currentActiveTherapies, therapyCandidateHints, sources });
+}
+
+function snapshot(value: unknown, now: string): SmartImportProjection {
+    const root = exact(value, ['schemaVersion', 'capability', 'patientRef', 'selectionEpoch', 'patientRevision', 'sourceRevision', 'capturedAt',
+        'currentDiagnoses', 'currentActiveTherapies', 'therapyCandidateHints', 'sources']);
+    if (root.schemaVersion !== 'mediflow.smart-import.projection.v1' || root.capability !== 'smart_import') fail('projection_invalid');
+    return Object.freeze({ schemaVersion: 'mediflow.smart-import.projection.v1', capability: 'smart_import', patientRef: opaque(root.patientRef),
+        selectionEpoch: positive(root.selectionEpoch), ...snapshotContent(root, now) });
 }
 
 export function snapshotSmartImportProjection(value: unknown, now: string): SmartImportProjection {
     try { return snapshot(value, now); } catch (error) {
+        if (error instanceof SmartImportProjectionError) throw error;
+        return fail('projection_invalid');
+    }
+}
+
+export function snapshotSmartImportProjectionAttachment(value: unknown, now: string): SmartImportProjectionAttachment {
+    try {
+        const root = exact(value, ['schemaVersion', 'capability', 'patientRevision', 'sourceRevision', 'capturedAt',
+            'currentDiagnoses', 'currentActiveTherapies', 'therapyCandidateHints', 'sources']);
+        if (root.schemaVersion !== 'mediflow.smart-import.projection-attachment.v1' || root.capability !== 'smart_import') fail('projection_invalid');
+        return Object.freeze({ schemaVersion: 'mediflow.smart-import.projection-attachment.v1', capability: 'smart_import',
+            ...snapshotContent(root, now) });
+    } catch (error) {
         if (error instanceof SmartImportProjectionError) throw error;
         return fail('projection_invalid');
     }


### PR DESCRIPTION
## Summary
- aggiunge un payload Smart Import browser-safe e chiuso senza riferimenti di sessione, paziente, selezione o lease
- riusa la validazione tipizzata per copiare e congelare revisioni, fonti, diagnosi, terapie e hint
- aggiunge un attacher server-only che applica una sola snapshot della authority canonica e usa il clock host
- mappa authority e source non validi a errori fissi senza testo grezzo

## Verification
- 11 test focali projection e host attachment
- 179 regressioni mirate broker, capability host, Fabric e ai-context
- npm run test:unit: 1153 passed
- npm run lint
- npm run typecheck
- npm run check:never-regress
- npm run check:claims
- npm run check:claims -- --self-test
- npm run build con Node 24.18.0
- git diff --check e scan browser/server, import, rete e log

## Risk / Notes
- draft PR stacked su #228
- il modulo pure non importa server-only o API Node; il modulo host importa il pure in una sola direzione
- nessun broker, owner, route, consumer o call site production viene aggiunto
- il seam clock iniettato serve solo alle fixture sintetiche; la produzione usa il clock host interno
- nessuna PHI/PII, persistenza, rete o log

## Ticket
Refs WUL-522