### PR TITLE
feat(ui): prepara la rail clinica raggruppata

### DIFF
--- a/components/kree8/kree8-workspace-shell.module.css
+++ b/components/kree8/kree8-workspace-shell.module.css
@@ -340,6 +340,54 @@
 
 .sectionRail::-webkit-scrollbar { display: none; }
 
+/* @Codex WUL-560 L7A: grouped disclosure is opt-in. Flat callers keep the
+   exact unmapped rail until their own mapping packet supplies the closed tuple. */
+.groupedSectionRail {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  align-items: start;
+  overflow: visible;
+  scroll-snap-type: none;
+}
+
+.sectionGroup {
+  min-width: 0;
+  border: 1px solid var(--k8-line-strong);
+  border-radius: 12px;
+  background: var(--k8-control-bg);
+}
+
+.sectionGroupButton {
+  width: 100%;
+  min-height: 38px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 7px 10px;
+  border: 0;
+  border-radius: 11px;
+  background: transparent;
+  color: var(--k8-ink);
+  font: inherit;
+  font-size: 11px;
+  font-weight: 700;
+  text-align: left;
+  cursor: pointer;
+}
+
+.sectionGroupButton:focus-visible {
+  outline: 2px solid var(--k8-focus);
+  outline-offset: 2px;
+}
+
+.sectionGroupChevron { flex: 0 0 auto; transition: transform var(--lume-dur-fuoco) var(--lume-ease); }
+.sectionGroupButton[aria-expanded='true'] .sectionGroupChevron { transform: rotate(90deg); }
+.sectionGroupItems { margin: 0; padding: 0 6px 6px; list-style: none; }
+.sectionGroupItems li + li { margin-top: 4px; }
+.sectionGroupItems .sectionLink { width: 100%; justify-content: space-between; }
+.sectionActivePeek { width: calc(100% - 12px); margin: 0 6px 6px; justify-content: space-between; }
+
 .sectionLink {
   flex: 0 0 auto;
   scroll-snap-align: start;
@@ -375,6 +423,14 @@
     width: 100%;
     justify-content: space-between;
   }
