### PR TITLE
fix(release): enforce macOS release path hygiene

### DIFF
--- a/scripts/build-apple-macos-app.sh
+++ b/scripts/build-apple-macos-app.sh
@@ -22,6 +22,10 @@ SCHEME="MediFlowMacApp"
 CONFIG="${MEDIFLOW_MAC_CONFIG:-Debug}"
 DERIVED="${MEDIFLOW_MAC_DERIVED_DATA:-$ROOT_DIR/tmp-mac-derived-data}"
 
+if [[ "$CONFIG" == "Release" ]]; then
+  node "$ROOT_DIR/scripts/macos-release-path-hygiene.mjs" --source-root "$ROOT_DIR" --check-source
+fi
+
 # xcodebuild needs a full Xcode (the Liquid Glass code needs the 26 SDK).
 if [[ "$(xcode-select -p 2>/dev/null)" == *CommandLineTools* ]] || ! command -v xcodebuild >/dev/null 2>&1; then
   for dev in /Applications/Xcode.app/Contents/Developer /Applications/Xcode-beta.app/Contents/Developer; do
@@ -71,6 +75,8 @@ cp -R "$ROOT_DIR/$NEXT_DIST_DIR/static" "$WEB/.next/static"
 [[ -d "$ROOT_DIR/public" ]] && cp -R "$ROOT_DIR/public" "$WEB/public"
 cp "$ROOT_DIR/scripts/local-api-tls-proxy.mjs" "$RES/local-api-tls-proxy.mjs"
 "$ROOT_DIR/scripts/check-macos-web-runtime-native-payload.sh" --normalize --web-runtime "$WEB"
+# @Codex: remove only local symbols before optional signing, then reject personal markers.
+node "$ROOT_DIR/scripts/macos-release-path-hygiene.mjs" --app "$APP" --strip --check
 
 # 4. Optional codesign (so the injected runtime is covered for distribution)
 if [[ -n "${MEDIFLOW_CODESIGN_IDENTITY:-}" ]]; then

--- a/scripts/macos-release-path-hygiene.mjs
+++ b/scripts/macos-release-path-hygiene.mjs
@@ -29,16 +29,21 @@ for (let index = 0; index < args.length; index += 1) {
 }
 if ((!checkSource && !strip && !check && !smoke) || (checkSource && !sourceRoot) || ((strip || check || smoke) && !app)) usage();
 if (app) { app = path.resolve(app); if (!fs.existsSync(app)) fail('app must exist'); }
+function localHomes() {
+  const declared = [...new Set([os.homedir(), process.env.HOME].filter(Boolean).map((home) => path.resolve(home)))];
+  try { return [...new Set([...declared, ...declared.map((home) => fs.realpathSync.native(home))])]; }
+  catch { fail('cannot canonicalize local home'); }
+}
+const homes = localHomes();
 function unsafeSourceRoot(root) {
   if (!path.isAbsolute(root)) fail('source root must be absolute');
   let stat; try { stat = fs.statSync(root); } catch { fail('source root must be an existing directory'); }
   if (!stat.isDirectory()) fail('source root must be an existing directory');
   let resolved; try { resolved = fs.realpathSync.native(root); } catch { fail('source root must be an existing directory'); }
-  const home = fs.realpathSync.native(os.homedir());
   const inside = (value, base) => value === base || value.startsWith(`${base}${path.sep}`);
   const inCodex = resolved.split(path.sep).some((part, index, parts) => part === '.codex' && parts[index + 1] === 'worktrees');
   return inside(resolved, '/Users') || inCodex ||
-    (home !== '/' && inside(resolved, home));
+    homes.some((home) => home !== '/' && inside(resolved, home));
 }
 function executable() { return path.join(app, 'Contents', 'MacOS', 'MediFlow'); }
 function webRuntime() { return path.join(app, 'Contents', 'Resources', 'WebRuntime'); }
