### PR TITLE
feat(ui): raggruppa la rail clinica della scheda

### DIFF
--- a/app/patients/[id]/modules/page.tsx
+++ b/app/patients/[id]/modules/page.tsx
@@ -44,6 +44,7 @@ import { classifyObservationRange, toNumericValue } from '@/lib/observation-rang
 import { resolveStaticTerminology } from '@/lib/terminology';
 import { projectFollowupSuggestions } from '@/lib/patient-followup-projection';
 import { deriveOpenLoopProjection, type OpenLoop } from '@/lib/patient-open-loops';
+import { buildPatientModuleRailGroups } from '@/lib/patient-module-rail-mapping';
 import FollowupSuggestions from '@/components/followup-suggestions';
 import { calculateAge, estimateBirthYearFromTaxCode } from '@/lib/utils';
 
@@ -503,22 +504,24 @@ export default function PatientDetailPage() {
     });
     const openLoopCount = openLoopProjection.groups.reduce((total, group) => total + group.loops.length, 0)
         + openLoopProjection.standaloneLoops.length;
-    /* @Codex LUME-104/68: il rail segue l'ordine clinico della superficie unica. */
+    /* @Codex WUL-560 L7B / D-WebRail-01: ordine raggruppato esplicito; ogni
+       oggetto conserva href, label e meta del caller senza binding inferiti. */
     const workspaceNavItems: Kree8WorkspaceNavItem[] = [
-        { href: '#attenzione', label: 'Attenzione', meta: String(reviewQueueSummary.attentionCount + openLoopCount) },
         { href: '#quadro', label: 'Quadro' },
+        { href: '#attenzione', label: 'Attenzione', meta: String(reviewQueueSummary.attentionCount + openLoopCount) },
         { href: '#identita', label: 'Identità' },
-        { href: '#timeline', label: 'Timeline', meta: String(nonScaleEntries.length + (checkups ?? []).length + documentInsights.length) },
-        { href: '#diario', label: 'Diario', meta: String(nonScaleEntries.length) },
+        { href: '#parametri', label: 'Parametri', meta: workspace ? String(workspace.observationsCount) : undefined },
         { href: '#terapie', label: 'Terapie', meta: workspace ? String(workspace.activeTherapiesCount) : undefined },
         { href: '#prestazioni', label: 'Prestazioni', meta: prestazioniCount !== undefined ? String(prestazioniCount) : undefined },
-        { href: '#parametri', label: 'Parametri', meta: workspace ? String(workspace.observationsCount) : undefined },
         { href: '#protesica', label: 'Protesica', meta: protesicaCount !== undefined ? String(protesicaCount) : undefined },
-        { href: '#siss', label: 'SISS/FSE' },
-        { href: '#documenti', label: 'Documenti', meta: String(attachmentItems.length) },
         { href: '#scale', label: 'Scale' },
+        { href: '#documenti', label: 'Documenti', meta: String(attachmentItems.length) },
+        { href: '#siss', label: 'SISS/FSE' },
+        { href: '#timeline', label: 'Timeline', meta: String(nonScaleEntries.length + (checkups ?? []).length + documentInsights.length) },
+        { href: '#diario', label: 'Diario', meta: String(nonScaleEntries.length) },
         { href: '#follow-up', label: 'Follow-up', meta: workspace ? String(workspace.pendingCheckupsCount) : undefined },
     ];
