### PR TITLE
feat(settings): disclose declared Fabric provider paths

### DIFF
--- a/app/settings/ai/fabric/page.tsx
+++ b/app/settings/ai/fabric/page.tsx
@@ -79,7 +79,7 @@ export default function SettingsAiFabricPage() {
             {state.kind === 'error' ? <FabricErrorState /> : null}
             {state.kind === 'ready' ? (
                 <div className="space-y-6">
-                    <FabricVenueSection snapshot={state.observability} />
+                    <FabricVenueSection snapshot={state.observability} status={state.status} />
                     <FabricEgressSection snapshot={state.status} />
                     <FabricCapabilityRegistry snapshot={state.status} />
                 </div>

--- a/components/settings/fabric-venue-section.tsx
+++ b/components/settings/fabric-venue-section.tsx
@@ -2,19 +2,24 @@
 import {
     FABRIC_VENUE_COPY,
     VENUE_OBSERVATION_STATE_LABELS,
+    buildFabricProviderDisclosures,
     orderVenueObservations,
     venueReasonLabel,
 } from '@/lib/fabric-settings-view';
 import type { FabricObservabilitySnapshot } from '@/lib/ai-providers/fabric/routing-observability';
+import type { FabricStatusSnapshot } from '@/lib/ai-providers/fabric/status';
 import { SETTINGS_CARD_CLASS } from './settings-ui';
 import styles from './settings-lume.module.css';
 
 export function FabricVenueSection({
     snapshot,
+    status,
 }: {
     snapshot: FabricObservabilitySnapshot;
+    status: FabricStatusSnapshot;
 }) {
     const observations = orderVenueObservations(snapshot.observations);
+    const providerDisclosures = buildFabricProviderDisclosures(status, snapshot);
 
     return (
         <section className={SETTINGS_CARD_CLASS} data-testid="fabric-venue-section">
@@ -59,6 +64,26 @@ export function FabricVenueSection({
                     );
                 })}
             </dl>
+
+            <section className={styles.fabricProviderDisclosure} data-testid="fabric-provider-disclosure" aria-labelledby="fabric-provider-disclosure-title">
+                <header className={styles.fabricBlockHeader}>
+                    <h3 id="fabric-provider-disclosure-title">Provider e percorsi dichiarati</h3>
+                    <p>Questa proiezione descrive i percorsi dichiarati. Non configura accessi, modelli o servizi.</p>
+                </header>
+
+                <ul className={styles.fabricProviderList}>
+                    {providerDisclosures.map((provider) => (
+                        <li key={provider.id} className={styles.fabricProviderRow} data-testid={`fabric-provider-${provider.id}`}>
+                            <span className={styles.fabricProviderMark} aria-hidden="true">{provider.mark}</span>
+                            <div>
+                                <h4>{provider.title}</h4>
+                                <p>{provider.detail}</p>
+                                <p className={styles.fabricProviderObservation}>{provider.observation}</p>
+                            </div>
+                        </li>
+                    ))}
+                </ul>
+            </section>
         </section>
     );
 }

--- a/components/settings/settings-lume.module.css
+++ b/components/settings/settings-lume.module.css
@@ -443,6 +443,69 @@
 .fabricEgressRow dd .fabricCount {
     margin-top: 0.55rem;
 }
+.fabricProviderDisclosure {
+    margin-top: 1.5rem;
+    border-top: 1px solid color-mix(in srgb, var(--lume-ink) 12%, transparent);
+    padding-top: 1.25rem;
+}
+.fabricProviderDisclosure .fabricBlockHeader {
+    margin-bottom: 0.85rem;
+}
+.fabricProviderDisclosure h3 {
+    margin: 0;
+    color: var(--lume-ink);
+    font-size: 0.92rem;
+    font-weight: 650;
+}
+.fabricProviderList {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+.fabricProviderRow {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 0.7rem;
+    align-items: start;
+    border: 1px solid color-mix(in srgb, var(--lume-ink) 12%, transparent);
+    border-radius: var(--lume-radius-card);
+    background: var(--lume-surface-field);
+    padding: 0.85rem;
+}
+.fabricProviderMark {
+    display: grid;
+    width: 1.8rem;
+    height: 1.8rem;
+    place-items: center;
+    border: 1px solid color-mix(in srgb, var(--lume-ink) 18%, transparent);
+    border-radius: 999px;
+    color: var(--lume-ink-muted);
+    font-family: var(--lume-settings-register-family, "IBM Plex Mono", var(--font-registro), "SF Mono", monospace);
+    font-size: 0.72rem;
+    font-weight: 650;
+}
+.fabricProviderRow h4,
+.fabricProviderRow p {
+    margin: 0;
+}
+.fabricProviderRow h4 {
+    color: var(--lume-ink);
+    font-size: 0.78rem;
+    font-weight: 650;
+}
+.fabricProviderRow p {
+    margin-top: 0.3rem;
+    color: var(--lume-ink-muted);
+    font-size: 0.7rem;
+    line-height: 1.45;
+}
+.fabricProviderRow .fabricProviderObservation {
+    color: var(--lume-ink-muted);
+    font-size: 0.64rem;
+}
 .fabricRegistryGroups {
     display: grid;
     gap: 1.75rem;
@@ -750,6 +813,9 @@
     .fabricVenueRow,
     .fabricEgressRow,
     .fabricCapabilityRow {
+        grid-template-columns: minmax(0, 1fr);
+    }
+    .fabricProviderList {
         grid-template-columns: minmax(0, 1fr);
     }
     .fabricGuarantee code {

--- a/e2e/settings-fabric.spec.ts
+++ b/e2e/settings-fabric.spec.ts
@@ -21,6 +21,17 @@ test('Fabric settings renders the read-only venue and capability registry', asyn
   await expect(surface).toContainText('Fuori dalla postazione');
   await expect(surface).toContainText('la richiesta viene rifiutata');
 
+  const providerDisclosure = page.getByTestId('fabric-provider-disclosure');
+  await expect(providerDisclosure).toBeVisible();
+  for (const provider of ['ollama', 'athena', 'apple_vision_ocr', 'openai', 'anthropic']) {
+    await expect(page.getByTestId(`fabric-provider-${provider}`)).toBeVisible();
+  }
+  await expect(providerDisclosure).toContainText('Il modello è configurato per capacità e non è esposto qui.');
+  await expect(providerDisclosure).toContainText('ATHENA-R1-Qwen3-8B');
+  await expect(providerDisclosure).toContainText('Non è una capacità Fabric on-device');
+  await expect(providerDisclosure).toContainText('Accesso non configurabile. Egress chiuso.');
+  await expect(providerDisclosure).toContainText('Disponibilità non qualificata');
+
   await expect(page.getByTestId('fabric-capability-patient_insight')).toBeVisible();
   await expect(page.getByTestId('fabric-capability-icd_lookup')).toBeVisible();
   await expect(page.getByTestId('fabric-group-generative')).toBeVisible();
@@ -29,6 +40,7 @@ test('Fabric settings renders the read-only venue and capability registry', asyn
 
   await expect(surface.locator('form')).toHaveCount(0);
   await expect(surface.locator('input, select, textarea, button, [role="switch"], [contenteditable="true"]')).toHaveCount(0);
+  await expect(providerDisclosure.locator('a, [role="link"]')).toHaveCount(0);
 
   await page.screenshot({
     path: '/tmp/mediflow-settings-fabric.png',
@@ -41,6 +53,10 @@ test('Fabric settings renders the read-only venue and capability registry', asyn
   });
   await page.getByTestId('fabric-capability-registry').screenshot({
     path: '/tmp/mediflow-settings-fabric-registry.png',
+    animations: 'disabled',
+  });
+  await providerDisclosure.screenshot({
+    path: '/tmp/mediflow-settings-fabric-providers.png',
     animations: 'disabled',
   });
 });

--- a/e2e/settings-fabric.spec.ts
+++ b/e2e/settings-fabric.spec.ts
@@ -30,7 +30,10 @@ test('Fabric settings renders the read-only venue and capability registry', asyn
   await expect(providerDisclosure).toContainText('ATHENA-R1-Qwen3-8B');
   await expect(providerDisclosure).toContainText('Non è una capacità Fabric on-device');
   await expect(providerDisclosure).toContainText('Accesso non configurabile. Egress chiuso.');
-  await expect(providerDisclosure).toContainText('Disponibilità non qualificata');
+  await expect(page.getByTestId('fabric-provider-ollama')).toContainText('Disponibilità non qualificata');
+  for (const provider of ['athena', 'apple_vision_ocr', 'openai', 'anthropic']) {
+    await expect(page.getByTestId(`fabric-provider-${provider}`)).not.toContainText('Disponibilità non qualificata');
+  }
 
   await expect(page.getByTestId('fabric-capability-patient_insight')).toBeVisible();
   await expect(page.getByTestId('fabric-capability-icd_lookup')).toBeVisible();

--- a/lib/fabric-settings-view.test.ts
+++ b/lib/fabric-settings-view.test.ts
@@ -1,5 +1,6 @@
 /* @Codex */
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import { test } from 'node:test';
 
 import { FABRIC_CAPABILITY_DESCRIPTORS } from './ai-providers/fabric/catalog';
@@ -13,6 +14,7 @@ import {
     FABRIC_CAPABILITY_LABELS,
     FABRIC_VENUE_COPY,
     VENUE_OBSERVATION_REASON_LABELS,
+    buildFabricProviderDisclosures,
     groupFabricCapabilities,
 } from './fabric-settings-view';
 
@@ -56,4 +58,46 @@ test('groups and orders the complete registry by capability class', () => {
     assert.deepEqual(groups[0].capabilities.map((item) => item.id), [...GENERATIVE_CAPABILITY_IDS]);
     assert.equal(groups[1].id, 'deterministic');
     assert.deepEqual(groups[1].capabilities.map((item) => item.id), [...DETERMINISTIC_CAPABILITY_IDS]);
+});
+
+test('projects five provider paths without turning the snapshots into readiness or access claims', () => {
+    const disclosures = buildFabricProviderDisclosures({
+        schemaVersion: 'mediflow.ai.fabric-status.v1',
+        contractVersion: 'mediflow.ai.fabric.v1',
+        egressGateOpen: false,
+        readinessNote: 'available_unqualified',
+        capabilities: [],
+    }, {
+        schemaVersion: 'mediflow.ai.fabric-observability.v1',
+        fallback: 'denied_by_contract',
+        observations: [
+            { venue: 'local_process', state: 'available', reason: null },
+            { venue: 'home_base', state: 'offline', reason: 'mode_disabled' },
+            { venue: 'on_device', state: 'unknown', reason: 'not_implemented' },
+            { venue: 'cloud', state: 'offline', reason: 'egress_profile_closed' },
+        ],
+    });
+
+    assert.deepEqual(disclosures.map((disclosure) => disclosure.id), [
+        'ollama', 'athena', 'apple_vision_ocr', 'openai', 'anthropic',
+    ]);
+    assert.deepEqual(disclosures.map((disclosure) => disclosure.mark), ['O', 'A', 'V', 'O', 'A']);
+    assert.match(disclosures[0].detail, /local_process/u);
+    assert.match(disclosures[0].detail, /modello.*capacità.*non è esposto qui/u);
+    assert.match(disclosures[1].detail, /athena_mlx.*ATHENA-R1-Qwen3-8B.*non è osservato/u);
+    assert.match(disclosures[2].detail, /solo macOS.*Non è una capacità Fabric on-device/u);
+    for (const disclosure of disclosures.slice(3)) {
+        assert.match(disclosure.detail, /consumer_login.*Accesso non configurabile.*Egress chiuso/u);
+    }
+    assert.match(disclosures[0].observation, /Disponibilità non qualificata/u);
+    assert.doesNotMatch(JSON.stringify(disclosures), /ready|pronto|autenticat|abilitat|configura.*modello|kill.?switch/iu);
+});
+
+test('keeps the provider disclosure component static and free of actions or provider calls', () => {
+    const source = readFileSync(new URL('../components/settings/fabric-venue-section.tsx', import.meta.url), 'utf8');
+
+    assert.match(source, /<section/u);
+    assert.match(source, /<li/u);
+    assert.doesNotMatch(source, /<form|<button|<input|<select|<textarea|<a\s|<Link\b|fetch\(|useEffect|useState|onClick|onSubmit|href=/u);
+    assert.doesNotMatch(source, /killSwitch|model\s*:|route|router|egressGateOpen\s*=|isEgressGateOpen/u);
 });

--- a/lib/fabric-settings-view.test.ts
+++ b/lib/fabric-settings-view.test.ts
@@ -90,7 +90,14 @@ test('projects five provider paths without turning the snapshots into readiness 
         assert.match(disclosure.detail, /consumer_login.*Accesso non configurabile.*Egress chiuso/u);
     }
     assert.match(disclosures[0].observation, /Disponibilità non qualificata/u);
-    assert.doesNotMatch(JSON.stringify(disclosures), /ready|pronto|autenticat|abilitat|configura.*modello|kill.?switch/iu);
+    assert.match(disclosures[1].observation, /ATHENA.*stato.*non osservato/u);
+    assert.match(disclosures[2].observation, /Fallback macOS locale.*on-device Fabric/u);
+    assert.match(disclosures[3].observation, /OpenAI.*candidato.*consumer_login.*Egress chiuso/u);
+    assert.match(disclosures[4].observation, /Anthropic.*candidato.*consumer_login.*Egress chiuso/u);
+    for (const disclosure of disclosures.slice(1)) {
+        assert.doesNotMatch(disclosure.observation, /Disponibilità non qualificata/u);
+    }
+    assert.doesNotMatch(JSON.stringify(disclosures), /\bready\b|\bpronto\b|\bautenticato\b|\babilitato\b|configura.*modello|kill.?switch/iu);
 });
 
 test('keeps the provider disclosure component static and free of actions or provider calls', () => {

--- a/lib/fabric-settings-view.ts
+++ b/lib/fabric-settings-view.ts
@@ -78,7 +78,7 @@ export function buildFabricProviderDisclosures(
     const localProcessObservation = localProcess
         ? `Percorso registrato: local_process (${VENUE_OBSERVATION_STATE_LABELS[localProcess.state]}).`
         : 'Percorso local_process non presente nel registro.';
-    const availabilityNote = status.readinessNote === 'available_unqualified'
+    const ollamaAvailabilityNote = status.readinessNote === 'available_unqualified'
         ? 'Disponibilità non qualificata: non indica accesso, autenticazione, attivazione o prontezza.'
         : 'Il registro non qualifica accesso, autenticazione, attivazione o prontezza.';
     const closedEgress = status.egressGateOpen === false
@@ -91,35 +91,35 @@ export function buildFabricProviderDisclosures(
             mark: 'O' as const,
             title: 'Ollama',
             detail: 'Ollama usa local_process osservato. Il modello è configurato per capacità e non è esposto qui.',
-            observation: `${localProcessObservation} ${availabilityNote}`,
+            observation: `${localProcessObservation} ${ollamaAvailabilityNote}`,
         }),
         Object.freeze({
             id: 'athena' as const,
             mark: 'A' as const,
             title: 'ATHENA',
             detail: 'Provider athena_mlx con ATHENA-R1-Qwen3-8B. Lo stato non è osservato in questo registro.',
-            observation: availabilityNote,
+            observation: 'ATHENA: stato provider non osservato in questo registro.',
         }),
         Object.freeze({
             id: 'apple_vision_ocr' as const,
             mark: 'V' as const,
             title: 'Apple Vision OCR',
             detail: 'Fallback locale solo macOS. Non è una capacità Fabric on-device.',
-            observation: availabilityNote,
+            observation: 'Fallback macOS locale; nessuna venue on-device Fabric dichiarata.',
         }),
         Object.freeze({
             id: 'openai' as const,
             mark: 'O' as const,
             title: 'OpenAI',
             detail: `Candidato consumer_login. Accesso non configurabile. ${closedEgress}`,
-            observation: availabilityNote,
+            observation: `OpenAI: candidato consumer_login disabilitato. Accesso non configurabile. ${closedEgress}`,
         }),
         Object.freeze({
             id: 'anthropic' as const,
             mark: 'A' as const,
             title: 'Anthropic',
             detail: `Candidato consumer_login. Accesso non configurabile. ${closedEgress}`,
-            observation: availabilityNote,
+            observation: `Anthropic: candidato consumer_login disabilitato. Accesso non configurabile. ${closedEgress}`,
         }),
     ]);
 }

--- a/lib/fabric-settings-view.ts
+++ b/lib/fabric-settings-view.ts
@@ -27,6 +27,14 @@ export type FabricVenueCopy = Readonly<{
     description: string;
 }>;
 
+export type FabricProviderDisclosure = Readonly<{
+    id: 'ollama' | 'athena' | 'apple_vision_ocr' | 'openai' | 'anthropic';
+    mark: 'O' | 'A' | 'V';
+    title: string;
+    detail: string;
+    observation: string;
+}>;
+
 export const FABRIC_VENUE_COPY: Readonly<Record<FabricVenue, FabricVenueCopy>> = Object.freeze({
     local_process: Object.freeze({
         title: 'Questo Mac',
@@ -61,6 +69,60 @@ export const VENUE_OBSERVATION_STATE_LABELS: Readonly<Record<VenueObservationSta
     offline: 'Non disponibile',
     unknown: 'Stato non verificato',
 });
+
+export function buildFabricProviderDisclosures(
+    status: FabricStatusSnapshot,
+    observability: FabricObservabilitySnapshot,
+): readonly FabricProviderDisclosure[] {
+    const localProcess = observability.observations.find((observation) => observation.venue === 'local_process');
+    const localProcessObservation = localProcess
+        ? `Percorso registrato: local_process (${VENUE_OBSERVATION_STATE_LABELS[localProcess.state]}).`
+        : 'Percorso local_process non presente nel registro.';
+    const availabilityNote = status.readinessNote === 'available_unqualified'
+        ? 'Disponibilità non qualificata: non indica accesso, autenticazione, attivazione o prontezza.'
+        : 'Il registro non qualifica accesso, autenticazione, attivazione o prontezza.';
+    const closedEgress = status.egressGateOpen === false
+        ? 'Egress chiuso.'
+        : 'Lo stato egress non viene dichiarato chiuso in questa proiezione.';
+
+    return Object.freeze([
+        Object.freeze({
+            id: 'ollama' as const,
+            mark: 'O' as const,
+            title: 'Ollama',
+            detail: 'Ollama usa local_process osservato. Il modello è configurato per capacità e non è esposto qui.',
+            observation: `${localProcessObservation} ${availabilityNote}`,
+        }),
+        Object.freeze({
+            id: 'athena' as const,
+            mark: 'A' as const,
+            title: 'ATHENA',
+            detail: 'Provider athena_mlx con ATHENA-R1-Qwen3-8B. Lo stato non è osservato in questo registro.',
+            observation: availabilityNote,
+        }),
+        Object.freeze({
+            id: 'apple_vision_ocr' as const,
+            mark: 'V' as const,
+            title: 'Apple Vision OCR',
+            detail: 'Fallback locale solo macOS. Non è una capacità Fabric on-device.',
+            observation: availabilityNote,
+        }),
+        Object.freeze({
+            id: 'openai' as const,
+            mark: 'O' as const,
+            title: 'OpenAI',
+            detail: `Candidato consumer_login. Accesso non configurabile. ${closedEgress}`,
+            observation: availabilityNote,
+        }),
+        Object.freeze({
+            id: 'anthropic' as const,
+            mark: 'A' as const,
+            title: 'Anthropic',
+            detail: `Candidato consumer_login. Accesso non configurabile. ${closedEgress}`,
+            observation: availabilityNote,
+        }),
+    ]);
+}
 
 export const FABRIC_CAPABILITY_LABELS: Readonly<Record<FabricCapabilityId, string>> = Object.freeze({
     patient_insight: 'Sintesi del quadro paziente',


### PR DESCRIPTION
## Summary
- render static disclosure cards for Ollama, ATHENA, Apple Vision OCR, OpenAI, and Anthropic
- project only existing host-observed status into provider-specific, non-qualifying wording
- keep provider access, readiness, login, configuration, invocation, and egress controls out of scope

## Verification
- logical P5 head `4d98ee8bf9475a32323d8163ad3b57686e7068c9`; composed PR head `e90a9fe882f3d751542378e7163155268b15350c` over accepted fixture base `f4ec87b5799cc5fcf4d661c66af7b01e7ca068fb`
- Fabric settings view-model tests: 5/5; patient-cascade fixture: 3/3
- full unit suite on composed head: 1402/1402
- synthetic rendered E2E: 1/1; typecheck, full lint, production build and proportional guards
- fresh independent review accepted the logical six-file P5 diff; GitHub CI is terminal green on the composed exact head

## Risk / Notes
- synthetic fixtures only; no PHI/PII or real patient data
- `available_unqualified` is disclosed only for Ollama; other providers retain explicit non-observed, fallback, or disabled status
- this is a static read-only candidate and does not prove provider availability, authentication, native parity, integration, or release readiness
- preparation and publication of this draft PR do not authorize merge or promotion

## Ticket
Refs WUL-522