### PR TITLE
feat(fabric): add Treatment preview capability

### DIFF
--- a/lib/ai-providers/fabric/treatment-reasoning-preview-capability.test.ts
+++ b/lib/ai-providers/fabric/treatment-reasoning-preview-capability.test.ts
@@ -1,0 +1,108 @@
+/* @Codex */
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+import {
+    createTreatmentReasoningPreviewCapability,
+    TreatmentReasoningPreviewCapabilityConfigurationError,
+} from './treatment-reasoning-preview-capability.ts';
+
+const proposal = () => ({
+    projection: {
+        schema: 'mediflow.ai.treatment-reasoning-projection.v1', capability: 'treatment_reasoning', stage: 'preview',
+        sourceRevision: 'source_synthetic_01', therapyRefs: ['therapy.synthetic.alpha'], evidenceRefs: ['evidence.synthetic.alpha'],
+    },
+    provenanceRef: 'provenance_synthetic_01', receiptRef: 'receipt_synthetic_01',
+});
+
+const admissionHost = () => ({
+    readiness: { provider: 'athena_mlx', locality: 'local_process', status: 'available_unqualified' },
+    receipt: { schema: 'mediflow.ai.treatment-reasoning-host-receipt.v1', reference: 'receipt_synthetic_01', capability: 'treatment_reasoning', provider: 'athena_mlx', venue: 'local_process', egress: 'none', fallback: 'denied_by_contract' },
+    provenance: { schema: 'mediflow.ai.treatment-reasoning-host-provenance.v1', reference: 'provenance_synthetic_01', capability: 'treatment_reasoning', provider: 'athena_mlx', receiptRef: 'receipt_synthetic_01' },
+    evidenceRefs: ['evidence.synthetic.alpha'],
+});
+
+const lifecycle = (status: 'available_unqualified' | 'degraded' | 'revoked' = 'available_unqualified') => ({
+    status: 'available',
+    record: {
+        schemaVersion: 'mediflow.ai.provider-lifecycle-record.v1',
+        lifecycle: { schemaVersion: 'mediflow.ai.provider-lifecycle.v1', provider: 'athena_mlx', credentialClass: 'local_model', status },
+        actorClass: 'host_service', actorRef: 'actor_0123456789abcdef0123456789abcdef', version: 1,
+        hostTimestamp: '2026-08-24T10:00:00.000Z', receiptRef: 'receipt_0123456789abcdef0123456789abcdef',
+    },
+});
+
+function service(read: () => unknown = lifecycle) {
+    return createTreatmentReasoningPreviewCapability({ proposalHost: proposal(), admissionHost: admissionHost(), lifecycle: { read } });
+}
+
+test('declares a server-only, zero-argument preview surface', () => {
+    const source = readFileSync(new URL('./treatment-reasoning-preview-capability.ts', import.meta.url), 'utf8');
+    assert.match(source, /^import 'server-only';\n/u);
+    assert.match(source, /preview\(\): TreatmentReasoningPreviewCapabilityResult/u);
+});
+
+test('composes the fixed host proposal and accepted admission after exactly one lifecycle read', () => {
+    let reads = 0;
+    const result = service(() => { reads += 1; return lifecycle(); }).preview();
+    assert.equal(reads, 1);
+    assert.deepEqual(result, {
+        status: 'admitted', code: null,
+        preview: {
+            schema: 'mediflow.ai.treatment-reasoning-preview-envelope.v1', capability: 'treatment_reasoning', stage: 'preview', review: 'required',
+            uncertainty: { level: 'low', source: 'degraded_default' }, evidence: { source: 'host_minimized', count: 1 },
+            provenanceRef: 'provenance_synthetic_01', receiptRef: 'receipt_synthetic_01',
+        },
+        writesPerformed: 0, applyPolicy: 'none',
+    });
+    assert.equal(Object.isFrozen(result), true);
+    assert.equal(Object.isFrozen(result.preview), true);
+    assert.equal(Object.isFrozen(result.preview?.uncertainty), true);
+    assert.equal(Object.isFrozen(result.preview?.evidence), true);
+});
+
+test('denies non-admissible lifecycle outcomes without reading again', () => {
+    const cases: readonly [string, () => unknown, string][] = [
+        ['unavailable', () => ({ status: 'denied', reason: 'unavailable' }), 'lifecycle_unavailable'],
+        ['missing', () => ({ status: 'denied', reason: 'missing' }), 'lifecycle_unavailable'],
+        ['degraded', () => lifecycle('degraded'), 'lifecycle_not_available'],
+        ['revoked', () => lifecycle('revoked'), 'lifecycle_not_available'],
+        ['throwing read', () => { throw new Error('synthetic'); }, 'lifecycle_unavailable'],
+    ];
+    for (const [, read, code] of cases) assert.deepEqual(service(read).preview(), {
+        status: 'denied', code, preview: null, writesPerformed: 0, applyPolicy: 'none',
+    });
+});
+
+test('rejects proxies, accessors, ambient fields, and malformed lifecycle records fail-closed', () => {
+    const accessor = lifecycle();
+    Object.defineProperty(accessor.record.lifecycle, 'status', { enumerable: true, get: () => 'available_unqualified' });
+    const provider = lifecycle();
+    provider.record.lifecycle.provider = 'ollama';
+    const hostile = new Proxy(lifecycle(), {});
+    for (const value of [accessor, provider, hostile, { status: 'available', record: lifecycle().record, then: () => undefined }]) {
+        assert.deepEqual(service(() => value).preview(), {
+            status: 'denied', code: 'lifecycle_invalid', preview: null, writesPerformed: 0, applyPolicy: 'none',
+        });
+    }
+});
+
+test('rejects malformed configuration before it can invoke its lifecycle callable', () => {
+    let reads = 0;
+    const accessor = { proposalHost: proposal(), admissionHost: admissionHost(), lifecycle: {} };
+    Object.defineProperty(accessor.lifecycle, 'read', { enumerable: true, get: () => () => { reads += 1; return lifecycle(); } });
+    for (const configuration of [
+        accessor,
+        new Proxy({ proposalHost: proposal(), admissionHost: admissionHost(), lifecycle: { read: lifecycle } }, {}),
+        { proposalHost: proposal(), admissionHost: admissionHost(), lifecycle: { read: new Proxy(lifecycle, {}) } },
+    ]) {
+        assert.throws(() => createTreatmentReasoningPreviewCapability(configuration), TreatmentReasoningPreviewCapabilityConfigurationError);
+    }
+    assert.equal(reads, 0);
+});
+
+test('does not accept caller input, prompts, authority, provider invocation, or apply policy', () => {
+    const preview = service().preview as unknown as (...args: unknown[]) => unknown;
+    assert.deepEqual(preview(proposal(), 'invoke'), service().preview());
+});

