### PR TITLE
fix(ocr): sigilla la currentness della sorgente locale

### DIFF
--- a/lib/ai-providers/fabric/local-ocr-host-source.test.ts
+++ b/lib/ai-providers/fabric/local-ocr-host-source.test.ts
@@ -2,118 +2,105 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { createLocalOcrHostSource } from './local-ocr-host-source.ts';
+import {
+    advanceLocalOcrHostSourceOwner,
+    createLocalOcrHostSource,
+    createLocalOcrHostSourceOwner,
+    disposeLocalOcrHostSourceOwner,
+} from './local-ocr-host-source.ts';
 
 const BYTES = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0, 0, 0, 1, 8, 6, 0, 0, 0, 0, 0, 0, 0]);
 const state = (overrides: Record<string, unknown> = {}) => ({ sessionActive: true, current: true, revoked: false, selectionEpoch: 7, stateEpoch: 1, expiresAt: 2_000, observedAt: 1_000, ...overrides });
+const next = (overrides: Record<string, unknown> = {}) => state({ stateEpoch: 2, observedAt: 1_001, ...overrides });
 const input = (overrides: Record<string, unknown> = {}) => ({ mode: 'ephemeral_image', content: { mimeType: 'image/png', bytes: BYTES }, ...overrides });
-const host = (snapshot: () => unknown = () => state()) => ({ snapshot });
 const code = (value: unknown) => (value as { code?: unknown }).code;
 