@@ -67,7 +72,7 @@ function stripExecutable() {
   assertArm64Macho(file);
 }
 const forbidden = [
-  ['current home directory', path.resolve(os.homedir())],
+  ...homes.map((home) => ['current home directory', home]),
   ['Codex worktree', '/.codex/worktrees/'],
 ].map(([label, literal]) => [label, (text) => text.includes(literal)]).concat([
   ['private key', /-----BEGIN(?: [A-Z]+)? PRIVATE KEY-----[\s\S]{20,}?-----END(?: [A-Z]+)? PRIVATE KEY-----/],

--- a/scripts/macos-release-path-hygiene.mjs
+++ b/scripts/macos-release-path-hygiene.mjs
@@ -5,10 +5,8 @@ import http from 'node:http';
 import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
-
 function fail(message) { throw new Error(`macOS release path hygiene: ${message}`); }
 function usage() { fail('usage: --source-root <absolute path> --check-source | --app <MediFlow.app> [--strip] [--check] [--smoke]'); }
-
 const args = process.argv.slice(2);
 let app;
 let sourceRoot;
@@ -30,33 +28,44 @@ for (let index = 0; index < args.length; index += 1) {
   else usage();
 }
 if ((!checkSource && !strip && !check && !smoke) || (checkSource && !sourceRoot) || ((strip || check || smoke) && !app)) usage();
-if (app) {
-  app = path.resolve(app);
-  if (!fs.existsSync(app)) fail('app must exist');
-}
-
+if (app) { app = path.resolve(app); if (!fs.existsSync(app)) fail('app must exist'); }
 function unsafeSourceRoot(root) {
   if (!path.isAbsolute(root)) fail('source root must be absolute');
-  const resolved = path.resolve(root);
-  const home = path.resolve(os.homedir());
-  return resolved.includes('/Users/') || resolved.includes('/.codex/worktrees/') ||
-    (home !== '/' && (resolved === home || resolved.startsWith(`${home}${path.sep}`)));
+  let stat; try { stat = fs.statSync(root); } catch { fail('source root must be an existing directory'); }
+  if (!stat.isDirectory()) fail('source root must be an existing directory');
+  let resolved; try { resolved = fs.realpathSync.native(root); } catch { fail('source root must be an existing directory'); }
+  const home = fs.realpathSync.native(os.homedir());
+  const inside = (value, base) => value === base || value.startsWith(`${base}${path.sep}`);
+  const inCodex = resolved.split(path.sep).some((part, index, parts) => part === '.codex' && parts[index + 1] === 'worktrees');
+  return inside(resolved, '/Users') || inCodex ||
+    (home !== '/' && inside(resolved, home));
 }
-
-function checkSourceRoot() {
-  if (unsafeSourceRoot(sourceRoot)) fail('unsafe source root: use a neutral archive path');
-}
-
 function executable() { return path.join(app, 'Contents', 'MacOS', 'MediFlow'); }
 function webRuntime() { return path.join(app, 'Contents', 'Resources', 'WebRuntime'); }
 
+const MACHO_ARM64 = 0x0100000c;
+function isArm64Macho(file) {
+  try {
+    const data = fs.readFileSync(file);
+    if (data.length < 8) return false;
+    const le = data.readUInt32LE(0), be = data.readUInt32BE(0);
+    if (le === 0xfeedfacf || be === 0xfeedfacf) return (le === 0xfeedfacf ? data.readUInt32LE(4) : data.readUInt32BE(4)) === MACHO_ARM64;
+    const fat = be === 0xcafebabe || be === 0xcafebabf ? { little: false, step: be === 0xcafebabf ? 32 : 20 } : be === 0xbebafeca || be === 0xbfbafeca ? { little: true, step: be === 0xbfbafeca ? 32 : 20 } : null;
+    if (!fat) return false;
+    const read = (offset) => fat.little ? data.readUInt32LE(offset) : data.readUInt32BE(offset);
+    for (let index = 0; index < read(4) && 8 + index * fat.step + 4 <= data.length; index += 1) if (read(8 + index * fat.step) === MACHO_ARM64) return true;
+  } catch {}
+  return false;
+}
+function assertArm64Macho(file) { if (!isArm64Macho(file)) fail('native executable must be a Mach-O arm64 binary'); }
 function stripExecutable() {
   const file = executable();
   if (!fs.existsSync(file)) fail('missing native executable');
+  assertArm64Macho(file);
   const result = spawnSync('strip', ['-x', file], { encoding: 'utf8' });
   if (result.status !== 0) fail(`strip failed: ${(result.stderr || result.error?.message || 'unknown error').trim()}`);
+  assertArm64Macho(file);
 }
-
 const forbidden = [
   ['current home directory', path.resolve(os.homedir())],
   ['Codex worktree', '/.codex/worktrees/'],
@@ -66,59 +75,94 @@ const forbidden = [
   ['GitHub token', '\\bgh[pousr]_[A-Za-z0-9]{20,}\\b'],
   ['Slack token', '\\bxox[baprs]-[A-Za-z0-9-]{20,}\\b'],
 ].map(([label, pattern]) => [label, (text) => new RegExp(pattern).test(text)]));
-
 function checkPayload() {
   const contents = path.join(app, 'Contents');
-  if (!fs.existsSync(contents)) fail('missing app Contents');
+  let canonicalApp, canonicalContents;
+  try { canonicalApp = fs.realpathSync.native(app); canonicalContents = fs.realpathSync.native(contents); }
+  catch { fail('missing app Contents'); }
+  const visited = new Set(), inside = (value, base) => value === base || value.startsWith(`${base}${path.sep}`);
+  if (!inside(canonicalContents, canonicalApp)) fail('payload link escapes bundle: Contents');
   const violations = [];
-  function inspect(file) {
-    const text = fs.readFileSync(file).toString('latin1');
-    for (const [label, matches] of forbidden) {
-      if (matches(text)) violations.push(`${path.relative(app, file)} contains forbidden marker: ${label}`);
+  function visit(candidate, label) {
+    let real;
+    try { real = fs.realpathSync.native(candidate); }
+    catch { fail(`invalid payload link: ${path.relative(app, label)}`); }
+    if (!inside(real, canonicalContents)) fail(`payload link escapes bundle: ${path.relative(app, label)}`);
+    if (visited.has(real)) return;
+    visited.add(real);
+    const stat = fs.statSync(real);
+    if (stat.isDirectory()) {
+      for (const entry of fs.readdirSync(real, { withFileTypes: true })) visit(path.join(real, entry.name), path.join(label, entry.name));
+      return;
     }
+    if (!stat.isFile()) fail(`unsupported payload entry: ${path.relative(app, label)}`);
+    const text = fs.readFileSync(real).toString('latin1');
+    for (const [marker, matches] of forbidden) if (matches(text)) violations.push(`${path.relative(app, label)} contains forbidden marker: ${marker}`);
   }
-  function walk(directory) {
-    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
-      const file = path.join(directory, entry.name);
-      if (entry.isDirectory()) walk(file);
-      else if (entry.isFile()) inspect(file);
-      else if (entry.isSymbolicLink()) {
-        const target = fs.readlinkSync(file);
-        for (const [label, matches] of forbidden) {
-          if (matches(target)) violations.push(`${path.relative(app, file)} contains forbidden marker: ${label}`);
-        }
-      }
-    }
-  }
-  walk(contents);
+  visit(canonicalContents, contents);
   if (violations.length) fail(violations.slice(0, 10).join('\n'));
 }
-
 function freePort() {
   return new Promise((resolve, reject) => {
     const server = net.createServer();
     server.once('error', reject);
-    server.listen(0, '127.0.0.1', () => {
-      const address = server.address();
-      server.close((error) => error ? reject(error) : resolve(address.port));
-    });
+    server.listen(0, '127.0.0.1', () => { const address = server.address(); server.close((error) => error ? reject(error) : resolve(address.port)); });
   });
 }
-
-function requestRoot(port, attempts = 20) {
+function smokePort() {
+  if (process.env.MEDIFLOW_SMOKE_PORT === undefined) return freePort();
+  const port = Number(process.env.MEDIFLOW_SMOKE_PORT);
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) fail('invalid smoke port');
+  return port;
+}
+function requestRoot(port, attempts = 20, deadline = 2_000) {
   return new Promise((resolve, reject) => {
-    const request = () => http.get({ host: '127.0.0.1', port, path: '/', timeout: 500 }, (response) => {
-      response.resume();
-      if (response.statusCode && response.statusCode < 400) resolve();
-      else reject(new Error(`GET / returned ${response.statusCode}`));
-    }).on('error', (error) => {
-      if (attempts-- > 0) setTimeout(request, 100);
-      else reject(error);
-    });
-    request();
+    const expires = Date.now() + deadline;
+    let settled = false, lastError;
+    const finish = (error) => { if (settled) return; settled = true; error ? reject(error) : resolve(); };
+    const attempt = () => {
+      if (settled) return;
+      const remaining = expires - Date.now();
+      if (remaining <= 0 || attempts-- < 0) return finish(lastError || new Error('GET / timed out'));
+      let done = false, timer;
+      const retry = (error) => {
+        if (done) return;
+        done = true;
+        clearTimeout(timer);
+        lastError = error;
+        if (Date.now() < expires && attempts >= 0) setTimeout(attempt, 50);
+        else finish(error);
+      };
+      const req = http.get({ host: '127.0.0.1', port, path: '/' }, (response) => {
+        if (done) return;
+        done = true;
+        clearTimeout(timer);
+        response.resume();
+        if (response.statusCode && response.statusCode < 400) finish();
+        else finish(new Error(`GET / returned ${response.statusCode}`));
+      });
+      req.once('error', retry);
+      timer = setTimeout(() => { retry(new Error('GET / timed out')); req.destroy(); }, Math.min(500, remaining));
+    };
+    attempt();
   });
 }
-
+function waitForExit(child, timeout = 500) {
+  if (child.exitCode !== null) return Promise.resolve(true);
+  return new Promise((resolve) => {
+    const done = () => { clearTimeout(timer); resolve(true); };
+    const timer = setTimeout(() => { child.removeListener('exit', done); resolve(false); }, timeout);
+    child.once('exit', done);
+    if (child.exitCode !== null) done();
+  });
+}
+async function stopChild(child) {
+  if (!child || child.exitCode !== null) return;
+  try { child.kill('SIGTERM'); } catch {}
+  if (await waitForExit(child)) return;
+  try { child.kill('SIGKILL'); } catch {}
+  if (!(await waitForExit(child))) fail('relocated runtime did not exit');
+}
 async function smokeRelocatedRuntime() {
   const runtime = webRuntime();
   if (!fs.existsSync(path.join(runtime, 'server.js'))) fail('missing WebRuntime/server.js');
@@ -127,17 +171,15 @@ async function smokeRelocatedRuntime() {
   let child;
   try {
     fs.cpSync(app, copied, { recursive: true });
-    const port = await freePort();
+    const port = await smokePort();
     child = spawn(process.execPath, ['server.js'], { cwd: path.join(copied, 'Contents', 'Resources', 'WebRuntime'), env: { ...process.env, HOSTNAME: '127.0.0.1', PORT: String(port) }, stdio: 'ignore' });
     await requestRoot(port);
   } finally {
-    child?.kill();
-    fs.rmSync(temporary, { recursive: true, force: true });
+    try { await stopChild(child); } finally { fs.rmSync(temporary, { recursive: true, force: true }); }
   }
 }
-
 try {
-  if (checkSource) checkSourceRoot();
+  if (checkSource && unsafeSourceRoot(sourceRoot)) fail('unsafe source root: use a neutral archive path');
   if (strip) stripExecutable();
   if (check) checkPayload();
   if (smoke) await smokeRelocatedRuntime();

--- a/scripts/macos-release-path-hygiene.mjs
+++ b/scripts/macos-release-path-hygiene.mjs
@@ -1,0 +1,148 @@
+/* @Codex */
+import { spawn, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import http from 'node:http';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+
+function fail(message) { throw new Error(`macOS release path hygiene: ${message}`); }
+function usage() { fail('usage: --source-root <absolute path> --check-source | --app <MediFlow.app> [--strip] [--check] [--smoke]'); }
+
+const args = process.argv.slice(2);
+let app;
+let sourceRoot;
+let checkSource = false;
+let strip = false;
+let check = false;
+let smoke = false;
+for (let index = 0; index < args.length; index += 1) {
+  const value = args[index];
+  if (value === '--app' || value === '--source-root') {
+    const next = args[index += 1];
+    if (!next) usage();
+    if (value === '--app') app = next;
+    else sourceRoot = next;
+  } else if (value === '--check-source') checkSource = true;
+  else if (value === '--strip') strip = true;
+  else if (value === '--check') check = true;
+  else if (value === '--smoke') smoke = true;
+  else usage();
+}
+if ((!checkSource && !strip && !check && !smoke) || (checkSource && !sourceRoot) || ((strip || check || smoke) && !app)) usage();
+if (app) {
+  app = path.resolve(app);
+  if (!fs.existsSync(app)) fail('app must exist');
+}
+
+function unsafeSourceRoot(root) {
+  if (!path.isAbsolute(root)) fail('source root must be absolute');
+  const resolved = path.resolve(root);
+  const home = path.resolve(os.homedir());
+  return resolved.includes('/Users/') || resolved.includes('/.codex/worktrees/') ||
+    (home !== '/' && (resolved === home || resolved.startsWith(`${home}${path.sep}`)));
+}
+
+function checkSourceRoot() {
+  if (unsafeSourceRoot(sourceRoot)) fail('unsafe source root: use a neutral archive path');
+}
+
+function executable() { return path.join(app, 'Contents', 'MacOS', 'MediFlow'); }
+function webRuntime() { return path.join(app, 'Contents', 'Resources', 'WebRuntime'); }
+
+function stripExecutable() {
+  const file = executable();
+  if (!fs.existsSync(file)) fail('missing native executable');
+  const result = spawnSync('strip', ['-x', file], { encoding: 'utf8' });
+  if (result.status !== 0) fail(`strip failed: ${(result.stderr || result.error?.message || 'unknown error').trim()}`);
+}
+
+const forbidden = [
+  ['current home directory', path.resolve(os.homedir())],
+  ['Codex worktree', '/.codex/worktrees/'],
+].map(([label, literal]) => [label, (text) => text.includes(literal)]).concat([
+  ['private key', /-----BEGIN(?: [A-Z]+)? PRIVATE KEY-----[\s\S]{20,}?-----END(?: [A-Z]+)? PRIVATE KEY-----/],
+  ['AWS access key', '\\bAKIA[0-9A-Z]{16}\\b'],
+  ['GitHub token', '\\bgh[pousr]_[A-Za-z0-9]{20,}\\b'],
+  ['Slack token', '\\bxox[baprs]-[A-Za-z0-9-]{20,}\\b'],
+].map(([label, pattern]) => [label, (text) => new RegExp(pattern).test(text)]));
+
+function checkPayload() {
+  const contents = path.join(app, 'Contents');
+  if (!fs.existsSync(contents)) fail('missing app Contents');
+  const violations = [];
+  function inspect(file) {
+    const text = fs.readFileSync(file).toString('latin1');
+    for (const [label, matches] of forbidden) {
+      if (matches(text)) violations.push(`${path.relative(app, file)} contains forbidden marker: ${label}`);
+    }
+  }
+  function walk(directory) {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const file = path.join(directory, entry.name);
+      if (entry.isDirectory()) walk(file);
+      else if (entry.isFile()) inspect(file);
+      else if (entry.isSymbolicLink()) {
+        const target = fs.readlinkSync(file);
+        for (const [label, matches] of forbidden) {
+          if (matches(target)) violations.push(`${path.relative(app, file)} contains forbidden marker: ${label}`);
+        }
+      }
+    }
+  }
+  walk(contents);
+  if (violations.length) fail(violations.slice(0, 10).join('\n'));
+}
+
+function freePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      server.close((error) => error ? reject(error) : resolve(address.port));
+    });
+  });
+}
+
+function requestRoot(port, attempts = 20) {
+  return new Promise((resolve, reject) => {
+    const request = () => http.get({ host: '127.0.0.1', port, path: '/', timeout: 500 }, (response) => {
+      response.resume();
+      if (response.statusCode && response.statusCode < 400) resolve();
+      else reject(new Error(`GET / returned ${response.statusCode}`));
+    }).on('error', (error) => {
+      if (attempts-- > 0) setTimeout(request, 100);
+      else reject(error);
+    });
+    request();
+  });
+}
+
+async function smokeRelocatedRuntime() {
+  const runtime = webRuntime();
+  if (!fs.existsSync(path.join(runtime, 'server.js'))) fail('missing WebRuntime/server.js');
+  const temporary = fs.mkdtempSync(path.join(os.tmpdir(), 'mediflow-relocated-'));
+  const copied = path.join(temporary, 'MediFlow.app');
+  let child;
+  try {
+    fs.cpSync(app, copied, { recursive: true });
+    const port = await freePort();
+    child = spawn(process.execPath, ['server.js'], { cwd: path.join(copied, 'Contents', 'Resources', 'WebRuntime'), env: { ...process.env, HOSTNAME: '127.0.0.1', PORT: String(port) }, stdio: 'ignore' });
+    await requestRoot(port);
+  } finally {
+    child?.kill();
+    fs.rmSync(temporary, { recursive: true, force: true });
+  }
+}
+
+try {
+  if (checkSource) checkSourceRoot();
+  if (strip) stripExecutable();
+  if (check) checkPayload();
+  if (smoke) await smokeRelocatedRuntime();
+  console.log('macOS release path hygiene passed');
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/scripts/macos-release-path-hygiene.mjs
+++ b/scripts/macos-release-path-hygiene.mjs
@@ -34,7 +34,9 @@ function localHomes() {
   try { return [...new Set([...declared, ...declared.map((home) => fs.realpathSync.native(home))])]; }
   catch { fail('cannot canonicalize local home'); }
 }
-const homes = localHomes();
+let homes = [], homesUnavailable = false;
+try { homes = localHomes(); } catch { homesUnavailable = true; }
+function requireHomes() { if (homesUnavailable) fail('cannot canonicalize local home'); return homes; }
 function unsafeSourceRoot(root) {
   if (!path.isAbsolute(root)) fail('source root must be absolute');
   let stat; try { stat = fs.statSync(root); } catch { fail('source root must be an existing directory'); }
@@ -43,33 +45,29 @@ function unsafeSourceRoot(root) {
   const inside = (value, base) => value === base || value.startsWith(`${base}${path.sep}`);
   const inCodex = resolved.split(path.sep).some((part, index, parts) => part === '.codex' && parts[index + 1] === 'worktrees');
   return inside(resolved, '/Users') || inCodex ||
-    homes.some((home) => home !== '/' && inside(resolved, home));
+    requireHomes().some((home) => home !== '/' && inside(resolved, home));
 }
 function executable() { return path.join(app, 'Contents', 'MacOS', 'MediFlow'); }
 function webRuntime() { return path.join(app, 'Contents', 'Resources', 'WebRuntime'); }
 
-const MACHO_ARM64 = 0x0100000c;
-function isArm64Macho(file) {
+const MACHO_CPUS = new Set([0x0100000c, 0x01000007]);
+function isSupportedMacho(file) {
   try {
     const data = fs.readFileSync(file);
-    if (data.length < 8) return false;
-    const le = data.readUInt32LE(0), be = data.readUInt32BE(0);
-    if (le === 0xfeedfacf || be === 0xfeedfacf) return (le === 0xfeedfacf ? data.readUInt32LE(4) : data.readUInt32BE(4)) === MACHO_ARM64;
-    const fat = be === 0xcafebabe || be === 0xcafebabf ? { little: false, step: be === 0xcafebabf ? 32 : 20 } : be === 0xbebafeca || be === 0xbfbafeca ? { little: true, step: be === 0xbfbafeca ? 32 : 20 } : null;
-    if (!fat) return false;
-    const read = (offset) => fat.little ? data.readUInt32LE(offset) : data.readUInt32BE(offset);
-    for (let index = 0; index < read(4) && 8 + index * fat.step + 4 <= data.length; index += 1) if (read(8 + index * fat.step) === MACHO_ARM64) return true;
+    if (data.length < 32) return false;
+    const le = data.readUInt32LE(0);
+    if (le === 0xfeedfacf) return MACHO_CPUS.has(data.readUInt32LE(4));
   } catch {}
   return false;
 }
-function assertArm64Macho(file) { if (!isArm64Macho(file)) fail('native executable must be a Mach-O arm64 binary'); }
+function assertSupportedMacho(file) { if (!isSupportedMacho(file)) fail('native executable must be a Mach-O arm64 or x86_64 binary'); }
 function stripExecutable() {
   const file = executable();
   if (!fs.existsSync(file)) fail('missing native executable');
-  assertArm64Macho(file);
+  assertSupportedMacho(file);
   const result = spawnSync('strip', ['-x', file], { encoding: 'utf8' });
-  if (result.status !== 0) fail(`strip failed: ${(result.stderr || result.error?.message || 'unknown error').trim()}`);
-  assertArm64Macho(file);
+  if (result.status !== 0) fail('strip failed');
+  assertSupportedMacho(file);
 }
 const forbidden = [
   ...homes.map((home) => ['current home directory', home]),
@@ -81,6 +79,7 @@ const forbidden = [
   ['Slack token', '\\bxox[baprs]-[A-Za-z0-9-]{20,}\\b'],
 ].map(([label, pattern]) => [label, (text) => new RegExp(pattern).test(text)]));
 function checkPayload() {
+  requireHomes();
   const contents = path.join(app, 'Contents');
   let canonicalApp, canonicalContents;
   try { canonicalApp = fs.realpathSync.native(app); canonicalContents = fs.realpathSync.native(contents); }
@@ -190,6 +189,6 @@ try {
   if (smoke) await smokeRelocatedRuntime();
   console.log('macOS release path hygiene passed');
 } catch (error) {
-  console.error(error instanceof Error ? error.message : String(error));
+  console.error(error instanceof Error && error.message.startsWith('macOS release path hygiene:') ? error.message : 'macOS release path hygiene: operation failed');
   process.exitCode = 1;
 }

--- a/scripts/macos-release-path-hygiene.test.mjs
+++ b/scripts/macos-release-path-hygiene.test.mjs
@@ -1,0 +1,90 @@
+/* @Codex */
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+
+const script = path.resolve('scripts/macos-release-path-hygiene.mjs');
+const server = "require('node:http').createServer((_, r) => r.end('ok')).listen(process.env.PORT, process.env.HOSTNAME);\n";
+
+function fixture(payload = server) {
+  const app = fs.mkdtempSync(path.join(os.tmpdir(), 'mediflow-path-hygiene-'));
+  fs.mkdirSync(path.join(app, 'Contents', 'MacOS'), { recursive: true });
+  fs.mkdirSync(path.join(app, 'Contents', 'Resources', 'WebRuntime'), { recursive: true });
+  fs.writeFileSync(path.join(app, 'Contents', 'MacOS', 'MediFlow'), 'synthetic executable');
+  fs.writeFileSync(path.join(app, 'Contents', 'Resources', 'WebRuntime', 'server.js'), payload);
+  return app;
+}
+
+function run(args, env = {}) {
+  return spawnSync(process.execPath, [script, ...args], { encoding: 'utf8', env: { ...process.env, ...env } });
+}
+
+test('accepts a neutral source root', () => {
+  const result = run(['--source-root', '/private/tmp/mediflow-source', '--check-source']);
+  assert.equal(result.status, 0, result.stderr);
+});
+
+for (const sourceRoot of ['/Users/example/repo', os.homedir(), '/private/tmp/.codex/worktrees/repo']) {
+  test(`fails closed for personal or Codex source root ${sourceRoot}`, () => {
+    const result = run(['--source-root', sourceRoot, '--check-source']);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /unsafe source root/);
+  });
+}
+
+test('fails closed when shipped payload retains a personal marker', () => {
+  const app = fixture(`${server}// ${os.homedir()}/repo\n`);
+  try {
+    const result = run(['--app', app, '--check']);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /forbidden marker/);
+  } finally { fs.rmSync(app, { recursive: true, force: true }); }
+});
+
+test('fails closed when shipped payload retains a known secret marker', () => {
+  const app = fixture(`${server}// ghp_1234567890123456789012345678901234567890\n`);
+  try {
+    const result = run(['--app', app, '--check']);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /GitHub token/);
+  } finally { fs.rmSync(app, { recursive: true, force: true }); }
+});
+
+test('allows neutral build-root strings in the shipped payload', () => {
+  const app = fixture(`${server}// /private/tmp/mediflow-source\n`);
+  try {
+    const result = run(['--app', app, '--check']);
+    assert.equal(result.status, 0, result.stderr);
+  } finally { fs.rmSync(app, { recursive: true, force: true }); }
+});
+
+test('fails closed when strip fails', () => {
+  const app = fixture();
+  const bin = fs.mkdtempSync(path.join(os.tmpdir(), 'mediflow-fake-strip-'));
+  try {
+    fs.writeFileSync(path.join(bin, 'strip'), '#!/bin/sh\nexit 7\n', { mode: 0o755 });
+    const result = run(['--app', app, '--strip'], { PATH: `${bin}:${process.env.PATH}` });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /strip failed/);
+  } finally {
+    fs.rmSync(app, { recursive: true, force: true });
+    fs.rmSync(bin, { recursive: true, force: true });
+  }
+});
+
+test('smokes copied WebRuntime on loopback only', () => {
+  const app = fixture();
+  try {
+    const result = run(['--app', app, '--smoke']);
+    assert.equal(result.status, 0, result.stderr);
+  } finally { fs.rmSync(app, { recursive: true, force: true }); }
+});
+
+test('fails closed for unexpected input', () => {
+  const result = run(['--unexpected']);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /usage:/);
+});

