### PR TITLE
fix(native): verifica reachability e stati paired

### DIFF
--- a/native/MediFlowAppleApp/MediFlowAppleApp.xcodeproj/project.pbxproj
+++ b/native/MediFlowAppleApp/MediFlowAppleApp.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		033BF77802FE8AAAEA132414 /* MediFlowAppleShared in Frameworks */ = {isa = PBXBuildFile; productRef = 72EEC18E3E55264AEE14AA58 /* MediFlowAppleShared */; };
 		18CDE82377A243F4B41B0C9B /* MediFlowMacShellApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4691B9860CA77FA5871DC2A8 /* MediFlowMacShellApp.swift */; };
+		1D1D34F7A87FD455B29493B7 /* MobilePairedStatusOverrideUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC5F0A7BD278D6125B67FD3A /* MobilePairedStatusOverrideUITests.swift */; };
 		45E4F741A3B8FBFFA75DD465 /* MediFlowMobileAppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22294E85FD406F50AFBC48A9 /* MediFlowMobileAppUITests.swift */; };
 		4D5A03A67EC34FC88CAF655C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8724FDBA2290730AC0ED1F7E /* Assets.xcassets */; };
 		72DB344A36DDDCFFBD637E1F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8724FDBA2290730AC0ED1F7E /* Assets.xcassets */; };
@@ -35,6 +36,7 @@
 		4D79840B7DA781EA15CC8B29 /* MediFlowMobileApp.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = MediFlowMobileApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8724FDBA2290730AC0ED1F7E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		AFEA3F590AD845053A0F0558 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		CC5F0A7BD278D6125B67FD3A /* MobilePairedStatusOverrideUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobilePairedStatusOverrideUITests.swift; sourceTree = "<group>"; };
 		E91940CED10687F6D9D7CF0F /* MediFlowMacApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MediFlowMacApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		FFE1A092411BBD96AD35DDFF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -107,6 +109,7 @@
 			isa = PBXGroup;
 			children = (
 				22294E85FD406F50AFBC48A9 /* MediFlowMobileAppUITests.swift */,
+				CC5F0A7BD278D6125B67FD3A /* MobilePairedStatusOverrideUITests.swift */,
 			);
 			path = MediFlowMobileAppUITests;
 			sourceTree = "<group>";
