### PR TITLE
feat(ui): raccogli le azioni Incarico in overflow

### DIFF
--- a/components/kree8/areas/incarico-area.tsx
+++ b/components/kree8/areas/incarico-area.tsx
@@ -6,6 +6,7 @@ import {
   Activity,
   Archive,
   Cloud,
+  Ellipsis,
   FileSearch,
   FileText,
   MapPin,
@@ -67,7 +68,11 @@ function IncaricoArea({
   const [scope, setScope] = useState<InboxScope>('ambulatorio');
   const [list, setList] = useState<InboxList>('attivi');
   const [query, setQuery] = useState('');
+  const [isActionsOpen, setIsActionsOpen] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const actionsRef = useRef<HTMLDivElement>(null);
+  const actionsTriggerRef = useRef<HTMLButtonElement>(null);
+  const actionsMenuRef = useRef<HTMLDivElement>(null);
   const normalizedQuery = useMemo(() => normalizeClinicalSearch(query), [query]);
 
   useEffect(() => {
@@ -94,6 +99,50 @@ function IncaricoArea({
   );
 
   const selected = visible.find((p) => p.id === selectedPatientId) ?? visible[0] ?? null;
+
+  /* @Codex WUL-560 L6A: the disclosure owns focus and closes when its patient
+     context changes. The four existing actions keep their original handlers. */
+  useEffect(() => {
+    setIsActionsOpen(false);
+  }, [selected?.id]);
+
+  useEffect(() => {
+    if (!isActionsOpen) return;
+    const firstItem = actionsMenuRef.current?.querySelector<HTMLElement>('[role="menuitem"]');
+    window.requestAnimationFrame(() => firstItem?.focus());
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (event.target instanceof Node && !actionsRef.current?.contains(event.target)) {
+        setIsActionsOpen(false);
+      }
+    };
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+      event.preventDefault();
+      setIsActionsOpen(false);
+      window.requestAnimationFrame(() => actionsTriggerRef.current?.focus());
+    };
+    document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [isActionsOpen]);
+
+  const handleActionMenuKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    const items = [...event.currentTarget.querySelectorAll<HTMLElement>('[role="menuitem"]')];
+    const currentIndex = items.findIndex((item) => item === document.activeElement);
+    const lastIndex = items.length - 1;
+    let nextIndex: number | null = null;
+    if (event.key === 'ArrowDown') nextIndex = currentIndex >= lastIndex ? 0 : currentIndex + 1;
+    else if (event.key === 'ArrowUp') nextIndex = currentIndex <= 0 ? lastIndex : currentIndex - 1;
+    else if (event.key === 'Home') nextIndex = 0;
+    else if (event.key === 'End') nextIndex = lastIndex;
+    if (nextIndex === null) return;
+    event.preventDefault();
+    items[nextIndex]?.focus();
+  };
 
   const patientListParentRef = useRef<HTMLDivElement>(null);
 
@@ -481,22 +530,83 @@ function IncaricoArea({
                 <UserSquare2 size={13} />
                 Apri scheda paziente
               </Link>
-              <button type="button" className={styles.ghostBtnSm} data-lume-action="quiet" onClick={() => onOpenArea('scheda')}>
-                <FileSearch size={12} />
-                Quadro
-              </button>
-              <Link href={`${selected.href}/entries/new`} className={styles.ghostBtnSm} data-lume-action="quiet">
-                <Plus size={12} />
-                Nuova voce
-              </Link>
-              <Link href={`${selected.modulesHref}#documenti`} className={styles.ghostBtnSm} data-lume-action="quiet">
-                <FileText size={12} />
-                Documenti
-              </Link>
-              <button type="button" className={styles.ghostBtnSm} data-lume-action="quiet" onClick={() => onOpenArea('handoff')}>
-                <Workflow size={12} />
-                Prepara SISS
-              </button>
+              <div ref={actionsRef} className={patientStyles.caseLensActionOverflow}>
+                <button
+                  ref={actionsTriggerRef}
+                  type="button"
+                  className={patientStyles.caseLensOverflowTrigger}
+                  aria-label="Altre azioni paziente"
+                  aria-haspopup="menu"
+                  aria-expanded={isActionsOpen}
+                  aria-controls={isActionsOpen ? 'lume-patient-actions-menu' : undefined}
+                  data-lume-action="overflow"
+                  onClick={() => setIsActionsOpen((open) => !open)}
+                  onKeyDown={(event) => {
+                    if (event.key !== 'ArrowDown') return;
+                    event.preventDefault();
+                    setIsActionsOpen(true);
+                  }}
+                >
+                  <Ellipsis size={18} aria-hidden="true" />
+                </button>
+                {isActionsOpen ? (
+                  <div
+                    ref={actionsMenuRef}
+                    id="lume-patient-actions-menu"
+                    className={patientStyles.caseLensActionMenu}
+                    role="menu"
+                    aria-label="Azioni paziente"
+                    onKeyDown={handleActionMenuKeyDown}
+                  >
+                    <button
+                      type="button"
+                      className={patientStyles.caseLensMenuItem}
+                      role="menuitem"
+                      tabIndex={-1}
+                      onClick={() => {
+                        setIsActionsOpen(false);
+                        onOpenArea('scheda');
+                      }}
+                    >
+                      <FileSearch size={14} aria-hidden="true" />
+                      Quadro
+                    </button>
+                    <Link
+                      href={`${selected.href}/entries/new`}
+                      className={patientStyles.caseLensMenuItem}
+                      role="menuitem"
+                      tabIndex={-1}
+                      onClick={() => setIsActionsOpen(false)}
+                    >
+                      <Plus size={14} aria-hidden="true" />
+                      Nuova voce
+                    </Link>
+                    <Link
+                      href={`${selected.modulesHref}#documenti`}
+                      className={patientStyles.caseLensMenuItem}
+                      role="menuitem"
+                      tabIndex={-1}
+                      onClick={() => setIsActionsOpen(false)}
+                    >
+                      <FileText size={14} aria-hidden="true" />
+                      Documenti
+                    </Link>
+                    <button
+                      type="button"
+                      className={patientStyles.caseLensMenuItem}
+                      role="menuitem"
+                      tabIndex={-1}
+                      onClick={() => {
+                        setIsActionsOpen(false);
+                        onOpenArea('handoff');
+                      }}
+                    >
+                      <Workflow size={14} aria-hidden="true" />
+                      Prepara SISS
+                    </button>
+                  </div>
+                ) : null}
+              </div>
             </div>
           </aside>
         ) : (

--- a/components/kree8/areas/incarico-area.tsx
+++ b/components/kree8/areas/incarico-area.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import { createPortal } from 'react-dom';
 import {
   Activity,
   Archive,
@@ -69,6 +70,7 @@ function IncaricoArea({
   const [list, setList] = useState<InboxList>('attivi');
   const [query, setQuery] = useState('');
   const [isActionsOpen, setIsActionsOpen] = useState(false);
+  const [actionsMenuPosition, setActionsMenuPosition] = useState<{ left: number; top: number } | null>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const actionsRef = useRef<HTMLDivElement>(null);
   const actionsTriggerRef = useRef<HTMLButtonElement>(null);
@@ -106,13 +108,38 @@ function IncaricoArea({
     setIsActionsOpen(false);
   }, [selected?.id]);
 
+  useLayoutEffect(() => {
+    if (!isActionsOpen) return;
+    const positionMenu = () => {
+      const trigger = actionsTriggerRef.current?.getBoundingClientRect();
+      const menu = actionsMenuRef.current;
+      if (!trigger || !menu) return;
+      const margin = 8;
+      const gap = 8;
+      const below = trigger.bottom + gap;
+      const above = trigger.top - gap - menu.offsetHeight;
+      const top = below + menu.offsetHeight <= innerHeight - margin
+        ? below
+        : above >= margin && above + menu.offsetHeight <= innerHeight - margin ? above : Math.max(margin, innerHeight - margin - menu.offsetHeight);
+      const left = Math.min(Math.max(margin, trigger.right - menu.offsetWidth), innerWidth - margin - menu.offsetWidth);
+      setActionsMenuPosition({ left, top });
+    };
+    positionMenu();
+    window.addEventListener('resize', positionMenu);
+    window.addEventListener('scroll', positionMenu, true);
+    return () => {
+      window.removeEventListener('resize', positionMenu);
+      window.removeEventListener('scroll', positionMenu, true);
+    };
+  }, [isActionsOpen]);
+
   useEffect(() => {
     if (!isActionsOpen) return;
     const firstItem = actionsMenuRef.current?.querySelector<HTMLElement>('[role="menuitem"]');
     window.requestAnimationFrame(() => firstItem?.focus());
 
     const handlePointerDown = (event: PointerEvent) => {
-      if (event.target instanceof Node && !actionsRef.current?.contains(event.target)) {
+      if (event.target instanceof Node && !actionsRef.current?.contains(event.target) && !actionsMenuRef.current?.contains(event.target)) {
         setIsActionsOpen(false);
       }
     };
@@ -143,6 +170,13 @@ function IncaricoArea({
     event.preventDefault();
     items[nextIndex]?.focus();
   };
+
+  const overflowActions: Array<{ href?: string; icon: ReactNode; label: string; run?: () => void }> = selected ? [
+    { label: 'Quadro', icon: <FileSearch size={14} aria-hidden="true" />, run: () => onOpenArea('scheda') },
+    { label: 'Nuova voce', icon: <Plus size={14} aria-hidden="true" />, href: `${selected.href}/entries/new` },
+    { label: 'Documenti', icon: <FileText size={14} aria-hidden="true" />, href: `${selected.modulesHref}#documenti` },
+    { label: 'Prepara SISS', icon: <Workflow size={14} aria-hidden="true" />, run: () => onOpenArea('handoff') },
+  ] : [];
 
   const patientListParentRef = useRef<HTMLDivElement>(null);
 
@@ -549,62 +583,28 @@ function IncaricoArea({
                 >
                   <Ellipsis size={18} aria-hidden="true" />
                 </button>
-                {isActionsOpen ? (
+                {isActionsOpen ? createPortal(
                   <div
                     ref={actionsMenuRef}
                     id="lume-patient-actions-menu"
                     className={patientStyles.caseLensActionMenu}
                     role="menu"
                     aria-label="Azioni paziente"
+                    data-positioned={actionsMenuPosition ? 'true' : 'false'}
+                    style={actionsMenuPosition ?? undefined}
                     onKeyDown={handleActionMenuKeyDown}
                   >
-                    <button
-                      type="button"
-                      className={patientStyles.caseLensMenuItem}
-                      role="menuitem"
-                      tabIndex={-1}
-                      onClick={() => {
-                        setIsActionsOpen(false);
-                        onOpenArea('scheda');
-                      }}
-                    >
-                      <FileSearch size={14} aria-hidden="true" />
-                      Quadro
-                    </button>
-                    <Link
-                      href={`${selected.href}/entries/new`}
-                      className={patientStyles.caseLensMenuItem}
-                      role="menuitem"
-                      tabIndex={-1}
-                      onClick={() => setIsActionsOpen(false)}
-                    >
-                      <Plus size={14} aria-hidden="true" />
-                      Nuova voce
-                    </Link>
-                    <Link
-                      href={`${selected.modulesHref}#documenti`}
-                      className={patientStyles.caseLensMenuItem}
-                      role="menuitem"
-                      tabIndex={-1}
-                      onClick={() => setIsActionsOpen(false)}
-                    >
-                      <FileText size={14} aria-hidden="true" />
-                      Documenti
-                    </Link>
-                    <button
-                      type="button"
-                      className={patientStyles.caseLensMenuItem}
-                      role="menuitem"
-                      tabIndex={-1}
-                      onClick={() => {
-                        setIsActionsOpen(false);
-                        onOpenArea('handoff');
-                      }}
-                    >
-                      <Workflow size={14} aria-hidden="true" />
-                      Prepara SISS
-                    </button>
-                  </div>
+                    {overflowActions.map(({ href, icon, label, run }) => href ? (
+                      <Link key={label} href={href} className={patientStyles.caseLensMenuItem} role="menuitem" tabIndex={-1} onClick={() => setIsActionsOpen(false)}>
+                        {icon}{label}
+                      </Link>
+                    ) : (
+                      <button key={label} type="button" className={patientStyles.caseLensMenuItem} role="menuitem" tabIndex={-1} onClick={() => { setIsActionsOpen(false); run?.(); }}>
+                        {icon}{label}
+                      </button>
+                    ))}
+                  </div>,
+                  document.body,
                 ) : null}
               </div>
             </div>

--- a/components/kree8/kree8-clinical-cockpit-patient-inbox.module.css
+++ b/components/kree8/kree8-clinical-cockpit-patient-inbox.module.css
@@ -356,7 +356,78 @@
   line-height: 1.55;
 }
 
-.caseLensActions { display: flex; gap: 6px; flex-wrap: wrap; }
+.caseLensActions {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+}
+
+.worklistLensActions > [data-lume-action='primary'] {
+  min-height: 44px;
+  min-width: 0;
+  justify-content: center;
+}
+
+.caseLensActionOverflow { position: relative; }
+
+.caseLensOverflowTrigger {
+  width: 44px;
+  height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid color-mix(in srgb, var(--lume-ink) 14%, transparent);
+  border-radius: 12px;
+  background: var(--lume-surface-field);
+  color: var(--lume-ink);
+  cursor: pointer;
+}
+
+.caseLensOverflowTrigger:hover,
+.caseLensMenuItem:hover {
+  background: color-mix(in srgb, var(--lume-accent) 7%, var(--lume-surface-field));
+}
+
+.caseLensOverflowTrigger:focus-visible,
+.caseLensMenuItem:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--lume-accent) 40%, transparent);
+}
+
+.caseLensActionMenu {
+  position: absolute;
+  z-index: 20;
+  top: calc(100% + 8px);
+  right: 0;
+  width: min(230px, calc(100vw - 40px));
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  border: 1px solid color-mix(in srgb, var(--lume-ink) 16%, transparent);
+  border-radius: 14px;
+  background: var(--lume-surface-focal);
+  box-shadow: 0 12px 28px color-mix(in srgb, var(--lume-ink) 16%, transparent);
+}
+
+.caseLensMenuItem {
+  min-height: 44px;
+  width: 100%;
+  padding: 9px 10px;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  border: 0;
+  border-radius: 10px;
+  background: transparent;
+  color: var(--lume-ink);
+  font: inherit;
+  font-size: 13px;
+  text-align: left;
+  text-decoration: none;
+  cursor: pointer;
+}
 
 @media (max-width: 700px) {
   .worklistPanelHeader {
@@ -387,8 +458,11 @@
     position: static;
   }
 
-  .worklistLensActions > * {
-    max-width: 100%;
+  .worklistLensActions { grid-template-columns: minmax(0, 1fr) auto; }
+
+  .caseLensActionMenu {
+    top: auto;
+    bottom: calc(100% + 8px);
   }
 
 }

--- a/components/kree8/kree8-clinical-cockpit-patient-inbox.module.css
+++ b/components/kree8/kree8-clinical-cockpit-patient-inbox.module.css
@@ -396,10 +396,10 @@
 }
 
 .caseLensActionMenu {
-  position: absolute;
-  z-index: 20;
-  top: calc(100% + 8px);
-  right: 0;
+  position: fixed;
+  z-index: 1050;
+  top: 0;
+  left: 0;
   width: min(230px, calc(100vw - 40px));
   padding: 6px;
   display: flex;
@@ -409,7 +409,10 @@
   border-radius: 14px;
   background: var(--lume-surface-focal);
   box-shadow: 0 12px 28px color-mix(in srgb, var(--lume-ink) 16%, transparent);
+  visibility: hidden;
 }
+
+.caseLensActionMenu[data-positioned='true'] { visibility: visible; }
 
 .caseLensMenuItem {
   min-height: 44px;
@@ -459,11 +462,6 @@
   }
 
   .worklistLensActions { grid-template-columns: minmax(0, 1fr) auto; }
-
-  .caseLensActionMenu {
-    top: auto;
-    bottom: calc(100% + 8px);
-  }
 
 }
 

--- a/e2e/lume-quadro.spec.ts
+++ b/e2e/lume-quadro.spec.ts
@@ -61,6 +61,13 @@ async function setRegister(page: Page, register: QuadroCase['register']): Promis
   }, register);
 }
 
+async function openPatientActionsMenu(lens: Locator): Promise<Locator> {
+  await lens.getByRole('button', { name: 'Altre azioni paziente', exact: true }).click();
+  const menu = lens.page().getByRole('menu', { name: 'Azioni paziente', exact: true });
+  await expect(menu).toBeVisible();
+  return menu;
+}
+
 async function openSyntheticQuadro(page: Page, quadroCase: QuadroCase): Promise<Locator> {
   await page.setViewportSize({ width: quadroCase.width, height: quadroCase.height });
   await bootstrapUnlockedSession(page, process.env.E2E_PIN || '1234');
@@ -68,8 +75,9 @@ async function openSyntheticQuadro(page: Page, quadroCase: QuadroCase): Promise<
   await page.waitForLoadState('domcontentloaded');
   await setRegister(page, quadroCase.register);
   await page.getByRole('button', { name: /Pazienti/ }).click();
-  await expect(page.getByTestId('lume-patient-lens')).toBeVisible();
-  await page.getByRole('button', { name: 'Quadro', exact: true }).click();
+  const lens = page.getByTestId('lume-patient-lens');
+  await expect(lens).toBeVisible();
+  await (await openPatientActionsMenu(lens)).getByRole('menuitem', { name: 'Quadro', exact: true }).click();
   const quadro = page.getByTestId('lume-quadro');
   await expect(quadro).toBeVisible();
   return quadro;
@@ -188,7 +196,7 @@ test('la navigazione Quadro del paziente selezionato converge sulla Scheda', asy
   await page.goto(`/?area=incarico&paziente=${patient.id}`);
   const lens = page.getByTestId('lume-patient-lens');
   await expect(lens.getByRole('heading', { name: patient.name, level: 2 })).toBeVisible();
-  await lens.getByRole('button', { name: 'Quadro', exact: true }).click();
+  await (await openPatientActionsMenu(lens)).getByRole('menuitem', { name: 'Quadro', exact: true }).click();
 
   await expect(page).toHaveURL(new RegExp(`/patients/${patient.id}/modules$`));
   await expect(page.getByTestId('lume-scheda-header')).toHaveCount(1);

--- a/e2e/lume-worklist.spec.ts
+++ b/e2e/lume-worklist.spec.ts
@@ -63,6 +63,53 @@ async function resolvedFontFamily(locator: Locator): Promise<string> {
   return locator.evaluate((element) => getComputedStyle(element).fontFamily);
 }
 
+/* @Codex WUL-560 L6A: the patient lens exposes one focal action while the
+   other four remain keyboard-reachable in a single disclosure menu. */
+async function assertLensActionContract(page: Page): Promise<void> {
+  const lens = page.getByTestId('lume-patient-lens');
+  const primary = lens.getByRole('link', { name: 'Apri scheda paziente', exact: true });
+  const trigger = lens.getByRole('button', { name: 'Altre azioni paziente', exact: true });
+
+  await expect(primary).toBeVisible();
+  await expect(lens.locator('[data-lume-action="primary"]')).toHaveCount(1);
+  await expect(trigger).toBeVisible();
+  await expect(trigger).toHaveAttribute('aria-haspopup', 'menu');
+  await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  await expect(lens.getByRole('menu', { name: 'Azioni paziente' })).toHaveCount(0);
+
+  await trigger.focus();
+  await trigger.press('Enter');
+  const menu = lens.getByRole('menu', { name: 'Azioni paziente' });
+  await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  await expect(menu).toBeVisible();
+
+  const items = menu.getByRole('menuitem');
+  await expect(items).toHaveCount(4);
+  await expect(items.nth(0)).toHaveText('Quadro');
+  await expect(items.nth(1)).toHaveText('Nuova voce');
+  await expect(items.nth(2)).toHaveText('Documenti');
+  await expect(items.nth(3)).toHaveText('Prepara SISS');
+  await expect(items.nth(0)).toBeFocused();
+
+  const menuGeometry = await menu.evaluate((element) => {
+    const box = element.getBoundingClientRect();
+    return { left: box.left, right: box.right, top: box.top, bottom: box.bottom };
+  });
+  expect(menuGeometry.left).toBeGreaterThanOrEqual(-1);
+  expect(menuGeometry.right).toBeLessThanOrEqual(await page.evaluate(() => innerWidth + 1));
+  expect(menuGeometry.top).toBeGreaterThanOrEqual(-1);
+  expect(menuGeometry.bottom).toBeLessThanOrEqual(await page.evaluate(() => innerHeight + 1));
+
+  await page.keyboard.press('End');
+  await expect(items.nth(3)).toBeFocused();
+  await page.keyboard.press('ArrowDown');
+  await expect(items.nth(0)).toBeFocused();
+  await page.keyboard.press('Escape');
+  await expect(menu).toHaveCount(0);
+  await expect(trigger).toBeFocused();
+  await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+}
+
 async function assertWorklistContract(page: Page): Promise<void> {
   const list = page.getByRole('listbox', { name: 'Elenco pazienti in carico', exact: true });
   const listItems = list.getByRole('option');
@@ -136,8 +183,7 @@ async function assertWorklistContract(page: Page): Promise<void> {
 
   const lens = page.getByTestId('lume-patient-lens');
   expect(await resolvedFontFamily(lens.getByTestId('lume-patient-atoms'))).toBe(registerFamily);
-  await expect(lens.locator('[data-lume-action="primary"]')).toHaveCount(1);
-  await expect(lens.locator('[data-lume-action="quiet"]')).toHaveCount(4);
+  await assertLensActionContract(page);
 
   const search = page.getByRole('searchbox', { name: 'Cerca nella lista pazienti', exact: true });
   await search.fill('nessun caso sintetico corrispondente');
@@ -296,6 +342,13 @@ for (const worklistCase of WORKLIST_CASES) {
     });
   });
 }
+
+test('L6A mantiene quattro azioni nell’overflow mobile accessibile', async ({ page }) => {
+  await openSyntheticWorklist(page, {
+    register: 'giorno', viewport: 'phone', width: 390, height: 844,
+  });
+  await assertLensActionContract(page);
+});
 
 test('la worklist virtuale attraversa l’indice completo e apre la sola Scheda', async ({ page }) => {
   test.setTimeout(90_000);

--- a/e2e/lume-worklist.spec.ts
+++ b/e2e/lume-worklist.spec.ts
@@ -26,6 +26,7 @@ const WORKLIST_CASES: WorklistCase[] = (['giorno', 'grafite'] as const).flatMap(
   WORKLIST_VIEWPORTS.map((viewport) => ({ register, ...viewport })),
 );
 
+const MENU_COLLISION_VIEWPORTS: Omit<WorklistCase, 'register'>[] = [{ viewport: 'compact-transition', width: 640, height: 1024 }, { viewport: 'rail-boundary', width: 701, height: 900 }];
 async function setRegister(page: Page, register: WorklistCase['register']): Promise<void> {
   await page.evaluate((nextRegister) => {
     const theme = nextRegister === 'grafite' ? 'dark' : 'light';
@@ -75,11 +76,11 @@ async function assertLensActionContract(page: Page): Promise<void> {
   await expect(trigger).toBeVisible();
   await expect(trigger).toHaveAttribute('aria-haspopup', 'menu');
   await expect(trigger).toHaveAttribute('aria-expanded', 'false');
-  await expect(lens.getByRole('menu', { name: 'Azioni paziente' })).toHaveCount(0);
+  await expect(page.getByRole('menu', { name: 'Azioni paziente' })).toHaveCount(0);
 
   await trigger.focus();
   await trigger.press('Enter');
-  const menu = lens.getByRole('menu', { name: 'Azioni paziente' });
+  const menu = page.getByRole('menu', { name: 'Azioni paziente' });
   await expect(trigger).toHaveAttribute('aria-expanded', 'true');
   await expect(menu).toBeVisible();
 
@@ -349,6 +350,24 @@ test('L6A mantiene quattro azioni nell’overflow mobile accessibile', async ({ 
   });
   await assertLensActionContract(page);
 });
+for (const register of ['giorno', 'grafite'] as const) {
+  for (const viewport of MENU_COLLISION_VIEWPORTS) {
+    test(`L6A contiene il menu senza scroll a ${viewport.width}px in registro ${register}`, async ({ page }) => {
+      await openSyntheticWorklist(page, { register, ...viewport });
+      expect(await page.evaluate(() => scrollY)).toBe(0);
+      const lens = page.getByTestId('lume-patient-lens'); const trigger = lens.getByRole('button', { name: 'Altre azioni paziente', exact: true });
+      await trigger.evaluate((element) => (element as HTMLElement).click());
+      const menu = page.getByRole('menu', { name: 'Azioni paziente', exact: true });
+      await expect(menu).toBeVisible();
+      const fitsViewport = await menu.evaluate((element, size) => {
+        const box = element.getBoundingClientRect();
+        return box.top >= 8 && box.bottom <= size.height - 8 && box.left >= 8 && box.right <= size.width - 8;
+      }, viewport);
+      expect(await page.evaluate(() => scrollY)).toBe(0);
+      expect(fitsViewport).toBe(true);
+    });
+  }
+}
 
 test('la worklist virtuale attraversa l’indice completo e apre la sola Scheda', async ({ page }) => {
   test.setTimeout(90_000);


### PR DESCRIPTION
## Summary
- raccoglie le azioni secondarie Incarico in un menu accessibile
- mantiene menu e contenuto entro viewport ai breakpoint compatti e intermedi
- aggiorna il contratto Quadro per attraversare il menu accessibile senza indebolire le asserzioni Scheda
- aggiunge regressioni sintetiche per focus, ARIA, target e geometria responsive

## Verification
- L6 worklist/menu: 17/17 PASS in fresh review
- Quadro: 9/9 PASS su archivio fresco, DB sintetico, un worker, retries=0
- Frame: 9/9 PASS; owner combined Webpack matrix: 29/29 PASS
- confronto base/head prima della correzione: base PASS e held head FAIL sui due seam Quadro
- exact head CI: E2E, Web Core, build macOS/Ubuntu/Windows, lint/typecheck e guard applicabili PASS
- typecheck, full lint, Lume checks/tests 30/30, claims, never-regress, node-runtime, AI-write, schema/OpenAPI drift e git diff --check: PASS

## Risk / Notes
- PR draft figlio di #247; exact corrected head f08d05c62930427eb286adabee3ec263c1f987f4
- il precedente E2E è stato cancellato dopo 18 fallimenti deterministici sul vecchio pulsante; la correzione usa Altre azioni paziente → Azioni paziente → Quadro
- il primo Web Core sul corrected head ha avuto 1/1083 failure nel test PDF concurrency fuori diff; blob base/head identici e 7/7 su entrambi, unica ripetizione same-head verde: likely transient, non provato
- nessun timeout CI, route, provider, authority, schema o apply change; fixture sintetiche soltanto
- candidato terminale di lane; non integrated, release-ready o released

## Ticket
Refs WUL-560