--- a/lib/ai-providers/fabric/treatment-reasoning-preview-capability.ts
+++ b/lib/ai-providers/fabric/treatment-reasoning-preview-capability.ts
@@ -1,0 +1,80 @@
+import 'server-only';
+
+/* @Codex */
+import { types } from 'node:util';
+
+import { createTreatmentReasoningAthenaAdmission } from './treatment-reasoning-athena-admission';
+import { buildTreatmentReasoningReviewProposal } from './treatment-reasoning-host-boundary';
+import { snapshotProviderLifecycle } from './provider-lifecycle';
+
+export const TREATMENT_REASONING_PREVIEW_ENVELOPE_SCHEMA = 'mediflow.ai.treatment-reasoning-preview-envelope.v1' as const;
+type Admission = ReturnType<typeof createTreatmentReasoningAthenaAdmission>;
+type DenialCode = 'lifecycle_invalid' | 'lifecycle_not_available' | 'lifecycle_unavailable';
+type LifecycleGate = 'available' | 'invalid' | 'not_available' | 'unavailable';
+export type TreatmentReasoningPreviewCapabilityResult = Readonly<{ status: 'admitted'; code: null; preview: Readonly<{ schema: typeof TREATMENT_REASONING_PREVIEW_ENVELOPE_SCHEMA; capability: 'treatment_reasoning'; stage: 'preview'; review: 'required'; uncertainty: Readonly<{ level: 'low'; source: 'degraded_default' }>; evidence: Readonly<{ source: 'host_minimized'; count: number }>; provenanceRef: string; receiptRef: string }>; writesPerformed: 0; applyPolicy: 'none' }> | Readonly<{ status: 'denied'; code: DenialCode; preview: null; writesPerformed: 0; applyPolicy: 'none' }>;
+
+export class TreatmentReasoningPreviewCapabilityConfigurationError extends Error {
+    constructor() { super('Treatment reasoning preview capability configuration rejected'); this.name = 'TreatmentReasoningPreviewCapabilityConfigurationError'; }
+}
+
+const COMMON = Object.freeze({ writesPerformed: 0 as const, applyPolicy: 'none' as const });
+const ACTOR = /^actor_[0-9a-f]{32,64}$/u;
+const RECEIPT = /^receipt_[0-9a-f]{32,64}$/u;
+
+function record(value: unknown, expected: readonly string[]): Record<string, unknown> | null {
+    try {
+        if (typeof value !== 'object' || value === null || types.isProxy(value) || Object.getPrototypeOf(value) !== Object.prototype) return null;
+        const keys = Reflect.ownKeys(value);
+        if (keys.length !== expected.length || !expected.every((key) => keys.includes(key))) return null;
+        const descriptors = Object.getOwnPropertyDescriptors(value);
+        if (!expected.every((key) => descriptors[key]?.enumerable && 'value' in descriptors[key])) return null;
+        return value as Record<string, unknown>;
+    } catch { return null; }
+}
+
+function lifecycleGate(value: unknown): LifecycleGate {
+    const response = record(value, ['status', 'record']) ?? record(value, ['status', 'reason']);
+    if (!response) return 'invalid';
+    if (response.status === 'denied') return response.reason === 'missing' || response.reason === 'corrupt' || response.reason === 'unavailable' ? 'unavailable' : 'invalid';
+    if (response.status !== 'available') return 'invalid';
+    const envelope = record(response.record, ['schemaVersion', 'lifecycle', 'actorClass', 'actorRef', 'version', 'hostTimestamp', 'receiptRef']);
+    const state = envelope && record(envelope.lifecycle, ['schemaVersion', 'provider', 'credentialClass', 'status']);
+    if (!envelope || !state || envelope.schemaVersion !== 'mediflow.ai.provider-lifecycle-record.v1'
+        || (envelope.actorClass !== 'physician' && envelope.actorClass !== 'host_service') || typeof envelope.actorRef !== 'string' || !ACTOR.test(envelope.actorRef)
+        || !Number.isSafeInteger(envelope.version) || (envelope.version as number) < 1 || typeof envelope.hostTimestamp !== 'string'
+        || new Date(envelope.hostTimestamp).toISOString() !== envelope.hostTimestamp || typeof envelope.receiptRef !== 'string' || !RECEIPT.test(envelope.receiptRef)) return 'invalid';
+    try {
+        const canonical = snapshotProviderLifecycle(Object.freeze({ schemaVersion: state.schemaVersion, provider: state.provider, credentialClass: state.credentialClass, status: state.status }));
+        if (canonical.provider !== 'athena_mlx' || canonical.credentialClass !== 'local_model') return 'invalid';
+        return canonical.status === 'available_unqualified' ? 'available' : 'not_available';
+    } catch { return 'invalid'; }
+}
+
+function deny(code: DenialCode): TreatmentReasoningPreviewCapabilityResult {
+    return Object.freeze({ status: 'denied' as const, code, preview: null, ...COMMON });
+}
+
+function admit(result: Extract<ReturnType<Admission['admit']>, { status: 'admitted' }>): TreatmentReasoningPreviewCapabilityResult {
+    const admission = result.admission;
+    const preview = Object.freeze({ schema: TREATMENT_REASONING_PREVIEW_ENVELOPE_SCHEMA, capability: admission.capability, stage: admission.stage, review: admission.review, uncertainty: Object.freeze({ ...admission.uncertainty }), evidence: Object.freeze({ ...admission.evidence }), provenanceRef: admission.provenanceRef, receiptRef: admission.receiptRef });
+    return Object.freeze({ status: 'admitted' as const, code: null, preview, ...COMMON });
+}
+
+/** Server-only, host-fixed, review-only preview. It neither accepts caller input nor invokes a provider. */
+export function createTreatmentReasoningPreviewCapability(configuration: unknown): Readonly<{ preview(): TreatmentReasoningPreviewCapabilityResult }> {
+    const input = record(configuration, ['proposalHost', 'admissionHost', 'lifecycle']);
+    const lifecycle = input && record(input.lifecycle, ['read']);
+    const read = lifecycle && Object.getOwnPropertyDescriptor(lifecycle, 'read')?.value;
+    if (!input || !lifecycle || typeof read !== 'function' || types.isProxy(read)) throw new TreatmentReasoningPreviewCapabilityConfigurationError();
+    let proposal: ReturnType<typeof buildTreatmentReasoningReviewProposal>; let admission: Admission;
+    try { proposal = buildTreatmentReasoningReviewProposal(input.proposalHost); admission = createTreatmentReasoningAthenaAdmission(input.admissionHost); } catch { throw new TreatmentReasoningPreviewCapabilityConfigurationError(); }
+    const host = Object.freeze({ read: read as () => unknown });
+    return Object.freeze({ preview(): TreatmentReasoningPreviewCapabilityResult {
+        let gate: LifecycleGate;
+        try { gate = lifecycleGate(host.read()); } catch { return deny('lifecycle_unavailable'); }
+        if (gate === 'unavailable') return deny('lifecycle_unavailable');
+        if (gate === 'not_available') return deny('lifecycle_not_available');
+        if (gate === 'invalid') return deny('lifecycle_invalid');
+        try { const result = admission.admit(proposal); return result.status === 'admitted' ? admit(result) : deny('lifecycle_invalid'); } catch { return deny('lifecycle_invalid'); }
+    } });
+}


### PR DESCRIPTION
## Summary\n- composes the accepted host boundary and ATHENA admission into a frozen review-only preview\n- reads lifecycle once and permits only the fixed local ATHENA binding\n- preserves zero writes and applyPolicy=none\n\n## Verification\n- fresh independent archive review accepted exact head ca745251b19dcd882914a2a6e9ecd7a51309f711\n- preview/admission/host tests passed 18/18; combined Fabric/Treatment tests passed 147/147\n- typecheck, ESLint and proportional repository guards passed\n\n## Risk / Notes\n- synthetic-only; no PHI/PII or real clinical data\n- candidate preview only: no provider execution, route, persistence, integration or release claim\n\n## Ticket\nRefs WUL-522