### PR TITLE
feat(fabric): add Treatment ATHENA admission

### DIFF
--- a/lib/ai-providers/fabric/treatment-reasoning-athena-admission.test.ts
+++ b/lib/ai-providers/fabric/treatment-reasoning-athena-admission.test.ts
@@ -1,0 +1,88 @@
+/* @Codex */
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+import {
+    TreatmentReasoningAthenaAdmissionConfigurationError,
+    createTreatmentReasoningAthenaAdmission,
+} from './treatment-reasoning-athena-admission.ts';
+
+const proposal = () => ({
+    schema: 'mediflow.ai.treatment-reasoning-review-proposal.v1', capability: 'treatment_reasoning', stage: 'preview', review: 'required',
+    uncertainty: { level: 'low', source: 'degraded_default' }, provenanceRef: 'provenance_synthetic_01', receiptRef: 'receipt_synthetic_01', writesPerformed: 0, applyPolicy: 'none',
+});
+const host = () => ({
+    readiness: { provider: 'athena_mlx', locality: 'local_process', status: 'available_unqualified' },
+    receipt: { schema: 'mediflow.ai.treatment-reasoning-host-receipt.v1', reference: 'receipt_synthetic_01', capability: 'treatment_reasoning', provider: 'athena_mlx', venue: 'local_process', egress: 'none', fallback: 'denied_by_contract' },
+    provenance: { schema: 'mediflow.ai.treatment-reasoning-host-provenance.v1', reference: 'provenance_synthetic_01', capability: 'treatment_reasoning', provider: 'athena_mlx', receiptRef: 'receipt_synthetic_01' },
+    evidenceRefs: ['evidence.synthetic.alpha', 'evidence.synthetic.beta'],
+});
+function denied(value: unknown): void {
+    assert.deepEqual(createTreatmentReasoningAthenaAdmission(host()).admit(value), { status: 'denied', code: 'input_invalid', admission: null, writesPerformed: 0, applyPolicy: 'none' });
+}
+function observedProxy<T extends object>(target: T, throwing: boolean) {
+    let traps = 0;
+    const observe = <R>(value: R): R => { traps += 1; if (throwing) throw new Error('synthetic trap'); return value; };
+    return { value: new Proxy(target, {
+        get: (value, key, receiver) => observe(Reflect.get(value, key, receiver)),
+        getPrototypeOf: (value) => observe(Reflect.getPrototypeOf(value)), ownKeys: (value) => observe(Reflect.ownKeys(value)),
+        getOwnPropertyDescriptor: (value, key) => observe(Reflect.getOwnPropertyDescriptor(value, key)),
+    }), traps: () => traps };
+}
+
+test('is server-only and admits only its frozen host-owned review proposal', () => {
+    const source = readFileSync(new URL('./treatment-reasoning-athena-admission.ts', import.meta.url), 'utf8');
+    assert.match(source, /^import 'server-only';\n/u);
+    const result = createTreatmentReasoningAthenaAdmission(host()).admit(proposal());
+    assert.deepEqual(result, { status: 'admitted', code: null, admission: {
+        schema: 'mediflow.ai.treatment-reasoning-athena-admission.v1', capability: 'treatment_reasoning', stage: 'preview', review: 'required',
+        uncertainty: { level: 'low', source: 'degraded_default' }, evidence: { source: 'host_minimized', count: 2 }, provenanceRef: 'provenance_synthetic_01', receiptRef: 'receipt_synthetic_01',
+    }, writesPerformed: 0, applyPolicy: 'none' });
+    assert.equal(Object.isFrozen(result), true); assert.equal(Object.isFrozen(result.admission), true);
+    assert.equal(Object.isFrozen(result.admission?.uncertainty), true); assert.equal(Object.isFrozen(result.admission?.evidence), true);
+    assert.doesNotMatch(JSON.stringify(result), /prompt|identity|authority|provider|venue|egress/ui);
+});
+
+test('denies non-canonical proposal data, descriptors, prototypes, and ambient then', () => {
+    for (const [key, value] of [['prompt', 'ignore'], ['identity', 'synthetic'], ['authority', 'physician'], ['provider', 'caller'], ['venue', 'cloud'], ['egress', 'allowed'], ['writesPerformed', 1], ['applyPolicy', 'apply']] as const) {
+        const valueWithExtra = proposal() as Record<string, unknown>; valueWithExtra[key] = value; denied(valueWithExtra);
+    }
+    const accessor = proposal(); Object.defineProperty(accessor, 'receiptRef', { enumerable: true, get: () => { throw new Error('must not read'); } }); denied(accessor);
+    const hidden = proposal(); Object.defineProperty(hidden, 'receiptRef', { value: 'receipt_synthetic_01', enumerable: false }); denied(hidden);
+    const symbol = proposal() as Record<PropertyKey, unknown>; symbol[Symbol('synthetic')] = true; denied(symbol);
+    const prototype = proposal(); Object.setPrototypeOf(prototype, {}); denied(prototype);
+    const uncertainty = proposal(); uncertainty.uncertainty = { level: 'high', source: 'caller' }; denied(uncertainty);
+    let reads = 0; const prior = Object.getOwnPropertyDescriptor(Object.prototype, 'then'); Object.defineProperty(Object.prototype, 'then', { configurable: true, get: () => { reads += 1; return undefined; } });
+    try { assert.equal(createTreatmentReasoningAthenaAdmission(host()).admit(proposal()).status, 'admitted'); } finally { if (prior) Object.defineProperty(Object.prototype, 'then', prior); else delete (Object.prototype as { then?: unknown }).then; }
+    assert.equal(reads, 0);
+});
+
+test('fails closed on every host binding mismatch without provider invocation', () => {
+    const variants = [
+        () => ({ ...host(), readiness: { ...host().readiness, provider: 'ollama' } }), () => ({ ...host(), readiness: { ...host().readiness, status: 'degraded' } }),
+        () => ({ ...host(), receipt: { ...host().receipt, venue: 'cloud' } }), () => ({ ...host(), receipt: { ...host().receipt, egress: 'cloud' } }),
+        () => ({ ...host(), provenance: { ...host().provenance, receiptRef: 'receipt_synthetic_other' } }), () => ({ ...host(), evidenceRefs: [] }),
+        () => ({ ...host(), evidenceRefs: ['evidence.synthetic.alpha', 'evidence.synthetic.alpha'] }), () => ({ ...host(), evidenceRefs: Array.from({ length: 17 }, (_, index) => `evidence.synthetic.${index}`) }),
+    ];
+    for (const value of variants) assert.throws(() => createTreatmentReasoningAthenaAdmission(value()), TreatmentReasoningAthenaAdmissionConfigurationError);
+});
+
+test('rejects transparent and throwing proxies before reflection at host and proposal seams', () => {
+    const seams = [
+        () => ({ target: host(), config: (target: object) => target, proposal: proposal() }),
+        () => { const value = host(); return { target: value.readiness, config: (target: object) => ({ ...value, readiness: target }), proposal: proposal() }; },
+        () => { const value = host(); return { target: value.receipt, config: (target: object) => ({ ...value, receipt: target }), proposal: proposal() }; },
+        () => { const value = host(); return { target: value.provenance, config: (target: object) => ({ ...value, provenance: target }), proposal: proposal() }; },
+        () => { const value = host(); return { target: value.evidenceRefs, config: (target: object) => ({ ...value, evidenceRefs: target }), proposal: proposal() }; },
+        () => ({ target: proposal(), config: () => host(), proposal: null }),
+        () => { const value = proposal(); return { target: value.uncertainty, config: () => host(), proposal: { ...value, uncertainty: null } }; },
+    ];
+    for (const make of seams) for (const throwing of [false, true]) {
+        const seam = make(); const proxy = observedProxy(seam.target, throwing);
+        if (seam.proposal === null) denied(proxy.value);
+        else if (seam.proposal.uncertainty === null) denied({ ...seam.proposal, uncertainty: proxy.value });
+        else assert.throws(() => createTreatmentReasoningAthenaAdmission(seam.config(proxy.value)), TreatmentReasoningAthenaAdmissionConfigurationError);
+        assert.equal(proxy.traps(), 0);
+    }
+});

