### PR TITLE
fix(ocr): inizializza lo schema su database vuoto

### DIFF
--- a/lib/db-server-attachment-currentness-bootstrap.test.ts
+++ b/lib/db-server-attachment-currentness-bootstrap.test.ts
@@ -85,6 +85,21 @@ function attachmentSnapshot(dbPath: string): unknown {
     }
 }
 
+/* @Codex */
+test('attachment currentness guard permits a new database with no attachments table', () => {
+    const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mediflow-currentness-empty-'));
+    try {
+        const result = bootstrap(dataDir);
+        assert.equal(result.status, 0, result.output);
+
+        const db = new Database(path.join(dataDir, 'medical.db'), { readonly: true });
+        assert.equal(db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'attachments'").get(), undefined);
+        db.close();
+    } finally {
+        fs.rmSync(dataDir, { recursive: true, force: true });
+    }
+});
+
 test('attachment currentness guard upgrades legacy data and is stable across restart', () => withLegacyDatabase('mediflow-currentness-live-', (dbPath, dataDir) => {
     const beforeDb = new Database(dbPath, { readonly: true });
     const before = beforeDb.prepare(`SELECT ${LEGACY_COLUMNS.join(', ')} FROM attachments ORDER BY id`).all();

--- a/lib/db-server-attachment-currentness-bootstrap.test.ts
+++ b/lib/db-server-attachment-currentness-bootstrap.test.ts
@@ -86,6 +86,22 @@ function attachmentSnapshot(dbPath: string): unknown {
 }
 
 /* @Codex */
+function catalogSnapshot(dbPath: string): unknown {
+    const db = new Database(dbPath, { readonly: true });
+    try {
+        return {
+            catalog: db.prepare('SELECT type, name, tbl_name, sql FROM sqlite_master ORDER BY type, name, tbl_name').all(),
+            sourceRows: db.prepare('SELECT * FROM attachment_hostile_source ORDER BY id').all(),
+        };
+    } finally {
+        db.close();
+    }
+}
+
+/* @Codex */
+type SqliteExecutor = { exec(sql: string): unknown };
+
+/* @Codex */
 test('attachment currentness guard permits a new database with no attachments table', () => {
     const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mediflow-currentness-empty-'));
     try {
@@ -97,6 +113,51 @@ test('attachment currentness guard permits a new database with no attachments ta
         db.close();
     } finally {
         fs.rmSync(dataDir, { recursive: true, force: true });
+    }
+});
+
+/* @Codex */
+test('attachment currentness guard rejects case-insensitive attachment object names without mutation', () => {
+    const hostileObjects = [
+        {
+            name: 'ATTACHMENTS',
+            create(db: SqliteExecutor) {
+                db.exec('ALTER TABLE attachments RENAME TO attachment_hostile_source; CREATE TABLE ATTACHMENTS AS SELECT * FROM attachment_hostile_source;');
+            },
+        },
+        {
+            name: 'Attachments',
+            create(db: SqliteExecutor) {
+                db.exec('ALTER TABLE attachments RENAME TO attachment_hostile_source; CREATE VIEW Attachments AS SELECT id FROM attachment_hostile_source;');
+            },
+        },
+        {
+            name: 'aTtAcHmEnTs',
+            create(db: SqliteExecutor) {
+                db.exec('ALTER TABLE attachments RENAME TO attachment_hostile_source; CREATE TABLE attachment_hostile_target (id TEXT PRIMARY KEY); CREATE TRIGGER aTtAcHmEnTs AFTER INSERT ON attachment_hostile_target BEGIN SELECT 1; END;');
+            },
+        },
+        {
+            name: 'AtTaChMeNtS',
+            create(db: SqliteExecutor) {
+                db.exec('ALTER TABLE attachments RENAME TO attachment_hostile_source; CREATE TABLE attachment_hostile_target (id TEXT PRIMARY KEY); CREATE INDEX AtTaChMeNtS ON attachment_hostile_target(id);');
+            },
+        },
+    ];
+
+    for (const hostile of hostileObjects) {
+        withLegacyDatabase(`mediflow-currentness-hostile-${hostile.name}-`, (dbPath, dataDir) => {
+            assert.equal(bootstrap(dataDir).status, 0);
+            const db = new Database(dbPath);
+            hostile.create(db);
+            db.close();
+
+            const before = catalogSnapshot(dbPath);
+            const result = bootstrap(dataDir);
+            assert.notEqual(result.status, 0, result.output);
+            assert.match(result.output, /Attachment currentness schema is not canonical\./u);
+            assert.deepEqual(catalogSnapshot(dbPath), before);
+        });
     }
 });
 

--- a/lib/db-server.ts
+++ b/lib/db-server.ts
@@ -279,7 +279,10 @@ function hasCanonicalLegacyAttachmentFingerprint(): boolean {
         && hasCanonicalAttachmentIndexes(false);
 }
 /* @Codex */
-function attachmentCurrentnessState(): 'legacy' | 'canonical' {
+function attachmentCurrentnessState(): 'missing' | 'legacy' | 'canonical' {
+    const attachmentTable = sqlite.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'attachments'").get();
+    if (!attachmentTable) return 'missing';
+
     const columns = (sqlite.prepare("SELECT name FROM pragma_table_xinfo('attachments')").all() as TableInfoRow[])
         .map((column) => column.name);
     const present = ATTACHMENTS_CURRENTNESS_COLUMNS.filter((name) => columns.includes(name));
@@ -309,7 +312,8 @@ function attachmentCurrentnessState(): 'legacy' | 'canonical' {
 }
 /* @Codex */
 function upgradeLegacyAttachmentCurrentness(): void {
-    if (attachmentCurrentnessState() === 'canonical') return;
+    const state = attachmentCurrentnessState();
+    if (state === 'missing' || state === 'canonical') return;
 
     sqlite.exec('ALTER TABLE attachments RENAME TO attachments_currentness_legacy');
     sqlite.exec(ATTACHMENTS_CURRENTNESS_DDL);

--- a/lib/db-server.ts
+++ b/lib/db-server.ts
@@ -280,8 +280,11 @@ function hasCanonicalLegacyAttachmentFingerprint(): boolean {
 }
 /* @Codex */
 function attachmentCurrentnessState(): 'missing' | 'legacy' | 'canonical' {
-    const attachmentTable = sqlite.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'attachments'").get();
-    if (!attachmentTable) return 'missing';
+    const attachmentObject = sqlite.prepare("SELECT type, name FROM sqlite_master WHERE name = 'attachments' COLLATE NOCASE").get() as { type: string; name: string } | undefined;
+    if (!attachmentObject) return 'missing';
+    if (attachmentObject.type !== 'table' || attachmentObject.name !== 'attachments') {
+        throw new Error('Attachment currentness schema is not canonical.');
+    }
 
     const columns = (sqlite.prepare("SELECT name FROM pragma_table_xinfo('attachments')").all() as TableInfoRow[])
         .map((column) => column.name);


### PR DESCRIPTION
## Summary
- tratta un database senza oggetti SQLite come prima inizializzazione, senza eseguire l'upgrade legacy di attachments
- rifiuta in modo fail-closed tabelle, view, trigger o indici case-insensitive chiamati attachments
- aggiunge regressioni sintetiche per bootstrap vuoto, oggetti ostili, schema legacy, drift e restart

## Verification
- suite focalizzata bootstrap attachment-currentness: 7/7 PASS
- review indipendente su archive esatto: ACCEPT candidate-only
- falsificatori indipendenti per table/view/trigger/index case-variant: rifiuto senza mutazione del file SQLite
- typecheck, ESLint mirato, build locale, claims, AI clinical writes, never-regress, node-runtime, schema/OpenAPI drift e git diff --check: PASS nella verifica owner

## Risk / Notes
- PR draft figlio di #242; corregge il solo debito empty-DB ereditato dalla base
- nessuna route, provider, persistenza clinica, authority, write/apply o integrazione WUL-564 aggiunta
- usa solo fixture sintetiche; nessuna PHI/PII
- candidate locale ≠ integrata, release-ready o released

## Ticket
Refs WUL-522