+    const workspaceNavGroups = buildPatientModuleRailGroups(workspaceNavItems);
 
     /* @Codex Validates against the FSE and builds the bundle, or returns null
        when the export must not proceed.
@@ -621,7 +624,7 @@ export default function PatientDetailPage() {
                 ageLabel,
                 `Aggiornato ${updatedLabel}`,
             ]}
-            navItems={workspaceNavItems}
+            navGroups={workspaceNavGroups}
             primaryAction={{ href: `/patients/${id}/entries/new`, label: 'Nuova voce', icon: Plus }}
             headerActions={(
                 <PatientSheetActionsMenu

--- a/components/kree8/kree8-workspace-shell.module.css
+++ b/components/kree8/kree8-workspace-shell.module.css
@@ -358,6 +358,7 @@
 }
 
 .sectionGroupButton {
+  box-sizing: border-box;
   width: 100%;
   min-height: 44px;
   display: flex;
@@ -385,8 +386,8 @@
 .sectionGroupButton[aria-expanded='true'] .sectionGroupChevron { transform: rotate(90deg); }
 .sectionGroupItems { margin: 0; padding: 0 6px 6px; list-style: none; }
 .sectionGroupItems li + li { margin-top: 4px; }
-.sectionGroupItems .sectionLink { width: 100%; min-height: 44px; justify-content: space-between; }
-.sectionActivePeek { width: calc(100% - 12px); min-height: 44px; margin: 0 6px 6px; justify-content: space-between; }
+.sectionGroupItems .sectionLink { box-sizing: border-box; width: 100%; min-height: 44px; justify-content: space-between; }
+.sectionActivePeek { box-sizing: border-box; width: calc(100% - 12px); min-height: 44px; margin: 0 6px 6px; justify-content: space-between; }
 
 .sectionLink {
   flex: 0 0 auto;
@@ -423,6 +424,8 @@
     width: 100%;
     justify-content: space-between;
   }
+
+  .groupedSectionRail .sectionActivePeek { width: calc(100% - 12px); }
 }
 
 @media (max-width: 900px) {

--- a/e2e/lume-scheda.spec.ts
+++ b/e2e/lume-scheda.spec.ts
@@ -231,31 +231,56 @@ test('il controllo back della Scheda torna alla lista pazienti', async ({ page }
   await expect(page.getByTestId('lume-scheda-header')).toHaveCount(0);
 });
 
-// @Codex WUL-560 L7A: L7B owns semantic grouping; until then every existing
-// destination remains present, ordered and reachable through the flat fallback.
-test('la rail conserva le tredici sezioni non mappate senza cambiare destinazione', async ({ page }) => {
+// @Codex WUL-560 L7B: D-WebRail-01 binds every canonical destination once.
+test('la rail raggruppa le tredici sezioni e mantiene una sola destinazione corrente', async ({ page }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
   await bootstrapUnlockedSession(page, process.env.E2E_PIN || '1234');
   const patient = await createFixture(page);
   await page.goto(`/patients/${patient.id}/modules`);
 
   const rail = page.getByRole('navigation', { name: 'Sezioni della vista' });
-  await expect(rail).toHaveAttribute('data-rail-mode', 'unmapped');
-  const links = rail.getByRole('link');
+  await expect(rail).toHaveAttribute('data-rail-mode', 'grouped');
+  const disclosures = rail.getByRole('button');
+  await expect(disclosures).toHaveText([
+    'Quadro e decisioni', 'Terapie e prescrizioni', 'Documenti e prove', 'Diario e follow-up',
+  ]);
+  await expect(disclosures.nth(0)).toHaveAttribute('aria-expanded', 'true');
+  for (let index = 1; index < 4; index += 1) {
+    await expect(disclosures.nth(index)).toHaveAttribute('aria-expanded', 'false');
+  }
+  expect(new Set(await disclosures.evaluateAll((buttons) => buttons.map((button) => button.getAttribute('aria-controls')))).size)
+    .toBe(4);
+
+  const links = rail.locator('a');
   await expect(links).toHaveCount(13);
   await expect(links).toHaveText([
-    /Attenzione/, /Quadro/, /Identità/, /Timeline/, /Diario/, /Terapie/,
-    /Prestazioni/, /Parametri/, /Protesica/, /SISS\/FSE/, /Documenti/, /Scale/, /Follow-up/,
+    /Quadro/, /Attenzione/, /Identità/, /Parametri/, /Terapie/, /Prestazioni/,
+    /Protesica/, /Scale/, /Documenti/, /SISS\/FSE/, /Timeline/, /Diario/, /Follow-up/,
   ]);
   expect(await links.evaluateAll((elements) => elements.map((element) => element.getAttribute('href')))).toEqual([
-    '#attenzione', '#quadro', '#identita', '#timeline', '#diario', '#terapie',
-    '#prestazioni', '#parametri', '#protesica', '#siss', '#documenti', '#scale', '#follow-up',
+    '#quadro', '#attenzione', '#identita', '#parametri', '#terapie', '#prestazioni',
+    '#protesica', '#scale', '#documenti', '#siss', '#timeline', '#diario', '#follow-up',
   ]);
 
-  await links.nth(1).focus();
-  await expect(links.nth(1)).toBeFocused();
+  const current = page.locator('[aria-current="location"]');
+  await expect.poll(() => current.count()).toBe(1);
+  const currentHref = await current.getAttribute('href');
+  await disclosures.nth(0).focus();
+  await page.keyboard.press('Space');
+  await expect(disclosures.nth(0)).toHaveAttribute('aria-expanded', 'false');
+  await expect(current).toHaveCount(1);
+  await expect(current).toBeVisible();
+  await expect(current).toHaveAttribute('href', currentHref!);
   await page.keyboard.press('Enter');
-  await expect(page).toHaveURL(/#quadro$/);
+  await expect(disclosures.nth(0)).toHaveAttribute('aria-expanded', 'true');
+  await expect(current).toHaveCount(1);
+
+  await disclosures.nth(1).focus();
+  await page.keyboard.press('Enter');
+  const therapies = rail.getByRole('link', { name: /Terapie/ });
+  await therapies.focus();
+  await page.keyboard.press('Enter');
+  await expect(page).toHaveURL(/#terapie$/);
 });
 
 for (const schedaCase of CASES) {

--- a/lib/patient-module-rail-mapping.test.ts
+++ b/lib/patient-module-rail-mapping.test.ts
@@ -1,0 +1,92 @@
+/* @Codex WUL-560 L7B */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+    buildPatientModuleRailGroups,
+    validatePatientModuleRailGroups,
+} from './patient-module-rail-mapping';
+
+const canonicalItems = () => [
+    { href: '#quadro', label: 'Quadro', meta: 'q' },
+    { href: '#attenzione', label: 'Attenzione', meta: 'a' },
+    { href: '#identita', label: 'Identità' },
+    { href: '#parametri', label: 'Parametri', meta: 'p' },
+    { href: '#terapie', label: 'Terapie', meta: 't' },
+    { href: '#prestazioni', label: 'Prestazioni' },
+    { href: '#protesica', label: 'Protesica' },
+    { href: '#scale', label: 'Scale' },
+    { href: '#documenti', label: 'Documenti', meta: 'd' },
+    { href: '#siss', label: 'SISS/FSE' },
+    { href: '#timeline', label: 'Timeline' },
+    { href: '#diario', label: 'Diario' },
+    { href: '#follow-up', label: 'Follow-up', meta: 'f' },
+] as const;
+
+test('builds the four D-WebRail-01 groups without cloning caller items', () => {
+    const items = canonicalItems();
+    const groups = buildPatientModuleRailGroups(items);
+
+    assert.deepEqual(groups.map(({ id, label }) => ({ id, label })), [
+        { id: 'quadro-decisioni', label: 'Quadro e decisioni' },
+        { id: 'terapie-prescrizioni', label: 'Terapie e prescrizioni' },
+        { id: 'documenti-prove', label: 'Documenti e prove' },
+        { id: 'diario-follow-up', label: 'Diario e follow-up' },
+    ]);
+    assert.deepEqual(groups.map((group) => group.items.map((item) => item.href)), [
+        ['#quadro', '#attenzione', '#identita', '#parametri'],
+        ['#terapie', '#prestazioni', '#protesica', '#scale'],
+        ['#documenti', '#siss'],
+        ['#timeline', '#diario', '#follow-up'],
+    ]);
+    assert.deepEqual(groups.flatMap((group) => group.items), items);
+    groups.flatMap((group) => group.items).forEach((item, index) => assert.equal(item, items[index]));
+});
+
+test('fails closed on incomplete, duplicate, unknown, reordered, query or label input', () => {
+    const cases = [
+        { name: 'missing', items: canonicalItems().slice(0, -1), reason: 'missing_item' },
+        { name: 'extra', items: [...canonicalItems(), { href: '#extra', label: 'Extra' }], reason: 'extra_item' },
+        { name: 'duplicate', items: canonicalItems().map((item, index) => index === 1 ? canonicalItems()[0] : item), reason: 'duplicate_href' },
+        { name: 'unknown', items: canonicalItems().map((item, index) => index === 0 ? { href: '#unknown', label: 'Quadro' } : item), reason: 'unknown_href' },
+        { name: 'reordered', items: [canonicalItems()[1], canonicalItems()[0], ...canonicalItems().slice(2)], reason: 'item_order' },
+        { name: 'query', items: canonicalItems().map((item, index) => index === 0 ? { href: '#quadro?copy=1', label: 'Quadro' } : item), reason: 'query_collision' },
+        { name: 'label', items: canonicalItems().map((item, index) => index === 0 ? { href: '#quadro', label: 'Quadro clinico' } : item), reason: 'label_drift' },
+    ];
+
+    for (const entry of cases) {
+        assert.throws(
+            () => buildPatientModuleRailGroups(entry.items),
+            new RegExp(`patient_module_rail_mapping_invalid:${entry.reason}`),
+            entry.name,
+        );
+    }
+});
+
+test('rejects group identity, order and caller-object drift', () => {
+    const items = canonicalItems();
+    const groups = buildPatientModuleRailGroups(items);
+    const cloned = groups.map((group) => ({ ...group, items: [...group.items] }));
+
+    assert.throws(
+        () => validatePatientModuleRailGroups(
+            cloned.map((group, index) => index === 0 ? { ...group, id: 'unknown-group' } : group),
+            items,
+        ),
+        /patient_module_rail_mapping_invalid:unknown_group/,
+    );
+    assert.throws(
+        () => validatePatientModuleRailGroups([cloned[1], cloned[0], cloned[2], cloned[3]], items),
+        /patient_module_rail_mapping_invalid:group_order/,
+    );
+    assert.throws(
+        () => validatePatientModuleRailGroups(
+            cloned.map((group, index) => index === 0
+                ? { ...group, items: [{ ...group.items[0] }, ...group.items.slice(1)] }
+                : group),
+            items,
+        ),
+        /patient_module_rail_mapping_invalid:item_identity_drift/,
+    );
+});

