### PR TITLE
chore(release): align Web package metadata to 0.8.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "medical-record-app",
-  "version": "0.8.2",
+  "version": "0.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "medical-record-app",
-      "version": "0.8.2",
+      "version": "0.8.5",
       "hasInstallScript": true,
       "dependencies": {
         "@firecrawl/pdf-inspector": "1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medical-record-app",
-  "version": "0.8.2",
+  "version": "0.8.5",
   "private": false,
   "engines": {
     "node": ">=24 <25"


### PR DESCRIPTION
## Summary
- set the root Web package metadata to version 0.8.5
- update only the corresponding root package-lock version fields
- preserve dependency versions, including unrelated packages that contain 0.8.2 in their own semver

## Verification
- exact diff is limited to `package.json` and root lockfile metadata
- arm64 and x86_64 WebRuntime Release bundles report version 0.8.5 on the exact descendant candidate
- production builds and standalone runtime guards passed on both architecture receipts
- exact ancestry and clean branch verified before publication

## Risk / Notes
- synthetic/local evidence only; no PHI/PII
- candidate metadata only; final `package.json` reconciliation remains owned by WUL-564 on the combined SHA
- no integration, release readiness, signing, notarization, or release claim
- preparation and publication of this draft PR do not authorize merge or promotion

## Ticket
Refs WUL-568