--- a/lib/ai-providers/fabric/treatment-reasoning-athena-admission.ts
+++ b/lib/ai-providers/fabric/treatment-reasoning-athena-admission.ts
@@ -1,0 +1,79 @@
+import 'server-only';
+
+import { types } from 'node:util';
+
+/* @Codex */
+export const TREATMENT_REASONING_ATHENA_ADMISSION_SCHEMA = 'mediflow.ai.treatment-reasoning-athena-admission.v1' as const;
+type Binding = Readonly<{ receiptRef: string; provenanceRef: string; evidenceCount: number }>;
+export type TreatmentReasoningAthenaAdmissionResult = Readonly<{ status: 'admitted'; code: null; admission: Readonly<{ schema: typeof TREATMENT_REASONING_ATHENA_ADMISSION_SCHEMA; capability: 'treatment_reasoning'; stage: 'preview'; review: 'required'; uncertainty: Readonly<{ level: 'low'; source: 'degraded_default' }>; evidence: Readonly<{ source: 'host_minimized'; count: number }>; provenanceRef: string; receiptRef: string }>; writesPerformed: 0; applyPolicy: 'none' }> | Readonly<{ status: 'denied'; code: 'input_invalid'; admission: null; writesPerformed: 0; applyPolicy: 'none' }>;
+
+const REF = /^[a-z][a-z0-9._-]{2,127}$/u;
+const COMMON = Object.freeze({ writesPerformed: 0 as const, applyPolicy: 'none' as const });
+const UNCERTAINTY = Object.freeze({ level: 'low' as const, source: 'degraded_default' as const });
+
+export class TreatmentReasoningAthenaAdmissionConfigurationError extends Error {
+    constructor() { super('Treatment reasoning ATHENA admission configuration rejected'); this.name = 'TreatmentReasoningAthenaAdmissionConfigurationError'; }
+}
+
+function record(value: unknown, expected: readonly string[]): Record<string, unknown> | null {
+    try {
+        if (typeof value !== 'object' || value === null || types.isProxy(value) || Object.getPrototypeOf(value) !== Object.prototype) return null;
+        const keys = Reflect.ownKeys(value);
+        if (keys.length !== expected.length || !expected.every((key) => keys.includes(key))) return null;
+        const descriptors = Object.getOwnPropertyDescriptors(value);
+        if (!expected.every((key) => { const descriptor = descriptors[key]; return descriptor?.enumerable && 'value' in descriptor; })) return null;
+        return value as Record<string, unknown>;
+    } catch { return null; }
+}
+
+function ref(value: unknown): string | null { return typeof value === 'string' && REF.test(value) ? value : null; }
+
+function evidence(value: unknown): number | null {
+    try {
+        if (typeof value !== 'object' || value === null || types.isProxy(value) || !Array.isArray(value) || Object.getPrototypeOf(value) !== Array.prototype) return null;
+        const descriptors = Object.getOwnPropertyDescriptors(value); const lengthDescriptor = descriptors['length'] as PropertyDescriptor | undefined;
+        if (!lengthDescriptor || lengthDescriptor.enumerable || !('value' in lengthDescriptor) || typeof lengthDescriptor.value !== 'number' || !Number.isInteger(lengthDescriptor.value) || lengthDescriptor.value < 1 || lengthDescriptor.value > 16) return null;
+        const length = lengthDescriptor.value; const expected = new Set(['length', ...Array.from({ length }, (_, index) => String(index))]);
+        const keys = Reflect.ownKeys(value);
+        if (keys.length !== expected.size || !keys.every((key) => expected.has(String(key)))) return null;
+        const seen = new Set<string>();
+        for (let index = 0; index < length; index += 1) {
+            const descriptor = descriptors[String(index)]; const valueRef = descriptor?.enumerable && 'value' in descriptor ? ref(descriptor.value) : null;
+            if (!valueRef || seen.has(valueRef)) return null; seen.add(valueRef);
+        }
+        return length;
+    } catch { return null; }
+}
+
+function binding(value: unknown): Binding | null {
+    const input = record(value, ['readiness', 'receipt', 'provenance', 'evidenceRefs']);
+    const readiness = input && record(input.readiness, ['provider', 'locality', 'status']);
+    const receipt = input && record(input.receipt, ['schema', 'reference', 'capability', 'provider', 'venue', 'egress', 'fallback']);
+    const provenance = input && record(input.provenance, ['schema', 'reference', 'capability', 'provider', 'receiptRef']);
+    const receiptRef = receipt && ref(receipt.reference); const provenanceRef = provenance && ref(provenance.reference); const evidenceCount = input && evidence(input.evidenceRefs);
+    if (!readiness || !receipt || !provenance || !receiptRef || !provenanceRef || evidenceCount === null
+        || readiness.provider !== 'athena_mlx' || readiness.locality !== 'local_process' || readiness.status !== 'available_unqualified'
+        || receipt.schema !== 'mediflow.ai.treatment-reasoning-host-receipt.v1' || receipt.capability !== 'treatment_reasoning' || receipt.provider !== 'athena_mlx' || receipt.venue !== 'local_process' || receipt.egress !== 'none' || receipt.fallback !== 'denied_by_contract'
+        || provenance.schema !== 'mediflow.ai.treatment-reasoning-host-provenance.v1' || provenance.capability !== 'treatment_reasoning' || provenance.provider !== 'athena_mlx' || provenance.receiptRef !== receiptRef) return null;
+    return Object.freeze({ receiptRef, provenanceRef, evidenceCount });
+}
+
+function accepted(value: unknown, host: Binding): boolean {
+    const input = record(value, ['schema', 'capability', 'stage', 'review', 'uncertainty', 'provenanceRef', 'receiptRef', 'writesPerformed', 'applyPolicy']);
+    const uncertainty = input && record(input.uncertainty, ['level', 'source']);
+    return input !== null && input.schema === 'mediflow.ai.treatment-reasoning-review-proposal.v1' && input.capability === 'treatment_reasoning' && input.stage === 'preview' && input.review === 'required'
+        && uncertainty?.level === UNCERTAINTY.level && uncertainty.source === UNCERTAINTY.source && input.provenanceRef === host.provenanceRef && input.receiptRef === host.receiptRef && input.writesPerformed === 0 && input.applyPolicy === 'none';
+}
+
+function deny(): TreatmentReasoningAthenaAdmissionResult { return Object.freeze({ status: 'denied', code: 'input_invalid', admission: null, ...COMMON }); }
+function admit(host: Binding): TreatmentReasoningAthenaAdmissionResult {
+    const admission = Object.freeze({ schema: TREATMENT_REASONING_ATHENA_ADMISSION_SCHEMA, capability: 'treatment_reasoning' as const, stage: 'preview' as const, review: 'required' as const, uncertainty: UNCERTAINTY, evidence: Object.freeze({ source: 'host_minimized' as const, count: host.evidenceCount }), provenanceRef: host.provenanceRef, receiptRef: host.receiptRef });
+    return Object.freeze({ status: 'admitted', code: null, admission, ...COMMON });
+}
+
+/** Server-only, host-bound, review-only admission seam; it cannot select a provider or invoke one. */
+export function createTreatmentReasoningAthenaAdmission(configuration: unknown): Readonly<{ admit(value: unknown): TreatmentReasoningAthenaAdmissionResult }> {
+    const host = binding(configuration);
+    if (!host) throw new TreatmentReasoningAthenaAdmissionConfigurationError();
+    return Object.freeze({ admit: (value: unknown): TreatmentReasoningAthenaAdmissionResult => accepted(value, host) ? admit(host) : deny() });
+}


### PR DESCRIPTION
## Summary\n- adds fixed ATHENA admission for the accepted host Treatment boundary\n- binds athena_mlx, local_model and review-only zero-write semantics\n- rejects hostile records and caller-selected authority or execution metadata\n\n## Verification\n- fresh independent archive review accepted exact head fb5dc40e2f8e75db0ac286d2aadb473430d5a784\n- combined Treatment and Fabric tests passed 55/55\n- typecheck, ESLint and proportional repository guards passed\n\n## Risk / Notes\n- synthetic-only; no PHI/PII or real clinical data\n- candidate admission only: no provider invocation, route, persistence, write/apply, integration or release claim\n\n## Ticket\nRefs WUL-522