### PR TITLE
chore(native): align Apple release metadata to 0.8.5

### DIFF
--- a/native/MediFlowAppleApp/MediFlowAppleApp.xcodeproj/project.pbxproj
+++ b/native/MediFlowAppleApp/MediFlowAppleApp.xcodeproj/project.pbxproj
@@ -223,8 +223,8 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				EA5A5E56B9AFA0C54E1C530F /* MediFlowMacApp */,
 				83356432730EE4403A18FB8C /* MediFlowMobileApp */,
+				EA5A5E56B9AFA0C54E1C530F /* MediFlowMacApp */,
 				AD8CE4C65DCDFB8994D15EFC /* MediFlowMobileAppUITests */,
 			);
 		};
@@ -308,14 +308,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 85;
 				INFOPLIST_FILE = Sources/MediFlowMacApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.8.2;
+				MARKETING_VERSION = 0.8.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mediflow.mobile;
 				PRODUCT_NAME = MediFlow;
 				SDKROOT = macosx;
@@ -345,14 +345,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 85;
 				INFOPLIST_FILE = Sources/MediFlowMacApp/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.8.2;
+				MARKETING_VERSION = 0.8.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mediflow.mobile;
 				PRODUCT_NAME = MediFlow;
 				SDKROOT = macosx;
@@ -364,14 +364,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 85;
 				INFOPLIST_FILE = Sources/MediFlowMobileApp/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.8.2;
+				MARKETING_VERSION = 0.8.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mediflow.mobile;
 				PRODUCT_NAME = MediFlow;
 				SDKROOT = iphoneos;
@@ -385,14 +385,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 85;
 				INFOPLIST_FILE = Sources/MediFlowMobileApp/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.8.2;
+				MARKETING_VERSION = 0.8.5;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mediflow.mobile;
 				PRODUCT_NAME = MediFlow;
 				SDKROOT = iphoneos;

--- a/native/MediFlowAppleApp/Sources/MediFlowMacApp/Info.plist
+++ b/native/MediFlowAppleApp/Sources/MediFlowMacApp/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.8.2</string>
+	<string>0.8.5</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<integer>85</integer>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.medical</string>
 	<key>NSBonjourServices</key>

--- a/native/MediFlowAppleApp/Sources/MediFlowMacApp/Info.plist
+++ b/native/MediFlowAppleApp/Sources/MediFlowMacApp/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.8.5</string>
 	<key>CFBundleVersion</key>
-	<integer>85</integer>
+	<string>85</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.medical</string>
 	<key>NSBonjourServices</key>

--- a/native/MediFlowAppleApp/Sources/MediFlowMobileApp/Info.plist
+++ b/native/MediFlowAppleApp/Sources/MediFlowMobileApp/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.8.2</string>
+	<string>0.8.5</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<integer>85</integer>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.medical</string>
 	<key>NSBonjourServices</key>

--- a/native/MediFlowAppleApp/Sources/MediFlowMobileApp/Info.plist
+++ b/native/MediFlowAppleApp/Sources/MediFlowMobileApp/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.8.5</string>
 	<key>CFBundleVersion</key>
-	<integer>85</integer>
+	<string>85</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.medical</string>
 	<key>NSBonjourServices</key>

--- a/native/MediFlowAppleApp/project.yml
+++ b/native/MediFlowAppleApp/project.yml
@@ -24,7 +24,7 @@ targets:
       properties:
         CFBundleDisplayName: MediFlow
         CFBundleShortVersionString: 0.8.5
-        CFBundleVersion: 85
+        CFBundleVersion: "85"
         LSApplicationCategoryType: public.app-category.medical
         UIApplicationSupportsIndirectInputEvents: true
         # Local-network discovery: required so Bonjour home-base discovery and
@@ -67,7 +67,7 @@ targets:
       properties:
         CFBundleDisplayName: MediFlow
         CFBundleShortVersionString: 0.8.5
-        CFBundleVersion: 85
+        CFBundleVersion: "85"
         LSApplicationCategoryType: public.app-category.medical
         # Local-network discovery for the home-base Bonjour service. Guarded by
         # check-apple-network-entitlements.sh.

--- a/native/MediFlowAppleApp/project.yml
+++ b/native/MediFlowAppleApp/project.yml
@@ -23,7 +23,8 @@ targets:
       path: Sources/MediFlowMobileApp/Info.plist
       properties:
         CFBundleDisplayName: MediFlow
-        CFBundleShortVersionString: 0.8.2
+        CFBundleShortVersionString: 0.8.5
+        CFBundleVersion: 85
         LSApplicationCategoryType: public.app-category.medical
         UIApplicationSupportsIndirectInputEvents: true
         # Local-network discovery: required so Bonjour home-base discovery and
@@ -47,8 +48,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.mediflow.mobile
         PRODUCT_NAME: MediFlow
         TARGETED_DEVICE_FAMILY: "1,2"
-        MARKETING_VERSION: 0.8.2
-        CURRENT_PROJECT_VERSION: 1
+        MARKETING_VERSION: 0.8.5
+        CURRENT_PROJECT_VERSION: 85
         SUPPORTS_MACCATALYST: NO
   MediFlowMacApp:
     type: application
@@ -65,7 +66,8 @@ targets:
       path: Sources/MediFlowMacApp/Info.plist
       properties:
         CFBundleDisplayName: MediFlow
-        CFBundleShortVersionString: 0.8.2
+        CFBundleShortVersionString: 0.8.5
+        CFBundleVersion: 85
         LSApplicationCategoryType: public.app-category.medical
         # Local-network discovery for the home-base Bonjour service. Guarded by
         # check-apple-network-entitlements.sh.
@@ -78,8 +80,8 @@ targets:
         # Same bundle id as iOS for a single universal-purchase app record.
         PRODUCT_BUNDLE_IDENTIFIER: com.mediflow.mobile
         PRODUCT_NAME: MediFlow
-        MARKETING_VERSION: 0.8.2
-        CURRENT_PROJECT_VERSION: 1
+        MARKETING_VERSION: 0.8.5
+        CURRENT_PROJECT_VERSION: 85
   MediFlowMobileAppUITests:
     type: bundle.ui-testing
     platform: iOS


### PR DESCRIPTION
## Summary
- align the Apple application release metadata to version 0.8.5 and build 85
- preserve `CFBundleVersion` as the string required by the generated project metadata
- keep Web package metadata and path-hygiene policy in later stacked packets

## Verification
- Xcode Release builds for arm64 and x86_64 on exact descendant candidate
- generated bundles report `CFBundleShortVersionString=0.8.5` and `CFBundleVersion=85`
- native structure and package validation checks
- exact ancestry and clean branch verified before publication

## Risk / Notes
- synthetic/local evidence only; no PHI/PII
- candidate metadata only; no signing, notarization, integration, release readiness, or release
- preparation and publication of this draft PR do not authorize merge or promotion

## Ticket
Refs WUL-568