### PR TITLE
feat(mini): add unbound Headless transport framing

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "check:mlx-operational-parity": "node scripts/check-mlx-operational-parity.mjs",
     "check:apple-wide-qa": "node scripts/check-apple-wide-qa-manifest.mjs",
     "check:claims": "node scripts/check-claims-guard.mjs",
+    "mini": "node scripts/run-strip-types.mjs packages/mini/src/cli.ts",
+    "test:mini-cli": "node scripts/run-strip-types.mjs --test packages/mini/src/cli.test.ts",
     "check:terminology-parity": "bash scripts/check-terminology-parity.sh",
     "workflow-monitor": "node scripts/codex-workflow-monitor.mjs",
     "rehearse:api-v1-compatibility": "node scripts/api-v1-compatibility-rehearsal.mjs",

--- a/packages/mini/src/cli.test.ts
+++ b/packages/mini/src/cli.test.ts
@@ -31,6 +31,9 @@ test('parses one exact JSON transport envelope without mapping a command', () =>
     assert.equal(parseMiniTransport(['--format', 'json', '--format', 'ndjson'], '{"command":"opaque.intent","args":{}}'), null);
     assert.equal(parseMiniTransport(['opaque.intent'], '{}'), null);
     assert.equal(parseMiniTransport([], '{"command":"x","args":{},"extra":"forged"}'), null);
+    assert.equal(parseMiniTransport([], '{"command":"first","command":"second","args":{}}'), null);
+    assert.equal(parseMiniTransport([], '{"command":"opaque.intent","args":{},"\\u0061rgs":{}}'), null);
+    assert.equal(parseMiniTransport([], '{"command":"opaque.intent","args":{"key":"first","key":"second"}}'), null);
 });
 
 test('renders JSON and ordered NDJSON without execution', () => {

--- a/packages/mini/src/cli.test.ts
+++ b/packages/mini/src/cli.test.ts
@@ -28,6 +28,7 @@ test('parses one exact JSON transport envelope without mapping a command', () =>
         format: 'ndjson', request: { command: 'opaque.intent', args: { key: 'value' } },
     });
     assert.equal(parseMiniTransport(['--format', 'xml'], '{}'), null);
+    assert.equal(parseMiniTransport(['--format', 'json', '--format', 'ndjson'], '{"command":"opaque.intent","args":{}}'), null);
     assert.equal(parseMiniTransport(['opaque.intent'], '{}'), null);
     assert.equal(parseMiniTransport([], '{"command":"x","args":{},"extra":"forged"}'), null);
 });
@@ -38,6 +39,8 @@ test('renders JSON and ordered NDJSON without execution', () => {
         { index: 0, item: 'first' }, { index: 1, item: 'second' },
     ]);
     assert.equal(renderMiniTransport({ items: [] }, 'ndjson'), '{"index":null,"item":null}\n');
