### PR TITLE
feat(ui): aggiungi Analisi e Scale ai comandi

### DIFF
--- a/components/kree8/kree8-command-center.tsx
+++ b/components/kree8/kree8-command-center.tsx
@@ -6,11 +6,13 @@ import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react'
 import { useRouter } from 'next/navigation';
 import {
   CalendarClock,
+  ChartNoAxesCombined,
   CircleHelp,
   CornerDownLeft,
   Database,
   FileText,
   Plus,
+  Scale,
   Search,
   Settings,
   Users,
@@ -68,11 +70,17 @@ export function Kree8CommandCenter({
       onOpenArea(area);
       onClose();
     };
+    const openRoute = (href: string) => {
+      router.push(href);
+      onClose();
+    };
     return [
       { id: 'agenda', label: 'Apri Agenda', hint: 'Area di turno', icon: CalendarClock, run: () => openArea('turno') },
       { id: 'patients', label: 'Apri Pazienti', hint: 'Lista e lente rapida', icon: Users, run: () => openArea('incarico') },
       { id: 'diary', label: 'Apri Diario', hint: 'Timeline clinica', icon: FileText, run: () => openArea('diario') },
       { id: 'catalogs', label: 'Apri Repertori', hint: 'Cataloghi locali', icon: Database, run: () => openArea('repertori') },
+      { id: 'analytics', label: 'Apri Analisi', hint: 'Cruscotto locale', icon: ChartNoAxesCombined, run: () => openRoute('/analytics') },
+      { id: 'scales', label: 'Apri Scale cliniche', hint: 'Catalogo e somministrazione', icon: Scale, run: () => openRoute('/scales') },
       { id: 'settings', label: 'Apri Impostazioni', hint: 'Governance locale', icon: Settings, run: () => openArea('governance') },
       {
         id: 'search',
@@ -84,7 +92,7 @@ export function Kree8CommandCenter({
           onClose();
         },
       },
-      { id: 'new', label: 'Nuova scheda', hint: 'Apri il flusso di inserimento', icon: Plus, run: () => router.push('/patients/new') },
+      { id: 'new', label: 'Nuova scheda', hint: 'Apri il flusso di inserimento', icon: Plus, run: () => openRoute('/patients/new') },
       { id: 'help', label: 'Aiuto tastiera', hint: 'Scorciatoie disponibili', icon: CircleHelp, run: onShowHelp },
     ];
   }, [onClose, onOpenArea, onSearchRequest, onShowHelp, router]);

--- a/e2e/kree8-keyboard.spec.ts
+++ b/e2e/kree8-keyboard.spec.ts
@@ -110,3 +110,53 @@ test('K4: tastiera cross-packet attraversa worklist, comandi e ricerca senza dup
 
   expect(consoleErrors).toEqual([]);
 });
+
+test('L9: i comandi raggiungono Analisi e Scale una sola volta senza scorciatoie di authority', async ({ page }) => {
+  const consoleErrors: string[] = [];
+  page.on('console', (message) => {
+    if (message.type() === 'error') consoleErrors.push(message.text());
+  });
+
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await bootstrapUnlockedSession(page, process.env.E2E_PIN || '1234');
+  await page.goto('/?area=incarico');
+
+  const commandTrigger = page.getByRole('button', { name: 'Apri comandi e aiuto tastiera', exact: true });
+  await commandTrigger.focus();
+  await page.keyboard.press('ControlOrMeta+KeyK');
+
+  const commandDialog = page.getByRole('dialog', { name: 'Comandi MediFlow', exact: true });
+  const commandSearch = page.getByRole('combobox', { name: 'Cerca un comando', exact: true });
+  await expect(commandDialog).toHaveCount(1);
+  await expect(commandSearch).toBeFocused();
+
+  await commandSearch.fill('Analisi');
+  const analyticsCommand = commandDialog.getByRole('option', { name: /Apri Analisi/ });
+  await expect(commandDialog.getByRole('option')).toHaveCount(1);
+  await expect(analyticsCommand).toHaveCount(1);
+  await expect(analyticsCommand).not.toHaveAttribute('aria-disabled', 'true');
+  await commandSearch.press('Enter');
+  await expect(page).toHaveURL(/\/analytics$/);
+  await expect(page.getByRole('heading', { name: 'Cruscotto locale', level: 1 })).toBeVisible();
+
+  await page.goto('/?area=incarico');
+  await commandTrigger.focus();
+  await page.keyboard.press('ControlOrMeta+KeyK');
+  await expect(commandSearch).toBeFocused();
+  await commandSearch.fill('Scale');
+  const scalesCommand = commandDialog.getByRole('option', { name: /Apri Scale cliniche/ });
+  await expect(commandDialog.getByRole('option')).toHaveCount(1);
+  await expect(scalesCommand).toHaveCount(1);
+  await expect(scalesCommand).not.toHaveAttribute('aria-disabled', 'true');
+  await commandSearch.press('Escape');
+  await expect(commandDialog).toHaveCount(0);
+  await expect(commandTrigger).toBeFocused();
+
+  await page.keyboard.press('ControlOrMeta+KeyK');
+  await commandSearch.fill('Scale');
+  await commandSearch.press('Enter');
+  await expect(page).toHaveURL(/\/scales$/);
+  await expect(page.getByRole('heading', { name: 'Scale cliniche', level: 1 })).toBeVisible();
+
+  expect(consoleErrors).toEqual([]);
+});


### PR DESCRIPTION
## Summary
- aggiunge due comandi univoci per raggiungere Analisi e Scale cliniche
- instrada le azioni alle route esistenti e chiude il command center dopo la selezione
- aggiunge E2E sintetico per unicità, focus, Escape, Enter e navigazione esatta

## Verification
- review indipendente su exact head: ACCEPT candidate-only
- keyboard + L9 + frame Webpack, one worker, retries=0: 11/11 PASS
- typecheck, full lint, Lume token check e test 30/30, claims, never-regress, node-runtime e AI-write gate: PASS
- git diff --check: PASS

## Risk / Notes
- PR draft figlio della base K5 corretta #244
- nessun nuovo confine authority/provider/apply, nessun prompt libero, schema o route aggiunta
- usa solo fixture sintetiche; candidate CI non equivale a integrated, release-ready o released

## Ticket
Refs WUL-560