@@ -255,6 +258,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				45E4F741A3B8FBFFA75DD465 /* MediFlowMobileAppUITests.swift in Sources */,
+				1D1D34F7A87FD455B29493B7 /* MobilePairedStatusOverrideUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/native/MediFlowAppleApp/Tests/MediFlowMobileAppUITests/MediFlowMobileAppUITests.swift
+++ b/native/MediFlowAppleApp/Tests/MediFlowMobileAppUITests/MediFlowMobileAppUITests.swift
@@ -289,6 +289,71 @@ final class MediFlowMobileAppUITests: XCTestCase {
             : "WUL-556-iPhone-Guardia-Carta")
     }
 
+    /// The paired state must not displace the first worklist row when the
+    /// compact iPhone workspace recomposes for landscape.
+    /* @Codex */
+    func testPairedStatusKeepsFirstPatientReachableAcrossIPhoneRotation() throws {
+        try XCTSkipUnless(UIDevice.current.userInterfaceIdiom == .phone, "iPhone-only first-viewport contract")
+        launch(seedPatients: true, section: "modules")
+        XCUIDevice.shared.orientation = .portrait
+
+        let workspace = sectionView("clinical-workspace-patients-view")
+        XCTAssertTrue(workspace.waitForExistence(timeout: 20))
+        let window = app.windows.firstMatch
+        let tabBar = app.tabBars.firstMatch
+        let firstRow = app.buttons["patient-cell-uitest-1"]
+        XCTAssertTrue(firstRow.waitForExistence(timeout: 15))
+        XCTAssertTrue(firstRow.isHittable, "the first patient must start reachable in portrait")
+        attachScreenshot(named: "WUL-556-F01-iPhone-portrait-before")
+
+        XCUIDevice.shared.orientation = .landscapeLeft
+        let landscapeCompleted = XCTNSPredicateExpectation(
+            predicate: NSPredicate { object, _ in
+                guard let element = object as? XCUIElement else { return false }
+                return element.frame.width > element.frame.height
+            },
+            object: window
+        )
+        XCTAssertEqual(
+            XCTWaiter.wait(for: [landscapeCompleted], timeout: 10),
+            .completed,
+            "the iPhone must complete the landscape transition"
+        )
+
+        XCTAssertTrue(firstRow.waitForExistence(timeout: 10))
+        attachScreenshot(named: "WUL-556-F01-iPhone-landscape-before")
+        XCTAssertTrue(tabBar.waitForExistence(timeout: 10))
+        let landscapeGeometry = """
+        viewport:  \(window.frame)
+        first row: \(firstRow.frame)
+        tab bar:   \(tabBar.frame)
+        """
+        let landscapeGeometryEvidence = XCTAttachment(string: landscapeGeometry)
+        landscapeGeometryEvidence.name = "WUL-556-F01-iPhone-landscape-geometry"
+        landscapeGeometryEvidence.lifetime = .keepAlways
+        add(landscapeGeometryEvidence)
+        XCTAssertTrue(firstRow.isHittable, "the first patient must remain reachable in landscape")
+        XCTAssertLessThanOrEqual(
+            firstRow.frame.maxY,
+            window.frame.maxY,
+            "the first patient row must not extend below the landscape viewport"
+        )
+        XCTAssertLessThanOrEqual(
+            firstRow.frame.maxY,
+            tabBar.frame.minY,
+            "the first patient row must clear the landscape tab bar. \(landscapeGeometry)"
+        )
+
+        firstRow.tap()
+        XCTAssertTrue(sectionView("patient-detail-name").waitForExistence(timeout: 15))
+        XCUIDevice.shared.orientation = .portrait
+        XCTAssertTrue(
+            sectionView("patient-detail-name").waitForExistence(timeout: 15),
+            "selecting a patient must survive the return to portrait"
+        )
+        attachScreenshot(named: "WUL-556-F01-iPhone-portrait-selection")
+    }
+
     // @Codex #142: AX Dynamic Type must select the existing single-column path.
     func testAccessibilityDynamicTypeUsesSinglePatientColumnOnIPad() throws {
         // Not applicable on iPhone: skipping keeps the iPhone suite meaningful

--- a/native/MediFlowAppleApp/Tests/MediFlowMobileAppUITests/MobilePairedStatusOverrideUITests.swift
+++ b/native/MediFlowAppleApp/Tests/MediFlowMobileAppUITests/MobilePairedStatusOverrideUITests.swift
@@ -1,0 +1,32 @@
+// @Codex
+import XCTest
+
+final class MobilePairedStatusOverrideUITests: XCTestCase {
+    private let app = XCUIApplication()
+
+    func testDebugOverrideMountsEveryPairedStatusPresentation() {
+        let expectedTitles = [
+            "online": "Home-base collegato",
+            "cached": "Cache locale",
+            "offline": "Offline, sola lettura",
+            "sessionExpired": "Sessione scaduta",
+            "error": "Aggiornamento non riuscito",
+            "loading": "Aggiornamento in corso",
+        ]
+
+        for (state, title) in expectedTitles {
+            app.terminate()
+            app.launchEnvironment = [
+                "MEDIFLOW_APPLE_UITEST_PATIENTS": "1",
+                "MEDIFLOW_APPLE_UITEST_PAIRED_STATUS": state,
+            ]
+            app.launch()
+
+            XCTAssertTrue(app.otherElements["mobile-paired-status"].waitForExistence(timeout: 10))
+            XCTAssertTrue(
+                app.staticTexts[title].waitForExistence(timeout: 5),
+                "Expected the \(state) presentation to mount."
+            )
+        }
+    }
+}

--- a/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/MobilePairedStatusUITestOverride.swift
+++ b/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/MobilePairedStatusUITestOverride.swift
@@ -1,0 +1,91 @@
+/* @Codex */
+#if DEBUG
+import Foundation
+
+/// A deterministic, debug-only presentation override for the paired-status UI.
+///
+/// It deliberately replaces only the value given to `MobilePairedStatusView`.
+/// It never mutates pairing, session, cache, or authorization state, so an
+/// automated UI test can prove the presentation without simulating a host.
+struct MobilePairedStatusUITestOverride: Equatable {
+    private static let environmentKey = "MEDIFLOW_APPLE_UITEST_PAIRED_STATUS"
+
+    enum State: String, CaseIterable {
+        case online
+        case cached
+        case offline
+        case sessionExpired
+        case error
+        case loading
+    }
+
+    let state: State
+
+    static func load(processInfo: ProcessInfo = .processInfo) -> Self? {
+        load(environment: processInfo.environment)
+    }
+
+    static func load(environment: [String: String]) -> Self? {
+        guard let value = environment[environmentKey]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased(),
+            let state = parse(value)
+        else {
+            return nil
+        }
+        return Self(state: state)
+    }
+
+    private static func parse(_ value: String) -> State? {
+        if value == "sessionexpired" { return .sessionExpired }
+        return State(rawValue: value)
+    }
+
+    var presentation: MobilePairedStatusPresentation {
+        switch state {
+        case .online:
+            return .make(
+                connectionState: .pairedOnline,
+                isWorking: false,
+                errorMessage: nil,
+                reconciliationLine: "Home-base disponibile."
+            )
+        case .cached:
+            return .make(
+                connectionState: .cached,
+                isWorking: false,
+                errorMessage: nil,
+                reconciliationLine: "Snapshot locale disponibile."
+            )
+        case .offline:
+            return .make(
+                connectionState: .pairedOfflineDegraded,
+                isWorking: false,
+                errorMessage: nil,
+                reconciliationLine: "Cache cifrata locale. Nessuna scrittura offline."
+            )
+        case .sessionExpired:
+            return .make(
+                connectionState: .sessionExpired,
+                isWorking: false,
+                errorMessage: nil,
+                reconciliationLine: ""
+            )
+        case .error:
+            return .make(
+                connectionState: .pairedOnline,
+                isWorking: false,
+                errorMessage: "errore sintetico",
+                reconciliationLine: ""
+            )
+        case .loading:
+            return .make(
+                connectionState: .pairedOnline,
+                isWorking: true,
+                errorMessage: nil,
+                reconciliationLine: ""
+            )
+        }
+    }
+}
+#endif

--- a/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/MobilePairedStatusView.swift
+++ b/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/MobilePairedStatusView.swift
@@ -47,38 +47,39 @@ struct MobilePairedStatusPresentation: Equatable {
 /* @Codex */
 struct MobilePairedStatusView: View {
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.verticalSizeClass) private var verticalSizeClass
 
     let presentation: MobilePairedStatusPresentation
     let onPrimaryAction: () -> Void
 
     var body: some View {
         HStack(alignment: .top, spacing: 12) {
-            statusSymbol
-            VStack(alignment: .leading, spacing: 4) {
-                Text(presentation.title)
-                    .font(.headline)
-                Text(presentation.detail)
-                    .font(.subheadline)
-                    .foregroundStyle(mutedColor)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-            Spacer(minLength: 8)
-            if let actionTitle = presentation.actionTitle {
-                Button(action: onPrimaryAction) {
-                    Text(actionTitle)
-                        .foregroundStyle(colorScheme == .dark ? Color.black : Color.white)
+            if dynamicTypeSize.isAccessibilitySize {
+                // The outer element retains the complete status and detail for
+                // assistive technologies. Keeping only the state symbol and its
+                // action on screen preserves the first patient row at AX sizes.
+                statusSymbol
+                Spacer(minLength: 8)
+                primaryActionButton(compact: true)
+            } else {
+                statusSymbol
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(presentation.title)
+                        .font(.headline)
+                        .lineLimit(isShortViewport ? 1 : nil)
+                    if !isShortViewport {
+                        Text(presentation.detail)
+                            .font(.subheadline)
+                            .foregroundStyle(mutedColor)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
                 }
-                .buttonStyle(.borderedProminent)
-                .tint(.primary)
-                .controlSize(.large)
-                .frame(minWidth: 48, minHeight: 48)
-                .contentShape(.interaction, Rectangle())
-                .hoverEffect(.highlight)
-                .keyboardShortcut("r", modifiers: .command)
-                .accessibilityHint("Aggiorna lo stato del collegamento con l'home-base.")
+                Spacer(minLength: 8)
+                primaryActionButton()
             }
         }
-        .padding(14)
+        .padding(dynamicTypeSize.isAccessibilitySize ? 8 : 14)
         .frame(maxWidth: .infinity, alignment: .leading)
         .lumeSurface(zone: .field)
         .accessibilityElement(children: .contain)
@@ -107,6 +108,37 @@ struct MobilePairedStatusView: View {
         case .offline, .sessionExpired: return LumePalette.warning
         case .loading, .cached, .notLoaded: return mutedColor
         }
+    }
+
+    @ViewBuilder
+    private func primaryActionButton(compact: Bool = false) -> some View {
+        if let actionTitle = presentation.actionTitle {
+            Button(action: onPrimaryAction) {
+                if compact {
+                    Image(systemName: actionTitle == "Configura" || actionTitle == "Accedi"
+                        ? "slider.horizontal.3"
+                        : "arrow.clockwise")
+                        .font(.system(size: 20, weight: .semibold))
+                } else {
+                    Text(actionTitle)
+                        .fixedSize()
+                        .foregroundStyle(colorScheme == .dark ? Color.black : Color.white)
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.primary)
+            .controlSize(.large)
+            .frame(minWidth: 48, minHeight: 48)
+            .contentShape(.interaction, Rectangle())
+            .hoverEffect(.highlight)
+            .keyboardShortcut("r", modifiers: .command)
+            .accessibilityLabel(actionTitle)
+            .accessibilityHint("Aggiorna lo stato del collegamento con l'home-base.")
+        }
+    }
+
+    private var isShortViewport: Bool {
+        verticalSizeClass == .compact
     }
 
     private var mutedColor: Color {

--- a/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/PairedPatientsWorkspaceView.swift
+++ b/native/MediFlowMac/Sources/MediFlowAppleShared/AppleFoundation/PairedPatientsWorkspaceView.swift
@@ -431,7 +431,20 @@ struct PairedPatientsWorkspaceView: View {
     }
 
     /* @Codex */
+    @ViewBuilder
     private var mobilePairedStatus: some View {
+        #if DEBUG
+        if let override = MobilePairedStatusUITestOverride.load() {
+            MobilePairedStatusView(presentation: override.presentation, onPrimaryAction: {})
+        } else {
+            liveMobilePairedStatus
+        }
+        #else
+        liveMobilePairedStatus
+        #endif
+    }
+
+    private var liveMobilePairedStatus: some View {
         MobilePairedStatusView(
             presentation: .make(
                 connectionState: model.connectionState,

--- a/native/MediFlowMac/Tests/MediFlowAppleSharedTests/MobilePairedStatusUITestOverrideTests.swift
+++ b/native/MediFlowMac/Tests/MediFlowAppleSharedTests/MobilePairedStatusUITestOverrideTests.swift
@@ -1,0 +1,43 @@
+// @Codex
+#if DEBUG
+import XCTest
+@testable import MediFlowAppleShared
+
+final class MobilePairedStatusUITestOverrideTests: XCTestCase {
+    func testAcceptsOnlyTheSixDocumentedStates() {
+        XCTAssertEqual(
+            Set(MobilePairedStatusUITestOverride.State.allCases.map(\.rawValue)),
+            Set(["online", "cached", "offline", "sessionExpired", "error", "loading"])
+        )
+    }
+
+    func testUnknownOrBlankEnvironmentValuesFailClosed() {
+        XCTAssertNil(MobilePairedStatusUITestOverride.load(environment: [:]))
+        XCTAssertNil(MobilePairedStatusUITestOverride.load(environment: [
+            "MEDIFLOW_APPLE_UITEST_PAIRED_STATUS": " ",
+        ]))
+        XCTAssertNil(MobilePairedStatusUITestOverride.load(environment: [
+            "MEDIFLOW_APPLE_UITEST_PAIRED_STATUS": "stale",
+        ]))
+    }
+
+    func testEveryOverrideBuildsTheExpectedPresentation() {
+        let expectations: [(MobilePairedStatusUITestOverride.State, MobilePairedStatusPresentation.Phase, String)] = [
+            (.online, .online, "Home-base collegato"),
+            (.cached, .cached, "Cache locale"),
+            (.offline, .offline, "Offline, sola lettura"),
+            (.sessionExpired, .sessionExpired, "Sessione scaduta"),
+            (.error, .error, "Aggiornamento non riuscito"),
+            (.loading, .loading, "Aggiornamento in corso"),
+        ]
+
+        for (state, phase, title) in expectations {
+            let override = MobilePairedStatusUITestOverride.load(environment: [
+                "MEDIFLOW_APPLE_UITEST_PAIRED_STATUS": state.rawValue,
+            ])
+            XCTAssertEqual(override?.presentation.phase, phase)
+            XCTAssertEqual(override?.presentation.title, title)
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- mantiene la prima riga della worklist raggiungibile su iPhone portrait e landscape
- aggiunge un override solo DEBUG per verificare i sei stati paired su iPhone e iPad
- conserva il dettaglio accessibile e non introduce hook nel binario Release

## Verification
- XcodeBuildMCP iPhone: F-01 landscape e F-02 sei stati, 2/2 passati
- XcodeBuildMCP iPad: sei stati e regressioni layout, 5/5 passati nel packet di ricomposizione
- SwiftPM presentation/parser: 6/6 passati
- build iOS Simulator Release riuscita; nessun token override nel binario Release
- controller rerun exact head 7bb2fe7d6931bdadb42d43c65b747ed1977f5722: 2/2 test iPhone passati

## Risk / Notes
- stacked sulla candidata WUL-556 runtime; non prova integrazione 0.8.5
- VoiceOver su dispositivo fisico non verificato
- solo fixture sintetiche; nessuna PHI/PII o authority apply/headless

## Ticket
Refs WUL-556