+    const sparse = ['first']; sparse.length = 2;
+    assert.deepEqual(JSON.parse(renderMiniTransport({ items: sparse }, 'ndjson')), { error: 'NDJSON_SPARSE_ITEMS', index: 1 });
 });
 
 test('keeps the CLI unbound and help transport-only', () => {
@@ -46,6 +49,9 @@ test('keeps the CLI unbound and help transport-only', () => {
     assert.deepEqual(JSON.parse(result.stdout), {
         schemaVersion: 'mediflow.mini.transport.v1', ok: false, error: 'TRANSPORT_UNBOUND',
     });
+    const duplicate = runMiniTransport(['--format', 'ndjson', '--format', 'json'], '{"command":"opaque.intent","args":{}}');
+    assert.equal(duplicate.exitCode, MINI_EXIT.USAGE);
+    assert.deepEqual(JSON.parse(duplicate.stdout), { schemaVersion: 'mediflow.mini.transport.v1', ok: false, error: 'USAGE' });
     assert.equal(MINI_HELP, `MediFlow Mini transport candidate
 
 Usage: npm run --silent mini -- [--format json|ndjson]

--- a/packages/mini/src/cli.test.ts
+++ b/packages/mini/src/cli.test.ts
@@ -1,0 +1,67 @@
+/* @Codex */
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import test from 'node:test';
+
+import {
+    MINI_EXIT, MINI_HELP, MINI_STDIN_MAX_BYTES, parseMiniTransport, renderMiniTransport, runMiniTransport,
+} from './cli';
+
+const CLI = ['scripts/run-strip-types.mjs', 'packages/mini/src/cli.ts'];
+
+function runWithOpenStdin(args: readonly string[], input: string): Promise<{ code: number | null; stdout: string; stderr: string }> {
+    return new Promise((resolve, reject) => {
+        const child = spawn(process.execPath, [...CLI, ...args], { stdio: ['pipe', 'pipe', 'pipe'] });
+        let stdout = ''; let stderr = '';
+        child.stdout.setEncoding('utf8').on('data', (chunk) => { stdout += chunk; });
+        child.stderr.setEncoding('utf8').on('data', (chunk) => { stderr += chunk; });
+        child.stdin.on('error', () => undefined);
+        child.stdin.write(input);
+        const timeout = setTimeout(() => { child.kill(); reject(new Error('Mini waited for stdin')); }, 1_500);
+        child.on('error', reject);
+        child.on('close', (code) => { clearTimeout(timeout); resolve({ code, stdout, stderr }); });
+    });
+}
+
+test('parses one exact JSON transport envelope without mapping a command', () => {
+    assert.deepEqual(parseMiniTransport(['--format', 'ndjson'], '{"command":"opaque.intent","args":{"key":"value"}}'), {
+        format: 'ndjson', request: { command: 'opaque.intent', args: { key: 'value' } },
+    });
+    assert.equal(parseMiniTransport(['--format', 'xml'], '{}'), null);
+    assert.equal(parseMiniTransport(['opaque.intent'], '{}'), null);
+    assert.equal(parseMiniTransport([], '{"command":"x","args":{},"extra":"forged"}'), null);
+});
+
+test('renders JSON and ordered NDJSON without execution', () => {
+    assert.equal(renderMiniTransport({ items: ['first', 'second'] }, 'json'), '{\n  "items": [\n    "first",\n    "second"\n  ]\n}\n');
+    assert.deepEqual(renderMiniTransport({ items: ['first', 'second'] }, 'ndjson').trim().split('\n').map((line) => JSON.parse(line)), [
+        { index: 0, item: 'first' }, { index: 1, item: 'second' },
+    ]);
+    assert.equal(renderMiniTransport({ items: [] }, 'ndjson'), '{"index":null,"item":null}\n');
+});
+
+test('keeps the CLI unbound and help transport-only', () => {
+    const result = runMiniTransport([], '{"command":"opaque.intent","args":{}}');
+    assert.equal(result.exitCode, MINI_EXIT.BROKER_UNAVAILABLE);
+    assert.deepEqual(JSON.parse(result.stdout), {
+        schemaVersion: 'mediflow.mini.transport.v1', ok: false, error: 'TRANSPORT_UNBOUND',
+    });
+    assert.equal(MINI_HELP, `MediFlow Mini transport candidate
+
+Usage: npm run --silent mini -- [--format json|ndjson]
+       printf '{"command":"opaque.intent","args":{}}' | npm run --silent mini --
+
+This candidate only validates and renders transport envelopes. It does not bind
+an application service or execute a command.
+`);
+});
+
+test('keeps stdout clean and terminates oversized stdin before EOF', async () => {
+    const oversized = await runWithOpenStdin(['--format', 'json'], 'caller-text'.repeat(Math.ceil((MINI_STDIN_MAX_BYTES + 1) / 11)));
+    assert.equal(oversized.code, MINI_EXIT.USAGE);
+    assert.equal(oversized.stderr, '');
+    assert.deepEqual(JSON.parse(oversized.stdout), {
+        schemaVersion: 'mediflow.mini.transport.v1', ok: false, error: 'INPUT_TOO_LARGE',
+    });
+    assert.equal(oversized.stdout.includes('caller-text'), false);
+});

--- a/packages/mini/src/cli.ts
+++ b/packages/mini/src/cli.ts
@@ -1,0 +1,97 @@
+/* @Codex */
+import { fileURLToPath } from 'node:url';
+
+export const MINI_EXIT = Object.freeze({ OK: 0, USAGE: 2, BROKER_UNAVAILABLE: 69 });
+export const MINI_STDIN_MAX_BYTES = 16 * 1024;
+export const MINI_HELP = `MediFlow Mini transport candidate
+
+Usage: npm run --silent mini -- [--format json|ndjson]
+       printf '{"command":"opaque.intent","args":{}}' | npm run --silent mini --
+
+This candidate only validates and renders transport envelopes. It does not bind
+an application service or execute a command.
+`;
+
+type Format = 'json' | 'ndjson';
+type TransportRequest = Readonly<{ command: string; args: Record<string, unknown> }>;
+export type MiniTransport = Readonly<{ format: Format; request: TransportRequest }>;
+export type MiniRun = Readonly<{ exitCode: number; stdout: string; stderr: string }>;
+
+function parseFormat(argv: readonly string[]): Format | null {
+    let format: Format = 'json';
+    for (let index = 0; index < argv.length; index += 1) {
+        if (argv[index] !== '--format') return null;
+        const value = argv[index + 1];
+        if (value !== 'json' && value !== 'ndjson') return null;
+        format = value;
+        index += 1;
+    }
+    return format;
+}
+
+function parseEnvelope(raw: string): TransportRequest | null {
+    try {
+        const value = JSON.parse(raw);
+        if (typeof value !== 'object' || value === null || Array.isArray(value)
+            || Object.keys(value).sort().join(',') !== 'args,command'
+            || typeof value.command !== 'string' || typeof value.args !== 'object'
+            || value.args === null || Array.isArray(value.args)) return null;
+        return { command: value.command, args: value.args as Record<string, unknown> };
+    } catch {
+        return null;
+    }
+}
+
+export function parseMiniTransport(argv: readonly string[], stdin: string): MiniTransport | null {
+    const format = parseFormat(argv);
+    if (!format) return null;
+    const request = parseEnvelope(stdin);
+    return request ? { format, request } : null;
+}
+
+export function renderMiniTransport(value: Record<string, unknown>, format: Format): string {
+    if (format === 'json') return `${JSON.stringify(value, null, 2)}\n`;
+    const items = value.items;
+    if (!Array.isArray(items)) return `${JSON.stringify(value)}\n`;
+    if (items.length === 0) return `${JSON.stringify({ index: null, item: null })}\n`;
+    return items.map((item, index) => JSON.stringify({ index, item })).join('\n') + '\n';
+}
+
+function failure(error: string, exitCode: number, format: Format): MiniRun {
+    return {
+        exitCode,
+        stdout: renderMiniTransport({ schemaVersion: 'mediflow.mini.transport.v1', ok: false, error }, format),
+        stderr: '',
+    };
+}
+
+function requestedFormat(argv: readonly string[]): Format {
+    const formatIndex = argv.indexOf('--format');
+    return argv[formatIndex + 1] === 'ndjson' ? 'ndjson' : 'json';
+}
+
+export function runMiniTransport(argv: readonly string[], stdin = '', inputTooLarge = false): MiniRun {
+    if (argv.includes('--help') || argv.includes('-h')) return { exitCode: MINI_EXIT.OK, stdout: MINI_HELP, stderr: '' };
+    const format = requestedFormat(argv);
+    if (parseFormat(argv) === null) return failure('USAGE', MINI_EXIT.USAGE, format);
+    if (inputTooLarge) return failure('INPUT_TOO_LARGE', MINI_EXIT.USAGE, format);
+    if (!parseMiniTransport(argv, stdin)) return failure('USAGE', MINI_EXIT.USAGE, format);
+    return failure('TRANSPORT_UNBOUND', MINI_EXIT.BROKER_UNAVAILABLE, format);
+}
+
+async function main(): Promise<void> {
+    const argv = process.argv.slice(2);
+    let stdin = ''; let inputBytes = 0; let inputTooLarge = false;
+    if (parseFormat(argv) !== null && !process.stdin.isTTY && !argv.includes('--help') && !argv.includes('-h')) {
+        process.stdin.setEncoding('utf8');
+        for await (const chunk of process.stdin) {
+            inputBytes += Buffer.byteLength(chunk, 'utf8');
+            if (inputBytes > MINI_STDIN_MAX_BYTES) { inputTooLarge = true; process.stdin.destroy(); break; }
+            stdin += chunk;
+        }
+    }
+    const result = runMiniTransport(argv, stdin, inputTooLarge);
+    process.stdout.write(result.stdout); process.stderr.write(result.stderr); process.exitCode = result.exitCode;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) void main();

--- a/packages/mini/src/cli.ts
+++ b/packages/mini/src/cli.ts
@@ -30,9 +30,34 @@ function parseFormat(argv: readonly string[]): Format | null {
     return format;
 }
 
+function hasDuplicateObjectKeys(raw: string): boolean {
+    const objectKeys: Array<Set<string> | null> = [];
+    for (let index = 0; index < raw.length; index += 1) {
+        const character = raw[index];
+        if (character === '{') { objectKeys.push(new Set()); continue; }
+        if (character === '[') { objectKeys.push(null); continue; }
+        if (character === '}' || character === ']') { objectKeys.pop(); continue; }
+        if (character !== '"') continue;
+        const start = index;
+        for (index += 1; index < raw.length; index += 1) {
+            if (raw[index] === '\\') { index += 1; continue; }
+            if (raw[index] === '"') break;
+        }
+        let next = index + 1;
+        while (/\s/u.test(raw[next] ?? '')) next += 1;
+        const keys = objectKeys.at(-1);
+        if (raw[next] !== ':' || !keys) continue;
+        const key = JSON.parse(raw.slice(start, index + 1)) as string;
+        if (keys.has(key)) return true;
+        keys.add(key);
+    }
+    return false;
+}
+
 function parseEnvelope(raw: string): TransportRequest | null {
     try {
         const value = JSON.parse(raw);
+        if (hasDuplicateObjectKeys(raw)) return null;
         if (typeof value !== 'object' || value === null || Array.isArray(value)
             || Object.keys(value).sort().join(',') !== 'args,command'
             || typeof value.command !== 'string' || typeof value.args !== 'object'

--- a/packages/mini/src/cli.ts
+++ b/packages/mini/src/cli.ts
@@ -18,12 +18,13 @@ export type MiniTransport = Readonly<{ format: Format; request: TransportRequest
 export type MiniRun = Readonly<{ exitCode: number; stdout: string; stderr: string }>;
 
 function parseFormat(argv: readonly string[]): Format | null {
-    let format: Format = 'json';
+    let format: Format = 'json'; let seen = false;
     for (let index = 0; index < argv.length; index += 1) {
-        if (argv[index] !== '--format') return null;
+        if (argv[index] !== '--format' || seen) return null;
         const value = argv[index + 1];
         if (value !== 'json' && value !== 'ndjson') return null;
         format = value;
+        seen = true;
         index += 1;
     }
     return format;
@@ -54,6 +55,9 @@ export function renderMiniTransport(value: Record<string, unknown>, format: Form
     const items = value.items;
     if (!Array.isArray(items)) return `${JSON.stringify(value)}\n`;
     if (items.length === 0) return `${JSON.stringify({ index: null, item: null })}\n`;
+    for (let index = 0; index < items.length; index += 1) {
+        if (!Object.hasOwn(items, index)) return `${JSON.stringify({ error: 'NDJSON_SPARSE_ITEMS', index })}\n`;
+    }
     return items.map((item, index) => JSON.stringify({ index, item })).join('\n') + '\n';
 }
 
@@ -65,15 +69,10 @@ function failure(error: string, exitCode: number, format: Format): MiniRun {
     };
 }
 
-function requestedFormat(argv: readonly string[]): Format {
-    const formatIndex = argv.indexOf('--format');
-    return argv[formatIndex + 1] === 'ndjson' ? 'ndjson' : 'json';
-}
-
 export function runMiniTransport(argv: readonly string[], stdin = '', inputTooLarge = false): MiniRun {
     if (argv.includes('--help') || argv.includes('-h')) return { exitCode: MINI_EXIT.OK, stdout: MINI_HELP, stderr: '' };
-    const format = requestedFormat(argv);
-    if (parseFormat(argv) === null) return failure('USAGE', MINI_EXIT.USAGE, format);
+    const parsedFormat = parseFormat(argv); const format = parsedFormat ?? 'json';
+    if (!parsedFormat) return failure('USAGE', MINI_EXIT.USAGE, format);
     if (inputTooLarge) return failure('INPUT_TOO_LARGE', MINI_EXIT.USAGE, format);
     if (!parseMiniTransport(argv, stdin)) return failure('USAGE', MINI_EXIT.USAGE, format);
     return failure('TRANSPORT_UNBOUND', MINI_EXIT.BROKER_UNAVAILABLE, format);


### PR DESCRIPTION
## Summary
- add bounded Mini CLI parsing and JSON/NDJSON framing over the accepted Headless semantic harness
- reject duplicate formats, sparse NDJSON ambiguity, oversized input, and unsupported transport commands deterministically
- keep transport unbound from authority, patient context, business execution, provider choice, SQL, write, and apply

## Verification
- Mini CLI: 4/4
- Headless P3: 5/5; P2: 4/4; P1: 4/4; mapping: 15/15
- Smart Import focused suite: 24/24
- typecheck, lint, claims, AI-write, never-regress, node-runtime, and git diff --check
- fresh independent exact-archive review: ACCEPT

## Risk / Notes
- Candidate transport framing only; no runtime service or semantic receipt is bound
- opaque nested args are not recursively sanitized or interpreted
- no PHI/PII, real patient data, credentials, provider invocation, write, or apply
- draft PR preparation is not integration, promotion, or release

## Ticket
Refs WUL-522