### PR TITLE
fix(security): clear local Web key on lock

### DIFF
--- a/components/security-provider.tsx
+++ b/components/security-provider.tsx
@@ -25,6 +25,7 @@ import { useInactivityLock } from '@/lib/hooks/use-inactivity-lock';
 /* @Codex */
 import {
     clearSecuritySession,
+    lockSecuritySession,
     persistSecuritySession,
     restoreSecuritySession,
 } from '@/lib/security/client-security-session';
@@ -138,8 +139,10 @@ export function SecurityProvider({ children }: { children: React.ReactNode }) {
     const lock = () => {
         setIsLocked(true);
         setAuthErrorMessage(null);
-        // @Codex - clear server session when locking
-        logoutSecuritySession();
+        lockSecuritySession(
+            () => setActiveMasterKey(null),
+            logoutSecuritySession,
+        );
         // setIsAuthenticated(false); // Do not de-auth, just lock screen.
     };
 

--- a/lib/security/client-auth-api.ts
+++ b/lib/security/client-auth-api.ts
@@ -103,8 +103,8 @@ async function requestJson<T>(input: RequestInfo | URL, init?: RequestInit): Pro
 }
 
 /* @Codex */
-export function logoutSecuritySession(): void {
-    void fetch('/api/auth/logout', { method: 'POST' });
+export function logoutSecuritySession(): Promise<void> {
+    return fetch('/api/auth/logout', { method: 'POST' }).then(() => undefined);
 }
 
 /* @Codex */

--- a/lib/security/client-security-session.test.ts
+++ b/lib/security/client-security-session.test.ts
@@ -1,0 +1,145 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { db } from '../db';
+import {
+    clearSecuritySession,
+    lockSecuritySession,
+    restoreSecuritySession,
+} from './client-security-session';
+
+const SESSION_KEY_STORAGE_KEY = 'mediflow_session_key';
+const SESSION_USER_STORAGE_KEY = 'mediflow_user';
+
+class MemorySessionStorage {
+    private readonly values = new Map<string, string>();
+
+    get length() {
+        return this.values.size;
+    }
+
+    clear() {
+        this.values.clear();
+    }
+
+    getItem(key: string) {
+        return this.values.get(key) ?? null;
+    }
+
+    key(index: number) {
+        return Array.from(this.values.keys())[index] ?? null;
+    }
+
+    setItem(key: string, value: string) {
+        this.values.set(key, value);
+    }
+
+    removeItem(key: string) {
+        this.values.delete(key);
+    }
+}
+
+function installSessionStorage(storage: Storage) {
+    const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'sessionStorage');
+    Object.defineProperty(globalThis, 'sessionStorage', {
+        configurable: true,
+        value: storage,
+    });
+
+    return () => {
+        if (descriptor) {
+            Object.defineProperty(globalThis, 'sessionStorage', descriptor);
+        } else {
+            Reflect.deleteProperty(globalThis, 'sessionStorage');
+        }
+    };
+}
+
+function storeSyntheticSession(storage: Storage) {
+    storage.setItem(SESSION_KEY_STORAGE_KEY, '{"kty":"oct"}');
+    storage.setItem(SESSION_USER_STORAGE_KEY, '{"id":"synthetic-user"}');
+}
+
+test('lock clears persisted session data and the active database key before logout', async (t) => {
+    const storage = new MemorySessionStorage();
+    storeSyntheticSession(storage);
+    const restoreStorage = installSessionStorage(storage as unknown as Storage);
+    const activeKey = {} as CryptoKey;
+    db.setKey(activeKey);
+
+    t.after(() => {
+        db.setKey(null);
+        restoreStorage();
+    });
+
+    lockSecuritySession(
+        () => db.setKey(null),
+        () => {
+            assert.equal(storage.getItem(SESSION_KEY_STORAGE_KEY), null);
+            assert.equal(storage.getItem(SESSION_USER_STORAGE_KEY), null);
+            assert.equal(db.isKeySet(), false);
+        },
+    );
+
+    assert.equal(await restoreSecuritySession(), null);
+});
+
+test('a logout failure cannot retain the local key or persisted session', (t) => {
+    const storage = new MemorySessionStorage();
+    storeSyntheticSession(storage);
+    const restoreStorage = installSessionStorage(storage as unknown as Storage);
+    db.setKey({} as CryptoKey);
+
+    t.after(() => {
+        db.setKey(null);
+        restoreStorage();
+    });
+
+    assert.doesNotThrow(() => lockSecuritySession(
+        () => db.setKey(null),
+        () => {
+            throw new Error('synthetic logout failure');
+        },
+    ));
+    assert.equal(storage.getItem(SESSION_KEY_STORAGE_KEY), null);
+    assert.equal(storage.getItem(SESSION_USER_STORAGE_KEY), null);
+    assert.equal(db.isKeySet(), false);
+});
+
+test('a throwing session storage does not prevent clearing the active key', () => {
+    const restoreStorage = installSessionStorage({
+        removeItem() {
+            throw new Error('synthetic storage failure');
+        },
+    } as unknown as Storage);
+    let activeKeyCleared = false;
+
+    try {
+        assert.doesNotThrow(() => clearSecuritySession());
+        assert.doesNotThrow(() => lockSecuritySession(
+            () => {
+                activeKeyCleared = true;
+            },
+            () => undefined,
+        ));
+        assert.equal(activeKeyCleared, true);
+    } finally {
+        restoreStorage();
+    }
+});
+
+test('missing session storage does not prevent clearing the active key', (t) => {
+    const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'sessionStorage');
+    Reflect.deleteProperty(globalThis, 'sessionStorage');
+    db.setKey({} as CryptoKey);
+
+    t.after(() => {
+        db.setKey(null);
+        if (descriptor) Object.defineProperty(globalThis, 'sessionStorage', descriptor);
+    });
+
+    assert.doesNotThrow(() => lockSecuritySession(
+        () => db.setKey(null),
+        () => undefined,
+    ));
+    assert.equal(db.isKeySet(), false);
+});

