### PR TITLE
feat(mini): add bounded Headless intent adapter

### DIFF
--- a/packages/mini/src/headless-intent-adapter.test.ts
+++ b/packages/mini/src/headless-intent-adapter.test.ts
@@ -35,6 +35,16 @@ test('maps the named voice command without caller-supplied authority', () => {
     assert.deepEqual(Object.keys(result).sort(), ['adapterKind', 'idempotencyRef', 'intent', 'requestRef']);
 });
 
+test('detaches the frozen result from later opaque argument mutation', () => {
+    const value = transport('headless.intent.chat') as any;
+    const result = adaptMiniTransportToHeadlessRequest(value);
+    value.request.args.intent = 'synthetic: later mutation';
+    value.request.args.requestRef = 'req_opaque0002';
+    assert.equal(result.intent, 'synthetic: summarize the selected fixture');
+    assert.equal(result.requestRef, 'req_opaque0001');
+    assert.throws(() => { (result as any).intent = 'synthetic: forged'; }, TypeError);
+});
+
 function rejects(value: unknown): void {
     assert.throws(() => adaptMiniTransportToHeadlessRequest(value as MiniTransport), HeadlessIntentAdapterError);
 }
@@ -76,6 +86,26 @@ test('rejects hostile record boundaries without reading accessors', () => {
     requestThenable.request = Promise.resolve(requestThenable.request); rejects(requestThenable);
 });
 