--- a/scripts/macos-release-path-hygiene.test.mjs
+++ b/scripts/macos-release-path-hygiene.test.mjs
@@ -50,14 +50,18 @@ test('payload links are contained, dereferenced, and cycle-safe', () => {
     fs.unlinkSync(link); fs.symlinkSync('loop-b', path.join(resources, 'loop-a')); fs.symlinkSync('loop-a', link); assert.match(run(['--app', app, '--check']).stderr, /invalid payload link/);
   } finally { fs.rmSync(app, { recursive: true, force: true }); fs.rmSync(outside, { force: true }); }
 });
-test('strip requires arm64 Mach-O and rechecks after strip', () => {
-  const bad = fixture(server, Buffer.from('not Mach-O')), good = fixture(), okTools = tool('exit 0'), corruptTools = tool('printf bad > "$2"');
+test('strip requires a complete supported Mach-O and rechecks after strip', () => {
+  const x86 = Buffer.from(macho), unsupported = Buffer.from(macho); x86.writeUInt32LE(0x01000007, 4); unsupported.writeUInt32LE(0x01000008, 4);
+  const bad = fixture(server, Buffer.from('not Mach-O')), truncated = fixture(server, macho.subarray(0, 8)), other = fixture(server, unsupported), x86App = fixture(server, x86), good = fixture(), okTools = tool('exit 0'), corruptTools = tool('printf bad > "$2"');
   try {
     assert.match(run(['--app', bad, '--strip'], { PATH: `${okTools}:${process.env.PATH}` }).stderr, /Mach-O arm64/);
+    assert.match(run(['--app', truncated, '--strip'], { PATH: `${okTools}:${process.env.PATH}` }).stderr, /Mach-O arm64/);
+    assert.match(run(['--app', other, '--strip'], { PATH: `${okTools}:${process.env.PATH}` }).stderr, /Mach-O arm64/);
+    assert.equal(run(['--app', x86App, '--strip'], { PATH: `${okTools}:${process.env.PATH}` }).status, 0);
     assert.match(run(['--app', good, '--strip'], { PATH: `${corruptTools}:${process.env.PATH}` }).stderr, /Mach-O arm64/);
-  } finally { for (const item of [bad, good, okTools, corruptTools]) fs.rmSync(item, { recursive: true, force: true }); }
+  } finally { for (const item of [bad, truncated, other, x86App, good, okTools, corruptTools]) fs.rmSync(item, { recursive: true, force: true }); }
 });
-test('fails closed when strip fails', () => { const app = fixture(), bin = tool('exit 7'); try { const result = run(['--app', app, '--strip'], { PATH: `${bin}:${process.env.PATH}` }); assert.match(result.stderr, /strip failed/); } finally { fs.rmSync(app, { recursive: true, force: true }); fs.rmSync(bin, { recursive: true, force: true }); } });
+test('fails closed when strip fails without leaking tool diagnostics', () => { const app = fixture(), bin = tool("printf '/Users/example/secret' >&2\nexit 7"); try { const result = run(['--app', app, '--strip'], { PATH: `${bin}:${process.env.PATH}` }); assert.match(result.stderr, /strip failed/); assert.doesNotMatch(result.stderr, /\/Users\//); } finally { fs.rmSync(app, { recursive: true, force: true }); fs.rmSync(bin, { recursive: true, force: true }); } });
 test('smokes copied WebRuntime on loopback only', () => { const app = fixture(), pidFile = path.join(app, 'child.pid'); try { assert.equal(run(['--app', app, '--smoke'], { MEDIFLOW_TEST_PID_FILE: pidFile }).status, 0); gone(pidFile); } finally { fs.rmSync(app, { recursive: true, force: true }); } });
 test('bounds smoke timeout, collision, and child cleanup', async () => {
   const hanging = "const fs=require('node:fs');if(process.env.MEDIFLOW_TEST_PID_FILE)fs.writeFileSync(process.env.MEDIFLOW_TEST_PID_FILE,String(process.pid));require('node:http').createServer(()=>{}).listen(process.env.PORT,process.env.HOSTNAME);";

--- a/scripts/macos-release-path-hygiene.test.mjs
+++ b/scripts/macos-release-path-hygiene.test.mjs
@@ -1,90 +1,61 @@
 /* @Codex */
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
+import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import test from 'node:test';
-
 const script = path.resolve('scripts/macos-release-path-hygiene.mjs');
-const server = "require('node:http').createServer((_, r) => r.end('ok')).listen(process.env.PORT, process.env.HOSTNAME);\n";
-
-function fixture(payload = server) {
+const server = "const fs=require('node:fs');if(process.env.MEDIFLOW_TEST_PID_FILE)fs.writeFileSync(process.env.MEDIFLOW_TEST_PID_FILE,String(process.pid));require('node:http').createServer((_, r) => r.end('ok')).listen(process.env.PORT, process.env.HOSTNAME);\n";
+const macho = Buffer.alloc(32); macho.writeUInt32LE(0xfeedfacf, 0); macho.writeUInt32LE(0x0100000c, 4);
+function fixture(payload = server, executable = macho) {
   const app = fs.mkdtempSync(path.join(os.tmpdir(), 'mediflow-path-hygiene-'));
-  fs.mkdirSync(path.join(app, 'Contents', 'MacOS'), { recursive: true });
-  fs.mkdirSync(path.join(app, 'Contents', 'Resources', 'WebRuntime'), { recursive: true });
-  fs.writeFileSync(path.join(app, 'Contents', 'MacOS', 'MediFlow'), 'synthetic executable');
-  fs.writeFileSync(path.join(app, 'Contents', 'Resources', 'WebRuntime', 'server.js'), payload);
-  return app;
+  const mac = path.join(app, 'Contents', 'MacOS'), resources = path.join(app, 'Contents', 'Resources');
+  fs.mkdirSync(mac, { recursive: true }); fs.mkdirSync(path.join(resources, 'WebRuntime'), { recursive: true });
+  fs.writeFileSync(path.join(mac, 'MediFlow'), executable); fs.writeFileSync(path.join(resources, 'WebRuntime', 'server.js'), payload); return app;
 }
-
-function run(args, env = {}) {
-  return spawnSync(process.execPath, [script, ...args], { encoding: 'utf8', env: { ...process.env, ...env } });
+function run(args, env = {}) { return spawnSync(process.execPath, [script, ...args], { encoding: 'utf8', env: { ...process.env, ...env } }); }
+function tool(body) { const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mediflow-tool-')); fs.writeFileSync(path.join(dir, 'strip'), `#!/bin/sh\n${body}\n`, { mode: 0o755 }); return dir; }
+function gone(pidFile) { assert.throws(() => process.kill(Number(fs.readFileSync(pidFile)), 0)); }
+test('source root is existing, canonical, and neutral', () => {
+  const neutral = fs.mkdtempSync(path.join(os.tmpdir(), 'mediflow-source-')), link = `${neutral}-home`, worktreeLink = `${neutral}-worktree`;
+  const codex = path.join(neutral, '.codex', 'worktrees'); fs.mkdirSync(codex, { recursive: true }); fs.symlinkSync(os.homedir(), link, 'dir'); fs.symlinkSync(codex, worktreeLink, 'dir');
+  try {
+    for (const root of [neutral, `${neutral}-stale`, link, worktreeLink, codex, '/Users', '/Users/example/repo', os.homedir()]) {
+      const result = run(['--source-root', root, '--check-source']);
+      if (root === neutral) assert.equal(result.status, 0, result.stderr); else assert.notEqual(result.status, 0);
+    }
+  } finally { fs.rmSync(neutral, { recursive: true, force: true }); fs.rmSync(link, { force: true }); fs.rmSync(worktreeLink, { force: true }); }
+});
+for (const [name, payload, ok] of [['personal', `// ${os.homedir()}/repo`, false], ['pem', '-----BEGIN PRIVATE KEY-----\nAAAAAAAAAAAAAAAAAAAAAAAA\n-----END PRIVATE KEY-----', false], ['aws', 'AKIAAAAAAAAAAAAAAAAA', false], ['github', '// ghp_1234567890123456789012345678901234567890', false], ['slack', 'xoxb-AAAAAAAAAAAAAAAAAAAAAAAA', false], ['neutral', '// /private/tmp/mediflow-source', true]]) {
+  test(`payload marker policy: ${name}`, () => { const app = fixture(`${server}${payload}\n`); try { const result = run(['--app', app, '--check']); ok ? assert.equal(result.status, 0, result.stderr) : assert.notEqual(result.status, 0); } finally { fs.rmSync(app, { recursive: true, force: true }); } });
 }
-
-test('accepts a neutral source root', () => {
-  const result = run(['--source-root', '/private/tmp/mediflow-source', '--check-source']);
-  assert.equal(result.status, 0, result.stderr);
-});
-
-for (const sourceRoot of ['/Users/example/repo', os.homedir(), '/private/tmp/.codex/worktrees/repo']) {
-  test(`fails closed for personal or Codex source root ${sourceRoot}`, () => {
-    const result = run(['--source-root', sourceRoot, '--check-source']);
-    assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /unsafe source root/);
-  });
-}
-
-test('fails closed when shipped payload retains a personal marker', () => {
-  const app = fixture(`${server}// ${os.homedir()}/repo\n`);
+test('payload links are contained, dereferenced, and cycle-safe', () => {
+  const app = fixture(), resources = path.join(app, 'Contents', 'Resources'), link = path.join(resources, 'alias');
+  const outside = path.join(os.tmpdir(), `mediflow-secret-${Date.now()}`); fs.writeFileSync(outside, 'ghp_1234567890123456789012345678901234567890'); fs.symlinkSync(outside, link);
   try {
-    const result = run(['--app', app, '--check']);
-    assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /forbidden marker/);
-  } finally { fs.rmSync(app, { recursive: true, force: true }); }
+    assert.match(run(['--app', app, '--check']).stderr, /escapes bundle/); fs.unlinkSync(link); fs.symlinkSync('missing', link); assert.match(run(['--app', app, '--check']).stderr, /invalid payload link/);
+    fs.unlinkSync(link); fs.writeFileSync(path.join(resources, 'target'), 'ghp_123456789012345678901234567890'); fs.symlinkSync('target', link); assert.match(run(['--app', app, '--check']).stderr, /GitHub token/);
+    fs.unlinkSync(link); fs.symlinkSync('loop-b', path.join(resources, 'loop-a')); fs.symlinkSync('loop-a', link); assert.match(run(['--app', app, '--check']).stderr, /invalid payload link/);
+  } finally { fs.rmSync(app, { recursive: true, force: true }); fs.rmSync(outside, { force: true }); }
 });
-
-test('fails closed when shipped payload retains a known secret marker', () => {
-  const app = fixture(`${server}// ghp_1234567890123456789012345678901234567890\n`);
+test('strip requires arm64 Mach-O and rechecks after strip', () => {
+  const bad = fixture(server, Buffer.from('not Mach-O')), good = fixture(), okTools = tool('exit 0'), corruptTools = tool('printf bad > "$2"');
   try {
-    const result = run(['--app', app, '--check']);
-    assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /GitHub token/);
-  } finally { fs.rmSync(app, { recursive: true, force: true }); }
+    assert.match(run(['--app', bad, '--strip'], { PATH: `${okTools}:${process.env.PATH}` }).stderr, /Mach-O arm64/);
+    assert.match(run(['--app', good, '--strip'], { PATH: `${corruptTools}:${process.env.PATH}` }).stderr, /Mach-O arm64/);
+  } finally { for (const item of [bad, good, okTools, corruptTools]) fs.rmSync(item, { recursive: true, force: true }); }
 });
-
-test('allows neutral build-root strings in the shipped payload', () => {
-  const app = fixture(`${server}// /private/tmp/mediflow-source\n`);
+test('fails closed when strip fails', () => { const app = fixture(), bin = tool('exit 7'); try { const result = run(['--app', app, '--strip'], { PATH: `${bin}:${process.env.PATH}` }); assert.match(result.stderr, /strip failed/); } finally { fs.rmSync(app, { recursive: true, force: true }); fs.rmSync(bin, { recursive: true, force: true }); } });
+test('smokes copied WebRuntime on loopback only', () => { const app = fixture(), pidFile = path.join(app, 'child.pid'); try { assert.equal(run(['--app', app, '--smoke'], { MEDIFLOW_TEST_PID_FILE: pidFile }).status, 0); gone(pidFile); } finally { fs.rmSync(app, { recursive: true, force: true }); } });
+test('bounds smoke timeout, collision, and child cleanup', async () => {
+  const hanging = "const fs=require('node:fs');if(process.env.MEDIFLOW_TEST_PID_FILE)fs.writeFileSync(process.env.MEDIFLOW_TEST_PID_FILE,String(process.pid));require('node:http').createServer(()=>{}).listen(process.env.PORT,process.env.HOSTNAME);";
+  const app = fixture(hanging), pidFile = path.join(app, 'child.pid'), occupied = net.createServer();
   try {
-    const result = run(['--app', app, '--check']);
-    assert.equal(result.status, 0, result.stderr);
-  } finally { fs.rmSync(app, { recursive: true, force: true }); }
+    const timed = run(['--app', app, '--smoke'], { MEDIFLOW_TEST_PID_FILE: pidFile }); assert.notEqual(timed.status, 0); gone(pidFile);
+    await new Promise(resolve => occupied.listen(0, '127.0.0.1', resolve)); const port = occupied.address().port;
+    const collision = run(['--app', app, '--smoke'], { MEDIFLOW_TEST_PID_FILE: pidFile, MEDIFLOW_SMOKE_PORT: String(port) }); assert.notEqual(collision.status, 0); gone(pidFile);
+  } finally { occupied.close(); fs.rmSync(app, { recursive: true, force: true }); }
 });
-
-test('fails closed when strip fails', () => {
-  const app = fixture();
-  const bin = fs.mkdtempSync(path.join(os.tmpdir(), 'mediflow-fake-strip-'));
-  try {
-    fs.writeFileSync(path.join(bin, 'strip'), '#!/bin/sh\nexit 7\n', { mode: 0o755 });
-    const result = run(['--app', app, '--strip'], { PATH: `${bin}:${process.env.PATH}` });
-    assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /strip failed/);
-  } finally {
-    fs.rmSync(app, { recursive: true, force: true });
-    fs.rmSync(bin, { recursive: true, force: true });
-  }
-});
-
-test('smokes copied WebRuntime on loopback only', () => {
-  const app = fixture();
-  try {
-    const result = run(['--app', app, '--smoke']);
-    assert.equal(result.status, 0, result.stderr);
-  } finally { fs.rmSync(app, { recursive: true, force: true }); }
-});
-
-test('fails closed for unexpected input', () => {
-  const result = run(['--unexpected']);
-  assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /usage:/);
-});
+test('fails closed for unexpected input', () => { const result = run(['--unexpected']); assert.match(result.stderr, /usage:/); });

--- a/scripts/macos-release-path-hygiene.test.mjs
+++ b/scripts/macos-release-path-hygiene.test.mjs
@@ -31,6 +31,16 @@ test('source root is existing, canonical, and neutral', () => {
 for (const [name, payload, ok] of [['personal', `// ${os.homedir()}/repo`, false], ['pem', '-----BEGIN PRIVATE KEY-----\nAAAAAAAAAAAAAAAAAAAAAAAA\n-----END PRIVATE KEY-----', false], ['aws', 'AKIAAAAAAAAAAAAAAAAA', false], ['github', '// ghp_1234567890123456789012345678901234567890', false], ['slack', 'xoxb-AAAAAAAAAAAAAAAAAAAAAAAA', false], ['neutral', '// /private/tmp/mediflow-source', true]]) {
   test(`payload marker policy: ${name}`, () => { const app = fixture(`${server}${payload}\n`); try { const result = run(['--app', app, '--check']); ok ? assert.equal(result.status, 0, result.stderr) : assert.notEqual(result.status, 0); } finally { fs.rmSync(app, { recursive: true, force: true }); } });
 }
+test('denies canonical HOME markers through a declared-home symlink', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'mediflow-home-')), home = path.join(root, 'canonical'), declared = path.join(root, 'declared');
+  fs.mkdirSync(home); const canonical = fs.realpathSync.native(home); const app = fixture(`${server}// ${canonical}/secret\n`); fs.symlinkSync(home, declared, 'dir');
+  try {
+    const result = run(['--app', app, '--check'], { HOME: declared });
+    assert.notEqual(result.status, 0); assert.match(result.stderr, /current home directory/); assert.doesNotMatch(result.stderr, new RegExp(canonical));
+    const stale = path.join(root, 'stale'), staleResult = run(['--app', app, '--check'], { HOME: stale });
+    assert.notEqual(staleResult.status, 0); assert.match(staleResult.stderr, /cannot canonicalize local home/); assert.doesNotMatch(staleResult.stderr, new RegExp(stale));
+  } finally { fs.rmSync(app, { recursive: true, force: true }); fs.rmSync(root, { recursive: true, force: true }); }
+});
 test('payload links are contained, dereferenced, and cycle-safe', () => {
   const app = fixture(), resources = path.join(app, 'Contents', 'Resources'), link = path.join(resources, 'alias');
   const outside = path.join(os.tmpdir(), `mediflow-secret-${Date.now()}`); fs.writeFileSync(outside, 'ghp_1234567890123456789012345678901234567890'); fs.symlinkSync(outside, link);


### PR DESCRIPTION
## Summary
- enforce canonical neutral roots and full-payload local-marker checks for macOS Release bundles
- validate arm64 and x86_64 Mach-O payloads before and after symbol stripping with sanitized fail-closed diagnostics
- add bounded relocated runtime smoke checks with process cleanup

## Verification
- path-hygiene focused suite: 14/14 plus independent adversarial falsifiers
- unsigned arm64 Release bundle: build, payload guard, relocation and local smoke PASS
- unsigned x86_64 Release WebRuntime under Rosetta: lock-exact install, SQLite, sharp, PDF.js 25/25, standalone guard, relocation and `GET /` PASS
- typecheck, lint, Bash syntax, claims, AI-write, never-regress, runtime and drift checks
- fresh independent review accepted exact head `b1032bc5eedcc98731e12e139a39d13aafd02baa`

## Risk / Notes
- synthetic temporary data only; no PHI/PII
- shipped Next.js identifiers are not rewritten; no path-free or reproducible-build claim is made
- no Developer ID signing or notarization was performed
- this is an unsigned local release candidate, not integrated, release-ready, or released
- preparation and publication of this draft PR do not authorize merge or promotion

## Ticket
Refs WUL-568