--- a/lib/security/client-security-session.test.ts
+++ b/lib/security/client-security-session.test.ts
@@ -6,6 +6,7 @@ import {
     lockSecuritySession,
     restoreSecuritySession,
 } from './client-security-session';
+import { logoutSecuritySession } from './client-auth-api';
 
 const SESSION_KEY_STORAGE_KEY = 'mediflow_session_key';
 const SESSION_USER_STORAGE_KEY = 'mediflow_user';
@@ -100,6 +101,35 @@ test('a logout failure cannot retain the local key or persisted session', (t) =>
             throw new Error('synthetic logout failure');
         },
     ));
+    assert.equal(storage.getItem(SESSION_KEY_STORAGE_KEY), null);
+    assert.equal(storage.getItem(SESSION_USER_STORAGE_KEY), null);
+    assert.equal(db.isKeySet(), false);
+});
+
+test('a rejected logout request does not create an unhandled rejection', async (t) => {
+    const storage = new MemorySessionStorage();
+    storeSyntheticSession(storage);
+    const restoreStorage = installSessionStorage(storage as unknown as Storage);
+    const originalFetch = globalThis.fetch;
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+        unhandledRejections.push(reason);
+    };
+    db.setKey({} as CryptoKey);
+    globalThis.fetch = (() => Promise.reject(new Error('synthetic logout rejection'))) as typeof fetch;
+    process.on('unhandledRejection', onUnhandledRejection);
+
+    t.after(() => {
+        process.off('unhandledRejection', onUnhandledRejection);
+        globalThis.fetch = originalFetch;
+        db.setKey(null);
+        restoreStorage();
+    });
+
+    lockSecuritySession(() => db.setKey(null), logoutSecuritySession);
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.deepEqual(unhandledRejections, []);
     assert.equal(storage.getItem(SESSION_KEY_STORAGE_KEY), null);
     assert.equal(storage.getItem(SESSION_USER_STORAGE_KEY), null);
     assert.equal(db.isKeySet(), false);

--- a/lib/security/client-security-session.ts
+++ b/lib/security/client-security-session.ts
@@ -36,7 +36,43 @@ export async function restoreSecuritySession<T>(): Promise<RestoredSecuritySessi
 }
 
 /* @Codex */
+function getSessionStorage(): Storage | null {
+    try {
+        return typeof sessionStorage === 'undefined' ? null : sessionStorage;
+    } catch {
+        return null;
+    }
+}
+
+/* @Codex */
 export function clearSecuritySession(): void {
-    sessionStorage.removeItem(SESSION_KEY_STORAGE_KEY);
-    sessionStorage.removeItem(SESSION_USER_STORAGE_KEY);
+    const storage = getSessionStorage();
+    if (!storage) return;
+
+    try {
+        storage.removeItem(SESSION_KEY_STORAGE_KEY);
+    } catch {
+        // Storage can be unavailable in a restricted browser context.
+    }
+
+    try {
+        storage.removeItem(SESSION_USER_STORAGE_KEY);
+    } catch {
+        // Continue so an unavailable storage API cannot retain the active key.
+    }
+}
+
+/* @Codex */
+export function lockSecuritySession(
+    clearActiveMasterKey: () => void,
+    logoutServerSession: () => void,
+): void {
+    clearSecuritySession();
+    clearActiveMasterKey();
+
+    try {
+        logoutServerSession();
+    } catch {
+        // Local lock state must not depend on an asynchronous logout request.
+    }
 }

--- a/lib/security/client-security-session.ts
+++ b/lib/security/client-security-session.ts
@@ -65,13 +65,13 @@ export function clearSecuritySession(): void {
 /* @Codex */
 export function lockSecuritySession(
     clearActiveMasterKey: () => void,
-    logoutServerSession: () => void,
+    logoutServerSession: () => void | Promise<void>,
 ): void {
     clearSecuritySession();
     clearActiveMasterKey();
 
     try {
-        logoutServerSession();
+        void Promise.resolve(logoutServerSession()).catch(() => undefined);
     } catch {
         // Local lock state must not depend on an asynchronous logout request.
     }


### PR DESCRIPTION
## Summary
- clear the persisted Web session JWK and user entry when the local UI locks
- clear the in-process database master-key reference before dispatching logout
- contain synchronous and asynchronous best-effort logout failures without retaining local key state

## Verification
- focused lock/session tests: 5/5
- full unit suite: 1084/1084
- typecheck
- full and focused ESLint
- Web build
- claims, AI clinical-write, never-regress, and Node runtime guards
- fresh independent archive review on `a02a3987cae587461ae040295a1cd4faa8adc815`

## Risk / Notes
- Synthetic-only evidence; no PHI/PII or patient data.
- This proves local storage-entry and in-process key-reference cleanup only. It does not claim server-confirmed logout, JavaScript heap zeroization, cross-tab invalidation, or durable ciphertext deletion.
- Draft candidate only; not integrated, release-ready, or released.

## Ticket
Refs WUL-522
