### PR TITLE
feat(fabric): stabilize Patient Insight observations

### DIFF
--- a/lib/ai-providers/fabric/patient-insight-atomic-lease.test.ts
+++ b/lib/ai-providers/fabric/patient-insight-atomic-lease.test.ts
@@ -38,6 +38,37 @@ test('publishes one primitive staging result only after the P4 final currentness
     assert.throws(() => lease.consume(current, () => 'replay'), rejects('record_spent'));
 });
 
+test('rejects an issued record after its P4 selection epoch changes before consume', () => {
+    const { state, lease } = fixture();
+    const current = lease.replaceCurrentness(1, 1, 'fresh-1', false);
+    state.selectionEpoch += 1;
+    let published = false;
+    assert.throws(() => lease.consume(current, () => { published = true; return 'never'; }), rejects('stale_selection'));
+    assert.equal(published, false);
+});
+
+test('rejects an issued record after its P4 review-context epoch changes before consume', () => {
+    const { state, lease } = fixture();
+    const current = lease.replaceCurrentness(1, 1, 'fresh-1', false);
+    state.reviewContextEpoch += 1;
+    let published = false;
+    assert.throws(() => lease.consume(current, () => { published = true; return 'never'; }), rejects('stale_selection'));
+    assert.equal(published, false);
+});
+
+test('binds issued records to the real P4 selection and review-context epochs', () => {
+    const session = createSession({ id: ['synthetic', 'p4-binding'].join('-'), username: ['synthetic', 'clinician'].join('-'), role: 'clinician' });
+    const owner = createServerSessionProjectionOwnerRegistry({ resolve: (_session, pair) => pair }).acquire(session);
+    const first = owner.issueSelection({ expectedEpoch: 0, patientId: 'patient.synthetic.01', ambulatoryId: 'ambulatory.synthetic.01' });
+    assert.deepEqual({ selectionEpoch: owner.snapshotSelectionEpoch(session), reviewContextEpoch: owner.snapshotReviewContextEpoch(session) }, { selectionEpoch: 1, reviewContextEpoch: 1 });
+    const lease = createPatientInsightAtomicLease({ owner, session, entropy: () => new Uint8Array(16), clock: () => 1 });
+    const current = lease.replaceCurrentness(1, 1, 'fresh-1', false);
+    owner.issueSelection({ expectedEpoch: first.selectionEpoch, patientId: 'patient.synthetic.02', ambulatoryId: 'ambulatory.synthetic.01' });
+    let published = false;
+    assert.throws(() => lease.consume(current, () => { published = true; return 'never'; }), rejects('stale_selection'));
+    assert.equal(published, false);
+});
+
 test('allows two sequential stable same-snapshot observations as distinct opaque records', () => {
     const { lease } = fixture();
     const first = lease.replaceCurrentness(1, 1, 'fresh-1', false);

--- a/lib/ai-providers/fabric/patient-insight-atomic-lease.test.ts
+++ b/lib/ai-providers/fabric/patient-insight-atomic-lease.test.ts
@@ -38,12 +38,48 @@ test('publishes one primitive staging result only after the P4 final currentness
     assert.throws(() => lease.consume(current, () => 'replay'), rejects('record_spent'));
 });
 
-test('rejects stale, revoked, regressed, duplicate, and ABA currentness without publication', () => {
+test('allows two sequential stable same-snapshot observations as distinct opaque records', () => {
     const { lease } = fixture();
+    const first = lease.replaceCurrentness(1, 1, 'fresh-1', false);
+    assert.equal(lease.consume(first, () => 'staged-1'), 'staged-1');
+    const stable = lease.replaceCurrentness(1, 1, 'fresh-1', false);
+    assert.notEqual(first, stable);
+    assert.equal(lease.consume(stable, () => 'staged-2'), 'staged-2');
+});
+
+test('makes an unconsumed stable observation stale when a new observation replaces it', () => {
+    const { lease } = fixture();
+    const first = lease.replaceCurrentness(1, 1, 'fresh-1', false);
+    const stable = lease.replaceCurrentness(1, 1, 'fresh-1', false);
+    assert.notEqual(first, stable);
+    assert.throws(() => lease.consume(first, () => 'never'), rejects('stale_currentness'));
+    assert.throws(() => lease.consume(first, () => 'replay'), rejects('record_spent'));
+    assert.equal(lease.consume(stable, () => 'staged'), 'staged');
+});
+
+test('rejects changed same-epoch and duplicate transition currentness without residue', () => {
+    const { lease } = fixture();
+    const first = lease.replaceCurrentness(1, 1, 'fresh-1', false);
+    assert.throws(() => lease.replaceCurrentness(1, 2, 'fresh-1', false), rejects('epoch_aba'));
+    assert.throws(() => lease.replaceCurrentness(1, 1, 'fresh-2', false), rejects('epoch_aba'));
+    assert.throws(() => lease.replaceCurrentness(1, 1, 'fresh-1', true), rejects('epoch_aba'));
+    assert.equal(lease.consume(first, () => 'staged'), 'staged');
+
+    const transitions = fixture().lease;
+    transitions.replaceCurrentness(1, 1, 'fresh-1', false);
+    const second = transitions.replaceCurrentness(2, 2, 'fresh-2', false);
+    assert.throws(() => transitions.replaceCurrentness(3, 2, 'fresh-2', false), rejects('epoch_aba'));
+    assert.throws(() => transitions.replaceCurrentness(3, 1, 'fresh-1', false), rejects('epoch_aba'));
+    assert.equal(transitions.consume(second, () => 'staged'), 'staged');
+});
+
+test('rejects stale, revoked, regressed, and reset currentness without publication', () => {
+    const { lease } = fixture();
+    assert.throws(() => lease.replaceCurrentness(0, 1, 'fresh-0', false), rejects('input_invalid'));
     const first = lease.replaceCurrentness(1, 1, 'fresh-1', false);
     const second = lease.replaceCurrentness(2, 2, 'fresh-2', false);
     assert.throws(() => lease.consume(first, () => 'never'), rejects('stale_currentness'));
-    assert.throws(() => lease.replaceCurrentness(2, 1, 'fresh-1', false), rejects('epoch_regressed'));
+    assert.throws(() => lease.replaceCurrentness(1, 1, 'fresh-1', false), rejects('epoch_regressed'));
     assert.throws(() => lease.replaceCurrentness(3, 1, 'fresh-1', false), rejects('epoch_aba'));
     const revoked = lease.replaceCurrentness(3, 3, 'fresh-3', true);
     assert.throws(() => lease.consume(revoked, () => 'never'), rejects('revoked'));
@@ -111,7 +147,14 @@ test('fails closed for nested P4 use, dispose, promises, thenables, and hostile 
     assert.throws(() => lease.consume(again, () => accessor), rejects('input_invalid'));
     assert.equal(reads, 0);
 
-    const final = lease.replaceCurrentness(3, 3, 'fresh-3', false);
+    const callable = lease.replaceCurrentness(3, 3, 'fresh-3', false);
+    let applies = 0;
+    const callableProxy = new Proxy(() => 'unexpected', { get() { reads += 1; return undefined; }, apply() { applies += 1; return 'unexpected'; } });
+    assert.throws(() => lease.consume(callable, callableProxy), rejects('input_invalid'));
+    assert.equal(reads, 0);
+    assert.equal(applies, 0);
+
+    const final = lease.replaceCurrentness(4, 4, 'fresh-4', false);
     lease.dispose();
     assert.throws(() => lease.consume(final, () => 'never'), rejects('disposed'));
 });

--- a/lib/ai-providers/fabric/patient-insight-atomic-lease.ts
+++ b/lib/ai-providers/fabric/patient-insight-atomic-lease.ts
@@ -9,7 +9,8 @@ import type { ServerSession } from '../../security/server-session.ts';
 type Owner = Pick<ServerSessionProjectionOwner,
     'snapshotSelectionEpoch' | 'snapshotReviewContextEpoch' | 'withLeaseCriticalSection'>;
 type Currentness = Readonly<{ capabilityEpoch: number; revision: number; freshnessToken: string; revoked: boolean }>;
-type RecordState = { readonly currentness: Currentness; spent: boolean };
+type P4Boundary = Readonly<{ selectionEpoch: number; reviewContextEpoch: number }>;
+type RecordState = { readonly currentness: Currentness; readonly p4Boundary: P4Boundary; spent: boolean };
 
 export type PatientInsightAtomicLeaseErrorCode =
     | 'disposed' | 'epoch_aba' | 'epoch_regressed' | 'input_invalid' | 'record_spent' | 'revoked'
@@ -46,7 +47,7 @@ export function createPatientInsightAtomicLease(input: Readonly<{
 
     const fail = (code: PatientInsightAtomicLeaseErrorCode): never => { throw new PatientInsightAtomicLeaseError(code); };
     const insideP4 = <T>(callback: () => T): T => owner.withLeaseCriticalSection(session, callback);
-    const snapshot = () => Object.freeze({ selectionEpoch: owner.snapshotSelectionEpoch(session),
+    const snapshot = (): P4Boundary => Object.freeze({ selectionEpoch: owner.snapshotSelectionEpoch(session),
         reviewContextEpoch: owner.snapshotReviewContextEpoch(session) });
     const assertFiniteClock = () => {
         const now = clock();
@@ -57,7 +58,7 @@ export function createPatientInsightAtomicLease(input: Readonly<{
         if (!(value instanceof Uint8Array) || value.byteLength < 16) fail('input_invalid');
     };
     const fingerprint = (value: Currentness) => `${value.revision}\u0000${value.freshnessToken}\u0000${value.revoked}`;
-    const assertStable = (record: object, boundary: Readonly<{ selectionEpoch: number; reviewContextEpoch: number }>) => {
+    const assertStable = (record: object, boundary: P4Boundary) => {
         const next = snapshot();
         if (next.selectionEpoch !== boundary.selectionEpoch || next.reviewContextEpoch !== boundary.reviewContextEpoch) fail('stale_selection');
         if (current !== record) fail('stale_currentness');
@@ -89,7 +90,7 @@ export function createPatientInsightAtomicLease(input: Readonly<{
                     last = next;
                 }
                 const record = Object.freeze(Object.create(null));
-                records.set(record, { currentness: next, spent: false });
+                records.set(record, { currentness: next, p4Boundary: snapshot(), spent: false });
                 current = record;
                 if (isRevoked) revoked = true;
                 return record;
@@ -105,13 +106,12 @@ export function createPatientInsightAtomicLease(input: Readonly<{
             if (typeof stage !== 'function' || types.isProxy(stage)) fail('input_invalid');
             let staged: unknown;
             insideP4(() => {
-                const boundary = snapshot();
                 if (current !== record) fail('stale_currentness');
                 if (revoked || captured.currentness.revoked) fail('revoked');
-                assertEntropy(); assertFiniteClock(); assertStable(record, boundary);
+                assertEntropy(); assertFiniteClock(); assertStable(record, captured.p4Boundary);
                 staged = stage();
                 if (staged !== null && (typeof staged === 'object' || typeof staged === 'function')) fail('input_invalid');
-                assertStable(record, boundary);
+                assertStable(record, captured.p4Boundary);
                 return undefined;
             });
             return staged as never;

--- a/lib/ai-providers/fabric/patient-insight-atomic-lease.ts
+++ b/lib/ai-providers/fabric/patient-insight-atomic-lease.ts
@@ -1,6 +1,8 @@
 /* @Codex */
 import 'server-only';
 
+import { types } from 'node:util';
+
 import type { ServerSessionProjectionOwner } from '../../security/server-session-projection-owner.ts';
 import type { ServerSession } from '../../security/server-session.ts';
 
@@ -72,12 +74,23 @@ export function createPatientInsightAtomicLease(input: Readonly<{
                 }
                 if (revoked) fail('revoked');
                 const next = Object.freeze({ capabilityEpoch, revision, freshnessToken, revoked: isRevoked });
-                if (last && capabilityEpoch <= last.capabilityEpoch) fail('epoch_regressed');
                 const key = fingerprint(next);
-                if (fingerprints.has(key)) fail('epoch_aba');
+                if (last) {
+                    if (capabilityEpoch < last.capabilityEpoch) fail('epoch_regressed');
+                    if (capabilityEpoch === last.capabilityEpoch) {
+                        if (key !== fingerprint(last)) fail('epoch_aba');
+                    } else {
+                        if (fingerprints.has(key)) fail('epoch_aba');
+                        fingerprints.add(key);
+                        last = next;
+                    }
+                } else {
+                    fingerprints.add(key);
+                    last = next;
+                }
                 const record = Object.freeze(Object.create(null));
                 records.set(record, { currentness: next, spent: false });
-                fingerprints.add(key); last = next; current = record;
+                current = record;
                 if (isRevoked) revoked = true;
                 return record;
             });
@@ -89,7 +102,7 @@ export function createPatientInsightAtomicLease(input: Readonly<{
             if (!captured) throw new PatientInsightAtomicLeaseError('input_invalid');
             if (captured.spent) fail('record_spent');
             captured.spent = true;
-            if (typeof stage !== 'function') fail('input_invalid');
+            if (typeof stage !== 'function' || types.isProxy(stage)) fail('input_invalid');
             let staged: unknown;
             insideP4(() => {
                 const boundary = snapshot();


### PR DESCRIPTION
## Summary
- composes the accepted Patient Insight stable-observation lease onto the broker publication stack
- binds both selection and review-context epochs around staging
- preserves the exact broker implementation and limits the delta to the atomic lease and focused tests

## Verification
- focused broker/host/projection/atomic/P4/cascade suite: 50/50
- typecheck and focused ESLint
- claims, AI clinical writes, never-regress, Node runtime, OpenAPI/schema drift and schema-writer gates
- direct Next webpack build with 108/108 static pages
- independent adversarial review: ACCEPT on exact head `aea9b49ed6a924c63a939a1e4b206de0ca47ff19`

## Risk / Notes
- candidate stable-observation layer only; transactional broker, authentic broker-to-lease binding, P4 composer, route/provider/persistence/UI/write/apply and combined-base integration remain outside this PR
- draft base #254 must remain exact and terminal before any later promotion
- synthetic fixtures only; no PHI/PII or real patient data

## Ticket
Refs WUL-522
