### PR TITLE
test(ocr): allinea le fixture allo schema attachment

### DIFF
--- a/lib/backup-total-roundtrip.test.ts
+++ b/lib/backup-total-roundtrip.test.ts
@@ -254,6 +254,9 @@ async function populateSyntheticClinicalFixture(db: Database.Database, actorRef:
         id: 'w7-attachment', patient_id: 'w7-patient', type: 'application/pdf', size: 128,
         ...(await sealed('attachments', ['name', 'path', 'data', 'summary_snapshot', 'parse_evidence_artifact_snapshot', 'ocr_replay_artifact_snapshot'])),
         ocr_queue_state: 'ocr_done', ocr_queue_reason: 'synthetic', ocr_queue_updated_at: now + 22, created_at: now + 22,
+        document_source_ref: createHash('sha256').update('synthetic:w7-attachment').digest('hex'),
+        document_revision: 1,
+        document_freshness_epoch: 1,
     });
     insertRow(db, 'conversations', { id: 'w7-conversation', title: await seal('conversations.title'), updated_at: now + 23, is_archived: 1, is_deleted: 1, created_at: now + 23 });
     insertRow(db, 'messages', {

--- a/lib/patient-cascade.test.ts
+++ b/lib/patient-cascade.test.ts
@@ -1,5 +1,6 @@
 // WUL-306 (ADR 0066): behavioral coverage for the canonical patient cascade.
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -33,6 +34,24 @@ function bootstrapDatabase(): { sqlite: Database.Database; db: BetterSQLite3Data
         if (sql.trim().length === 0) continue;
         sqlite.exec(sql);
     }
+    // @Codex: db-server owns this runtime table; the cascade fixture must
+    // materialize its parent before exercising the migrated patient-link table.
+    sqlite.exec(`
+        CREATE TABLE IF NOT EXISTS durable_review_records (
+            id TEXT PRIMARY KEY NOT NULL,
+            patient_ref TEXT NOT NULL,
+            review_id TEXT NOT NULL UNIQUE,
+            review_revision INTEGER NOT NULL,
+            receipt_ref TEXT NOT NULL,
+            provenance_ref TEXT NOT NULL,
+            receipt_binding TEXT NOT NULL,
+            provenance_binding TEXT NOT NULL,
+            presentation_version TEXT NOT NULL,
+            sealed_ciphertext TEXT NOT NULL,
+            sealed_digest TEXT NOT NULL,
+            created_at INTEGER DEFAULT (unixepoch())
+        )
+    `);
     sqlite.pragma('foreign_keys = ON');
     return { sqlite, db: drizzle(sqlite) };
 }
@@ -46,6 +65,29 @@ function insertPatientWithChildren(sqlite: Database.Database, patientId: string)
     sqlite.prepare(
         "INSERT INTO patients (id, first_name, last_name, tax_code) VALUES (?, 'Mario', 'Rossi', 'RSSMRA80A01H501X')"
     ).run(patientId);
+    /* @Codex */
+    const reviewId = `review-${suffix}`;
+    sqlite.prepare(`
+        INSERT INTO durable_review_records (
+            id, patient_ref, review_id, review_revision, receipt_ref,
+            provenance_ref, receipt_binding, provenance_binding,
+            presentation_version, sealed_ciphertext, sealed_digest
+        ) VALUES (?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+        reviewId,
+        `ptr-${suffix}`,
+        reviewId,
+        `receipt-${suffix}`,
+        `provenance-${suffix}`,
+        '0'.repeat(64),
+        '1'.repeat(64),
+        'mediflow.ai.durable-review.presentation.v1',
+        'ENC:c3ludGhldGlj:Y2lwaGVy',
+        '2'.repeat(64),
+    );
+    sqlite.prepare(
+        'INSERT INTO durable_review_patient_links (review_id, patient_id) VALUES (?, ?)',
+    ).run(reviewId, patientId);
     sqlite.prepare(
         "INSERT INTO service_prescriptions (id, patient_id, prescribed_at, service_name) VALUES (?, ?, 1, 'Visita di controllo')"
     ).run(`sp-${suffix}`, patientId);
@@ -75,8 +117,8 @@ function insertPatientWithChildren(sqlite: Database.Database, patientId: string)
         "INSERT INTO entries (id, patient_id, type, date, content) VALUES (?, ?, 'note', 1, 'Nota di test')"
     ).run(`en-${suffix}`, patientId);
     sqlite.prepare(
-        "INSERT INTO attachments (id, patient_id, name, type, size, path) VALUES (?, ?, 'referto.pdf', 'application/pdf', 1, '/tmp/referto.pdf')"
-    ).run(`at-${suffix}`, patientId);
+        "INSERT INTO attachments (id, patient_id, name, type, size, path, document_source_ref, document_revision, document_freshness_epoch) VALUES (?, ?, 'referto.pdf', 'application/pdf', 1, '/tmp/referto.pdf', ?, 1, 1)"
+    ).run(`at-${suffix}`, patientId, createHash('sha256').update(`synthetic:attachment:${suffix}`).digest('hex'));
     sqlite.prepare(
         "INSERT INTO patients_to_ambulatories (patient_id, ambulatory_id) VALUES (?, 'amb-test')"
     ).run(patientId);

--- a/lib/patient-cascade.test.ts
+++ b/lib/patient-cascade.test.ts
@@ -66,7 +66,12 @@ function insertPatientWithChildren(sqlite: Database.Database, patientId: string)
         "INSERT INTO patients (id, first_name, last_name, tax_code) VALUES (?, 'Mario', 'Rossi', 'RSSMRA80A01H501X')"
     ).run(patientId);
     /* @Codex */
-    const reviewId = `review-${suffix}`;
+    const digest = (value: string): string => createHash('sha256').update(value).digest('hex');
+    const patientRef = `ptr_${digest(`synthetic:patient:${suffix}`).slice(0, 32)}`;
+    const reviewId = `review_${digest(`synthetic:review:${suffix}`).slice(0, 32)}`;
+    const receiptRef = `receipt_${digest(`synthetic:receipt:${suffix}`).slice(0, 32)}`;
+    const provenanceRef = `provenance_${digest(`synthetic:provenance:${suffix}`).slice(0, 32)}`;
+    const sealedCiphertext = 'ENC:c3ludGhldGlj:Y2lwaGVy';
     sqlite.prepare(`
         INSERT INTO durable_review_records (
             id, patient_ref, review_id, review_revision, receipt_ref,
@@ -75,15 +80,15 @@ function insertPatientWithChildren(sqlite: Database.Database, patientId: string)
         ) VALUES (?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?)
     `).run(
         reviewId,
-        `ptr-${suffix}`,
+        patientRef,
         reviewId,
-        `receipt-${suffix}`,
-        `provenance-${suffix}`,
-        '0'.repeat(64),
-        '1'.repeat(64),
+        receiptRef,
+        provenanceRef,
+        digest(`${patientRef}\0${reviewId}\0${receiptRef}`),
+        digest(`${patientRef}\0${reviewId}\0${provenanceRef}`),
         'mediflow.ai.durable-review.presentation.v1',
-        'ENC:c3ludGhldGlj:Y2lwaGVy',
-        '2'.repeat(64),
+        sealedCiphertext,
+        digest(sealedCiphertext),
     );
     sqlite.prepare(
         'INSERT INTO durable_review_patient_links (review_id, patient_id) VALUES (?, ?)',


### PR DESCRIPTION
## Summary
- aggiunge alle fixture attachment sintetiche i campi currentness canonici richiesti dallo schema
- materializza il parent durable-review sintetico con identificatori e binding conformi ai contratti locator/store
- mantiene invariati runtime, schema, route e asserzioni di backup/cascade

## Verification
- review indipendente su exact head: ACCEPT candidate-only
- suite focalizzate attachment/currentness, backup, cascade, bootstrap, locator e patient-link: 50/50 PASS
- full unit: 1445/1445 PASS
- typecheck, ESLint mirato, claims, AI clinical writes, never-regress, node-runtime, OpenAPI/schema drift e writers: PASS
- git diff --check: PASS

## Risk / Notes
- PR draft figlio di #245; corregge solo fixture sintetiche rese raggiungibili dal bootstrap vuoto
- nessuna PHI/PII, provider invocation, rete, write/apply o integrazione WUL-564
- candidate CI non equivale a integrated, release-ready o released

## Ticket
Refs WUL-522
