### PR TITLE
feat(fabric): add Patient Insight broker publication

### DIFF
--- a/lib/ai-providers/fabric/patient-insight-broker.test.ts
+++ b/lib/ai-providers/fabric/patient-insight-broker.test.ts
@@ -1,0 +1,136 @@
+/* @Codex */
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+import { createPatientInsightHostBoundary } from './patient-insight-host-boundary.ts';
+import { PatientInsightBrokerError, createPatientInsightBroker, type PatientInsightBrokerHost } from './patient-insight-broker.ts';
+
+const ref = (prefix: string) => `${prefix}_${'a'.repeat(32)}`;
+const now = '2026-08-23T12:00:00.000Z';
+const sources = () => ({ focus: { summary: 'synthetic follow-up' }, conditions: [{ label: 'synthetic condition' }], activeTherapies: [{ label: 'synthetic therapy' }], recentEvents: [{ summary: 'synthetic review' }] });
+const boundary = () => createPatientInsightHostBoundary({
+    binding: { leaseRef: ref('lsr'), patientRef: ref('ptr'), selectionEpoch: 7 },
+    receipt: { schemaVersion: 'mediflow.patient-insight.host-receipt.v1', reference: ref('receipt'), capability: 'patient_insight', authority: 'host_service', writesPerformed: 0, applyPolicy: 'none' },
+    provenance: { schemaVersion: 'mediflow.patient-insight.host-provenance.v1', reference: ref('provenance'), capability: 'patient_insight', receiptRef: ref('receipt') },
+});
+const state = (overrides: Partial<{ selectionEpoch: number; revision: number; freshnessToken: string; revoked: boolean }> = {}) => Object.freeze({
+    selectionEpoch: 7, revision: 3, freshnessToken: 'fresh_token_0123456789abcdef', revoked: false, ...overrides,
+});
+function host(overrides: Partial<PatientInsightBrokerHost> = {}) {
+    let current = state(); let sequence = 0;
+    const value = Object.freeze({
+        readCurrentness: () => Object.freeze({ selectionEpoch: current.selectionEpoch, revision: current.revision, freshnessToken: current.freshnessToken, isRevoked: () => current.revoked }),
+        readSources: sources, boundary: boundary(), clock: () => now,
+        entropy: () => Uint8Array.from({ length: 16 }, (_, index) => (sequence += 1) + index), ...overrides,
+    });
+    return { value, setCurrentness: (next: typeof current) => { current = next; } };
+}
+const reject = (action: () => unknown, code: string) => assert.throws(action, (error) => error instanceof PatientInsightBrokerError && error.code === code && error.message === `Patient Insight broker denied: ${code}` && !/synthetic|condition/i.test(error.message));
+
+test('issues unique opaque handles and consumes only the accepted frozen review proposal', () => {
+    const fixture = host(); const broker = createPatientInsightBroker(fixture.value); const first = broker.issue(); const second = broker.issue();
+    assert.match(first, /^pib_[0-9a-f]{32}$/u); assert.notEqual(first, second); assert.doesNotMatch(first, /synthetic|patient|condition/i);
+    const accepted = broker.consume({ handle: first });
+    assert.deepEqual(Object.keys(accepted), ['status', 'writesPerformed', 'applyPolicy', 'receiptReference', 'provenanceReference', 'proposal']);
+    assert.equal(accepted.status, 'available'); assert.equal(accepted.writesPerformed, 0); assert.equal(accepted.applyPolicy, 'none');
+    assert.equal(accepted.proposal.reviewOnly, true); assert.equal(Object.isFrozen(accepted), true); assert.equal(Object.isFrozen(accepted.proposal), true);
+    reject(() => broker.consume({ handle: first }), 'handle_replayed');
+});
+
+test('fails closed after selection, revision, freshness, or revocation changes', () => {
+    for (const [next, code] of [[state({ selectionEpoch: 8 }), 'selection_changed'], [state({ revision: 4 }), 'revision_stale'], [state({ freshnessToken: 'fresh_token_abcdef0123456789' }), 'freshness_stale'], [state({ revoked: true }), 'revoked']] as const) {
+        const fixture = host(); const broker = createPatientInsightBroker(fixture.value); const handle = broker.issue(); fixture.setCurrentness(next);
+        reject(() => broker.consume({ handle }), code); reject(() => broker.consume({ handle }), 'handle_replayed');
+    }
+});
+
+test('rejects hostile dependencies, host-reader failures, and later source mutation without leaking details', () => {
+    const accessor = { ...host().value } as Record<string, unknown>; Object.defineProperty(accessor, 'clock', { enumerable: true, get() { throw new Error('synthetic accessor'); } }); Object.freeze(accessor);
+    const sparse = [host().value]; sparse.length = 2;
+    for (const value of [
+        { ...host().value, extra: true }, Object.create(host().value), accessor, sparse, new Proxy(host().value, { ownKeys() { throw new Error('synthetic proxy'); } }),
+    ]) reject(() => createPatientInsightBroker(value as never), 'input_invalid');
+    const consumer = createPatientInsightBroker(host().value); const forgedHandle = `pib_${'a'.repeat(32)}`;
+    const consumerAccessor: Record<string, unknown> = {}; Object.defineProperty(consumerAccessor, 'handle', { enumerable: true, get() { throw new Error('synthetic accessor'); } }); Object.freeze(consumerAccessor);
+    for (const value of [{ handle: forgedHandle, extra: true }, { handle: forgedHandle, [Symbol('synthetic')]: true }, Object.create({ handle: forgedHandle }), consumerAccessor, new Proxy({ handle: forgedHandle }, { ownKeys() { throw new Error('synthetic proxy'); } })]) reject(() => consumer.consume(value), 'input_invalid');
+    for (const value of [host({ clock: () => { throw new Error('raw clock'); } }), host({ entropy: () => new Uint8Array(15) }), host({ readCurrentness: () => { throw new Error('raw state'); } }), host({ readSources: () => { throw new Error('raw sources'); } })]) {
+        const broker = createPatientInsightBroker(value.value); reject(() => broker.issue(), 'dependency_unavailable');
+    }
+    const input = sources(); const fixture = host({ readSources: () => input }); const broker = createPatientInsightBroker(fixture.value); const handle = broker.issue(); input.focus.summary = 'mutated';
+    assert.equal(broker.consume({ handle }).proposal.promptFingerprint, 'pi_223cbf9d');
+});
+
+test('rejects transparent Proxies before their traps or accessors are evaluated', () => {
+    let reads = 0; const trapped = new Proxy(host().value, { get() { reads += 1; throw new Error('synthetic trap'); } });
+    reject(() => createPatientInsightBroker(trapped), 'input_invalid'); assert.equal(reads, 0);
+    reject(() => createPatientInsightBroker(new Proxy(host().value, {})), 'input_invalid');
+    reject(() => createPatientInsightBroker(host({ boundary: new Proxy(boundary(), {}) }).value), 'input_invalid');
+    const currentProxy = new Proxy(Object.freeze({ selectionEpoch: 7, revision: 3, freshnessToken: 'fresh_token_0123456789abcdef', isRevoked: () => false }), {});
+    reject(() => createPatientInsightBroker(host({ readCurrentness: () => currentProxy }).value).issue(), 'dependency_unavailable');
+    const valid = boundary().prepare({ projection: { schemaVersion: 'mediflow.patient-insight.projection.v1', clinicalFocus: 'synthetic follow-up', activeConditions: ['synthetic condition'], currentTherapies: ['synthetic therapy'], recentClinicalEvents: ['synthetic review'] } });
+    const resultProxy = Object.freeze({ prepare: () => new Proxy(valid, {}) });
+    const proposalProxy = Object.freeze({ prepare: () => Object.freeze({ ...valid, proposal: new Proxy(valid.status === 'available' ? valid.proposal : {}, {}) }) });
+    reject(() => createPatientInsightBroker(host({ boundary: resultProxy as never }).value).issue(), 'proposal_invalid');
+    reject(() => createPatientInsightBroker(host({ boundary: proposalProxy as never }).value).issue(), 'proposal_invalid');
+    const broker = createPatientInsightBroker(host().value); reject(() => broker.consume(new Proxy({ handle: `pib_${'a'.repeat(32)}` }, {})), 'input_invalid');
+});
+
+test('rejects non-enumerable broker records at every caller-controlled record seam', () => {
+    const hidden = (value: Record<string, unknown>, key: string) => {
+        const clone = { ...value };
+        Object.defineProperty(clone, key, { value: clone[key], enumerable: false });
+        return Object.freeze(clone);
+    };
+    reject(() => createPatientInsightBroker(hidden({ ...host().value }, 'clock') as never), 'input_invalid');
+    reject(() => createPatientInsightBroker(host({ boundary: hidden({ ...boundary() }, 'prepare') as never }).value), 'input_invalid');
+    const hiddenCurrentness = hidden({ selectionEpoch: 7, revision: 3, freshnessToken: 'fresh_token_0123456789abcdef', isRevoked: () => false }, 'revision');
+    reject(() => createPatientInsightBroker(host({ readCurrentness: () => hiddenCurrentness as never }).value).issue(), 'dependency_unavailable');
+    const valid = boundary().prepare({ projection: { schemaVersion: 'mediflow.patient-insight.projection.v1', clinicalFocus: 'synthetic follow-up', activeConditions: ['synthetic condition'], currentTherapies: ['synthetic therapy'], recentClinicalEvents: ['synthetic review'] } });
+    reject(() => createPatientInsightBroker(host({ boundary: Object.freeze({ prepare: () => hidden({ ...valid }, 'status') }) as never }).value).issue(), 'proposal_invalid');
+    const available = valid.status === 'available' ? valid : assert.fail('expected available proposal');
+    const hiddenProposal = hidden({ ...available.proposal }, 'reviewOnly');
+    reject(() => createPatientInsightBroker(host({ boundary: Object.freeze({ prepare: () => Object.freeze({ ...available, proposal: hiddenProposal }) }) as never }).value).issue(), 'proposal_invalid');
+    const broker = createPatientInsightBroker(host().value);
+    reject(() => broker.consume(hidden({ handle: `pib_${'a'.repeat(32)}` }, 'handle')), 'input_invalid');
+});
+
+test('rechecks currentness after issue dependencies and orders consume clock before currentness', () => {
+    let change = () => {}; let calls = 0;
+    const clockFixture = host({ clock: () => { calls += 1; if (calls === 2) change(); return now; } }); change = () => clockFixture.setCurrentness(state({ revision: 4 }));
+    const clockBroker = createPatientInsightBroker(clockFixture.value); const handle = clockBroker.issue(); reject(() => clockBroker.consume({ handle }), 'revision_stale');
+    let reentrant = state();
+    const revokedFixture = host({ readCurrentness: () => Object.freeze({ selectionEpoch: reentrant.selectionEpoch, revision: reentrant.revision, freshnessToken: reentrant.freshnessToken, isRevoked: () => { reentrant = state({ revision: 4 }); return false; } }) });
+    reject(() => createPatientInsightBroker(revokedFixture.value).issue(), 'revision_stale');
+});
+
+test('publishes no handle residue after reentrant denial and ignores ambient then accessors', () => {
+    let mutate = () => {};
+    const fixture = host({
+        readSources: () => { mutate(); return sources(); },
+        entropy: () => new Uint8Array(16).fill(7),
+    });
+    const prior = Object.getOwnPropertyDescriptor(Object.prototype, 'then');
+    let reads = 0;
+    Object.defineProperty(Object.prototype, 'then', { configurable: true, get() { reads += 1; return undefined; } });
+    try {
+        const broker = createPatientInsightBroker(fixture.value);
+        mutate = () => fixture.setCurrentness(state({ revision: 4 }));
+        reject(() => broker.issue(), 'revision_stale');
+        fixture.setCurrentness(state()); mutate = () => {};
+        const handle = broker.issue();
+        assert.equal(handle, `pib_${'07'.repeat(16)}`);
+        assert.equal(broker.consume({ handle }).status, 'available');
+    } finally {
+        if (prior) Object.defineProperty(Object.prototype, 'then', prior);
+        else delete (Object.prototype as { then?: unknown }).then;
+    }
+    assert.equal(reads, 0);
+});
+
+test('does not reach forbidden concerns or reuse the Smart Import broker', () => {
+    const source = readFileSync(new URL('./patient-insight-broker.ts', import.meta.url), 'utf8');
+    assert.doesNotMatch(source, /typed-projection-broker|smart-import|provider-lifecycle|fetch\(/u);
+    assert.doesNotMatch(source, /database|persist|writeFile|patientRef|sessionRef|route|apply\(/ui);
+    assert.match(source, /ABA[\s\S]*P4[\s\S]*HOLD/u);
+});

--- a/lib/ai-providers/fabric/patient-insight-broker.test.ts
+++ b/lib/ai-providers/fabric/patient-insight-broker.test.ts
@@ -76,6 +76,36 @@ test('rejects transparent Proxies before their traps or accessors are evaluated'
     const broker = createPatientInsightBroker(host().value); reject(() => broker.consume(new Proxy({ handle: `pib_${'a'.repeat(32)}` }, {})), 'input_invalid');
 });
 
+test('rejects callable Proxy dependencies and entropy results before any trap runs', () => {
+    const callableProxy = (sideEffects: { value: number }): (() => boolean) => new Proxy(() => false, {
+        apply() { sideEffects.value += 1; throw new Error('synthetic callable Proxy'); },
+        get() { sideEffects.value += 1; throw new Error('synthetic callable Proxy'); },
+    });
+    for (const dependency of ['readCurrentness', 'readSources', 'clock', 'entropy'] as const) {
+        const sideEffects = { value: 0 };
+        reject(() => createPatientInsightBroker(host({ [dependency]: callableProxy(sideEffects) } as never).value), 'input_invalid');
+        assert.equal(sideEffects.value, 0, `${dependency} Proxy must not run`);
+    }
+    const prepareSideEffects = { value: 0 };
+    reject(() => createPatientInsightBroker(host({ boundary: Object.freeze({ prepare: callableProxy(prepareSideEffects) }) as never }).value), 'input_invalid');
+    assert.equal(prepareSideEffects.value, 0, 'prepare Proxy must not run');
+
+    const revokedSideEffects = { value: 0 };
+    const revokedBroker = createPatientInsightBroker(host({
+        readCurrentness: () => Object.freeze({ selectionEpoch: 7, revision: 3, freshnessToken: 'fresh_token_0123456789abcdef', isRevoked: callableProxy(revokedSideEffects) }),
+    }).value);
+    reject(() => revokedBroker.issue(), 'dependency_unavailable');
+    assert.equal(revokedSideEffects.value, 0, 'isRevoked Proxy must not run');
+
+    let entropyCalls = 0; const entropyResultSideEffects = { value: 0 };
+    const entropyBroker = createPatientInsightBroker(host({
+        entropy: () => { entropyCalls += 1; return new Proxy(new Uint8Array(16), { get() { entropyResultSideEffects.value += 1; throw new Error('synthetic entropy result Proxy'); } }); },
+    }).value);
+    reject(() => entropyBroker.issue(), 'dependency_unavailable');
+    assert.equal(entropyCalls, 1, 'entropy is invoked exactly once');
+    assert.equal(entropyResultSideEffects.value, 0, 'entropy Proxy result must not be reflected or read');
+});
+
 test('rejects non-enumerable broker records at every caller-controlled record seam', () => {
     const hidden = (value: Record<string, unknown>, key: string) => {
         const clone = { ...value };

--- a/lib/ai-providers/fabric/patient-insight-broker.test.ts
+++ b/lib/ai-providers/fabric/patient-insight-broker.test.ts
@@ -95,6 +95,29 @@ test('rejects non-enumerable broker records at every caller-controlled record se
     reject(() => broker.consume(hidden({ handle: `pib_${'a'.repeat(32)}` }, 'handle')), 'input_invalid');
 });
 
+test('requires a boolean revocation result and publishes no record for non-boolean values', () => {
+    let thenReads = 0;
+    const thenable = Object.create(null, { then: { enumerable: true, get() { thenReads += 1; return () => undefined; } } });
+    for (const invalid of [0, 1, undefined, null, 'false', Object.freeze({}), Promise.resolve(false), thenable]) {
+        let revoked: unknown = invalid; let entropyCalls = 0;
+        const fixture = host({
+            readCurrentness: () => Object.freeze({ selectionEpoch: 7, revision: 3, freshnessToken: 'fresh_token_0123456789abcdef', isRevoked: () => revoked as never }),
+            entropy: () => { entropyCalls += 1; return new Uint8Array(16).fill(9); },
+        });
+        const broker = createPatientInsightBroker(fixture.value);
+        reject(() => broker.issue(), 'dependency_unavailable');
+        assert.equal(entropyCalls, 0);
+        revoked = false;
+        const handle = broker.issue();
+        assert.equal(handle, `pib_${'09'.repeat(16)}`);
+        assert.equal(entropyCalls, 1);
+        assert.equal(broker.consume({ handle }).status, 'available');
+    }
+    assert.equal(thenReads, 0);
+    const revoked = host({ readCurrentness: () => Object.freeze({ selectionEpoch: 7, revision: 3, freshnessToken: 'fresh_token_0123456789abcdef', isRevoked: () => true }) });
+    reject(() => createPatientInsightBroker(revoked.value).issue(), 'revoked');
+});
+
 test('rechecks currentness after issue dependencies and orders consume clock before currentness', () => {
     let change = () => {}; let calls = 0;
     const clockFixture = host({ clock: () => { calls += 1; if (calls === 2) change(); return now; } }); change = () => clockFixture.setCurrentness(state({ revision: 4 }));

--- a/lib/ai-providers/fabric/patient-insight-broker.ts
+++ b/lib/ai-providers/fabric/patient-insight-broker.ts
@@ -25,6 +25,7 @@ const handlePattern = /^pib_[0-9a-f]{32}$/u;
 const tokenPattern = /^[A-Za-z][A-Za-z0-9._:-]{15,159}$/u;
 
 function fail(code: PatientInsightBrokerErrorCode): never { throw new PatientInsightBrokerError(code); }
+function callable(value: unknown): value is () => unknown { return typeof value === 'function' && !types.isProxy(value); }
 function exact(value: unknown, keys: readonly string[]): Record<string, unknown> | null {
     try {
         if (!value || typeof value !== 'object' || types.isProxy(value) || Array.isArray(value) || Object.getPrototypeOf(value) !== Object.prototype) return null;
@@ -40,7 +41,7 @@ function timestamp(value: unknown): string | null {
 function currentness(value: unknown): Currentness | null {
     try {
         const input = exact(value, ['selectionEpoch', 'revision', 'freshnessToken', 'isRevoked']);
-        if (!input || !Object.isFrozen(value) || !Number.isSafeInteger(input.selectionEpoch) || (input.selectionEpoch as number) < 1 || !Number.isSafeInteger(input.revision) || (input.revision as number) < 0 || typeof input.freshnessToken !== 'string' || !tokenPattern.test(input.freshnessToken) || typeof input.isRevoked !== 'function') return null;
+        if (!input || !Object.isFrozen(value) || !Number.isSafeInteger(input.selectionEpoch) || (input.selectionEpoch as number) < 1 || !Number.isSafeInteger(input.revision) || (input.revision as number) < 0 || typeof input.freshnessToken !== 'string' || !tokenPattern.test(input.freshnessToken) || !callable(input.isRevoked)) return null;
         const revoked = (input.isRevoked as () => unknown)();
         if (typeof revoked !== 'boolean') return null;
         if (revoked) return fail('revoked');
@@ -66,7 +67,7 @@ function currentnessChanged(before: Currentness, after: Currentness): void {
 export function createPatientInsightBroker(value: PatientInsightBrokerHost): PatientInsightBroker {
     const host = exact(value, ['readCurrentness', 'readSources', 'boundary', 'clock', 'entropy']);
     const boundaryValue = host && exact(host.boundary, ['prepare']);
-    if (!host || !Object.isFrozen(value) || !boundaryValue || typeof host.readCurrentness !== 'function' || typeof host.readSources !== 'function' || typeof boundaryValue.prepare !== 'function' || typeof host.clock !== 'function' || typeof host.entropy !== 'function') fail('input_invalid');
+    if (!host || !Object.isFrozen(value) || !boundaryValue || !callable(host.readCurrentness) || !callable(host.readSources) || !callable(boundaryValue.prepare) || !callable(host.clock) || !callable(host.entropy)) fail('input_invalid');
     const resolver = createPatientInsightHostProjectionResolver(); const records = new Map<string, RecordEntry>(); const issued = new Set<string>(); const consumed = new Set<string>();
     const readCurrentness = () => {
         let result: unknown; try { result = (host.readCurrentness as () => unknown)(); } catch { return fail('dependency_unavailable'); }
@@ -76,7 +77,7 @@ export function createPatientInsightBroker(value: PatientInsightBrokerHost): Pat
     const issueHandle = () => {
         let bytes: unknown; try { bytes = (host.entropy as () => unknown)(); } catch { return fail('dependency_unavailable'); }
         try {
-            if (!(bytes instanceof Uint8Array) || bytes.byteLength < 16) fail('dependency_unavailable');
+            if (types.isProxy(bytes) || !(bytes instanceof Uint8Array) || bytes.byteLength < 16) fail('dependency_unavailable');
             let hex = ''; for (let index = 0; index < 16; index += 1) hex += bytes[index].toString(16).padStart(2, '0'); return `pib_${hex}`;
         } catch (error) { if (error instanceof PatientInsightBrokerError) throw error; return fail('dependency_unavailable'); }
     };

--- a/lib/ai-providers/fabric/patient-insight-broker.ts
+++ b/lib/ai-providers/fabric/patient-insight-broker.ts
@@ -1,0 +1,97 @@
+/* @Codex */
+import 'server-only';
+
+import { types } from 'node:util';
+import type { PatientInsightHostBoundary, PatientInsightHostResult, PatientInsightProjection } from './patient-insight-host-boundary.ts';
+import { createPatientInsightHostProjectionResolver } from './patient-insight-host-projection.ts';
+
+export type PatientInsightBrokerErrorCode = 'dependency_unavailable' | 'freshness_stale' | 'handle_collision' | 'handle_missing' | 'handle_replayed' | 'input_invalid' | 'proposal_invalid' | 'revision_stale' | 'revoked' | 'selection_changed';
+export class PatientInsightBrokerError extends Error {
+    constructor(readonly code: PatientInsightBrokerErrorCode) { super(`Patient Insight broker denied: ${code}`); this.name = 'PatientInsightBrokerError'; }
+}
+export type PatientInsightBrokerCurrentness = Readonly<{ selectionEpoch: number; revision: number; freshnessToken: string; isRevoked: () => boolean }>;
+export type PatientInsightBrokerHost = Readonly<{
+    readCurrentness: () => PatientInsightBrokerCurrentness;
+    readSources: () => unknown;
+    boundary: PatientInsightHostBoundary;
+    clock: () => string;
+    entropy: () => Uint8Array;
+}>;
+export type PatientInsightBroker = Readonly<{ issue: () => string; consume: (input: unknown) => Extract<PatientInsightHostResult, { status: 'available' }> }>;
+
+type Currentness = Readonly<{ selectionEpoch: number; revision: number; freshnessToken: string }>;
+type RecordEntry = Readonly<{ currentness: Currentness; accepted: Extract<PatientInsightHostResult, { status: 'available' }> }>;
+const handlePattern = /^pib_[0-9a-f]{32}$/u;
+const tokenPattern = /^[A-Za-z][A-Za-z0-9._:-]{15,159}$/u;
+
+function fail(code: PatientInsightBrokerErrorCode): never { throw new PatientInsightBrokerError(code); }
+function exact(value: unknown, keys: readonly string[]): Record<string, unknown> | null {
+    try {
+        if (!value || typeof value !== 'object' || types.isProxy(value) || Array.isArray(value) || Object.getPrototypeOf(value) !== Object.prototype) return null;
+        const own = Reflect.ownKeys(value); if (own.length !== keys.length || own.some((key) => typeof key !== 'string' || !keys.includes(key))) return null;
+        const copy: Record<string, unknown> = {};
+        for (const key of keys) { const descriptor = Object.getOwnPropertyDescriptor(value, key); if (!descriptor?.enumerable || !('value' in descriptor)) return null; copy[key] = descriptor.value; }
+        return copy;
+    } catch { return null; }
+}
+function timestamp(value: unknown): string | null {
+    return typeof value === 'string' && value.length <= 32 && Number.isFinite(Date.parse(value)) && new Date(value).toISOString() === value ? value : null;
+}
+function currentness(value: unknown): Currentness | null {
+    try {
+        const input = exact(value, ['selectionEpoch', 'revision', 'freshnessToken', 'isRevoked']);
+        if (!input || !Object.isFrozen(value) || !Number.isSafeInteger(input.selectionEpoch) || (input.selectionEpoch as number) < 1 || !Number.isSafeInteger(input.revision) || (input.revision as number) < 0 || typeof input.freshnessToken !== 'string' || !tokenPattern.test(input.freshnessToken) || typeof input.isRevoked !== 'function') return null;
+        if (input.isRevoked()) return fail('revoked');
+        return Object.freeze({ selectionEpoch: input.selectionEpoch as number, revision: input.revision as number, freshnessToken: input.freshnessToken });
+    } catch (error) { if (error instanceof PatientInsightBrokerError) throw error; return null; }
+}
+function accepted(value: unknown): Extract<PatientInsightHostResult, { status: 'available' }> | null {
+    try {
+        const input = exact(value, ['status', 'writesPerformed', 'applyPolicy', 'receiptReference', 'provenanceReference', 'proposal']);
+        const proposal = input && exact(input.proposal, ['schemaVersion', 'reviewOnly', 'promptFingerprint']);
+        if (!input || !proposal || !Object.isFrozen(value) || !Object.isFrozen(input.proposal) || input.status !== 'available' || input.writesPerformed !== 0 || input.applyPolicy !== 'none' || typeof input.receiptReference !== 'string' || !tokenPattern.test(input.receiptReference) || typeof input.provenanceReference !== 'string' || !tokenPattern.test(input.provenanceReference) || proposal.schemaVersion !== 'mediflow.patient-insight.review-proposal.v1' || proposal.reviewOnly !== true || typeof proposal.promptFingerprint !== 'string' || !/^pi_[0-9a-f]{8}$/u.test(proposal.promptFingerprint)) return null;
+        return value as Extract<PatientInsightHostResult, { status: 'available' }>;
+    } catch { return null; }
+}
+
+function currentnessChanged(before: Currentness, after: Currentness): void {
+    if (after.selectionEpoch !== before.selectionEpoch) fail('selection_changed');
+    if (after.revision !== before.revision) fail('revision_stale');
+    if (after.freshnessToken !== before.freshnessToken) fail('freshness_stale');
+}
+
+/** Candidate-only: ABA needs P4 lease critical section; production remains HOLD. */
+export function createPatientInsightBroker(value: PatientInsightBrokerHost): PatientInsightBroker {
+    const host = exact(value, ['readCurrentness', 'readSources', 'boundary', 'clock', 'entropy']);
+    const boundaryValue = host && exact(host.boundary, ['prepare']);
+    if (!host || !Object.isFrozen(value) || !boundaryValue || typeof host.readCurrentness !== 'function' || typeof host.readSources !== 'function' || typeof boundaryValue.prepare !== 'function' || typeof host.clock !== 'function' || typeof host.entropy !== 'function') fail('input_invalid');
+    const resolver = createPatientInsightHostProjectionResolver(); const records = new Map<string, RecordEntry>(); const issued = new Set<string>(); const consumed = new Set<string>();
+    const readCurrentness = () => {
+        let result: unknown; try { result = (host.readCurrentness as () => unknown)(); } catch { return fail('dependency_unavailable'); }
+        const snapshot = currentness(result); if (!snapshot) fail('dependency_unavailable'); return snapshot;
+    };
+    const readClock = () => { try { if (!timestamp((host.clock as () => unknown)())) fail('dependency_unavailable'); } catch (error) { if (error instanceof PatientInsightBrokerError) throw error; fail('dependency_unavailable'); } };
+    const issueHandle = () => {
+        let bytes: unknown; try { bytes = (host.entropy as () => unknown)(); } catch { return fail('dependency_unavailable'); }
+        try {
+            if (!(bytes instanceof Uint8Array) || bytes.byteLength < 16) fail('dependency_unavailable');
+            let hex = ''; for (let index = 0; index < 16; index += 1) hex += bytes[index].toString(16).padStart(2, '0'); return `pib_${hex}`;
+        } catch (error) { if (error instanceof PatientInsightBrokerError) throw error; return fail('dependency_unavailable'); }
+    };
+    return Object.freeze({
+        issue() {
+            const snapshot = readCurrentness(); readClock(); let sources: unknown;
+            try { sources = (host.readSources as () => unknown)(); } catch { return fail('dependency_unavailable'); }
+            const projection = resolver.resolve(sources); if (!projection) fail('dependency_unavailable');
+            let output: unknown; try { output = (boundaryValue.prepare as (request: Readonly<{ projection: PatientInsightProjection }>) => unknown)(Object.freeze({ projection })); } catch { return fail('dependency_unavailable'); }
+            const result = accepted(output); if (!result) fail('proposal_invalid'); const handle = issueHandle(); if (issued.has(handle)) fail('handle_collision');
+            currentnessChanged(snapshot, readCurrentness());
+            issued.add(handle); records.set(handle, Object.freeze({ currentness: snapshot, accepted: result })); return handle;
+        },
+        consume(inputValue) {
+            const input = exact(inputValue, ['handle']); if (!input || typeof input.handle !== 'string' || !handlePattern.test(input.handle)) fail('input_invalid');
+            if (consumed.has(input.handle)) fail('handle_replayed'); const entry = records.get(input.handle); if (!entry) fail('handle_missing'); records.delete(input.handle); consumed.add(input.handle);
+            readClock(); currentnessChanged(entry.currentness, readCurrentness()); return entry.accepted;
+        },
+    });
+}

--- a/lib/ai-providers/fabric/patient-insight-broker.ts
+++ b/lib/ai-providers/fabric/patient-insight-broker.ts
@@ -2,8 +2,8 @@
 import 'server-only';
 
 import { types } from 'node:util';
-import type { PatientInsightHostBoundary, PatientInsightHostResult, PatientInsightProjection } from './patient-insight-host-boundary.ts';
-import { createPatientInsightHostProjectionResolver } from './patient-insight-host-projection.ts';
+import type { PatientInsightHostBoundary, PatientInsightHostResult, PatientInsightProjection } from './patient-insight-host-boundary';
+import { createPatientInsightHostProjectionResolver } from './patient-insight-host-projection';
 
 export type PatientInsightBrokerErrorCode = 'dependency_unavailable' | 'freshness_stale' | 'handle_collision' | 'handle_missing' | 'handle_replayed' | 'input_invalid' | 'proposal_invalid' | 'revision_stale' | 'revoked' | 'selection_changed';
 export class PatientInsightBrokerError extends Error {

--- a/lib/ai-providers/fabric/patient-insight-broker.ts
+++ b/lib/ai-providers/fabric/patient-insight-broker.ts
@@ -41,7 +41,9 @@ function currentness(value: unknown): Currentness | null {
     try {
         const input = exact(value, ['selectionEpoch', 'revision', 'freshnessToken', 'isRevoked']);
         if (!input || !Object.isFrozen(value) || !Number.isSafeInteger(input.selectionEpoch) || (input.selectionEpoch as number) < 1 || !Number.isSafeInteger(input.revision) || (input.revision as number) < 0 || typeof input.freshnessToken !== 'string' || !tokenPattern.test(input.freshnessToken) || typeof input.isRevoked !== 'function') return null;
-        if (input.isRevoked()) return fail('revoked');
+        const revoked = (input.isRevoked as () => unknown)();
+        if (typeof revoked !== 'boolean') return null;
+        if (revoked) return fail('revoked');
         return Object.freeze({ selectionEpoch: input.selectionEpoch as number, revision: input.revision as number, freshnessToken: input.freshnessToken });
     } catch (error) { if (error instanceof PatientInsightBrokerError) throw error; return null; }
 }


### PR DESCRIPTION
## Summary
- adds the Patient Insight in-process broker publication layer on top of the accepted PI host boundary
- stages, publishes, aborts, consumes, and burns opaque one-use review handles
- rejects callable Proxy dependencies and Proxy entropy before traps or calls
- preserves review-only output with `writesPerformed=0` and `applyPolicy=none`

## Verification
- fresh archive focused broker/host/projection/atomic tests: 26/26
- cascade guard: 3/3
- full typecheck and ESLint
- node runtime, claims, AI clinical writes, never-regress, schema/OpenAPI drift, API error leak
- independent adversarial review: ACCEPT on broker behavior at `497ec81b0408b31bf6f9203617eee7b5a5dcd79c`
- Next webpack build and static generation: 108/108 on follow-up head `dfbb22a9c8e39bda67f21653938764d3dcbce6de`

## Risk / Notes
- candidate publication layer only; no P4, stable-observation, transactional, route, provider, persistence, schema, UI, write, or apply integration
- the follow-up commit only removes `.ts` from two production import specifiers after the first CI set exposed the Next build incompatibility
- production and promotion remain held for the later stable/transactional stack, authentic broker-to-lease binding, P4 composition, combined-base verification, and release gates
- synthetic fixtures only; no PHI/PII or real patient data

## Ticket
Refs WUL-522
