### PR TITLE
test(db): completa la fixture cascade durevole

### DIFF
--- a/lib/patient-cascade.test.ts
+++ b/lib/patient-cascade.test.ts
@@ -1,5 +1,6 @@
 // WUL-306 (ADR 0066): behavioral coverage for the canonical patient cascade.
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -65,7 +66,12 @@ function insertPatientWithChildren(sqlite: Database.Database, patientId: string)
         "INSERT INTO patients (id, first_name, last_name, tax_code) VALUES (?, 'Mario', 'Rossi', 'RSSMRA80A01H501X')"
     ).run(patientId);
     /* @Codex */
-    const reviewId = `review-${suffix}`;
+    const digest = (value: string): string => createHash('sha256').update(value).digest('hex');
+    const patientRef = `ptr_${digest(`synthetic:patient:${suffix}`).slice(0, 32)}`;
+    const reviewId = `review_${digest(`synthetic:review:${suffix}`).slice(0, 32)}`;
+    const receiptRef = `receipt_${digest(`synthetic:receipt:${suffix}`).slice(0, 32)}`;
+    const provenanceRef = `provenance_${digest(`synthetic:provenance:${suffix}`).slice(0, 32)}`;
+    const sealedCiphertext = 'ENC:c3ludGhldGlj:Y2lwaGVy';
     sqlite.prepare(`
         INSERT INTO durable_review_records (
             id, patient_ref, review_id, review_revision, receipt_ref,
@@ -74,15 +80,15 @@ function insertPatientWithChildren(sqlite: Database.Database, patientId: string)
         ) VALUES (?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?)
     `).run(
         reviewId,
-        `ptr-${suffix}`,
+        patientRef,
         reviewId,
-        `receipt-${suffix}`,
-        `provenance-${suffix}`,
-        '0'.repeat(64),
-        '1'.repeat(64),
+        receiptRef,
+        provenanceRef,
+        digest(`${patientRef}\0${reviewId}\0${receiptRef}`),
+        digest(`${patientRef}\0${reviewId}\0${provenanceRef}`),
         'mediflow.ai.durable-review.presentation.v1',
-        'ENC:c3ludGhldGlj:Y2lwaGVy',
-        '2'.repeat(64)
+        sealedCiphertext,
+        digest(sealedCiphertext),
     );
     sqlite.prepare(
         'INSERT INTO durable_review_patient_links (review_id, patient_id) VALUES (?, ?)'

--- a/lib/patient-cascade.test.ts
+++ b/lib/patient-cascade.test.ts
@@ -33,6 +33,24 @@ function bootstrapDatabase(): { sqlite: Database.Database; db: BetterSQLite3Data
         if (sql.trim().length === 0) continue;
         sqlite.exec(sql);
     }
+    // @Codex: db-server owns this runtime table; the cascade fixture must
+    // materialize its parent before exercising the migrated patient-link table.
+    sqlite.exec(`
+        CREATE TABLE IF NOT EXISTS durable_review_records (
+            id TEXT PRIMARY KEY NOT NULL,
+            patient_ref TEXT NOT NULL,
+            review_id TEXT NOT NULL UNIQUE,
+            review_revision INTEGER NOT NULL,
+            receipt_ref TEXT NOT NULL,
+            provenance_ref TEXT NOT NULL,
+            receipt_binding TEXT NOT NULL,
+            provenance_binding TEXT NOT NULL,
+            presentation_version TEXT NOT NULL,
+            sealed_ciphertext TEXT NOT NULL,
+            sealed_digest TEXT NOT NULL,
+            created_at INTEGER DEFAULT (unixepoch())
+        )
+    `);
     sqlite.pragma('foreign_keys = ON');
     return { sqlite, db: drizzle(sqlite) };
 }
@@ -46,6 +64,29 @@ function insertPatientWithChildren(sqlite: Database.Database, patientId: string)
     sqlite.prepare(
         "INSERT INTO patients (id, first_name, last_name, tax_code) VALUES (?, 'Mario', 'Rossi', 'RSSMRA80A01H501X')"
     ).run(patientId);
+    /* @Codex */
+    const reviewId = `review-${suffix}`;
+    sqlite.prepare(`
+        INSERT INTO durable_review_records (
+            id, patient_ref, review_id, review_revision, receipt_ref,
+            provenance_ref, receipt_binding, provenance_binding,
+            presentation_version, sealed_ciphertext, sealed_digest
+        ) VALUES (?, ?, ?, 1, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+        reviewId,
+        `ptr-${suffix}`,
+        reviewId,
+        `receipt-${suffix}`,
+        `provenance-${suffix}`,
+        '0'.repeat(64),
+        '1'.repeat(64),
+        'mediflow.ai.durable-review.presentation.v1',
+        'ENC:c3ludGhldGlj:Y2lwaGVy',
+        '2'.repeat(64)
+    );
+    sqlite.prepare(
+        'INSERT INTO durable_review_patient_links (review_id, patient_id) VALUES (?, ?)'
+    ).run(reviewId, patientId);
     sqlite.prepare(
         "INSERT INTO service_prescriptions (id, patient_id, prescribed_at, service_name) VALUES (?, ?, 1, 'Visita di controllo')"
     ).run(`sp-${suffix}`, patientId);


### PR DESCRIPTION
## Summary
- Seed a canonical synthetic durable-review record and patient link in the patient-cascade fixture.
- Use parser-valid opaque references and exact receipt, provenance and sealed-content digests.
- Preserve cascade count, rollback and orphan semantics without importing Headless or runtime changes.

## Verification
- Exact base reproduces the three fixture failures; corrected head passes cascade 3/3.
- Durable store, locator, rerender, link and cascade suite: 21/21.
- Typecheck, full lint, claims, never-regress, Node runtime, schema/OpenAPI guards and diff-check.
- Fresh independent review accepted the exact one-file +47 diff.

## Risk / Notes
- Test-fixture-only candidate; no runtime/schema/Headless/attachment behavior changes.
- Synthetic fixtures only; no PHI/PII or clinical data.
- Physician attestations are outside PATIENT_CHILD_TABLES and are not invented here.
- Draft publication is not integration or release readiness.

## Ticket
Refs WUL-522