+}
+
+@media (max-width: 900px) {
+  .groupedSectionRail { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+
+@media (max-width: 480px) {
+  .groupedSectionRail { grid-template-columns: 1fr; }
 }
 
 /* @Codex WUL-UIUX: sezione attiva (scrollspy). Stile coerente con :hover ma
@@ -641,6 +697,7 @@
   .clinicalShell .headerPrimaryAction,
   .clinicalShell .headerActionButton,
   .clinicalShell .sectionLink,
+  .clinicalShell .sectionGroupButton,
   .clinicalShell :global([data-testid='privacy-mode-header-toggle']) { min-height: 44px; }
   .attentionBand,
   .clinicalSection,
@@ -671,6 +728,7 @@
   .headerActionButton,
   .backButton,
   .sectionLink,
+  .sectionGroupButton,
   .attentionAction {
     min-height: 44px;
   }

--- a/components/kree8/kree8-workspace-shell.module.css
+++ b/components/kree8/kree8-workspace-shell.module.css
@@ -359,7 +359,7 @@
 
 .sectionGroupButton {
   width: 100%;
-  min-height: 38px;
+  min-height: 44px;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -385,8 +385,8 @@
 .sectionGroupButton[aria-expanded='true'] .sectionGroupChevron { transform: rotate(90deg); }
 .sectionGroupItems { margin: 0; padding: 0 6px 6px; list-style: none; }
 .sectionGroupItems li + li { margin-top: 4px; }
-.sectionGroupItems .sectionLink { width: 100%; justify-content: space-between; }
-.sectionActivePeek { width: calc(100% - 12px); margin: 0 6px 6px; justify-content: space-between; }
+.sectionGroupItems .sectionLink { width: 100%; min-height: 44px; justify-content: space-between; }
+.sectionActivePeek { width: calc(100% - 12px); min-height: 44px; margin: 0 6px 6px; justify-content: space-between; }
 
 .sectionLink {
   flex: 0 0 auto;

--- a/components/kree8/kree8-workspace-shell.tsx
+++ b/components/kree8/kree8-workspace-shell.tsx
@@ -320,7 +320,7 @@ export function Kree8WorkspaceShell({
                         <a
                           href={item.href}
                           className={styles.sectionLink}
-                          aria-current={item.href === activeHref ? 'location' : undefined}
+                          aria-current={expanded && item.href === activeHref ? 'location' : undefined}
                         >
                           <span>{item.label}</span>
                           {item.meta ? <small>{item.meta}</small> : null}

--- a/components/kree8/kree8-workspace-shell.tsx
+++ b/components/kree8/kree8-workspace-shell.tsx
@@ -3,8 +3,8 @@
 /* @Codex */
 
 import Link from 'next/link';
-import { useEffect, useRef, useState, type ReactNode } from 'react';
-import { ArrowLeft, FolderOpen, type LucideIcon } from 'lucide-react';
+import { useEffect, useId, useRef, useState, type ReactNode } from 'react';
+import { ArrowLeft, ChevronRight, FolderOpen, type LucideIcon } from 'lucide-react';
 
 // WUL-297: Privacy Mode is always reachable from the workspace header.
 import PrivacyBlur from '@/components/privacy-blur';
@@ -17,6 +17,23 @@ export type Kree8WorkspaceNavItem = {
   meta?: string;
 };
 
+/* @Codex WUL-560 L7A: the group vocabulary is closed here; callers may only
+   bind existing sections in the separate mapping packet. */
+export const KREE8_CLINICAL_RAIL_GROUPS = [
+  { id: 'quadro-decisioni', label: 'Quadro e decisioni' },
+  { id: 'terapie-prescrizioni', label: 'Terapie e prescrizioni' },
+  { id: 'documenti-prove', label: 'Documenti e prove' },
+  { id: 'diario-follow-up', label: 'Diario e follow-up' },
+] as const;
+
+type Kree8ClinicalRailDefinition = typeof KREE8_CLINICAL_RAIL_GROUPS;
+export type Kree8WorkspaceNavGroups = readonly [
+  Kree8ClinicalRailDefinition[0] & { items: readonly Kree8WorkspaceNavItem[] },
+  Kree8ClinicalRailDefinition[1] & { items: readonly Kree8WorkspaceNavItem[] },
+  Kree8ClinicalRailDefinition[2] & { items: readonly Kree8WorkspaceNavItem[] },
+  Kree8ClinicalRailDefinition[3] & { items: readonly Kree8WorkspaceNavItem[] },
+];
+
 type Kree8WorkspaceShellProps = {
   variant?: 'default' | 'clinical';
   eyebrow: string;
@@ -28,6 +45,7 @@ type Kree8WorkspaceShellProps = {
   patientAtoms?: string[];
   statusLabel?: string;
   navItems?: Kree8WorkspaceNavItem[];
+  navGroups?: Kree8WorkspaceNavGroups;
   primaryAction?: { href: string; label: string; icon: LucideIcon };
   headerActions?: ReactNode;
   children: ReactNode;
@@ -44,6 +62,7 @@ export function Kree8WorkspaceShell({
   patientAtoms = [],
   statusLabel,
   navItems = [],
+  navGroups,
   primaryAction,
   headerActions,
   children,
@@ -57,7 +76,12 @@ export function Kree8WorkspaceShell({
      aria-current stantio invece di ereditarlo. */
   const activeHrefRef = useRef<string | null>(null);
   const rootRef = useRef<HTMLDivElement>(null);
-  const navKey = navItems.map((item) => item.href).join('|');
+  const railId = useId();
+  const [openGroups, setOpenGroups] = useState<Partial<Record<Kree8ClinicalRailDefinition[number]['id'], boolean>>>({
+    'quadro-decisioni': true,
+  });
+  const renderedNavItems = navGroups ? navGroups.flatMap((group) => group.items) : navItems;
+  const navKey = renderedNavItems.map((item) => item.href).join('|');
   const PrimaryActionIcon = primaryAction?.icon;
 
   /* Lume focal locus + scrollspy (WUL-55, F2c). Un solo effetto governa la vita
@@ -268,9 +292,51 @@ export function Kree8WorkspaceShell({
           )}
         </header>
 
-        {navItems.length > 0 ? (
-          <nav className={styles.sectionRail} aria-label="Sezioni della vista">
-            {navItems.map((item) => (
+        {renderedNavItems.length > 0 ? (
+          <nav
+            className={`${styles.sectionRail} ${navGroups ? styles.groupedSectionRail : ''}`}
+            aria-label="Sezioni della vista"
+            data-rail-mode={navGroups ? 'grouped' : 'unmapped'}
+          >
+            {navGroups ? navGroups.map((group) => {
+              const activeItem = group.items.find((item) => item.href === activeHref);
+              const expanded = openGroups[group.id] === true;
+              const panelId = `${railId}-${group.id}`;
+              return (
+                <div className={styles.sectionGroup} key={group.id}>
+                  <button
+                    type="button"
+                    className={styles.sectionGroupButton}
+                    aria-controls={panelId}
+                    aria-expanded={expanded}
+                    onClick={() => setOpenGroups((current) => ({ ...current, [group.id]: !expanded }))}
+                  >
+                    <span>{group.label}</span>
+                    <ChevronRight className={styles.sectionGroupChevron} size={14} aria-hidden="true" />
+                  </button>
+                  <ul id={panelId} className={styles.sectionGroupItems} hidden={!expanded}>
+                    {group.items.map((item) => (
+                      <li key={item.href}>
+                        <a
+                          href={item.href}
+                          className={styles.sectionLink}
+                          aria-current={item.href === activeHref ? 'location' : undefined}
+                        >
+                          <span>{item.label}</span>
+                          {item.meta ? <small>{item.meta}</small> : null}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                  {!expanded && activeItem ? (
+                    <a href={activeItem.href} className={`${styles.sectionLink} ${styles.sectionActivePeek}`} aria-current="location">
+                      <span>{activeItem.label}</span>
+                      {activeItem.meta ? <small>{activeItem.meta}</small> : null}
+                    </a>
+                  ) : null}
+                </div>
+              );
+            }) : navItems.map((item) => (
               <a
                 key={item.href}
                 href={item.href}

--- a/e2e/lume-scheda.spec.ts
+++ b/e2e/lume-scheda.spec.ts
@@ -231,6 +231,33 @@ test('il controllo back della Scheda torna alla lista pazienti', async ({ page }
   await expect(page.getByTestId('lume-scheda-header')).toHaveCount(0);
 });
 
+// @Codex WUL-560 L7A: L7B owns semantic grouping; until then every existing
+// destination remains present, ordered and reachable through the flat fallback.
+test('la rail conserva le tredici sezioni non mappate senza cambiare destinazione', async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await bootstrapUnlockedSession(page, process.env.E2E_PIN || '1234');
+  const patient = await createFixture(page);
+  await page.goto(`/patients/${patient.id}/modules`);
+
+  const rail = page.getByRole('navigation', { name: 'Sezioni della vista' });
+  await expect(rail).toHaveAttribute('data-rail-mode', 'unmapped');
+  const links = rail.getByRole('link');
+  await expect(links).toHaveCount(13);
+  await expect(links).toHaveText([
+    /Attenzione/, /Quadro/, /Identità/, /Timeline/, /Diario/, /Terapie/,
+    /Prestazioni/, /Parametri/, /Protesica/, /SISS\/FSE/, /Documenti/, /Scale/, /Follow-up/,
+  ]);
+  expect(await links.evaluateAll((elements) => elements.map((element) => element.getAttribute('href')))).toEqual([
+    '#attenzione', '#quadro', '#identita', '#timeline', '#diario', '#terapie',
+    '#prestazioni', '#parametri', '#protesica', '#siss', '#documenti', '#scale', '#follow-up',
+  ]);
+
+  await links.nth(1).focus();
+  await expect(links.nth(1)).toBeFocused();
+  await page.keyboard.press('Enter');
+  await expect(page).toHaveURL(/#quadro$/);
+});
+
 for (const schedaCase of CASES) {
   test(`Scheda Lume ${schedaCase.register} ${schedaCase.viewport}`, async ({ page }) => {
     await page.setViewportSize({ width: schedaCase.width, height: schedaCase.height });


### PR DESCRIPTION
## Summary
- prepara la shell Scheda per la rail clinica raggruppata mantenendo il fallback piatto
- conserva stato attivo, destinazioni esistenti e target compatti da 44 px
- aggiunge una regressione sintetica per tutte le tredici sezioni non ancora mappate

## Verification
- fresh independent Webpack E2E: 45/45 PASS, DB sintetico, workers=1, retries=0
- owner combined matrix: 36/36 PASS
- typecheck, full lint, Lume checks/tests 42/42 e 30/30, claims, never-regress, node-runtime, AI-write, OpenAPI/schema/writers e git diff --check: PASS
- exact ancestry, commit order e blob equivalence con il candidato logico L7A: PASS

## Risk / Notes
- PR draft figlia di #248; exact base f08d05c62930427eb286adabee3ec263c1f987f4
- exact head 604b681c13a1e1090b294313ed93b50eb0cf9787
- il fallback resta piatto: la mappatura grouped rail appartiene al packet L7B successivo
- nessun route, provider, authority, schema, write o apply change; fixture sintetiche soltanto
- candidato di lane; non integrated, release-ready o released

## Ticket
Refs WUL-560