### PR TITLE
feat(ui): expose Analytics and Scales commands

### DIFF
--- a/components/kree8/kree8-command-center.tsx
+++ b/components/kree8/kree8-command-center.tsx
@@ -6,11 +6,13 @@ import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react'
 import { useRouter } from 'next/navigation';
 import {
   CalendarClock,
+  ChartNoAxesCombined,
   CircleHelp,
   CornerDownLeft,
   Database,
   FileText,
   Plus,
+  Scale,
   Search,
   Settings,
   Users,
@@ -68,11 +70,17 @@ export function Kree8CommandCenter({
       onOpenArea(area);
       onClose();
     };
+    const openRoute = (href: string) => {
+      router.push(href);
+      onClose();
+    };
     return [
       { id: 'agenda', label: 'Apri Agenda', hint: 'Area di turno', icon: CalendarClock, run: () => openArea('turno') },
       { id: 'patients', label: 'Apri Pazienti', hint: 'Lista e lente rapida', icon: Users, run: () => openArea('incarico') },
       { id: 'diary', label: 'Apri Diario', hint: 'Timeline clinica', icon: FileText, run: () => openArea('diario') },
       { id: 'catalogs', label: 'Apri Repertori', hint: 'Cataloghi locali', icon: Database, run: () => openArea('repertori') },
+      { id: 'analytics', label: 'Apri Analisi', hint: 'Cruscotto locale', icon: ChartNoAxesCombined, run: () => openRoute('/analytics') },
+      { id: 'scales', label: 'Apri Scale cliniche', hint: 'Catalogo e somministrazione', icon: Scale, run: () => openRoute('/scales') },
       { id: 'settings', label: 'Apri Impostazioni', hint: 'Governance locale', icon: Settings, run: () => openArea('governance') },
       {
         id: 'search',
@@ -84,7 +92,7 @@ export function Kree8CommandCenter({
           onClose();
         },
       },
-      { id: 'new', label: 'Nuova scheda', hint: 'Apri il flusso di inserimento', icon: Plus, run: () => router.push('/patients/new') },
+      { id: 'new', label: 'Nuova scheda', hint: 'Apri il flusso di inserimento', icon: Plus, run: () => openRoute('/patients/new') },
       { id: 'help', label: 'Aiuto tastiera', hint: 'Scorciatoie disponibili', icon: CircleHelp, run: onShowHelp },
     ];
   }, [onClose, onOpenArea, onSearchRequest, onShowHelp, router]);

--- a/e2e/kree8-keyboard.spec.ts
+++ b/e2e/kree8-keyboard.spec.ts
@@ -110,3 +110,53 @@ test('K4: tastiera cross-packet attraversa worklist, comandi e ricerca senza dup
 
   expect(consoleErrors).toEqual([]);
 });
+
+test('L9: i comandi raggiungono Analisi e Scale una sola volta senza scorciatoie di authority', async ({ page }) => {
+  const consoleErrors: string[] = [];
+  page.on('console', (message) => {
+    if (message.type() === 'error') consoleErrors.push(message.text());
+  });
+
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await bootstrapUnlockedSession(page, process.env.E2E_PIN || '1234');
+  await page.goto('/?area=incarico');
+
+  const commandTrigger = page.getByRole('button', { name: 'Apri comandi e aiuto tastiera', exact: true });
+  await commandTrigger.focus();
+  await page.keyboard.press('ControlOrMeta+KeyK');
+
+  const commandDialog = page.getByRole('dialog', { name: 'Comandi MediFlow', exact: true });
+  const commandSearch = page.getByRole('combobox', { name: 'Cerca un comando', exact: true });
+  await expect(commandDialog).toHaveCount(1);
+  await expect(commandSearch).toBeFocused();
+
+  await commandSearch.fill('Analisi');
+  const analyticsCommand = commandDialog.getByRole('option', { name: /Apri Analisi/ });
+  await expect(commandDialog.getByRole('option')).toHaveCount(1);
+  await expect(analyticsCommand).toHaveCount(1);
+  await expect(analyticsCommand).not.toHaveAttribute('aria-disabled', 'true');
+  await commandSearch.press('Enter');
+  await expect(page).toHaveURL(/\/analytics$/);
+  await expect(page.getByRole('heading', { name: 'Cruscotto locale', level: 1 })).toBeVisible();
+
+  await page.goto('/?area=incarico');
+  await commandTrigger.focus();
+  await page.keyboard.press('ControlOrMeta+KeyK');
+  await expect(commandSearch).toBeFocused();
+  await commandSearch.fill('Scale');
+  const scalesCommand = commandDialog.getByRole('option', { name: /Apri Scale cliniche/ });
+  await expect(commandDialog.getByRole('option')).toHaveCount(1);
+  await expect(scalesCommand).toHaveCount(1);
+  await expect(scalesCommand).not.toHaveAttribute('aria-disabled', 'true');
+  await commandSearch.press('Escape');
+  await expect(commandDialog).toHaveCount(0);
+  await expect(commandTrigger).toBeFocused();
+
+  await page.keyboard.press('ControlOrMeta+KeyK');
+  await commandSearch.fill('Scale');
+  await commandSearch.press('Enter');
+  await expect(page).toHaveURL(/\/scales$/);
+  await expect(page.getByRole('heading', { name: 'Scale cliniche', level: 1 })).toBeVisible();
+
+  expect(consoleErrors).toEqual([]);
+});


### PR DESCRIPTION
## Summary
- add unique command-center entries for the existing Analytics and Clinical Scales routes
- preserve the current keyboard, focus restoration, and route-close semantics
- keep route implementation, authentication, authority, schema, and provider behavior unchanged

## Verification
- keyboard E2E: 2/2 on fresh exact-head archive
- desktop 1440×900 and mobile 390×844 rendered QA, console clean and no overflow
- adversarial query-collision, Enter navigation and Escape/focus restoration checks
- typecheck, full lint, webpack build with standalone bundle, claims, AI-write, never-regress, runtime and drift checks
- fresh independent review accepted exact head `459aa1a4eff358e50e4a9f1299cf2ad2f8f93a58`

## Risk / Notes
- synthetic fixtures only; no PHI/PII or real patient data
- route reachability candidate only; no authority expansion, integration, release readiness, or release claim
- preparation and publication of this draft PR do not authorize merge or promotion

## Ticket
Refs WUL-560