+test('rejects revoked and trap-only proxies before any proxy trap', () => {
+    const revocable = Proxy.revocable(transport('headless.intent.chat'), {});
+    revocable.revoke();
+    rejects(revocable.proxy);
+
+    let traps = 0;
+    const trap = (): never => {
+        traps += 1;
+        throw new Error('proxy trap touched');
+    };
+    const throwingProxy = new Proxy(transport('headless.intent.chat'), {
+        get: trap,
+        getOwnPropertyDescriptor: trap,
+        getPrototypeOf: trap,
+        ownKeys: trap,
+    });
+    rejects(throwingProxy);
+    assert.equal(traps, 0);
+});
+
 test('enforces the synthetic intent and opaque-reference P3 limits', () => {
     for (const intent of [
         'free prompt', 'patient summary', 'synthetic: access patient', 'synthetic: choose provider',
@@ -96,4 +126,49 @@ test('enforces the synthetic intent and opaque-reference P3 limits', () => {
         value.request.args[key] = 'caller-choice';
         rejects(value);
     }
+});
+
+test('rejects forbidden intent tokens with case and underscore separators without substring false positives', () => {
+    for (const intent of [
+        'synthetic: clinical summary',
+        'synthetic: clinical_summary',
+        'synthetic: patient_summary',
+        'synthetic: FREE_PROMPT',
+        'synthetic: PROVIDER_STATUS',
+    ]) {
+        const value = transport('headless.intent.chat') as any;
+        value.request.args.intent = intent;
+        rejects(value);
+    }
+    for (const intent of [
+        'synthetic: patiently providerish clinicality',
+        'synthetic: riassumi la pressione arteriosa',
+    ]) {
+        const value = transport('headless.intent.chat') as any;
+        value.request.args.intent = intent;
+        assert.doesNotThrow(() => adaptMiniTransportToHeadlessRequest(value));
+    }
+});
+
+test('requires stable NFKC Latin input with bounded punctuation and no controls or confusables', () => {
+    const accepted = transport('headless.intent.chat') as any;
+    accepted.request.args.intent = 'synthetic: riassumi l’anamnesi clinica – 2026';
+    assert.equal(adaptMiniTransportToHeadlessRequest(accepted).intent, accepted.request.args.intent);
+
+    for (const intent of [
+        'synthetic: provіder',
+        'synthetic: testo\u202E provider',
+        'synthetic: ｒiassumi la fonte',
+        'synthetic: riassum\u0065\u0301 la fonte',
+    ]) {
+        const value = transport('headless.intent.chat') as any;
+        value.request.args.intent = intent;
+        rejects(value);
+    }
+});
+
+test('documents duplicate raw JSON keys as an upstream P4a parser boundary', () => {
+    // P4b accepts an already-parsed object; raw duplicate-key detection belongs to P4a.
+    const parsed = JSON.parse(`{"format":"json","request":{"command":"headless.intent.chat","args":{"intent":"synthetic: first","requestRef":"req_opaque0001","idempotencyRef":"idem_opaque0001"},"args":{"intent":"synthetic: riassumi la fonte","requestRef":"req_opaque0001","idempotencyRef":"idem_opaque0001"}}}`) as MiniTransport;
+    assert.equal(adaptMiniTransportToHeadlessRequest(parsed).intent, 'synthetic: riassumi la fonte');
 });

--- a/packages/mini/src/headless-intent-adapter.test.ts
+++ b/packages/mini/src/headless-intent-adapter.test.ts
@@ -1,0 +1,99 @@
+/* @Codex */
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import type { MiniTransport } from './cli';
+import { adaptMiniTransportToHeadlessRequest, HeadlessIntentAdapterError } from './headless-intent-adapter';
+
+const transport = (command: string): MiniTransport => ({
+    format: 'json',
+    request: {
+        command,
+        args: {
+            intent: 'synthetic: summarize the selected fixture',
+            requestRef: 'req_opaque0001',
+            idempotencyRef: 'idem_opaque0001',
+        },
+    },
+});
+
+test('maps the named chat transport command to a frozen P3 request', () => {
+    const result = adaptMiniTransportToHeadlessRequest(transport('headless.intent.chat'));
+    assert.deepEqual(result, {
+        adapterKind: 'chat',
+        intent: 'synthetic: summarize the selected fixture',
+        requestRef: 'req_opaque0001',
+        idempotencyRef: 'idem_opaque0001',
+    });
+    assert.equal(Object.isFrozen(result), true);
+});
+
+test('maps the named voice command without caller-supplied authority', () => {
+    const result = adaptMiniTransportToHeadlessRequest(transport('headless.intent.voice'));
+    assert.equal(result.adapterKind, 'voice');
+    assert.equal(Object.getPrototypeOf(result), Object.prototype);
+    assert.deepEqual(Object.keys(result).sort(), ['adapterKind', 'idempotencyRef', 'intent', 'requestRef']);
+});
+
+function rejects(value: unknown): void {
+    assert.throws(() => adaptMiniTransportToHeadlessRequest(value as MiniTransport), HeadlessIntentAdapterError);
+}
+
+test('rejects unknown commands, duplicate kinds, and closed-record violations', () => {
+    rejects(transport('headless.intent.other'));
+    for (const kind of ['chat', 'voice']) {
+        const duplicate = transport('headless.intent.chat') as any;
+        duplicate.request.args.adapterKind = kind;
+        rejects(duplicate);
+    }
+    const extra = transport('headless.intent.chat') as any;
+    extra.request.args.extra = 'forged'; rejects(extra);
+    const symbol = transport('headless.intent.chat') as any;
+    symbol[Symbol('authority')] = true; rejects(symbol);
+    const sparse = [] as unknown[]; sparse.length = 1; rejects(sparse);
+    rejects(Promise.resolve(transport('headless.intent.chat')));
+    const thenable = { ...transport('headless.intent.chat'), then: () => undefined };
+    rejects(thenable);
+    const accessor = transport('headless.intent.chat') as any; let reads = 0;
+    Object.defineProperty(accessor.request.args, 'intent', { enumerable: true, get: () => { reads += 1; return 'synthetic: trapped'; } });
+    rejects(accessor); assert.equal(reads, 0);
+});
+
+test('rejects hostile record boundaries without reading accessors', () => {
+    const envelopeProxy = new Proxy(transport('headless.intent.chat'), {});
+    rejects(envelopeProxy);
+    const requestProxy = transport('headless.intent.chat') as any;
+    requestProxy.request = new Proxy(requestProxy.request, {}); rejects(requestProxy);
+    const argsProxy = transport('headless.intent.chat') as any;
+    argsProxy.request.args = new Proxy(argsProxy.request.args, {}); rejects(argsProxy);
+    const customPrototype = Object.create({ inherited: true });
+    Object.assign(customPrototype, transport('headless.intent.chat')); rejects(customPrototype);
+    const nullPrototype = Object.create(null);
+    Object.assign(nullPrototype, transport('headless.intent.chat')); rejects(nullPrototype);
+    const sparseArgs = transport('headless.intent.chat') as any;
+    sparseArgs.request.args = new Array(3); rejects(sparseArgs);
+    const requestThenable = transport('headless.intent.chat') as any;
+    requestThenable.request = Promise.resolve(requestThenable.request); rejects(requestThenable);
+});
+
+test('enforces the synthetic intent and opaque-reference P3 limits', () => {
+    for (const intent of [
+        'free prompt', 'patient summary', 'synthetic: access patient', 'synthetic: choose provider',
+        'synthetic: use session role', 'synthetic: execute SQL', 'synthetic: write apply',
+        `synthetic: ${'x'.repeat(150)}`,
+    ]) {
+        const value = transport('headless.intent.chat') as any;
+        value.request.args.intent = intent;
+        rejects(value);
+    }
+    for (const ref of ['', 'opaque0001', 'patient_opaque0001', 'clinical_opaque0001', 'req_x']) {
+        const value = transport('headless.intent.chat') as any;
+        value.request.args.requestRef = ref;
+        rejects(value);
+    }
+    for (const key of ['authority', 'session', 'role', 'patient', 'provider', 'venue', 'egress', 'prompt', 'sql', 'sqlite', 'write', 'apply']) {
+        const value = transport('headless.intent.chat') as any;
+        value.request.args[key] = 'caller-choice';
+        rejects(value);
+    }
+});

--- a/packages/mini/src/headless-intent-adapter.ts
+++ b/packages/mini/src/headless-intent-adapter.ts
@@ -1,0 +1,59 @@
+/* @Codex */
+import { types } from 'node:util';
+
+import type { HeadlessSemanticRequest } from '../../../lib/headless-semantic-orchestrator';
+import type { MiniTransport } from './cli';
+
+export const HEADLESS_INTENT_COMMANDS = Object.freeze({
+    chat: 'headless.intent.chat',
+    voice: 'headless.intent.voice',
+});
+
+const TRANSPORT_KEYS = ['format', 'request'] as const;
+const REQUEST_KEYS = ['command', 'args'] as const;
+const ARG_KEYS = ['intent', 'requestRef', 'idempotencyRef'] as const;
+const REF = /^[a-z][a-z0-9-]*_[a-z0-9][a-z0-9.-]{7,63}$/;
+const SENSITIVE_REF = /^(patient|clinical|prompt|model|credential|cookie|token)[-_.]/i;
+const FORBIDDEN_INTENT = /\b(authority|session|role|patient|provider|venue|egress|prompt|credential|cookie|token|sql|sqlite|write|apply)\b/i;
+
+export class HeadlessIntentAdapterError extends Error {
+    constructor(readonly code: string) {
+        super(code);
+        this.name = 'HeadlessIntentAdapterError';
+    }
+}
+
+function fail(code: string): never {
+    throw new HeadlessIntentAdapterError(code);
+}
+
+function exactDataRecord(value: unknown, keys: readonly string[], code: string): Record<string, unknown> {
+    if (!value || typeof value !== 'object' || Array.isArray(value) || types.isProxy(value)
+        || Object.getPrototypeOf(value) !== Object.prototype) fail(code);
+    const descriptors = Object.getOwnPropertyDescriptors(value);
+    const ownKeys = Reflect.ownKeys(descriptors);
+    if (ownKeys.some((key) => typeof key !== 'string') || Object.keys(descriptors).length !== keys.length) fail(code);
+    for (const key of keys) {
+        const descriptor = descriptors[key];
+        if (!descriptor || !descriptor.enumerable || !('value' in descriptor)) fail(code);
+    }
+    return Object.fromEntries(keys.map((key) => [key, descriptors[key]!.value]));
+}
+
+function safeRef(value: unknown): value is string {
+    return typeof value === 'string' && REF.test(value) && !SENSITIVE_REF.test(value);
+}
+
+export function adaptMiniTransportToHeadlessRequest(transport: MiniTransport): HeadlessSemanticRequest {
+    const envelope = exactDataRecord(transport, TRANSPORT_KEYS, 'transport_invalid');
+    if (envelope.format !== 'json' && envelope.format !== 'ndjson') fail('transport_invalid');
+    const request = exactDataRecord(envelope.request, REQUEST_KEYS, 'request_invalid');
+    const adapterKind = request.command === HEADLESS_INTENT_COMMANDS.chat ? 'chat'
+        : request.command === HEADLESS_INTENT_COMMANDS.voice ? 'voice' : fail('command_invalid');
+    const args = exactDataRecord(request.args, ARG_KEYS, 'request_invalid');
+    if (typeof args.intent !== 'string' || !args.intent.startsWith('synthetic: ') || args.intent.length > 160
+        || FORBIDDEN_INTENT.test(args.intent) || !safeRef(args.requestRef) || !safeRef(args.idempotencyRef)) fail('request_invalid');
+    return Object.freeze({
+        adapterKind, intent: args.intent, requestRef: args.requestRef, idempotencyRef: args.idempotencyRef,
+    });
+}

--- a/packages/mini/src/headless-intent-adapter.ts
+++ b/packages/mini/src/headless-intent-adapter.ts
@@ -14,7 +14,13 @@ const REQUEST_KEYS = ['command', 'args'] as const;
 const ARG_KEYS = ['intent', 'requestRef', 'idempotencyRef'] as const;
 const REF = /^[a-z][a-z0-9-]*_[a-z0-9][a-z0-9.-]{7,63}$/;
 const SENSITIVE_REF = /^(patient|clinical|prompt|model|credential|cookie|token)[-_.]/i;
-const FORBIDDEN_INTENT = /\b(authority|session|role|patient|provider|venue|egress|prompt|credential|cookie|token|sql|sqlite|write|apply)\b/i;
+const SYNTHETIC_INTENT_PREFIX = 'synthetic: ';
+const INTENT_ALLOWED_CHARS = /^[\p{Script=Latin}\p{Number} .,;:!?'"()/_+\-–—’]*$/u;
+const INTENT_TOKENS = /[\p{Letter}\p{Number}]+/gu;
+const FORBIDDEN_INTENT_TOKENS = new Set([
+    'authority', 'clinical', 'session', 'role', 'patient', 'provider', 'venue', 'egress',
+    'prompt', 'credential', 'cookie', 'token', 'sql', 'sqlite', 'write', 'apply',
+]);
 
 export class HeadlessIntentAdapterError extends Error {
     constructor(readonly code: string) {
@@ -28,8 +34,8 @@ function fail(code: string): never {
 }
 
 function exactDataRecord(value: unknown, keys: readonly string[], code: string): Record<string, unknown> {
-    if (!value || typeof value !== 'object' || Array.isArray(value) || types.isProxy(value)
-        || Object.getPrototypeOf(value) !== Object.prototype) fail(code);
+    if (!value || typeof value !== 'object' || types.isProxy(value)) fail(code);
+    if (Array.isArray(value) || Object.getPrototypeOf(value) !== Object.prototype) fail(code);
     const descriptors = Object.getOwnPropertyDescriptors(value);
     const ownKeys = Reflect.ownKeys(descriptors);
     if (ownKeys.some((key) => typeof key !== 'string') || Object.keys(descriptors).length !== keys.length) fail(code);
@@ -44,6 +50,21 @@ function safeRef(value: unknown): value is string {
     return typeof value === 'string' && REF.test(value) && !SENSITIVE_REF.test(value);
 }
 
+/**
+ * P4b receives parsed transport only; raw duplicate JSON-key detection stays
+ * with the P4a parser. NFKC is detection-only: a changed string is denied so
+ * the frozen result retains the caller's exact, already-normalized intent.
+ */
+function safeSyntheticIntent(value: unknown): value is string {
+    if (typeof value !== 'string') return false;
+    const normalized = value.normalize('NFKC');
+    if (normalized !== value || !normalized.startsWith(SYNTHETIC_INTENT_PREFIX) || normalized.length > 160) return false;
+    const body = normalized.slice(SYNTHETIC_INTENT_PREFIX.length);
+    if (!INTENT_ALLOWED_CHARS.test(body)) return false;
+    const tokens = body.toLocaleLowerCase('en-US').match(INTENT_TOKENS) ?? [];
+    return !tokens.some((token) => FORBIDDEN_INTENT_TOKENS.has(token));
+}
+
 export function adaptMiniTransportToHeadlessRequest(transport: MiniTransport): HeadlessSemanticRequest {
     const envelope = exactDataRecord(transport, TRANSPORT_KEYS, 'transport_invalid');
     if (envelope.format !== 'json' && envelope.format !== 'ndjson') fail('transport_invalid');
@@ -51,8 +72,7 @@ export function adaptMiniTransportToHeadlessRequest(transport: MiniTransport): H
     const adapterKind = request.command === HEADLESS_INTENT_COMMANDS.chat ? 'chat'
         : request.command === HEADLESS_INTENT_COMMANDS.voice ? 'voice' : fail('command_invalid');
     const args = exactDataRecord(request.args, ARG_KEYS, 'request_invalid');
-    if (typeof args.intent !== 'string' || !args.intent.startsWith('synthetic: ') || args.intent.length > 160
-        || FORBIDDEN_INTENT.test(args.intent) || !safeRef(args.requestRef) || !safeRef(args.idempotencyRef)) fail('request_invalid');
+    if (!safeSyntheticIntent(args.intent) || !safeRef(args.requestRef) || !safeRef(args.idempotencyRef)) fail('request_invalid');
     return Object.freeze({
         adapterKind, intent: args.intent, requestRef: args.requestRef, idempotencyRef: args.idempotencyRef,
     });


### PR DESCRIPTION
## Summary
- map only the named chat and voice Mini commands into the accepted Headless P3 request shape
- reject proxy/reflection hazards, normalization-changing or mixed-script confusables, and forbidden authority/clinical/provider/write tokens
- compose the independently accepted duplicate-key transport parser without invoking any orchestrator or Application Service

## Verification
- combined P4a/P4b: 14 focused tests; P3: 5; P1/P2/mapping: 23
- Smart Import: 24 focused and 153 expanded; Fabric: 115
- full unit: 1400/1400
- production build, typecheck, lint, Node runtime, schema/OpenAPI drift, claims, AI-write and never-regress guards
- fresh independent exact-merge-tree Luna review: ACCEPT

## Risk / Notes
- Parsed Mini transport and input-adapter candidate only; no runtime service, authority, provider/venue, database, receipt, write, or apply
- Unicode policy is deliberately bounded to normalized Latin-script synthetic intent
- no PHI/PII, real patient data, credentials, provider invocation, or external network
- draft PR is not integration, promotion, or release

## Ticket
Refs WUL-522