-test('admits one copied ephemeral image and denies replay without publishing identity', () => {
-    const boundary = createLocalOcrHostSource(host());
+test('mints an opaque owner, admits an immutable image copy once, and denies replay', () => {
+    const owner = createLocalOcrHostSourceOwner(state());
+    const boundary = createLocalOcrHostSource(owner);
     const admitted = boundary.admit(input());
     assert.equal(admitted.status, 'admitted');
     assert.equal(admitted.status === 'admitted' && admitted.source.kind, 'ephemeral_pre_persist_image');
-    assert.notEqual(admitted.status === 'admitted' && admitted.source.bytes, BYTES);
+    assert.equal(admitted.status === 'admitted' && admitted.source.encoding, 'base64');
+    assert.equal(admitted.status === 'admitted' && 'bytes' in admitted.source, false);
     const original = BYTES[0]; BYTES[0] = 0;
-    assert.equal(admitted.status === 'admitted' && admitted.source.bytes[0], original); BYTES[0] = original;
+    assert.equal(admitted.status === 'admitted' && admitted.source.contentBase64, Buffer.from(new Uint8Array([original, ...BYTES.slice(1)])).toString('base64'));
+    BYTES[0] = original;
     assert.equal(code(boundary.admit(input())), 'replayed');
-    assert.deepEqual(Object.keys(boundary), ['admit']);
+    assert.deepEqual(Object.keys(boundary), ['admit', 'dispose']);
 });
 
-test('denies persisted material and every caller identity or control field', () => {
-    assert.equal(code(createLocalOcrHostSource(host()).admit({ mode: 'persisted_attachment', content: 'ENC:YWJj:ZGVm' })), 'persisted_attachment_denied');
-    for (const field of ['attachmentId', 'sourceRef', 'revision', 'freshness', 'session', 'selectionEpoch', 'provider', 'venue', 'authority', 'apply']) {
-        assert.equal(code(createLocalOcrHostSource(host()).admit({ ...input(), [field]: 'forged' })), 'input_invalid');
-    }
-});
-
-test('rejects hostile caller records and bytes without reflection', () => {
-    let reads = 0; const accessor = {};
-    Object.defineProperty(accessor, 'mode', { enumerable: true, get: () => { reads += 1; return 'ephemeral_image'; } });
-    const revoked = Proxy.revocable(new Uint8Array(BYTES), {}); revoked.revoke();
-    for (const value of [accessor, Object.create(input()), input({ extra: true }), { then: () => undefined },
-        input({ content: { mimeType: 'image/png', bytes: revoked.proxy } }), input({ content: { mimeType: 'image/png', bytes: new Uint8Array() } }),
-        input({ content: { mimeType: 'image/png', bytes: new Uint8Array(5 * 1024 * 1024 + 1) } }), input({ content: 'data:image/png;base64,iVBORw0KGgo=' })]) {
-        assert.equal(code(createLocalOcrHostSource(host()).admit(value)), 'input_invalid');
-    }
-    assert.equal(reads, 0);
-});
-
-test('requires one exact synchronous data-only snapshot capability', () => {
-    let reads = 0; const accessor = {};
-    Object.defineProperty(accessor, 'snapshot', { enumerable: true, get: () => { reads += 1; return () => state(); } });
-    const functionProxy = new Proxy(() => state(), {});
-    const objectProxy = new Proxy(host(), {});
-    for (const value of [accessor, objectProxy, Object.create(host()), { snapshot: () => state(), extra: true }, { readState: () => state(), now: () => 1_000 },
-        host(async () => state()), host(functionProxy)]) {
+test('rejects forged, wrapped, proxied, or legacy caller-supplied host authority before reflection', () => {
+    const owner = createLocalOcrHostSourceOwner(state());
+    let traps = 0;
+    const proxy = new Proxy(owner, { get: () => { traps += 1; throw new Error('trap'); } });
+    for (const value of [{}, Object.create(owner), proxy, { snapshot: () => state() }]) {
         assert.throws(() => createLocalOcrHostSource(value), /host_invalid/);
     }
-    assert.equal(code(createLocalOcrHostSource(host(() => ({ then: () => undefined }))).admit(input())), 'host_invalid');
-    assert.equal(reads, 0);
+    assert.equal(traps, 0);
 });
 
-test('rejects hostile snapshot records without executing accessors or proxy traps', () => {
-    let accessorReads = 0; let proxyTraps = 0;
-    const accessor = state();
-    Object.defineProperty(accessor, 'observedAt', { enumerable: true, get: () => { accessorReads += 1; return 1_000; } });
-    const proxy = new Proxy(state(), { ownKeys: () => { proxyTraps += 1; return []; } });
-    for (const value of [accessor, proxy, Object.create(state())]) {
-        assert.equal(code(createLocalOcrHostSource(host(() => value)).admit(input())), 'host_invalid');
-    }
-    assert.equal(accessorReads, 0); assert.equal(proxyTraps, 0);
-});
-
-test('compares two atomic snapshots and denies drift, ABA, regression, revocation and expiry', () => {
-    for (const pair of [
-        [state(), state({ stateEpoch: 2 })], [state({ stateEpoch: 2 }), state({ stateEpoch: 1 })],
-        [state(), state({ selectionEpoch: 8 })], [state(), state({ observedAt: 999 })],
-        [state(), state({ current: false })], [state(), state({ revoked: true })],
-    ]) {
-        let reads = 0; assert.notEqual(createLocalOcrHostSource(host(() => pair[reads++])).admit(input()).status, 'admitted');
-    }
-    assert.equal(code(createLocalOcrHostSource(host(() => state({ sessionActive: false }))).admit(input())), 'host_inactive');
-    assert.equal(code(createLocalOcrHostSource(host(() => state({ revoked: true }))).admit(input())), 'revoked');
-    assert.equal(code(createLocalOcrHostSource(host(() => state({ observedAt: 2_000 }))).admit(input())), 'expired');
-    for (const invalid of [0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1]) {
-        assert.equal(code(createLocalOcrHostSource(host(() => state({ stateEpoch: invalid }))).admit(input())), 'host_invalid');
+test('accepts only exact data state and monotonically advances the internal owner state', () => {
+    const owner = createLocalOcrHostSourceOwner(state());
+    assert.equal(advanceLocalOcrHostSourceOwner(owner, next()), true);
+    assert.equal(advanceLocalOcrHostSourceOwner(owner, next({ stateEpoch: 2 })), false);
+    assert.equal(advanceLocalOcrHostSourceOwner(owner, next({ stateEpoch: 1 })), false);
+    assert.equal(advanceLocalOcrHostSourceOwner(owner, next({ selectionEpoch: 6 })), false);
+    assert.equal(advanceLocalOcrHostSourceOwner(owner, next({ observedAt: 999 })), false);
+    for (const invalid of [Object.create(state()), { ...next(), extra: true }, new Proxy(next(), {})]) {
+        assert.equal(advanceLocalOcrHostSourceOwner(owner, invalid), false);
     }
 });
 
-test('locks exact snapshot function identity and releases it after every denial', () => {
-    const snapshot = () => state(); const first = createLocalOcrHostSource(host(snapshot));
-    assert.throws(() => createLocalOcrHostSource(host(snapshot)), /host_in_use/);
-    assert.equal(code(first.admit(input({ extra: true }))), 'input_invalid');
-    assert.equal(createLocalOcrHostSource(host(snapshot)).admit(input()).status, 'admitted');
+test('latches revocation, expiry, inactivity and currentness loss from the module-owned state', () => {
+    for (const update of [next({ revoked: true }), next({ current: false }), next({ sessionActive: false }), next({ observedAt: 2_000 })]) {
+        const owner = createLocalOcrHostSourceOwner(state()); const boundary = createLocalOcrHostSource(owner);
+        assert.equal(advanceLocalOcrHostSourceOwner(owner, update), true);
+        assert.notEqual(boundary.admit(input()).status, 'admitted');
+    }
 });
 
-test('releases after exceptions and denies reentry without residue', () => {
-    let throws = true; const unstable = () => { if (throws) throw new Error('synthetic'); return state(); };
-    assert.equal(code(createLocalOcrHostSource(host(unstable)).admit(input())), 'host_invalid');
-    throws = false; assert.equal(createLocalOcrHostSource(host(unstable)).admit(input()).status, 'admitted');
-    let reenter = true; const holder: { boundary?: ReturnType<typeof createLocalOcrHostSource> } = {};
-    const snapshot = () => { if (reenter) { reenter = false; holder.boundary?.admit(input()); } return state(); };
-    const boundary = createLocalOcrHostSource(host(snapshot)); holder.boundary = boundary;
-    assert.equal(code(boundary.admit(input())), 'reentered');
+test('denies caller fields, hostile records, non-image data and persisted material', () => {
+    for (const value of [
+        { mode: 'persisted_attachment', content: 'ENC:YWJj:ZGVm' },
+        ...['attachmentId', 'sourceRef', 'revision', 'freshness', 'session', 'selectionEpoch', 'provider', 'venue', 'authority', 'apply'].map((field) => ({ ...input(), [field]: 'forged' })),
+        Object.create(input()), input({ extra: true }), { then: () => undefined },
+        input({ content: { mimeType: 'image/png', bytes: new Uint8Array() } }),
+        input({ content: { mimeType: 'image/png', bytes: new Uint8Array(5 * 1024 * 1024 + 1) } }),
+        input({ content: 'data:image/png;base64,iVBORw0KGgo=' }),
+    ]) assert.notEqual(createLocalOcrHostSource(createLocalOcrHostSourceOwner(state())).admit(value).status, 'admitted');
+});
+
+test('prevents a transition during the synchronous critical section and latches the boundary', () => {
+    const owner = createLocalOcrHostSourceOwner(state()); const boundary = createLocalOcrHostSource(owner);
+    const original = Object.getOwnPropertyDescriptor(Uint8Array.prototype, 'byteLength');
+    Object.defineProperty(Uint8Array.prototype, 'byteLength', { configurable: true, get: () => { advanceLocalOcrHostSourceOwner(owner, next()); return 33; } });
+    try { assert.equal(code(boundary.admit(input())), 'reentered'); } finally {
+        if (original) Object.defineProperty(Uint8Array.prototype, 'byteLength', original); else delete (Uint8Array.prototype as unknown as Record<string, unknown>).byteLength;
+    }
     assert.equal(code(boundary.admit(input())), 'replayed');
-    assert.equal(createLocalOcrHostSource(host(snapshot)).admit(input()).status, 'admitted');
+    assert.equal(createLocalOcrHostSource(owner).admit(input()).status, 'admitted');
 });
 
-test('atomic observedAt makes final-clock mutation a normal stale snapshot denial', () => {
-    let epoch = 1; let reads = 0;
-    const snapshot = () => { reads += 1; const result = state({ stateEpoch: epoch, observedAt: 1_000 + reads }); if (reads === 1) epoch += 1; return result; };
-    assert.equal(code(createLocalOcrHostSource(host(snapshot)).admit(input())), 'currentness_lost');
-    assert.equal(reads, 2);
+test('disposal releases the owner slot and terminally denies the disposed boundary or owner', () => {
+    const owner = createLocalOcrHostSourceOwner(state()); const first = createLocalOcrHostSource(owner);
+    assert.throws(() => createLocalOcrHostSource(owner), /host_in_use/);
+    first.dispose(); assert.equal(code(first.admit(input())), 'disposed');
+    assert.equal(createLocalOcrHostSource(owner).admit(input()).status, 'admitted');
+    const terminal = createLocalOcrHostSourceOwner(state()); const boundary = createLocalOcrHostSource(terminal);
+    disposeLocalOcrHostSourceOwner(terminal);
+    assert.equal(code(boundary.admit(input())), 'disposed');
+    assert.equal(advanceLocalOcrHostSourceOwner(terminal, next()), false);
+    assert.throws(() => createLocalOcrHostSource(terminal), /host_invalid/);
 });
 
 test('keeps screening limited to minimal PNG, JPEG and WebP signatures', () => {
     const jpeg = new Uint8Array([255, 216, 80, 75, 3, 4, 255, 217]);
     const webp = new Uint8Array([82, 73, 70, 70, 4, 0, 0, 0, 87, 69, 66, 80]);
-    assert.equal(createLocalOcrHostSource(host()).admit({ mode: 'ephemeral_image', content: { mimeType: 'image/jpeg', bytes: jpeg } }).status, 'admitted');
-    assert.equal(createLocalOcrHostSource(host()).admit({ mode: 'ephemeral_image', content: { mimeType: 'image/webp', bytes: webp } }).status, 'admitted');
-    for (const content of [{ mimeType: 'image/png', bytes: BYTES.slice(0, 8) }, { mimeType: 'image/jpeg', bytes: jpeg.slice(0, 2) },
-        { mimeType: 'image/webp', bytes: webp.slice(0, 8) }, { mimeType: 'image/jpeg', bytes: BYTES }]) {
-        assert.equal(code(createLocalOcrHostSource(host()).admit({ mode: 'ephemeral_image', content })), 'input_invalid');
+    for (const content of [{ mimeType: 'image/jpeg', bytes: jpeg }, { mimeType: 'image/webp', bytes: webp }]) {
+        assert.equal(createLocalOcrHostSource(createLocalOcrHostSourceOwner(state())).admit({ mode: 'ephemeral_image', content }).status, 'admitted');
+    }
+    for (const content of [{ mimeType: 'image/png', bytes: BYTES.slice(0, 8) }, { mimeType: 'image/jpeg', bytes: jpeg.slice(0, 2) }, { mimeType: 'image/webp', bytes: webp.slice(0, 8) }]) {
+        assert.equal(code(createLocalOcrHostSource(createLocalOcrHostSourceOwner(state())).admit({ mode: 'ephemeral_image', content })), 'input_invalid');
     }
 });

--- a/lib/ai-providers/fabric/local-ocr-host-source.test.ts
+++ b/lib/ai-providers/fabric/local-ocr-host-source.test.ts
@@ -4,20 +4,25 @@ import test from 'node:test';
 
 import { createLocalOcrHostSource } from './local-ocr-host-source.ts';
 
-const BYTES = new Uint8Array([137, 80, 78, 71]);
-const state = (overrides: Record<string, unknown> = {}) => ({ sessionActive: true, current: true, revoked: false, selectionEpoch: 7, expiresAt: 2_000, ...overrides });
+const BYTES = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0, 0, 0, 1, 8, 6, 0, 0, 0, 0, 0, 0, 0]);
+const state = (overrides: Record<string, unknown> = {}) => ({ sessionActive: true, current: true, revoked: false, selectionEpoch: 7, stateEpoch: 1, expiresAt: 2_000, ...overrides });
 const input = (overrides: Record<string, unknown> = {}) => ({ mode: 'ephemeral_image', content: { mimeType: 'image/png', bytes: BYTES }, ...overrides });
-const host = (readState: () => unknown = () => state()) => ({ readState, now: () => 1_000 });
+const host = (readState: () => unknown = () => state(), now: () => unknown = () => 1_000) => ({ readState, now });
 const code = (value: unknown) => (value as { code?: unknown }).code;
 
 test('admits one copied, ephemeral plaintext image only while host state stays current', () => {
-    const boundary = createLocalOcrHostSource(host());
+    const shared = state();
+    const boundary = createLocalOcrHostSource(host(() => shared));
     const admitted = boundary.admit(input());
     assert.equal(admitted.status, 'admitted');
     assert.equal(admitted.status === 'admitted' && admitted.source.kind, 'ephemeral_pre_persist_image');
     assert.equal(admitted.status === 'admitted' && admitted.source.mimeType, 'image/png');
     assert.notEqual(admitted.status === 'admitted' && admitted.source.bytes, BYTES);
     assert.equal(admitted.status === 'admitted' && 'locator' in admitted.source, false);
+    assert.equal(Object.isFrozen(shared), false);
+    const originalByte = BYTES[0]; BYTES[0] = 0;
+    assert.equal(admitted.status === 'admitted' && admitted.source.bytes[0], originalByte);
+    BYTES[0] = originalByte;
     assert.equal(code(boundary.admit(input())), 'replayed');
     assert.deepEqual(Object.keys(boundary), ['admit']);
 });
@@ -33,17 +38,18 @@ test('denies persisted encrypted material and all caller identity or control fie
 test('rejects hostile, empty, oversized, data-url, and unsupported caller content without accessors', () => {
     let reads = 0; const accessor = {};
     Object.defineProperty(accessor, 'mode', { enumerable: true, get: () => { reads += 1; return 'ephemeral_image'; } });
+    const revokedBytes = Proxy.revocable(new Uint8Array(BYTES), {}); revokedBytes.revoke();
     const hostile = [accessor, Object.create(input()), { mode: 'ephemeral_image' }, input({ extra: true }),
         input({ content: { mimeType: 'image/gif', bytes: BYTES } }), input({ content: { mimeType: 'image/png', bytes: new Uint8Array() } }),
         input({ content: { mimeType: 'image/png', bytes: new Uint8Array(5 * 1024 * 1024 + 1) } }),
-        input({ content: 'data:image/png;base64,iVBORw0KGgo=' }), { then: () => undefined }];
+        input({ content: 'data:image/png;base64,iVBORw0KGgo=' }), input({ content: { mimeType: 'image/png', bytes: revokedBytes.proxy } }), { then: () => undefined }];
     for (const value of hostile) assert.equal(code(createLocalOcrHostSource(host()).admit(value)), 'input_invalid');
     assert.equal(reads, 0);
 });
 
 test('fails closed for currentness drift, revocation, expiry, thenables, and reentry', () => {
     let reads = 0;
-    assert.equal(code(createLocalOcrHostSource(host(() => state({ selectionEpoch: ++reads }))).admit(input())), 'currentness_lost');
+    assert.equal(code(createLocalOcrHostSource(host(() => state({ selectionEpoch: ++reads, stateEpoch: reads }))).admit(input())), 'currentness_lost');
     assert.equal(code(createLocalOcrHostSource(host(() => state({ revoked: true }))).admit(input())), 'revoked');
     assert.equal(code(createLocalOcrHostSource(host(() => state({ expiresAt: 999 }))).admit(input())), 'expired');
     assert.equal(code(createLocalOcrHostSource(host(() => ({ then: () => undefined }))).admit(input())), 'host_invalid');
@@ -52,10 +58,60 @@ test('fails closed for currentness drift, revocation, expiry, thenables, and ree
     assert.equal(code(reentry.boundary.admit(input())), 'reentered');
 });
 
+test('rejects epoch change, regression, and ABA even when visible state returns to the same values', () => {
+    for (const epochs of [[1, 2], [2, 1], [1, 3]]) {
+        let reads = 0;
+        const boundary = createLocalOcrHostSource(host(() => state({ stateEpoch: epochs[reads++] })));
+        assert.equal(code(boundary.admit(input())), 'currentness_lost');
+    }
+    for (const invalid of [0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1]) {
+        assert.equal(code(createLocalOcrHostSource(host(() => state({ stateEpoch: invalid }))).admit(input())), 'host_invalid');
+    }
+});
+
+test('compares every host currentness field, not only the epoch', () => {
+    for (const [field, value, expected] of [
+        ['sessionActive', false, 'host_inactive'], ['current', false, 'currentness_lost'], ['revoked', true, 'revoked'],
+        ['selectionEpoch', 8, 'currentness_lost'], ['expiresAt', 3_000, 'currentness_lost'],
+    ] as const) {
+        let reads = 0;
+        const boundary = createLocalOcrHostSource(host(() => state(reads++ === 0 ? {} : { [field]: value })));
+        assert.equal(code(boundary.admit(input())), expected);
+    }
+});
+
+test('locks one exact host identity at a time and rechecks the clock at final consumption', () => {
+    const lease = host();
+    const first = createLocalOcrHostSource(lease);
+    assert.throws(() => createLocalOcrHostSource(lease), /host_in_use/);
+    assert.equal(first.admit(input()).status, 'admitted');
+    assert.equal(createLocalOcrHostSource(lease).admit(input()).status, 'admitted');
+
+    let nowReads = 0;
+    const expiring = createLocalOcrHostSource(host(() => state(), () => (++nowReads === 1 ? 1_000 : 3_000)));
+    assert.equal(code(expiring.admit(input())), 'expired');
+    assert.equal(code(createLocalOcrHostSource(host(() => state(), () => Number.NaN)).admit(input())), 'host_invalid');
+});
+
+test('requires coherent PNG, JPEG, and WebP magic bytes and rejects truncation or MIME mismatch', () => {
+    const jpeg = new Uint8Array([255, 216, 255, 224, 0, 16, 255, 217]);
+    const webp = new Uint8Array([82, 73, 70, 70, 4, 0, 0, 0, 87, 69, 66, 80]);
+    assert.equal(createLocalOcrHostSource(host()).admit({ mode: 'ephemeral_image', content: { mimeType: 'image/jpeg', bytes: jpeg } }).status, 'admitted');
+    assert.equal(createLocalOcrHostSource(host()).admit({ mode: 'ephemeral_image', content: { mimeType: 'image/webp', bytes: webp } }).status, 'admitted');
+    for (const content of [
+        { mimeType: 'image/png', bytes: new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]) },
+        { mimeType: 'image/jpeg', bytes: jpeg.slice(0, 2) },
+        { mimeType: 'image/webp', bytes: webp.slice(0, 8) },
+        { mimeType: 'image/jpeg', bytes: BYTES },
+    ]) assert.equal(code(createLocalOcrHostSource(host()).admit({ mode: 'ephemeral_image', content })), 'input_invalid');
+});
+
 test('rejects hostile host configuration and does not retain a restart locator or fixed entropy', () => {
     const accessor = {};
     Object.defineProperty(accessor, 'readState', { enumerable: true, get: () => () => state() });
-    for (const value of [accessor, Object.create(host()), { readState: () => state() }, host(async () => state()), new Proxy(host(), {})]) {
+    const revoked = Proxy.revocable(host(), {}); revoked.revoke();
+    const throwing = new Proxy(host(), { ownKeys: () => { throw new Error('trap'); } });
+    for (const value of [accessor, Object.create(host()), { readState: () => state() }, host(async () => state()), new Proxy(host(), {}), revoked.proxy, throwing]) {
         assert.throws(() => createLocalOcrHostSource(value), /host_invalid/);
     }
     const first = createLocalOcrHostSource(host()); first.admit(input());

--- a/lib/ai-providers/fabric/local-ocr-host-source.test.ts
+++ b/lib/ai-providers/fabric/local-ocr-host-source.test.ts
@@ -1,0 +1,64 @@
+/* @Codex */
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createLocalOcrHostSource } from './local-ocr-host-source.ts';
+
+const BYTES = new Uint8Array([137, 80, 78, 71]);
+const state = (overrides: Record<string, unknown> = {}) => ({ sessionActive: true, current: true, revoked: false, selectionEpoch: 7, expiresAt: 2_000, ...overrides });
+const input = (overrides: Record<string, unknown> = {}) => ({ mode: 'ephemeral_image', content: { mimeType: 'image/png', bytes: BYTES }, ...overrides });
+const host = (readState: () => unknown = () => state()) => ({ readState, now: () => 1_000 });
+const code = (value: unknown) => (value as { code?: unknown }).code;
+
+test('admits one copied, ephemeral plaintext image only while host state stays current', () => {
+    const boundary = createLocalOcrHostSource(host());
+    const admitted = boundary.admit(input());
+    assert.equal(admitted.status, 'admitted');
+    assert.equal(admitted.status === 'admitted' && admitted.source.kind, 'ephemeral_pre_persist_image');
+    assert.equal(admitted.status === 'admitted' && admitted.source.mimeType, 'image/png');
+    assert.notEqual(admitted.status === 'admitted' && admitted.source.bytes, BYTES);
+    assert.equal(admitted.status === 'admitted' && 'locator' in admitted.source, false);
+    assert.equal(code(boundary.admit(input())), 'replayed');
+    assert.deepEqual(Object.keys(boundary), ['admit']);
+});
+
+test('denies persisted encrypted material and all caller identity or control fields', () => {
+    const boundary = createLocalOcrHostSource(host());
+    assert.equal(code(boundary.admit({ mode: 'persisted_attachment', content: 'ENC:YWJj:ZGVm' })), 'persisted_attachment_denied');
+    for (const field of ['attachmentId', 'sourceRef', 'revision', 'freshness', 'session', 'selectionEpoch', 'provider', 'venue', 'authority', 'apply']) {
+        assert.equal(code(createLocalOcrHostSource(host()).admit({ ...input(), [field]: 'forged' })), 'input_invalid');
+    }
+});
+
+test('rejects hostile, empty, oversized, data-url, and unsupported caller content without accessors', () => {
+    let reads = 0; const accessor = {};
+    Object.defineProperty(accessor, 'mode', { enumerable: true, get: () => { reads += 1; return 'ephemeral_image'; } });
+    const hostile = [accessor, Object.create(input()), { mode: 'ephemeral_image' }, input({ extra: true }),
+        input({ content: { mimeType: 'image/gif', bytes: BYTES } }), input({ content: { mimeType: 'image/png', bytes: new Uint8Array() } }),
+        input({ content: { mimeType: 'image/png', bytes: new Uint8Array(5 * 1024 * 1024 + 1) } }),
+        input({ content: 'data:image/png;base64,iVBORw0KGgo=' }), { then: () => undefined }];
+    for (const value of hostile) assert.equal(code(createLocalOcrHostSource(host()).admit(value)), 'input_invalid');
+    assert.equal(reads, 0);
+});
+
+test('fails closed for currentness drift, revocation, expiry, thenables, and reentry', () => {
+    let reads = 0;
+    assert.equal(code(createLocalOcrHostSource(host(() => state({ selectionEpoch: ++reads }))).admit(input())), 'currentness_lost');
+    assert.equal(code(createLocalOcrHostSource(host(() => state({ revoked: true }))).admit(input())), 'revoked');
+    assert.equal(code(createLocalOcrHostSource(host(() => state({ expiresAt: 999 }))).admit(input())), 'expired');
+    assert.equal(code(createLocalOcrHostSource(host(() => ({ then: () => undefined }))).admit(input())), 'host_invalid');
+    const reentry: { boundary?: ReturnType<typeof createLocalOcrHostSource> } = {};
+    reentry.boundary = createLocalOcrHostSource(host(() => { reentry.boundary?.admit(input()); return state(); }));
+    assert.equal(code(reentry.boundary.admit(input())), 'reentered');
+});
+
+test('rejects hostile host configuration and does not retain a restart locator or fixed entropy', () => {
+    const accessor = {};
+    Object.defineProperty(accessor, 'readState', { enumerable: true, get: () => () => state() });
+    for (const value of [accessor, Object.create(host()), { readState: () => state() }, host(async () => state()), new Proxy(host(), {})]) {
+        assert.throws(() => createLocalOcrHostSource(value), /host_invalid/);
+    }
+    const first = createLocalOcrHostSource(host()); first.admit(input());
+    const restarted = createLocalOcrHostSource(host());
+    assert.equal(code(restarted.admit({ mode: 'persisted_attachment', content: 'ENC:YWJj:ZGVm' })), 'persisted_attachment_denied');
+});

--- a/lib/ai-providers/fabric/local-ocr-host-source.test.ts
+++ b/lib/ai-providers/fabric/local-ocr-host-source.test.ts
@@ -5,116 +5,115 @@ import test from 'node:test';
 import { createLocalOcrHostSource } from './local-ocr-host-source.ts';
 
 const BYTES = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0, 0, 0, 1, 8, 6, 0, 0, 0, 0, 0, 0, 0]);
-const state = (overrides: Record<string, unknown> = {}) => ({ sessionActive: true, current: true, revoked: false, selectionEpoch: 7, stateEpoch: 1, expiresAt: 2_000, ...overrides });
+const state = (overrides: Record<string, unknown> = {}) => ({ sessionActive: true, current: true, revoked: false, selectionEpoch: 7, stateEpoch: 1, expiresAt: 2_000, observedAt: 1_000, ...overrides });
 const input = (overrides: Record<string, unknown> = {}) => ({ mode: 'ephemeral_image', content: { mimeType: 'image/png', bytes: BYTES }, ...overrides });
-const host = (readState: () => unknown = () => state(), now: () => unknown = () => 1_000) => ({ readState, now });
+const host = (snapshot: () => unknown = () => state()) => ({ snapshot });
 const code = (value: unknown) => (value as { code?: unknown }).code;
 
-test('admits one copied, ephemeral plaintext image only while host state stays current', () => {
-    const shared = state();
-    const boundary = createLocalOcrHostSource(host(() => shared));
+test('admits one copied ephemeral image and denies replay without publishing identity', () => {
+    const boundary = createLocalOcrHostSource(host());
     const admitted = boundary.admit(input());
     assert.equal(admitted.status, 'admitted');
     assert.equal(admitted.status === 'admitted' && admitted.source.kind, 'ephemeral_pre_persist_image');
-    assert.equal(admitted.status === 'admitted' && admitted.source.mimeType, 'image/png');
     assert.notEqual(admitted.status === 'admitted' && admitted.source.bytes, BYTES);
-    assert.equal(admitted.status === 'admitted' && 'locator' in admitted.source, false);
-    assert.equal(Object.isFrozen(shared), false);
-    const originalByte = BYTES[0]; BYTES[0] = 0;
-    assert.equal(admitted.status === 'admitted' && admitted.source.bytes[0], originalByte);
-    BYTES[0] = originalByte;
+    const original = BYTES[0]; BYTES[0] = 0;
+    assert.equal(admitted.status === 'admitted' && admitted.source.bytes[0], original); BYTES[0] = original;
     assert.equal(code(boundary.admit(input())), 'replayed');
     assert.deepEqual(Object.keys(boundary), ['admit']);
 });
 
-test('denies persisted encrypted material and all caller identity or control fields', () => {
-    const boundary = createLocalOcrHostSource(host());
-    assert.equal(code(boundary.admit({ mode: 'persisted_attachment', content: 'ENC:YWJj:ZGVm' })), 'persisted_attachment_denied');
+test('denies persisted material and every caller identity or control field', () => {
+    assert.equal(code(createLocalOcrHostSource(host()).admit({ mode: 'persisted_attachment', content: 'ENC:YWJj:ZGVm' })), 'persisted_attachment_denied');
     for (const field of ['attachmentId', 'sourceRef', 'revision', 'freshness', 'session', 'selectionEpoch', 'provider', 'venue', 'authority', 'apply']) {
         assert.equal(code(createLocalOcrHostSource(host()).admit({ ...input(), [field]: 'forged' })), 'input_invalid');
     }
 });
 
-test('rejects hostile, empty, oversized, data-url, and unsupported caller content without accessors', () => {
+test('rejects hostile caller records and bytes without reflection', () => {
     let reads = 0; const accessor = {};
     Object.defineProperty(accessor, 'mode', { enumerable: true, get: () => { reads += 1; return 'ephemeral_image'; } });
-    const revokedBytes = Proxy.revocable(new Uint8Array(BYTES), {}); revokedBytes.revoke();
-    const hostile = [accessor, Object.create(input()), { mode: 'ephemeral_image' }, input({ extra: true }),
-        input({ content: { mimeType: 'image/gif', bytes: BYTES } }), input({ content: { mimeType: 'image/png', bytes: new Uint8Array() } }),
-        input({ content: { mimeType: 'image/png', bytes: new Uint8Array(5 * 1024 * 1024 + 1) } }),
-        input({ content: 'data:image/png;base64,iVBORw0KGgo=' }), input({ content: { mimeType: 'image/png', bytes: revokedBytes.proxy } }), { then: () => undefined }];
-    for (const value of hostile) assert.equal(code(createLocalOcrHostSource(host()).admit(value)), 'input_invalid');
+    const revoked = Proxy.revocable(new Uint8Array(BYTES), {}); revoked.revoke();
+    for (const value of [accessor, Object.create(input()), input({ extra: true }), { then: () => undefined },
+        input({ content: { mimeType: 'image/png', bytes: revoked.proxy } }), input({ content: { mimeType: 'image/png', bytes: new Uint8Array() } }),
+        input({ content: { mimeType: 'image/png', bytes: new Uint8Array(5 * 1024 * 1024 + 1) } }), input({ content: 'data:image/png;base64,iVBORw0KGgo=' })]) {
+        assert.equal(code(createLocalOcrHostSource(host()).admit(value)), 'input_invalid');
+    }
     assert.equal(reads, 0);
 });
 
-test('fails closed for currentness drift, revocation, expiry, thenables, and reentry', () => {
-    let reads = 0;
-    assert.equal(code(createLocalOcrHostSource(host(() => state({ selectionEpoch: ++reads, stateEpoch: reads }))).admit(input())), 'currentness_lost');
-    assert.equal(code(createLocalOcrHostSource(host(() => state({ revoked: true }))).admit(input())), 'revoked');
-    assert.equal(code(createLocalOcrHostSource(host(() => state({ expiresAt: 999 }))).admit(input())), 'expired');
+test('requires one exact synchronous data-only snapshot capability', () => {
+    let reads = 0; const accessor = {};
+    Object.defineProperty(accessor, 'snapshot', { enumerable: true, get: () => { reads += 1; return () => state(); } });
+    const functionProxy = new Proxy(() => state(), {});
+    const objectProxy = new Proxy(host(), {});
+    for (const value of [accessor, objectProxy, Object.create(host()), { snapshot: () => state(), extra: true }, { readState: () => state(), now: () => 1_000 },
+        host(async () => state()), host(functionProxy)]) {
+        assert.throws(() => createLocalOcrHostSource(value), /host_invalid/);
+    }
     assert.equal(code(createLocalOcrHostSource(host(() => ({ then: () => undefined }))).admit(input())), 'host_invalid');
-    const reentry: { boundary?: ReturnType<typeof createLocalOcrHostSource> } = {};
-    reentry.boundary = createLocalOcrHostSource(host(() => { reentry.boundary?.admit(input()); return state(); }));
-    assert.equal(code(reentry.boundary.admit(input())), 'reentered');
+    assert.equal(reads, 0);
 });
 
-test('rejects epoch change, regression, and ABA even when visible state returns to the same values', () => {
-    for (const epochs of [[1, 2], [2, 1], [1, 3]]) {
-        let reads = 0;
-        const boundary = createLocalOcrHostSource(host(() => state({ stateEpoch: epochs[reads++] })));
-        assert.equal(code(boundary.admit(input())), 'currentness_lost');
+test('rejects hostile snapshot records without executing accessors or proxy traps', () => {
+    let accessorReads = 0; let proxyTraps = 0;
+    const accessor = state();
+    Object.defineProperty(accessor, 'observedAt', { enumerable: true, get: () => { accessorReads += 1; return 1_000; } });
+    const proxy = new Proxy(state(), { ownKeys: () => { proxyTraps += 1; return []; } });
+    for (const value of [accessor, proxy, Object.create(state())]) {
+        assert.equal(code(createLocalOcrHostSource(host(() => value)).admit(input())), 'host_invalid');
     }
+    assert.equal(accessorReads, 0); assert.equal(proxyTraps, 0);
+});
+
+test('compares two atomic snapshots and denies drift, ABA, regression, revocation and expiry', () => {
+    for (const pair of [
+        [state(), state({ stateEpoch: 2 })], [state({ stateEpoch: 2 }), state({ stateEpoch: 1 })],
+        [state(), state({ selectionEpoch: 8 })], [state(), state({ observedAt: 999 })],
+        [state(), state({ current: false })], [state(), state({ revoked: true })],
+    ]) {
+        let reads = 0; assert.notEqual(createLocalOcrHostSource(host(() => pair[reads++])).admit(input()).status, 'admitted');
+    }
+    assert.equal(code(createLocalOcrHostSource(host(() => state({ sessionActive: false }))).admit(input())), 'host_inactive');
+    assert.equal(code(createLocalOcrHostSource(host(() => state({ revoked: true }))).admit(input())), 'revoked');
+    assert.equal(code(createLocalOcrHostSource(host(() => state({ observedAt: 2_000 }))).admit(input())), 'expired');
     for (const invalid of [0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1]) {
         assert.equal(code(createLocalOcrHostSource(host(() => state({ stateEpoch: invalid }))).admit(input())), 'host_invalid');
     }
 });
 
-test('compares every host currentness field, not only the epoch', () => {
-    for (const [field, value, expected] of [
-        ['sessionActive', false, 'host_inactive'], ['current', false, 'currentness_lost'], ['revoked', true, 'revoked'],
-        ['selectionEpoch', 8, 'currentness_lost'], ['expiresAt', 3_000, 'currentness_lost'],
-    ] as const) {
-        let reads = 0;
-        const boundary = createLocalOcrHostSource(host(() => state(reads++ === 0 ? {} : { [field]: value })));
-        assert.equal(code(boundary.admit(input())), expected);
-    }
+test('locks exact snapshot function identity and releases it after every denial', () => {
+    const snapshot = () => state(); const first = createLocalOcrHostSource(host(snapshot));
+    assert.throws(() => createLocalOcrHostSource(host(snapshot)), /host_in_use/);
+    assert.equal(code(first.admit(input({ extra: true }))), 'input_invalid');
+    assert.equal(createLocalOcrHostSource(host(snapshot)).admit(input()).status, 'admitted');
 });
 
-test('locks one exact host identity at a time and rechecks the clock at final consumption', () => {
-    const lease = host();
-    const first = createLocalOcrHostSource(lease);
-    assert.throws(() => createLocalOcrHostSource(lease), /host_in_use/);
-    assert.equal(first.admit(input()).status, 'admitted');
-    assert.equal(createLocalOcrHostSource(lease).admit(input()).status, 'admitted');
-
-    let nowReads = 0;
-    const expiring = createLocalOcrHostSource(host(() => state(), () => (++nowReads === 1 ? 1_000 : 3_000)));
-    assert.equal(code(expiring.admit(input())), 'expired');
-    assert.equal(code(createLocalOcrHostSource(host(() => state(), () => Number.NaN)).admit(input())), 'host_invalid');
+test('releases after exceptions and denies reentry without residue', () => {
+    let throws = true; const unstable = () => { if (throws) throw new Error('synthetic'); return state(); };
+    assert.equal(code(createLocalOcrHostSource(host(unstable)).admit(input())), 'host_invalid');
+    throws = false; assert.equal(createLocalOcrHostSource(host(unstable)).admit(input()).status, 'admitted');
+    let reenter = true; const holder: { boundary?: ReturnType<typeof createLocalOcrHostSource> } = {};
+    const snapshot = () => { if (reenter) { reenter = false; holder.boundary?.admit(input()); } return state(); };
+    const boundary = createLocalOcrHostSource(host(snapshot)); holder.boundary = boundary;
+    assert.equal(code(boundary.admit(input())), 'reentered');
+    assert.equal(code(boundary.admit(input())), 'replayed');
+    assert.equal(createLocalOcrHostSource(host(snapshot)).admit(input()).status, 'admitted');
 });
 
-test('requires coherent PNG, JPEG, and WebP magic bytes and rejects truncation or MIME mismatch', () => {
-    const jpeg = new Uint8Array([255, 216, 255, 224, 0, 16, 255, 217]);
+test('atomic observedAt makes final-clock mutation a normal stale snapshot denial', () => {
+    let epoch = 1; let reads = 0;
+    const snapshot = () => { reads += 1; const result = state({ stateEpoch: epoch, observedAt: 1_000 + reads }); if (reads === 1) epoch += 1; return result; };
+    assert.equal(code(createLocalOcrHostSource(host(snapshot)).admit(input())), 'currentness_lost');
+    assert.equal(reads, 2);
+});
+
+test('keeps screening limited to minimal PNG, JPEG and WebP signatures', () => {
+    const jpeg = new Uint8Array([255, 216, 80, 75, 3, 4, 255, 217]);
     const webp = new Uint8Array([82, 73, 70, 70, 4, 0, 0, 0, 87, 69, 66, 80]);
     assert.equal(createLocalOcrHostSource(host()).admit({ mode: 'ephemeral_image', content: { mimeType: 'image/jpeg', bytes: jpeg } }).status, 'admitted');
     assert.equal(createLocalOcrHostSource(host()).admit({ mode: 'ephemeral_image', content: { mimeType: 'image/webp', bytes: webp } }).status, 'admitted');
-    for (const content of [
-        { mimeType: 'image/png', bytes: new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]) },
-        { mimeType: 'image/jpeg', bytes: jpeg.slice(0, 2) },
-        { mimeType: 'image/webp', bytes: webp.slice(0, 8) },
-        { mimeType: 'image/jpeg', bytes: BYTES },
-    ]) assert.equal(code(createLocalOcrHostSource(host()).admit({ mode: 'ephemeral_image', content })), 'input_invalid');
-});
-
-test('rejects hostile host configuration and does not retain a restart locator or fixed entropy', () => {
-    const accessor = {};
-    Object.defineProperty(accessor, 'readState', { enumerable: true, get: () => () => state() });
-    const revoked = Proxy.revocable(host(), {}); revoked.revoke();
-    const throwing = new Proxy(host(), { ownKeys: () => { throw new Error('trap'); } });
-    for (const value of [accessor, Object.create(host()), { readState: () => state() }, host(async () => state()), new Proxy(host(), {}), revoked.proxy, throwing]) {
-        assert.throws(() => createLocalOcrHostSource(value), /host_invalid/);
+    for (const content of [{ mimeType: 'image/png', bytes: BYTES.slice(0, 8) }, { mimeType: 'image/jpeg', bytes: jpeg.slice(0, 2) },
+        { mimeType: 'image/webp', bytes: webp.slice(0, 8) }, { mimeType: 'image/jpeg', bytes: BYTES }]) {
+        assert.equal(code(createLocalOcrHostSource(host()).admit({ mode: 'ephemeral_image', content })), 'input_invalid');
     }
-    const first = createLocalOcrHostSource(host()); first.admit(input());
-    const restarted = createLocalOcrHostSource(host());
-    assert.equal(code(restarted.admit({ mode: 'persisted_attachment', content: 'ENC:YWJj:ZGVm' })), 'persisted_attachment_denied');
 });

--- a/lib/ai-providers/fabric/local-ocr-host-source.ts
+++ b/lib/ai-providers/fabric/local-ocr-host-source.ts
@@ -3,142 +3,127 @@ import 'server-only';
 
 import { types } from 'node:util';
 
-/**
- * The host owns a monotonic, latching stateEpoch: every lease/currentness change increments it,
- * and revoked/non-current state must not be cleared. This seam rejects any changed snapshot.
- */
-type HostState = Readonly<{ sessionActive: boolean; current: boolean; revoked: boolean; selectionEpoch: number; stateEpoch: number; expiresAt: number }>;
-type Host = Readonly<{ readState: () => unknown; now: () => unknown }>;
+type HostSnapshot = Readonly<{
+    sessionActive: boolean; current: boolean; revoked: boolean; selectionEpoch: number;
+    stateEpoch: number; expiresAt: number; observedAt: number;
+}>;
 type Image = Readonly<{ mimeType: 'image/jpeg' | 'image/png' | 'image/webp'; bytes: Uint8Array }>;
+type DenialCode = 'input_invalid' | 'persisted_attachment_denied' | 'host_invalid' | 'host_in_use'
+    | 'host_inactive' | 'currentness_lost' | 'revoked' | 'expired' | 'replayed' | 'reentered';
 export type LocalOcrHostSourceOutcome =
     | Readonly<{ status: 'admitted'; source: Readonly<{ kind: 'ephemeral_pre_persist_image'; mimeType: Image['mimeType']; bytes: Uint8Array }> }>
-    | Readonly<{ status: 'denied'; code: 'input_invalid' | 'persisted_attachment_denied' | 'host_invalid' | 'host_in_use' | 'host_inactive' | 'currentness_lost' | 'revoked' | 'expired' | 'replayed' | 'reentered' }>;
+    | Readonly<{ status: 'denied'; code: DenialCode }>;
 
-const HOST_KEYS = ['readState', 'now'] as const;
-const STATE_KEYS = ['sessionActive', 'current', 'revoked', 'selectionEpoch', 'stateEpoch', 'expiresAt'] as const;
+const HOST_KEYS = ['snapshot'] as const;
+const STATE_KEYS = ['sessionActive', 'current', 'revoked', 'selectionEpoch', 'stateEpoch', 'expiresAt', 'observedAt'] as const;
 const IMAGE_KEYS = ['mimeType', 'bytes'] as const;
 const INPUT_KEYS = ['mode', 'content'] as const;
 const MAX_BYTES = 5 * 1024 * 1024;
-// This exact object is the in-process lease identity; restart/new-process behavior is outside this seam.
-const activeBoundaries = new WeakMap<object, object>();
-const activeOperations = new WeakMap<object, { reentered: boolean }>();
+const activeBoundaries = new WeakMap<() => unknown, object>();
+const activeOperations = new WeakMap<() => unknown, { reentered: boolean }>();
 const PNG_SIGNATURE = [137, 80, 78, 71, 13, 10, 26, 10];
-const PNG_MIN_BYTES = 33;
 
 export class LocalOcrHostSourceError extends Error {
-    constructor(readonly code: 'host_invalid' | 'host_in_use') { super(`Local OCR host source rejected: ${code}`); this.name = 'LocalOcrHostSourceError'; }
+    constructor(readonly code: 'host_invalid' | 'host_in_use') {
+        super(`Local OCR host source rejected: ${code}`); this.name = 'LocalOcrHostSourceError';
+    }
 }
 
 function exactRecord(value: unknown, keys: readonly string[]): value is Record<string, unknown> {
-    if (!value || typeof value !== 'object' || types.isProxy(value) || Array.isArray(value) || Object.getPrototypeOf(value) !== Object.prototype) return false;
+    if (!value || typeof value !== 'object' || types.isProxy(value) || Array.isArray(value)
+        || Object.getPrototypeOf(value) !== Object.prototype) return false;
     const descriptors = Object.getOwnPropertyDescriptors(value);
     return Reflect.ownKeys(descriptors).length === keys.length && keys.every((key) => {
-        const descriptor = descriptors[key]; return descriptor !== undefined && 'value' in descriptor && descriptor.enumerable;
+        const descriptor = descriptors[key];
+        return descriptor !== undefined && 'value' in descriptor && descriptor.enumerable;
     });
 }
 
-function snapshotHost(value: unknown): Readonly<{ identity: object; host: Host }> {
+function hostCapability(value: unknown): () => unknown {
     if (!exactRecord(value, HOST_KEYS)) throw new LocalOcrHostSourceError('host_invalid');
-    const readState = value.readState; const now = value.now;
-    if (typeof readState !== 'function' || typeof now !== 'function' || types.isProxy(readState) || types.isProxy(now)
-        || types.isAsyncFunction(readState) || types.isAsyncFunction(now)) throw new LocalOcrHostSourceError('host_invalid');
-    return Object.freeze({ identity: value, host: Object.freeze({ readState: readState as () => unknown, now: now as () => unknown }) });
+    const snapshot = value.snapshot;
+    if (typeof snapshot !== 'function' || types.isProxy(snapshot) || types.isAsyncFunction(snapshot)
+        || Object.getPrototypeOf(snapshot) !== Function.prototype
+        || Object.getOwnPropertyDescriptor(snapshot, 'then') !== undefined) throw new LocalOcrHostSourceError('host_invalid');
+    return snapshot as () => unknown;
 }
 
-function readState(host: Host): HostState | null {
+function readSnapshot(snapshot: () => unknown): HostSnapshot | null {
     let value: unknown;
-    try { value = host.readState(); } catch { return null; }
+    try { value = snapshot(); } catch { return null; }
     if (!exactRecord(value, STATE_KEYS)) return null;
     const state = value as Record<string, unknown>;
-    if (typeof state.sessionActive !== 'boolean' || typeof state.current !== 'boolean' || typeof state.revoked !== 'boolean'
-        || typeof state.selectionEpoch !== 'number' || !Number.isSafeInteger(state.selectionEpoch) || state.selectionEpoch < 1
-        || typeof state.stateEpoch !== 'number' || !Number.isSafeInteger(state.stateEpoch) || state.stateEpoch < 1
-        || typeof state.expiresAt !== 'number' || !Number.isSafeInteger(state.expiresAt) || state.expiresAt < 0) return null;
+    for (const key of ['selectionEpoch', 'stateEpoch', 'expiresAt', 'observedAt'] as const) {
+        if (typeof state[key] !== 'number' || !Number.isSafeInteger(state[key]) || state[key] < (key.endsWith('Epoch') ? 1 : 0)) return null;
+    }
+    if (typeof state.sessionActive !== 'boolean' || typeof state.current !== 'boolean' || typeof state.revoked !== 'boolean') return null;
     return Object.freeze({
-        sessionActive: state.sessionActive,
-        current: state.current,
-        revoked: state.revoked,
-        selectionEpoch: state.selectionEpoch,
-        stateEpoch: state.stateEpoch,
-        expiresAt: state.expiresAt,
+        sessionActive: state.sessionActive, current: state.current, revoked: state.revoked,
+        selectionEpoch: state.selectionEpoch as number, stateEpoch: state.stateEpoch as number,
+        expiresAt: state.expiresAt as number, observedAt: state.observedAt as number,
     });
 }
 
-function parseImage(value: unknown): Image | null {
-    if (!exactRecord(value, IMAGE_KEYS)) return null;
-    const image = value as Record<string, unknown>;
-    if ((image.mimeType !== 'image/jpeg' && image.mimeType !== 'image/png' && image.mimeType !== 'image/webp')
-        || types.isProxy(image.bytes) || !(image.bytes instanceof Uint8Array) || Buffer.isBuffer(image.bytes)
-        || Object.getPrototypeOf(image.bytes) !== Uint8Array.prototype || image.bytes.byteLength < 1 || image.bytes.byteLength > MAX_BYTES
-        || !hasCoherentMagic(image.mimeType, image.bytes)) return null;
-    return Object.freeze({ mimeType: image.mimeType, bytes: new Uint8Array(image.bytes) });
-}
-
-function hasCoherentMagic(mimeType: Image['mimeType'], bytes: Uint8Array): boolean {
-    if (mimeType === 'image/png') return bytes.byteLength >= PNG_MIN_BYTES && PNG_SIGNATURE.every((byte, index) => bytes[index] === byte)
+function hasMinimalMagic(mimeType: Image['mimeType'], bytes: Uint8Array): boolean {
+    if (mimeType === 'image/png') return bytes.byteLength >= 33
+        && PNG_SIGNATURE.every((byte, index) => bytes[index] === byte)
         && bytes[8] === 0 && bytes[9] === 0 && bytes[10] === 0 && bytes[11] === 13
         && bytes[12] === 73 && bytes[13] === 72 && bytes[14] === 68 && bytes[15] === 82;
     if (mimeType === 'image/jpeg') return bytes.byteLength >= 4 && bytes[0] === 255 && bytes[1] === 216
-        && bytes[bytes.byteLength - 2] === 255 && bytes[bytes.byteLength - 1] === 217;
+        && bytes.at(-2) === 255 && bytes.at(-1) === 217;
     return bytes.byteLength >= 12 && bytes[0] === 82 && bytes[1] === 73 && bytes[2] === 70 && bytes[3] === 70
         && bytes[8] === 87 && bytes[9] === 69 && bytes[10] === 66 && bytes[11] === 80;
 }
 
-function deny(code: Extract<LocalOcrHostSourceOutcome, { status: 'denied' }>['code']): LocalOcrHostSourceOutcome {
-    return Object.freeze({ status: 'denied', code });
+function parseImage(value: unknown): Image | null {
+    if (!exactRecord(value, IMAGE_KEYS)) return null;
+    const image = value as Record<string, unknown>; const mimeType = image.mimeType;
+    if ((mimeType !== 'image/jpeg' && mimeType !== 'image/png' && mimeType !== 'image/webp')
+        || types.isProxy(image.bytes) || !(image.bytes instanceof Uint8Array) || Buffer.isBuffer(image.bytes)
+        || Object.getPrototypeOf(image.bytes) !== Uint8Array.prototype || image.bytes.byteLength < 1 || image.bytes.byteLength > MAX_BYTES) return null;
+    const bytes = new Uint8Array(image.bytes);
+    return hasMinimalMagic(mimeType, bytes) ? Object.freeze({ mimeType, bytes }) : null;
 }
 
-function stateDenial(state: HostState, now: unknown): LocalOcrHostSourceOutcome | null {
-    if (typeof now !== 'number' || !Number.isSafeInteger(now) || now < 0) return deny('host_invalid');
+const deny = (code: DenialCode): LocalOcrHostSourceOutcome => Object.freeze({ status: 'denied', code });
+
+function stateDenial(state: HostSnapshot): LocalOcrHostSourceOutcome | null {
     if (state.revoked) return deny('revoked');
     if (!state.sessionActive) return deny('host_inactive');
     if (!state.current) return deny('currentness_lost');
-    return state.expiresAt <= now ? deny('expired') : null;
+    return state.expiresAt <= state.observedAt ? deny('expired') : null;
 }
 
-function readNow(host: Host): number | null {
-    try {
-        const now = host.now();
-        return typeof now === 'number' && Number.isSafeInteger(now) && now >= 0 ? now : null;
-    } catch { return null; }
-}
-
-function sameState(first: HostState, second: HostState): boolean {
+function sameCurrentness(first: HostSnapshot, second: HostSnapshot): boolean {
     return first.sessionActive === second.sessionActive && first.current === second.current && first.revoked === second.revoked
         && first.selectionEpoch === second.selectionEpoch && first.stateEpoch === second.stateEpoch && first.expiresAt === second.expiresAt;
 }
 
 export function createLocalOcrHostSource(value: unknown) {
-    const snapshot = snapshotHost(value);
-    if (activeBoundaries.has(snapshot.identity)) throw new LocalOcrHostSourceError('host_in_use');
-    const boundary = {};
-    activeBoundaries.set(snapshot.identity, boundary);
-    let consumed = false;
-    const release = () => activeBoundaries.delete(snapshot.identity);
+    const snapshot = hostCapability(value);
+    if (activeBoundaries.has(snapshot)) throw new LocalOcrHostSourceError('host_in_use');
+    activeBoundaries.set(snapshot, {}); let consumed = false;
     return Object.freeze({
         admit(input: unknown): LocalOcrHostSourceOutcome {
+            const active = activeOperations.get(snapshot);
+            if (active) { active.reentered = true; return deny('reentered'); }
             if (consumed) return deny('replayed');
-            if (!exactRecord(input, INPUT_KEYS)) return deny('input_invalid');
-            const request = input as Record<string, unknown>;
-            if (request.mode === 'persisted_attachment') return deny('persisted_attachment_denied');
-            if (request.mode !== 'ephemeral_image') return deny('input_invalid');
-            const image = parseImage(request.content); if (!image) return deny('input_invalid');
-            const existing = activeOperations.get(snapshot.identity);
-            if (existing) { existing.reentered = true; return deny('reentered'); }
-            const operation = { reentered: false }; activeOperations.set(snapshot.identity, operation);
+            consumed = true; const operation = { reentered: false }; activeOperations.set(snapshot, operation);
             try {
-                const first = readState(snapshot.host); const firstNow = readNow(snapshot.host);
-                if (!first || firstNow === null) return deny('host_invalid');
-                const firstDenial = stateDenial(first, firstNow); if (firstDenial || operation.reentered) return firstDenial ?? deny('reentered');
-                const second = readState(snapshot.host); const finalNow = readNow(snapshot.host);
-                if (!second || finalNow === null) return deny('host_invalid');
-                const secondDenial = stateDenial(second, finalNow);
-                if (secondDenial || operation.reentered) return secondDenial ?? deny('reentered');
-                if (finalNow < firstNow || second.stateEpoch < first.stateEpoch || !sameState(first, second)) return deny('currentness_lost');
-                consumed = true;
-                release();
+                if (!exactRecord(input, INPUT_KEYS)) return deny('input_invalid');
+                const request = input as Record<string, unknown>;
+                if (request.mode === 'persisted_attachment') return deny('persisted_attachment_denied');
+                if (request.mode !== 'ephemeral_image') return deny('input_invalid');
+                const first = readSnapshot(snapshot); if (!first) return deny('host_invalid');
+                const firstDenial = stateDenial(first); if (firstDenial || operation.reentered) return firstDenial ?? deny('reentered');
+                const image = parseImage(request.content); if (!image) return deny('input_invalid');
+                const second = readSnapshot(snapshot); if (!second) return deny('host_invalid');
+                const secondDenial = stateDenial(second); if (secondDenial || operation.reentered) return secondDenial ?? deny('reentered');
+                if (second.observedAt < first.observedAt || !sameCurrentness(first, second)) return deny('currentness_lost');
                 return Object.freeze({ status: 'admitted', source: Object.freeze({ kind: 'ephemeral_pre_persist_image', mimeType: image.mimeType, bytes: image.bytes }) });
-            } catch { release(); return deny('host_invalid'); } finally { activeOperations.delete(snapshot.identity); }
+            } catch { return deny('host_invalid'); } finally {
+                activeOperations.delete(snapshot); activeBoundaries.delete(snapshot);
+            }
         },
     });
 }

--- a/lib/ai-providers/fabric/local-ocr-host-source.ts
+++ b/lib/ai-providers/fabric/local-ocr-host-source.ts
@@ -3,38 +3,46 @@ import 'server-only';
 
 import { types } from 'node:util';
 
-type HostState = Readonly<{ sessionActive: boolean; current: boolean; revoked: boolean; selectionEpoch: number; expiresAt: number }>;
+/**
+ * The host owns a monotonic, latching stateEpoch: every lease/currentness change increments it,
+ * and revoked/non-current state must not be cleared. This seam rejects any changed snapshot.
+ */
+type HostState = Readonly<{ sessionActive: boolean; current: boolean; revoked: boolean; selectionEpoch: number; stateEpoch: number; expiresAt: number }>;
 type Host = Readonly<{ readState: () => unknown; now: () => unknown }>;
 type Image = Readonly<{ mimeType: 'image/jpeg' | 'image/png' | 'image/webp'; bytes: Uint8Array }>;
 export type LocalOcrHostSourceOutcome =
     | Readonly<{ status: 'admitted'; source: Readonly<{ kind: 'ephemeral_pre_persist_image'; mimeType: Image['mimeType']; bytes: Uint8Array }> }>
-    | Readonly<{ status: 'denied'; code: 'input_invalid' | 'persisted_attachment_denied' | 'host_invalid' | 'host_inactive' | 'currentness_lost' | 'revoked' | 'expired' | 'replayed' | 'reentered' }>;
+    | Readonly<{ status: 'denied'; code: 'input_invalid' | 'persisted_attachment_denied' | 'host_invalid' | 'host_in_use' | 'host_inactive' | 'currentness_lost' | 'revoked' | 'expired' | 'replayed' | 'reentered' }>;
 
 const HOST_KEYS = ['readState', 'now'] as const;
-const STATE_KEYS = ['sessionActive', 'current', 'revoked', 'selectionEpoch', 'expiresAt'] as const;
+const STATE_KEYS = ['sessionActive', 'current', 'revoked', 'selectionEpoch', 'stateEpoch', 'expiresAt'] as const;
 const IMAGE_KEYS = ['mimeType', 'bytes'] as const;
 const INPUT_KEYS = ['mode', 'content'] as const;
 const MAX_BYTES = 5 * 1024 * 1024;
-const activeHosts = new WeakMap<object, { reentered: boolean }>();
+// This exact object is the in-process lease identity; restart/new-process behavior is outside this seam.
+const activeBoundaries = new WeakMap<object, object>();
+const activeOperations = new WeakMap<object, { reentered: boolean }>();
+const PNG_SIGNATURE = [137, 80, 78, 71, 13, 10, 26, 10];
+const PNG_MIN_BYTES = 33;
 
 export class LocalOcrHostSourceError extends Error {
-    constructor(readonly code: 'host_invalid') { super(`Local OCR host source rejected: ${code}`); this.name = 'LocalOcrHostSourceError'; }
+    constructor(readonly code: 'host_invalid' | 'host_in_use') { super(`Local OCR host source rejected: ${code}`); this.name = 'LocalOcrHostSourceError'; }
 }
 
 function exactRecord(value: unknown, keys: readonly string[]): value is Record<string, unknown> {
-    if (!value || typeof value !== 'object' || Array.isArray(value) || types.isProxy(value) || Object.getPrototypeOf(value) !== Object.prototype) return false;
+    if (!value || typeof value !== 'object' || types.isProxy(value) || Array.isArray(value) || Object.getPrototypeOf(value) !== Object.prototype) return false;
     const descriptors = Object.getOwnPropertyDescriptors(value);
     return Reflect.ownKeys(descriptors).length === keys.length && keys.every((key) => {
         const descriptor = descriptors[key]; return descriptor !== undefined && 'value' in descriptor && descriptor.enumerable;
     });
 }
 
-function snapshotHost(value: unknown): Host {
+function snapshotHost(value: unknown): Readonly<{ identity: object; host: Host }> {
     if (!exactRecord(value, HOST_KEYS)) throw new LocalOcrHostSourceError('host_invalid');
     const readState = value.readState; const now = value.now;
     if (typeof readState !== 'function' || typeof now !== 'function' || types.isProxy(readState) || types.isProxy(now)
         || types.isAsyncFunction(readState) || types.isAsyncFunction(now)) throw new LocalOcrHostSourceError('host_invalid');
-    return Object.freeze({ readState: readState as () => unknown, now: now as () => unknown });
+    return Object.freeze({ identity: value, host: Object.freeze({ readState: readState as () => unknown, now: now as () => unknown }) });
 }
 
 function readState(host: Host): HostState | null {
@@ -44,17 +52,36 @@ function readState(host: Host): HostState | null {
     const state = value as Record<string, unknown>;
     if (typeof state.sessionActive !== 'boolean' || typeof state.current !== 'boolean' || typeof state.revoked !== 'boolean'
         || typeof state.selectionEpoch !== 'number' || !Number.isSafeInteger(state.selectionEpoch) || state.selectionEpoch < 1
+        || typeof state.stateEpoch !== 'number' || !Number.isSafeInteger(state.stateEpoch) || state.stateEpoch < 1
         || typeof state.expiresAt !== 'number' || !Number.isSafeInteger(state.expiresAt) || state.expiresAt < 0) return null;
-    return Object.freeze(state as HostState);
+    return Object.freeze({
+        sessionActive: state.sessionActive,
+        current: state.current,
+        revoked: state.revoked,
+        selectionEpoch: state.selectionEpoch,
+        stateEpoch: state.stateEpoch,
+        expiresAt: state.expiresAt,
+    });
 }
 
 function parseImage(value: unknown): Image | null {
     if (!exactRecord(value, IMAGE_KEYS)) return null;
     const image = value as Record<string, unknown>;
     if ((image.mimeType !== 'image/jpeg' && image.mimeType !== 'image/png' && image.mimeType !== 'image/webp')
-        || !(image.bytes instanceof Uint8Array) || Buffer.isBuffer(image.bytes) || types.isProxy(image.bytes)
-        || Object.getPrototypeOf(image.bytes) !== Uint8Array.prototype || image.bytes.byteLength < 1 || image.bytes.byteLength > MAX_BYTES) return null;
+        || types.isProxy(image.bytes) || !(image.bytes instanceof Uint8Array) || Buffer.isBuffer(image.bytes)
+        || Object.getPrototypeOf(image.bytes) !== Uint8Array.prototype || image.bytes.byteLength < 1 || image.bytes.byteLength > MAX_BYTES
+        || !hasCoherentMagic(image.mimeType, image.bytes)) return null;
     return Object.freeze({ mimeType: image.mimeType, bytes: new Uint8Array(image.bytes) });
+}
+
+function hasCoherentMagic(mimeType: Image['mimeType'], bytes: Uint8Array): boolean {
+    if (mimeType === 'image/png') return bytes.byteLength >= PNG_MIN_BYTES && PNG_SIGNATURE.every((byte, index) => bytes[index] === byte)
+        && bytes[8] === 0 && bytes[9] === 0 && bytes[10] === 0 && bytes[11] === 13
+        && bytes[12] === 73 && bytes[13] === 72 && bytes[14] === 68 && bytes[15] === 82;
+    if (mimeType === 'image/jpeg') return bytes.byteLength >= 4 && bytes[0] === 255 && bytes[1] === 216
+        && bytes[bytes.byteLength - 2] === 255 && bytes[bytes.byteLength - 1] === 217;
+    return bytes.byteLength >= 12 && bytes[0] === 82 && bytes[1] === 73 && bytes[2] === 70 && bytes[3] === 70
+        && bytes[8] === 87 && bytes[9] === 69 && bytes[10] === 66 && bytes[11] === 80;
 }
 
 function deny(code: Extract<LocalOcrHostSourceOutcome, { status: 'denied' }>['code']): LocalOcrHostSourceOutcome {
@@ -69,31 +96,49 @@ function stateDenial(state: HostState, now: unknown): LocalOcrHostSourceOutcome 
     return state.expiresAt <= now ? deny('expired') : null;
 }
 
+function readNow(host: Host): number | null {
+    try {
+        const now = host.now();
+        return typeof now === 'number' && Number.isSafeInteger(now) && now >= 0 ? now : null;
+    } catch { return null; }
+}
+
+function sameState(first: HostState, second: HostState): boolean {
+    return first.sessionActive === second.sessionActive && first.current === second.current && first.revoked === second.revoked
+        && first.selectionEpoch === second.selectionEpoch && first.stateEpoch === second.stateEpoch && first.expiresAt === second.expiresAt;
+}
+
 export function createLocalOcrHostSource(value: unknown) {
-    const host = snapshotHost(value); let consumed = false;
+    const snapshot = snapshotHost(value);
+    if (activeBoundaries.has(snapshot.identity)) throw new LocalOcrHostSourceError('host_in_use');
+    const boundary = {};
+    activeBoundaries.set(snapshot.identity, boundary);
+    let consumed = false;
+    const release = () => activeBoundaries.delete(snapshot.identity);
     return Object.freeze({
         admit(input: unknown): LocalOcrHostSourceOutcome {
+            if (consumed) return deny('replayed');
             if (!exactRecord(input, INPUT_KEYS)) return deny('input_invalid');
             const request = input as Record<string, unknown>;
             if (request.mode === 'persisted_attachment') return deny('persisted_attachment_denied');
             if (request.mode !== 'ephemeral_image') return deny('input_invalid');
             const image = parseImage(request.content); if (!image) return deny('input_invalid');
-            if (consumed) return deny('replayed');
-            const existing = activeHosts.get(host);
+            const existing = activeOperations.get(snapshot.identity);
             if (existing) { existing.reentered = true; return deny('reentered'); }
-            const operation = { reentered: false }; activeHosts.set(host, operation);
+            const operation = { reentered: false }; activeOperations.set(snapshot.identity, operation);
             try {
-                const first = readState(host); const now = host.now();
-                if (!first) return deny('host_invalid');
-                const firstDenial = stateDenial(first, now); if (firstDenial || operation.reentered) return firstDenial ?? deny('reentered');
-                const second = readState(host);
-                if (!second) return deny('host_invalid');
-                const secondDenial = stateDenial(second, now);
+                const first = readState(snapshot.host); const firstNow = readNow(snapshot.host);
+                if (!first || firstNow === null) return deny('host_invalid');
+                const firstDenial = stateDenial(first, firstNow); if (firstDenial || operation.reentered) return firstDenial ?? deny('reentered');
+                const second = readState(snapshot.host); const finalNow = readNow(snapshot.host);
+                if (!second || finalNow === null) return deny('host_invalid');
+                const secondDenial = stateDenial(second, finalNow);
                 if (secondDenial || operation.reentered) return secondDenial ?? deny('reentered');
-                if (first.selectionEpoch !== second.selectionEpoch) return deny('currentness_lost');
+                if (finalNow < firstNow || second.stateEpoch < first.stateEpoch || !sameState(first, second)) return deny('currentness_lost');
                 consumed = true;
+                release();
                 return Object.freeze({ status: 'admitted', source: Object.freeze({ kind: 'ephemeral_pre_persist_image', mimeType: image.mimeType, bytes: image.bytes }) });
-            } catch { return deny('host_invalid'); } finally { activeHosts.delete(host); }
+            } catch { release(); return deny('host_invalid'); } finally { activeOperations.delete(snapshot.identity); }
         },
     });
 }

--- a/lib/ai-providers/fabric/local-ocr-host-source.ts
+++ b/lib/ai-providers/fabric/local-ocr-host-source.ts
@@ -1,0 +1,99 @@
+/* @Codex */
+import 'server-only';
+
+import { types } from 'node:util';
+
+type HostState = Readonly<{ sessionActive: boolean; current: boolean; revoked: boolean; selectionEpoch: number; expiresAt: number }>;
+type Host = Readonly<{ readState: () => unknown; now: () => unknown }>;
+type Image = Readonly<{ mimeType: 'image/jpeg' | 'image/png' | 'image/webp'; bytes: Uint8Array }>;
+export type LocalOcrHostSourceOutcome =
+    | Readonly<{ status: 'admitted'; source: Readonly<{ kind: 'ephemeral_pre_persist_image'; mimeType: Image['mimeType']; bytes: Uint8Array }> }>
+    | Readonly<{ status: 'denied'; code: 'input_invalid' | 'persisted_attachment_denied' | 'host_invalid' | 'host_inactive' | 'currentness_lost' | 'revoked' | 'expired' | 'replayed' | 'reentered' }>;
+
+const HOST_KEYS = ['readState', 'now'] as const;
+const STATE_KEYS = ['sessionActive', 'current', 'revoked', 'selectionEpoch', 'expiresAt'] as const;
+const IMAGE_KEYS = ['mimeType', 'bytes'] as const;
+const INPUT_KEYS = ['mode', 'content'] as const;
+const MAX_BYTES = 5 * 1024 * 1024;
+const activeHosts = new WeakMap<object, { reentered: boolean }>();
+
+export class LocalOcrHostSourceError extends Error {
+    constructor(readonly code: 'host_invalid') { super(`Local OCR host source rejected: ${code}`); this.name = 'LocalOcrHostSourceError'; }
+}
+
+function exactRecord(value: unknown, keys: readonly string[]): value is Record<string, unknown> {
+    if (!value || typeof value !== 'object' || Array.isArray(value) || types.isProxy(value) || Object.getPrototypeOf(value) !== Object.prototype) return false;
+    const descriptors = Object.getOwnPropertyDescriptors(value);
+    return Reflect.ownKeys(descriptors).length === keys.length && keys.every((key) => {
+        const descriptor = descriptors[key]; return descriptor !== undefined && 'value' in descriptor && descriptor.enumerable;
+    });
+}
+
+function snapshotHost(value: unknown): Host {
+    if (!exactRecord(value, HOST_KEYS)) throw new LocalOcrHostSourceError('host_invalid');
+    const readState = value.readState; const now = value.now;
+    if (typeof readState !== 'function' || typeof now !== 'function' || types.isProxy(readState) || types.isProxy(now)
+        || types.isAsyncFunction(readState) || types.isAsyncFunction(now)) throw new LocalOcrHostSourceError('host_invalid');
+    return Object.freeze({ readState: readState as () => unknown, now: now as () => unknown });
+}
+
+function readState(host: Host): HostState | null {
+    let value: unknown;
+    try { value = host.readState(); } catch { return null; }
+    if (!exactRecord(value, STATE_KEYS)) return null;
+    const state = value as Record<string, unknown>;
+    if (typeof state.sessionActive !== 'boolean' || typeof state.current !== 'boolean' || typeof state.revoked !== 'boolean'
+        || typeof state.selectionEpoch !== 'number' || !Number.isSafeInteger(state.selectionEpoch) || state.selectionEpoch < 1
+        || typeof state.expiresAt !== 'number' || !Number.isSafeInteger(state.expiresAt) || state.expiresAt < 0) return null;
+    return Object.freeze(state as HostState);
+}
+
+function parseImage(value: unknown): Image | null {
+    if (!exactRecord(value, IMAGE_KEYS)) return null;
+    const image = value as Record<string, unknown>;
+    if ((image.mimeType !== 'image/jpeg' && image.mimeType !== 'image/png' && image.mimeType !== 'image/webp')
+        || !(image.bytes instanceof Uint8Array) || Buffer.isBuffer(image.bytes) || types.isProxy(image.bytes)
+        || Object.getPrototypeOf(image.bytes) !== Uint8Array.prototype || image.bytes.byteLength < 1 || image.bytes.byteLength > MAX_BYTES) return null;
+    return Object.freeze({ mimeType: image.mimeType, bytes: new Uint8Array(image.bytes) });
+}
+
+function deny(code: Extract<LocalOcrHostSourceOutcome, { status: 'denied' }>['code']): LocalOcrHostSourceOutcome {
+    return Object.freeze({ status: 'denied', code });
+}
+
+function stateDenial(state: HostState, now: unknown): LocalOcrHostSourceOutcome | null {
+    if (typeof now !== 'number' || !Number.isSafeInteger(now) || now < 0) return deny('host_invalid');
+    if (state.revoked) return deny('revoked');
+    if (!state.sessionActive) return deny('host_inactive');
+    if (!state.current) return deny('currentness_lost');
+    return state.expiresAt <= now ? deny('expired') : null;
+}
+
+export function createLocalOcrHostSource(value: unknown) {
+    const host = snapshotHost(value); let consumed = false;
+    return Object.freeze({
+        admit(input: unknown): LocalOcrHostSourceOutcome {
+            if (!exactRecord(input, INPUT_KEYS)) return deny('input_invalid');
+            const request = input as Record<string, unknown>;
+            if (request.mode === 'persisted_attachment') return deny('persisted_attachment_denied');
+            if (request.mode !== 'ephemeral_image') return deny('input_invalid');
+            const image = parseImage(request.content); if (!image) return deny('input_invalid');
+            if (consumed) return deny('replayed');
+            const existing = activeHosts.get(host);
+            if (existing) { existing.reentered = true; return deny('reentered'); }
+            const operation = { reentered: false }; activeHosts.set(host, operation);
+            try {
+                const first = readState(host); const now = host.now();
+                if (!first) return deny('host_invalid');
+                const firstDenial = stateDenial(first, now); if (firstDenial || operation.reentered) return firstDenial ?? deny('reentered');
+                const second = readState(host);
+                if (!second) return deny('host_invalid');
+                const secondDenial = stateDenial(second, now);
+                if (secondDenial || operation.reentered) return secondDenial ?? deny('reentered');
+                if (first.selectionEpoch !== second.selectionEpoch) return deny('currentness_lost');
+                consumed = true;
+                return Object.freeze({ status: 'admitted', source: Object.freeze({ kind: 'ephemeral_pre_persist_image', mimeType: image.mimeType, bytes: image.bytes }) });
+            } catch { return deny('host_invalid'); } finally { activeHosts.delete(host); }
+        },
+    });
+}

--- a/lib/ai-providers/fabric/local-ocr-host-source.ts
+++ b/lib/ai-providers/fabric/local-ocr-host-source.ts
@@ -3,127 +3,118 @@ import 'server-only';
 
 import { types } from 'node:util';
 
-type HostSnapshot = Readonly<{
-    sessionActive: boolean; current: boolean; revoked: boolean; selectionEpoch: number;
-    stateEpoch: number; expiresAt: number; observedAt: number;
-}>;
-type Image = Readonly<{ mimeType: 'image/jpeg' | 'image/png' | 'image/webp'; bytes: Uint8Array }>;
-type DenialCode = 'input_invalid' | 'persisted_attachment_denied' | 'host_invalid' | 'host_in_use'
-    | 'host_inactive' | 'currentness_lost' | 'revoked' | 'expired' | 'replayed' | 'reentered';
+type HostState = Readonly<{ sessionActive: boolean; current: boolean; revoked: boolean; selectionEpoch: number; stateEpoch: number; expiresAt: number; observedAt: number }>;
+type Image = Readonly<{ mimeType: 'image/jpeg' | 'image/png' | 'image/webp'; contentBase64: string }>;
+type DenialCode = 'input_invalid' | 'persisted_attachment_denied' | 'host_invalid' | 'host_in_use' | 'host_inactive' | 'currentness_lost' | 'revoked' | 'expired' | 'replayed' | 'reentered' | 'disposed';
 export type LocalOcrHostSourceOutcome =
-    | Readonly<{ status: 'admitted'; source: Readonly<{ kind: 'ephemeral_pre_persist_image'; mimeType: Image['mimeType']; bytes: Uint8Array }> }>
+    | Readonly<{ status: 'admitted'; source: Readonly<{ kind: 'ephemeral_pre_persist_image'; mimeType: Image['mimeType']; encoding: 'base64'; contentBase64: string }> }>
     | Readonly<{ status: 'denied'; code: DenialCode }>;
 
-const HOST_KEYS = ['snapshot'] as const;
+type OwnerRecord = { state: HostState; active: boolean; operating: boolean; reentered: boolean; disposed: boolean };
 const STATE_KEYS = ['sessionActive', 'current', 'revoked', 'selectionEpoch', 'stateEpoch', 'expiresAt', 'observedAt'] as const;
 const IMAGE_KEYS = ['mimeType', 'bytes'] as const;
 const INPUT_KEYS = ['mode', 'content'] as const;
 const MAX_BYTES = 5 * 1024 * 1024;
-const activeBoundaries = new WeakMap<() => unknown, object>();
-const activeOperations = new WeakMap<() => unknown, { reentered: boolean }>();
+const owners = new WeakMap<object, OwnerRecord>();
 const PNG_SIGNATURE = [137, 80, 78, 71, 13, 10, 26, 10];
 
 export class LocalOcrHostSourceError extends Error {
-    constructor(readonly code: 'host_invalid' | 'host_in_use') {
-        super(`Local OCR host source rejected: ${code}`); this.name = 'LocalOcrHostSourceError';
-    }
+    constructor(readonly code: 'host_invalid' | 'host_in_use') { super(`Local OCR host source rejected: ${code}`); this.name = 'LocalOcrHostSourceError'; }
 }
 
 function exactRecord(value: unknown, keys: readonly string[]): value is Record<string, unknown> {
-    if (!value || typeof value !== 'object' || types.isProxy(value) || Array.isArray(value)
-        || Object.getPrototypeOf(value) !== Object.prototype) return false;
+    if (!value || typeof value !== 'object' || types.isProxy(value) || Array.isArray(value) || Object.getPrototypeOf(value) !== Object.prototype) return false;
     const descriptors = Object.getOwnPropertyDescriptors(value);
     return Reflect.ownKeys(descriptors).length === keys.length && keys.every((key) => {
-        const descriptor = descriptors[key];
-        return descriptor !== undefined && 'value' in descriptor && descriptor.enumerable;
+        const descriptor = descriptors[key]; return descriptor !== undefined && 'value' in descriptor && descriptor.enumerable;
     });
 }
 
-function hostCapability(value: unknown): () => unknown {
-    if (!exactRecord(value, HOST_KEYS)) throw new LocalOcrHostSourceError('host_invalid');
-    const snapshot = value.snapshot;
-    if (typeof snapshot !== 'function' || types.isProxy(snapshot) || types.isAsyncFunction(snapshot)
-        || Object.getPrototypeOf(snapshot) !== Function.prototype
-        || Object.getOwnPropertyDescriptor(snapshot, 'then') !== undefined) throw new LocalOcrHostSourceError('host_invalid');
-    return snapshot as () => unknown;
-}
-
-function readSnapshot(snapshot: () => unknown): HostSnapshot | null {
-    let value: unknown;
-    try { value = snapshot(); } catch { return null; }
+function parseState(value: unknown): HostState | null {
     if (!exactRecord(value, STATE_KEYS)) return null;
     const state = value as Record<string, unknown>;
     for (const key of ['selectionEpoch', 'stateEpoch', 'expiresAt', 'observedAt'] as const) {
         if (typeof state[key] !== 'number' || !Number.isSafeInteger(state[key]) || state[key] < (key.endsWith('Epoch') ? 1 : 0)) return null;
     }
     if (typeof state.sessionActive !== 'boolean' || typeof state.current !== 'boolean' || typeof state.revoked !== 'boolean') return null;
-    return Object.freeze({
-        sessionActive: state.sessionActive, current: state.current, revoked: state.revoked,
-        selectionEpoch: state.selectionEpoch as number, stateEpoch: state.stateEpoch as number,
-        expiresAt: state.expiresAt as number, observedAt: state.observedAt as number,
-    });
+    return Object.freeze({ sessionActive: state.sessionActive, current: state.current, revoked: state.revoked, selectionEpoch: state.selectionEpoch as number, stateEpoch: state.stateEpoch as number, expiresAt: state.expiresAt as number, observedAt: state.observedAt as number });
+}
+
+function ownerRecord(value: unknown): OwnerRecord | null {
+    if (!value || typeof value !== 'object' || types.isProxy(value)) return null;
+    return owners.get(value as object) ?? null;
+}
+
+function terminal(state: HostState): boolean { return state.revoked || !state.sessionActive || !state.current || state.expiresAt <= state.observedAt; }
+
+function canAdvance(previous: HostState, next: HostState): boolean {
+    return !terminal(previous) && next.stateEpoch > previous.stateEpoch && next.selectionEpoch >= previous.selectionEpoch
+        && next.observedAt >= previous.observedAt && (next.expiresAt >= previous.expiresAt || terminal(next));
+}
+
+export function createLocalOcrHostSourceOwner(initial: unknown): object {
+    const state = parseState(initial);
+    if (!state) throw new LocalOcrHostSourceError('host_invalid');
+    const owner = Object.freeze(Object.create(null)); owners.set(owner, { state, active: false, operating: false, reentered: false, disposed: false });
+    return owner;
+}
+
+export function advanceLocalOcrHostSourceOwner(owner: unknown, nextValue: unknown): boolean {
+    const record = ownerRecord(owner); const next = parseState(nextValue);
+    if (!record || !next || record.disposed) return false;
+    if (record.operating) { record.reentered = true; return false; }
+    if (!canAdvance(record.state, next)) return false;
+    record.state = next; return true;
+}
+
+export function disposeLocalOcrHostSourceOwner(owner: unknown): boolean {
+    const record = ownerRecord(owner); if (!record || record.disposed) return false;
+    if (record.operating) record.reentered = true;
+    record.disposed = true; record.active = false; return true;
 }
 
 function hasMinimalMagic(mimeType: Image['mimeType'], bytes: Uint8Array): boolean {
-    if (mimeType === 'image/png') return bytes.byteLength >= 33
-        && PNG_SIGNATURE.every((byte, index) => bytes[index] === byte)
-        && bytes[8] === 0 && bytes[9] === 0 && bytes[10] === 0 && bytes[11] === 13
-        && bytes[12] === 73 && bytes[13] === 72 && bytes[14] === 68 && bytes[15] === 82;
-    if (mimeType === 'image/jpeg') return bytes.byteLength >= 4 && bytes[0] === 255 && bytes[1] === 216
-        && bytes.at(-2) === 255 && bytes.at(-1) === 217;
-    return bytes.byteLength >= 12 && bytes[0] === 82 && bytes[1] === 73 && bytes[2] === 70 && bytes[3] === 70
-        && bytes[8] === 87 && bytes[9] === 69 && bytes[10] === 66 && bytes[11] === 80;
+    if (mimeType === 'image/png') return bytes.byteLength >= 33 && PNG_SIGNATURE.every((byte, index) => bytes[index] === byte) && bytes[8] === 0 && bytes[9] === 0 && bytes[10] === 0 && bytes[11] === 13 && bytes[12] === 73 && bytes[13] === 72 && bytes[14] === 68 && bytes[15] === 82;
+    if (mimeType === 'image/jpeg') return bytes.byteLength >= 4 && bytes[0] === 255 && bytes[1] === 216 && bytes.at(-2) === 255 && bytes.at(-1) === 217;
+    return bytes.byteLength >= 12 && bytes[0] === 82 && bytes[1] === 73 && bytes[2] === 70 && bytes[3] === 70 && bytes[8] === 87 && bytes[9] === 69 && bytes[10] === 66 && bytes[11] === 80;
 }
 
 function parseImage(value: unknown): Image | null {
     if (!exactRecord(value, IMAGE_KEYS)) return null;
     const image = value as Record<string, unknown>; const mimeType = image.mimeType;
-    if ((mimeType !== 'image/jpeg' && mimeType !== 'image/png' && mimeType !== 'image/webp')
-        || types.isProxy(image.bytes) || !(image.bytes instanceof Uint8Array) || Buffer.isBuffer(image.bytes)
-        || Object.getPrototypeOf(image.bytes) !== Uint8Array.prototype || image.bytes.byteLength < 1 || image.bytes.byteLength > MAX_BYTES) return null;
+    if ((mimeType !== 'image/jpeg' && mimeType !== 'image/png' && mimeType !== 'image/webp') || types.isProxy(image.bytes) || !(image.bytes instanceof Uint8Array) || Buffer.isBuffer(image.bytes) || Object.getPrototypeOf(image.bytes) !== Uint8Array.prototype || image.bytes.byteLength < 1 || image.bytes.byteLength > MAX_BYTES) return null;
     const bytes = new Uint8Array(image.bytes);
-    return hasMinimalMagic(mimeType, bytes) ? Object.freeze({ mimeType, bytes }) : null;
+    return hasMinimalMagic(mimeType, bytes) ? Object.freeze({ mimeType, contentBase64: Buffer.from(bytes).toString('base64') }) : null;
 }
 
 const deny = (code: DenialCode): LocalOcrHostSourceOutcome => Object.freeze({ status: 'denied', code });
-
-function stateDenial(state: HostSnapshot): LocalOcrHostSourceOutcome | null {
-    if (state.revoked) return deny('revoked');
-    if (!state.sessionActive) return deny('host_inactive');
-    if (!state.current) return deny('currentness_lost');
-    return state.expiresAt <= state.observedAt ? deny('expired') : null;
+function stateDenial(state: HostState): LocalOcrHostSourceOutcome | null {
+    if (state.revoked) return deny('revoked'); if (!state.sessionActive) return deny('host_inactive'); if (!state.current) return deny('currentness_lost'); return state.expiresAt <= state.observedAt ? deny('expired') : null;
 }
 
-function sameCurrentness(first: HostSnapshot, second: HostSnapshot): boolean {
-    return first.sessionActive === second.sessionActive && first.current === second.current && first.revoked === second.revoked
-        && first.selectionEpoch === second.selectionEpoch && first.stateEpoch === second.stateEpoch && first.expiresAt === second.expiresAt;
-}
-
-export function createLocalOcrHostSource(value: unknown) {
-    const snapshot = hostCapability(value);
-    if (activeBoundaries.has(snapshot)) throw new LocalOcrHostSourceError('host_in_use');
-    activeBoundaries.set(snapshot, {}); let consumed = false;
+export function createLocalOcrHostSource(owner: unknown) {
+    const record = ownerRecord(owner);
+    if (!record || record.disposed) throw new LocalOcrHostSourceError('host_invalid');
+    if (record.active) throw new LocalOcrHostSourceError('host_in_use');
+    record.active = true; let consumed = false; let disposed = false;
+    const release = () => { record.active = false; };
     return Object.freeze({
         admit(input: unknown): LocalOcrHostSourceOutcome {
-            const active = activeOperations.get(snapshot);
-            if (active) { active.reentered = true; return deny('reentered'); }
+            if (disposed || record.disposed) return deny('disposed');
             if (consumed) return deny('replayed');
-            consumed = true; const operation = { reentered: false }; activeOperations.set(snapshot, operation);
+            if (record.operating) { record.reentered = true; return deny('reentered'); }
+            consumed = true; record.operating = true;
             try {
                 if (!exactRecord(input, INPUT_KEYS)) return deny('input_invalid');
                 const request = input as Record<string, unknown>;
                 if (request.mode === 'persisted_attachment') return deny('persisted_attachment_denied');
                 if (request.mode !== 'ephemeral_image') return deny('input_invalid');
-                const first = readSnapshot(snapshot); if (!first) return deny('host_invalid');
-                const firstDenial = stateDenial(first); if (firstDenial || operation.reentered) return firstDenial ?? deny('reentered');
-                const image = parseImage(request.content); if (!image) return deny('input_invalid');
-                const second = readSnapshot(snapshot); if (!second) return deny('host_invalid');
-                const secondDenial = stateDenial(second); if (secondDenial || operation.reentered) return secondDenial ?? deny('reentered');
-                if (second.observedAt < first.observedAt || !sameCurrentness(first, second)) return deny('currentness_lost');
-                return Object.freeze({ status: 'admitted', source: Object.freeze({ kind: 'ephemeral_pre_persist_image', mimeType: image.mimeType, bytes: image.bytes }) });
-            } catch { return deny('host_invalid'); } finally {
-                activeOperations.delete(snapshot); activeBoundaries.delete(snapshot);
-            }
+                const currentDenial = stateDenial(record.state); if (currentDenial) return currentDenial;
+                const image = parseImage(request.content); if (!image) return deny(record.reentered ? 'reentered' : 'input_invalid');
+                if (record.reentered) return deny('reentered');
+                return Object.freeze({ status: 'admitted', source: Object.freeze({ kind: 'ephemeral_pre_persist_image', mimeType: image.mimeType, encoding: 'base64', contentBase64: image.contentBase64 }) });
+            } catch { return deny(record.reentered ? 'reentered' : 'host_invalid'); } finally { record.operating = false; record.reentered = false; release(); }
         },
+        dispose(): void { if (!disposed) { if (record.operating) record.reentered = true; disposed = true; release(); } },
     });
 }


### PR DESCRIPTION
## Summary
- Introduce un owner OCR opaco creato dal modulo, con stato interno monotono e sezione critica sincrona.
- Respinge owner forgiati, wrapper, proxy, reentry e replay; aggiunge dispose esplicito.
- Restituisce payload Base64 immutabile dopo screening minimale PNG, JPEG o WebP.

## Verification
- Test OCR/currentness combinati: 27/27
- Test focalizzati freschi: 8/8
- Typecheck ed ESLint mirato
- Claims: 498 file, 0 claim ad alto rischio
- AI clinical writes: 104 file, 7 writer dichiarati
- Never-regress, node-runtime Node 24.19 ABI137, schema drift/writers, OpenAPI e git diff --check
- Review avversariale indipendente su owner forgiati, proxy, reentry, dispose e immutabilita.

## Risk / Notes
- Candidate stacked sul currentness head esatto f4d1ae2393ce3ad8150afc33119cd731e0e8abd6.
- Screening delle firme soltanto: nessun claim di decoding, autenticita o anti-polyglot.
- Nessun provider, route, persistenza, rete, write o apply; non integrato e non release-ready.
- Solo fixture sintetiche; nessuna PHI/PII.

## Ticket
Refs WUL-522