--- a/lib/patient-module-rail-mapping.test.ts
+++ b/lib/patient-module-rail-mapping.test.ts
@@ -6,7 +6,7 @@ import test from 'node:test';
 import {
     buildPatientModuleRailGroups,
     validatePatientModuleRailGroups,
-} from './patient-module-rail-mapping';
+} from './patient-module-rail-mapping.ts';
 
 const canonicalItems = () => [
     { href: '#quadro', label: 'Quadro', meta: 'q' },

--- a/lib/patient-module-rail-mapping.ts
+++ b/lib/patient-module-rail-mapping.ts
@@ -1,0 +1,129 @@
+/* @Codex WUL-560 L7B */
+
+import type {
+    Kree8WorkspaceNavGroups,
+    Kree8WorkspaceNavItem,
+} from '@/components/kree8/kree8-workspace-shell';
+
+/* D-WebRail-01 is the explicit product binding. Its flattened order replaces
+   the former flat rail; no label similarity or positional inference is used. */
+const PATIENT_MODULE_RAIL_SPEC = [
+    {
+        id: 'quadro-decisioni',
+        label: 'Quadro e decisioni',
+        items: [
+            { href: '#quadro', label: 'Quadro' },
+            { href: '#attenzione', label: 'Attenzione' },
+            { href: '#identita', label: 'Identità' },
+            { href: '#parametri', label: 'Parametri' },
+        ],
+    },
+    {
+        id: 'terapie-prescrizioni',
+        label: 'Terapie e prescrizioni',
+        items: [
+            { href: '#terapie', label: 'Terapie' },
+            { href: '#prestazioni', label: 'Prestazioni' },
+            { href: '#protesica', label: 'Protesica' },
+            { href: '#scale', label: 'Scale' },
+        ],
+    },
+    {
+        id: 'documenti-prove',
+        label: 'Documenti e prove',
+        items: [
+            { href: '#documenti', label: 'Documenti' },
+            { href: '#siss', label: 'SISS/FSE' },
+        ],
+    },
+    {
+        id: 'diario-follow-up',
+        label: 'Diario e follow-up',
+        items: [
+            { href: '#timeline', label: 'Timeline' },
+            { href: '#diario', label: 'Diario' },
+            { href: '#follow-up', label: 'Follow-up' },
+        ],
+    },
+] as const;
+
+type RailGroupCandidate = {
+    readonly id: string;
+    readonly label: string;
+    readonly items: readonly Kree8WorkspaceNavItem[];
+};
+
+type ExpectedItem = { readonly href: string; readonly label: string };
+
+const expectedItems = PATIENT_MODULE_RAIL_SPEC.reduce<ExpectedItem[]>(
+    (items, group) => [...items, ...group.items],
+    [],
+);
+const expectedHrefs = new Set(expectedItems.map((item) => item.href));
+const expectedGroupIds = new Set(PATIENT_MODULE_RAIL_SPEC.map((group) => group.id));
+
+function invalid(reason: string): never {
+    throw new Error(`patient_module_rail_mapping_invalid:${reason}`);
+}
+
+function validateSourceItems(items: readonly Kree8WorkspaceNavItem[]): void {
+    if (items.length < expectedItems.length) invalid('missing_item');
+    if (items.length > expectedItems.length) invalid('extra_item');
+
+    const seen = new Set<string>();
+    for (const item of items) {
+        if (seen.has(item.href)) invalid('duplicate_href');
+        seen.add(item.href);
+    }
+
+    items.forEach((item, index) => {
+        const expected = expectedItems[index];
+        if (item.href !== expected.href) {
+            const queryBase = item.href.split(/[?&]/, 1)[0];
+            if (queryBase === expected.href) invalid('query_collision');
+            if (expectedHrefs.has(item.href as typeof expected.href)) invalid('item_order');
+            invalid('unknown_href');
+        }
+        if (item.label !== expected.label) invalid('label_drift');
+    });
+}
+
+export function validatePatientModuleRailGroups(
+    groups: readonly RailGroupCandidate[],
+    sourceItems: readonly Kree8WorkspaceNavItem[],
+): void {
+    validateSourceItems(sourceItems);
+    if (groups.length !== PATIENT_MODULE_RAIL_SPEC.length) invalid('group_count');
+
+    let sourceIndex = 0;
+    groups.forEach((group, groupIndex) => {
+        const expectedGroup = PATIENT_MODULE_RAIL_SPEC[groupIndex];
+        if (group.id !== expectedGroup.id) {
+            if (expectedGroupIds.has(group.id as typeof expectedGroup.id)) invalid('group_order');
+            invalid('unknown_group');
+        }
+        if (group.label !== expectedGroup.label) invalid('group_label_drift');
+        if (group.items.length !== expectedGroup.items.length) invalid('group_item_count');
+
+        group.items.forEach((item, itemIndex) => {
+            const expected = (expectedGroup.items as readonly ExpectedItem[])[itemIndex];
+            if (item.href !== expected.href) invalid('group_item_order');
+            if (item !== sourceItems[sourceIndex]) invalid('item_identity_drift');
+            sourceIndex += 1;
+        });
+    });
+}
+
+export function buildPatientModuleRailGroups(
+    items: readonly Kree8WorkspaceNavItem[],
+): Kree8WorkspaceNavGroups {
+    validateSourceItems(items);
+    let sourceIndex = 0;
+    const groups = PATIENT_MODULE_RAIL_SPEC.map((group) => {
+        const groupedItems = Object.freeze(items.slice(sourceIndex, sourceIndex + group.items.length));
+        sourceIndex += group.items.length;
+        return Object.freeze({ id: group.id, label: group.label, items: groupedItems });
+    });
+    validatePatientModuleRailGroups(groups, items);
+    return Object.freeze(groups) as Kree8WorkspaceNavGroups;
+}


### PR DESCRIPTION
## Summary
- Introduce a closed 13-section mapping for the grouped patient-module rail.
- Render the patient sheet rail in four labelled groups while preserving exact section anchors and a single active state.
- Extend synthetic Scheda E2E coverage for grouped navigation, collapse/expand, keyboard focus and responsive layouts.

## Verification
- Mapping suite: 3/3; independent closed-bijection falsifiers: 13/13.
- Fresh synthetic Webpack E2E: owner matrix 45/45; independent focused matrix 6/6, workers=1 and retries=0.
- Typecheck, full lint, Lume token check and tests 30/30.
- Claims, AI clinical-write, never-regress, Node runtime, OpenAPI/schema drift and git diff --check.

## Risk / Notes
- Candidate-only stacked on exact L7A head 604b681c13a1e1090b294313ed93b50eb0cf9787.
- No route, provider, schema, authority, write or apply expansion.
- Synthetic fixtures only; no PHI/PII or clinical data.
- Draft publication is not merge, integration, release readiness or release.

## Ticket
Refs WUL-560