### PR TITLE
feat(fabric): add transactional PI broker lifecycle

### DIFF
--- a/lib/ai-providers/fabric/patient-insight-broker.test.ts
+++ b/lib/ai-providers/fabric/patient-insight-broker.test.ts
@@ -149,6 +149,36 @@ test('rejects transparent Proxies before their traps or accessors are evaluated'
     const broker = createPatientInsightBroker(host().value); reject(() => broker.consume(new Proxy({ handle: `pib_${'a'.repeat(32)}` }, {})), 'input_invalid');
 });
 
+test('rejects callable Proxy dependencies and entropy results before any trap runs', () => {
+    const callableProxy = (sideEffects: { value: number }): (() => boolean) => new Proxy(() => false, {
+        apply() { sideEffects.value += 1; throw new Error('synthetic callable Proxy'); },
+        get() { sideEffects.value += 1; throw new Error('synthetic callable Proxy'); },
+    });
+    for (const dependency of ['readCurrentness', 'readSources', 'clock', 'entropy'] as const) {
+        const sideEffects = { value: 0 };
+        reject(() => createPatientInsightBroker(host({ [dependency]: callableProxy(sideEffects) } as never).value), 'input_invalid');
+        assert.equal(sideEffects.value, 0, `${dependency} Proxy must not run`);
+    }
+    const prepareSideEffects = { value: 0 };
+    reject(() => createPatientInsightBroker(host({ boundary: Object.freeze({ prepare: callableProxy(prepareSideEffects) }) as never }).value), 'input_invalid');
+    assert.equal(prepareSideEffects.value, 0, 'prepare Proxy must not run');
+
+    const revokedSideEffects = { value: 0 };
+    const revokedBroker = createPatientInsightBroker(host({
+        readCurrentness: () => Object.freeze({ selectionEpoch: 7, revision: 3, freshnessToken: 'fresh_token_0123456789abcdef', isRevoked: callableProxy(revokedSideEffects) }),
+    }).value);
+    reject(() => revokedBroker.issue(), 'dependency_unavailable');
+    assert.equal(revokedSideEffects.value, 0, 'isRevoked Proxy must not run');
+
+    let entropyCalls = 0; const entropyResultSideEffects = { value: 0 };
+    const entropyBroker = createPatientInsightBroker(host({
+        entropy: () => { entropyCalls += 1; return new Proxy(new Uint8Array(16), { get() { entropyResultSideEffects.value += 1; throw new Error('synthetic entropy result Proxy'); } }); },
+    }).value);
+    reject(() => entropyBroker.issue(), 'dependency_unavailable');
+    assert.equal(entropyCalls, 1, 'entropy is invoked exactly once');
+    assert.equal(entropyResultSideEffects.value, 0, 'entropy Proxy result must not be reflected or read');
+});
+
 test('rejects non-enumerable broker records at every caller-controlled record seam', () => {
     const hidden = (value: Record<string, unknown>, key: string) => {
         const clone = { ...value };
@@ -228,5 +258,5 @@ test('does not reach forbidden concerns or reuse the Smart Import broker', () =>
     const source = readFileSync(new URL('./patient-insight-broker.ts', import.meta.url), 'utf8');
     assert.doesNotMatch(source, /typed-projection-broker|smart-import|provider-lifecycle|fetch\(/u);
     assert.doesNotMatch(source, /database|persist|writeFile|patientRef|sessionRef|route|apply\(/ui);
-    assert.match(source, /ABA[\s\S]*P4[\s\S]*HOLD/u);
+    assert.match(source, /P4 composer must retain a staged reservation and must not call publish before final P4 validation/u);
 });

--- a/lib/ai-providers/fabric/patient-insight-broker.test.ts
+++ b/lib/ai-providers/fabric/patient-insight-broker.test.ts
@@ -38,6 +38,79 @@ test('issues unique opaque handles and consumes only the accepted frozen review 
     reject(() => broker.consume({ handle: first }), 'handle_replayed');
 });
 
+test('stages an opaque reservation, publishes exactly once, and keeps the legacy issue boundary', () => {
+    const broker = createPatientInsightBroker(host().value); const reservation = broker.stage();
+    assert.equal(Object.getPrototypeOf(reservation), null); assert.equal(Object.isFrozen(reservation), true); assert.deepEqual(Reflect.ownKeys(reservation), []);
+    const handle = broker.publish(reservation); assert.match(handle, /^pib_[0-9a-f]{32}$/u);
+    reject(() => broker.publish(reservation), 'reservation_missing'); reject(() => broker.abort(reservation), 'reservation_missing');
+    assert.equal(broker.consume({ handle }).status, 'available'); reject(() => broker.consume({ handle }), 'handle_replayed');
+    const legacy = broker.issue(); assert.match(legacy, /^pib_[0-9a-f]{32}$/u);
+});
+
+test('aborts every staged record and releases fixed entropy for a retry', () => {
+    const fixed = Uint8Array.from({ length: 16 }, (_, index) => index); const broker = createPatientInsightBroker(host({ entropy: () => fixed }).value);
+    const first = broker.stage(); broker.abort(first);
+    const retry = broker.stage(); assert.notEqual(retry, first); const handle = broker.publish(retry); assert.equal(handle, `pib_${'000102030405060708090a0b0c0d0e0f'}`);
+    assert.equal(broker.consume({ handle }).proposal.reviewOnly, true); reject(() => broker.consume({ handle }), 'handle_replayed');
+    const afterConsume = broker.publish(broker.stage()); assert.notEqual(afterConsume, handle); reject(() => broker.consume({ handle }), 'handle_replayed'); assert.equal(broker.consume({ handle: afterConsume }).status, 'available');
+});
+
+test('retains a stage on denial so abort is complete and no denial or throw leaves a live reservation', () => {
+    const fixed = Uint8Array.from({ length: 16 }, (_, index) => index); const fixture = host({ entropy: () => fixed }); const broker = createPatientInsightBroker(fixture.value);
+    const denied = broker.stage(); fixture.setCurrentness(state({ revision: 4 })); reject(() => broker.publish(denied), 'revision_stale'); broker.abort(denied);
+    fixture.setCurrentness(state()); const afterDenial = broker.stage(); broker.abort(afterDenial);
+    const afterThrow = broker.stage(); try { throw new Error('synthetic P4 denial'); } catch { broker.abort(afterThrow); }
+    assert.equal(Object.getPrototypeOf(broker.stage()), null);
+});
+
+test('rejects fixed entropy only while its reservation or handle remains live', () => {
+    const fixed = Uint8Array.from({ length: 16 }, (_, index) => index); const broker = createPatientInsightBroker(host({ entropy: () => fixed }).value);
+    const staged = broker.stage(); reject(() => broker.stage(), 'handle_collision'); broker.abort(staged);
+    const retry = broker.stage(); reject(() => broker.publish(staged), 'reservation_missing'); const handle = broker.publish(retry); reject(() => broker.stage(), 'handle_collision');
+    assert.match(handle, /^pib_[0-9a-f]{32}$/u);
+});
+
+test('rejects forged, cross-broker, duplicate, accessor, Proxy, symbol, and thenable lifecycle inputs without reads', () => {
+    const first = createPatientInsightBroker(host().value); const second = createPatientInsightBroker(host().value); const reservation = first.stage();
+    const forged = Object.freeze(Object.create(null));
+    reject(() => second.publish(reservation), 'reservation_missing'); reject(() => second.abort(reservation), 'reservation_missing'); reject(() => first.publish(forged), 'reservation_missing');
+    const accessor = Object.create(null) as Record<string, unknown>; Object.defineProperty(accessor, 'reservation', { enumerable: true, get() { throw new Error('synthetic accessor'); } }); Object.freeze(accessor);
+    let proxyReads = 0; const proxy = new Proxy(Object.freeze(Object.create(null)), { get() { proxyReads += 1; throw new Error('synthetic proxy'); }, ownKeys() { proxyReads += 1; throw new Error('synthetic proxy'); } });
+    for (const value of [Object.freeze({}), Object.freeze(Object.assign(Object.create(null), { extra: true })), Object.freeze(Object.assign(Object.create(null), { [Symbol('synthetic')]: true })), accessor, proxy]) {
+        reject(() => first.publish(value), 'input_invalid'); reject(() => first.abort(value), 'input_invalid');
+    }
+    assert.equal(proxyReads, 0);
+    let thenReads = 0; Object.defineProperty(Object.prototype, 'then', { configurable: true, get() { thenReads += 1; throw new Error('ambient then'); } });
+    try { first.abort(reservation); } finally { delete (Object.prototype as Record<string, unknown>).then; }
+    assert.equal(thenReads, 0); reject(() => first.publish(reservation), 'reservation_missing'); reject(() => first.abort(reservation), 'reservation_missing');
+});
+
+test('fails closed on lifecycle reentry without publishing or reserving a partial result', () => {
+    const fixture = host({ clock: () => { broker.stage(); return now; } }); const broker = createPatientInsightBroker(fixture.value);
+    reject(() => broker.stage(), 'operation_reentered');
+});
+
+test('makes swallowed readSources reentry sticky before a stage can reserve or return', () => {
+    const fixed = Uint8Array.from({ length: 16 }, (_, index) => index); let reenter = true;
+    const fixture = host({ entropy: () => fixed, readSources: () => { if (reenter) { try { broker.stage(); } catch (error) { assert.equal((error as PatientInsightBrokerError).code, 'operation_reentered'); } } return sources(); } }); const broker = createPatientInsightBroker(fixture.value);
+    reject(() => broker.stage(), 'operation_reentered'); reenter = false;
+    const retry = broker.stage(); assert.equal(broker.publish(retry), `pib_${'000102030405060708090a0b0c0d0e0f'}`);
+});
+
+test('makes swallowed currentness reentry sticky at stage and releases the same entropy after reset', () => {
+    const fixed = Uint8Array.from({ length: 16 }, (_, index) => index); let reenter = true;
+    const fixture = host({ entropy: () => fixed, readCurrentness: () => { if (reenter) { try { broker.stage(); } catch (error) { assert.equal((error as PatientInsightBrokerError).code, 'operation_reentered'); } } return Object.freeze({ selectionEpoch: 7, revision: 3, freshnessToken: 'fresh_token_0123456789abcdef', isRevoked: () => false }); } }); const broker = createPatientInsightBroker(fixture.value);
+    reject(() => broker.stage(), 'operation_reentered'); reenter = false;
+    const retry = broker.stage(); assert.equal(broker.publish(retry), `pib_${'000102030405060708090a0b0c0d0e0f'}`);
+});
+
+test('makes swallowed currentness reentry sticky at publish without consuming its reservation', () => {
+    const fixed = Uint8Array.from({ length: 16 }, (_, index) => index); let reenter = false; const lifecycle = { reservation: null as object | null };
+    const fixture = host({ entropy: () => fixed, readCurrentness: () => { if (reenter && lifecycle.reservation) { try { broker.abort(lifecycle.reservation); } catch (error) { assert.equal((error as PatientInsightBrokerError).code, 'operation_reentered'); } } return Object.freeze({ selectionEpoch: 7, revision: 3, freshnessToken: 'fresh_token_0123456789abcdef', isRevoked: () => false }); } }); const broker = createPatientInsightBroker(fixture.value);
+    lifecycle.reservation = broker.stage(); reenter = true; reject(() => broker.publish(lifecycle.reservation), 'operation_reentered'); reenter = false;
+    broker.abort(lifecycle.reservation); const retry = broker.stage(); assert.equal(broker.publish(retry), `pib_${'000102030405060708090a0b0c0d0e0f'}`);
+});
+
 test('fails closed after selection, revision, freshness, or revocation changes', () => {
     for (const [next, code] of [[state({ selectionEpoch: 8 }), 'selection_changed'], [state({ revision: 4 }), 'revision_stale'], [state({ freshnessToken: 'fresh_token_abcdef0123456789' }), 'freshness_stale'], [state({ revoked: true }), 'revoked']] as const) {
         const fixture = host(); const broker = createPatientInsightBroker(fixture.value); const handle = broker.issue(); fixture.setCurrentness(next);

--- a/lib/ai-providers/fabric/patient-insight-broker.ts
+++ b/lib/ai-providers/fabric/patient-insight-broker.ts
@@ -32,6 +32,7 @@ const handlePattern = /^pib_[0-9a-f]{32}$/u;
 const tokenPattern = /^[A-Za-z][A-Za-z0-9._:-]{15,159}$/u;
 
 function fail(code: PatientInsightBrokerErrorCode): never { throw new PatientInsightBrokerError(code); }
+function callable(value: unknown): value is () => unknown { return typeof value === 'function' && !types.isProxy(value); }
 function exact(value: unknown, keys: readonly string[]): Record<string, unknown> | null {
     try {
         if (!value || typeof value !== 'object' || types.isProxy(value) || Array.isArray(value) || Object.getPrototypeOf(value) !== Object.prototype) return null;
@@ -47,7 +48,7 @@ function timestamp(value: unknown): string | null {
 function currentness(value: unknown): Currentness | null {
     try {
         const input = exact(value, ['selectionEpoch', 'revision', 'freshnessToken', 'isRevoked']);
-        if (!input || !Object.isFrozen(value) || !Number.isSafeInteger(input.selectionEpoch) || (input.selectionEpoch as number) < 1 || !Number.isSafeInteger(input.revision) || (input.revision as number) < 0 || typeof input.freshnessToken !== 'string' || !tokenPattern.test(input.freshnessToken) || typeof input.isRevoked !== 'function') return null;
+        if (!input || !Object.isFrozen(value) || !Number.isSafeInteger(input.selectionEpoch) || (input.selectionEpoch as number) < 1 || !Number.isSafeInteger(input.revision) || (input.revision as number) < 0 || typeof input.freshnessToken !== 'string' || !tokenPattern.test(input.freshnessToken) || !callable(input.isRevoked)) return null;
         const revoked = (input.isRevoked as () => unknown)();
         if (typeof revoked !== 'boolean') return null;
         if (revoked) return fail('revoked');
@@ -69,11 +70,11 @@ function currentnessChanged(before: Currentness, after: Currentness): void {
     if (after.freshnessToken !== before.freshnessToken) fail('freshness_stale');
 }
 
-/** Candidate-only: ABA needs P4 lease critical section; production remains HOLD. */
+/** Candidate-only: ABA needs P4 lease critical section; production remains HOLD. A P4 composer must retain a staged reservation and must not call publish before final P4 validation. */
 export function createPatientInsightBroker(value: PatientInsightBrokerHost): PatientInsightBroker {
     const host = exact(value, ['readCurrentness', 'readSources', 'boundary', 'clock', 'entropy']);
     const boundaryValue = host && exact(host.boundary, ['prepare']);
-    if (!host || !Object.isFrozen(value) || !boundaryValue || typeof host.readCurrentness !== 'function' || typeof host.readSources !== 'function' || typeof boundaryValue.prepare !== 'function' || typeof host.clock !== 'function' || typeof host.entropy !== 'function') fail('input_invalid');
+    if (!host || !Object.isFrozen(value) || !boundaryValue || !callable(host.readCurrentness) || !callable(host.readSources) || !callable(boundaryValue.prepare) || !callable(host.clock) || !callable(host.entropy)) fail('input_invalid');
     const resolver = createPatientInsightHostProjectionResolver(); const records = new Map<string, RecordEntry>(); const reservations = new WeakMap<object, ReservationEntry>(); const liveEntropyHandles = new Set<string>(); const reservedHandles = new Set<string>(); const consumed = new Set<string>();
     let operationActive = false; let operationPoisoned = false; let operationCleanup: (() => void) | null = null;
     const readCurrentness = () => {
@@ -84,7 +85,7 @@ export function createPatientInsightBroker(value: PatientInsightBrokerHost): Pat
     const issueHandle = () => {
         let bytes: unknown; try { bytes = (host.entropy as () => unknown)(); } catch { return fail('dependency_unavailable'); }
         try {
-            if (!(bytes instanceof Uint8Array) || bytes.byteLength < 16) fail('dependency_unavailable');
+            if (types.isProxy(bytes) || !(bytes instanceof Uint8Array) || bytes.byteLength < 16) fail('dependency_unavailable');
             let hex = ''; for (let index = 0; index < 16; index += 1) hex += bytes[index].toString(16).padStart(2, '0'); return `pib_${hex}`;
         } catch (error) { if (error instanceof PatientInsightBrokerError) throw error; return fail('dependency_unavailable'); }
     };

--- a/lib/ai-providers/fabric/patient-insight-broker.ts
+++ b/lib/ai-providers/fabric/patient-insight-broker.ts
@@ -5,7 +5,7 @@ import { types } from 'node:util';
 import type { PatientInsightHostBoundary, PatientInsightHostResult, PatientInsightProjection } from './patient-insight-host-boundary.ts';
 import { createPatientInsightHostProjectionResolver } from './patient-insight-host-projection.ts';
 
-export type PatientInsightBrokerErrorCode = 'dependency_unavailable' | 'freshness_stale' | 'handle_collision' | 'handle_missing' | 'handle_replayed' | 'input_invalid' | 'proposal_invalid' | 'revision_stale' | 'revoked' | 'selection_changed';
+export type PatientInsightBrokerErrorCode = 'dependency_unavailable' | 'freshness_stale' | 'handle_collision' | 'handle_missing' | 'handle_replayed' | 'input_invalid' | 'operation_reentered' | 'proposal_invalid' | 'reservation_missing' | 'revision_stale' | 'revoked' | 'selection_changed';
 export class PatientInsightBrokerError extends Error {
     constructor(readonly code: PatientInsightBrokerErrorCode) { super(`Patient Insight broker denied: ${code}`); this.name = 'PatientInsightBrokerError'; }
 }
@@ -17,10 +17,17 @@ export type PatientInsightBrokerHost = Readonly<{
     clock: () => string;
     entropy: () => Uint8Array;
 }>;
-export type PatientInsightBroker = Readonly<{ issue: () => string; consume: (input: unknown) => Extract<PatientInsightHostResult, { status: 'available' }> }>;
+export type PatientInsightBroker = Readonly<{
+    stage: () => object;
+    publish: (input: unknown) => string;
+    abort: (input: unknown) => void;
+    issue: () => string;
+    consume: (input: unknown) => Extract<PatientInsightHostResult, { status: 'available' }>;
+}>;
 
 type Currentness = Readonly<{ selectionEpoch: number; revision: number; freshnessToken: string }>;
-type RecordEntry = Readonly<{ currentness: Currentness; accepted: Extract<PatientInsightHostResult, { status: 'available' }> }>;
+type RecordEntry = Readonly<{ entropyHandle: string; currentness: Currentness; accepted: Extract<PatientInsightHostResult, { status: 'available' }> }>;
+type ReservationEntry = Readonly<{ entropyHandle: string; handle: string; currentness: Currentness; accepted: Extract<PatientInsightHostResult, { status: 'available' }> }>;
 const handlePattern = /^pib_[0-9a-f]{32}$/u;
 const tokenPattern = /^[A-Za-z][A-Za-z0-9._:-]{15,159}$/u;
 
@@ -67,7 +74,8 @@ export function createPatientInsightBroker(value: PatientInsightBrokerHost): Pat
     const host = exact(value, ['readCurrentness', 'readSources', 'boundary', 'clock', 'entropy']);
     const boundaryValue = host && exact(host.boundary, ['prepare']);
     if (!host || !Object.isFrozen(value) || !boundaryValue || typeof host.readCurrentness !== 'function' || typeof host.readSources !== 'function' || typeof boundaryValue.prepare !== 'function' || typeof host.clock !== 'function' || typeof host.entropy !== 'function') fail('input_invalid');
-    const resolver = createPatientInsightHostProjectionResolver(); const records = new Map<string, RecordEntry>(); const issued = new Set<string>(); const consumed = new Set<string>();
+    const resolver = createPatientInsightHostProjectionResolver(); const records = new Map<string, RecordEntry>(); const reservations = new WeakMap<object, ReservationEntry>(); const liveEntropyHandles = new Set<string>(); const reservedHandles = new Set<string>(); const consumed = new Set<string>();
+    let operationActive = false; let operationPoisoned = false; let operationCleanup: (() => void) | null = null;
     const readCurrentness = () => {
         let result: unknown; try { result = (host.readCurrentness as () => unknown)(); } catch { return fail('dependency_unavailable'); }
         const snapshot = currentness(result); if (!snapshot) fail('dependency_unavailable'); return snapshot;
@@ -80,20 +88,85 @@ export function createPatientInsightBroker(value: PatientInsightBrokerHost): Pat
             let hex = ''; for (let index = 0; index < 16; index += 1) hex += bytes[index].toString(16).padStart(2, '0'); return `pib_${hex}`;
         } catch (error) { if (error instanceof PatientInsightBrokerError) throw error; return fail('dependency_unavailable'); }
     };
+    const reservationInput = (value: unknown): object => {
+        try {
+            if (!value || typeof value !== 'object' || types.isProxy(value) || Array.isArray(value) || Object.getPrototypeOf(value) !== null || !Object.isFrozen(value) || Reflect.ownKeys(value).length !== 0) fail('input_invalid');
+            return value;
+        } catch (error) { if (error instanceof PatientInsightBrokerError) throw error; return fail('input_invalid'); }
+    };
+    const nextHandle = (handle: string): string | null => {
+        const digits = '0123456789abcdef'; const output = handle.slice(4).split('');
+        for (let index = output.length - 1; index >= 0; index -= 1) {
+            const digit = digits.indexOf(output[index]); if (digit < 15) { output[index] = digits[digit + 1]; return `pib_${output.join('')}`; }
+            output[index] = '0';
+        }
+        return null;
+    };
+    const availableHandle = (entropyHandle: string): string => {
+        let candidate = entropyHandle;
+        while (records.has(candidate) || reservedHandles.has(candidate) || consumed.has(candidate)) {
+            const next = nextHandle(candidate); if (!next) fail('handle_collision'); candidate = next;
+        }
+        return candidate;
+    };
+    const discardOperationState = (): void => {
+        const cleanup = operationCleanup as (() => void) | null; operationCleanup = null;
+        if (cleanup) cleanup();
+    };
+    const ensureNotPoisoned = (): void => { if (operationPoisoned) { discardOperationState(); fail('operation_reentered'); } };
+    const stage = (): object => {
+        const snapshot = readCurrentness(); ensureNotPoisoned(); readClock(); ensureNotPoisoned(); let sources: unknown;
+        try { sources = (host.readSources as () => unknown)(); } catch { return fail('dependency_unavailable'); }
+        ensureNotPoisoned();
+        const projection = resolver.resolve(sources); if (!projection) fail('dependency_unavailable');
+        let output: unknown; try { output = (boundaryValue.prepare as (request: Readonly<{ projection: PatientInsightProjection }>) => unknown)(Object.freeze({ projection })); } catch { return fail('dependency_unavailable'); }
+        ensureNotPoisoned();
+        const result = accepted(output); if (!result) fail('proposal_invalid'); const entropyHandle = issueHandle();
+        if (liveEntropyHandles.has(entropyHandle)) fail('handle_collision'); const handle = availableHandle(entropyHandle);
+        const current = readCurrentness(); ensureNotPoisoned(); currentnessChanged(snapshot, current);
+        const reservation = Object.freeze(Object.create(null)) as object; const entry = Object.freeze({ entropyHandle, handle, currentness: snapshot, accepted: result });
+        reservations.set(reservation, entry); liveEntropyHandles.add(entropyHandle); reservedHandles.add(handle);
+        operationCleanup = () => { if (reservations.get(reservation) === entry) { reservations.delete(reservation); liveEntropyHandles.delete(entry.entropyHandle); reservedHandles.delete(entry.handle); } };
+        ensureNotPoisoned();
+        return reservation;
+    };
+    const publish = (inputValue: unknown, verifyCurrentness = true): string => {
+        const reservation = reservationInput(inputValue); const entry = reservations.get(reservation); if (!entry) fail('reservation_missing');
+        if (verifyCurrentness) { readClock(); ensureNotPoisoned(); const current = readCurrentness(); ensureNotPoisoned(); currentnessChanged(entry.currentness, current); }
+        ensureNotPoisoned();
+        if (records.has(entry.handle)) fail('handle_collision');
+        const record = Object.freeze({ entropyHandle: entry.entropyHandle, currentness: entry.currentness, accepted: entry.accepted });
+        reservations.delete(reservation); reservedHandles.delete(entry.handle); records.set(entry.handle, record);
+        operationCleanup = () => { if (records.get(entry.handle) === record) { records.delete(entry.handle); liveEntropyHandles.delete(record.entropyHandle); } };
+        ensureNotPoisoned();
+        return entry.handle;
+    };
+    const abort = (inputValue: unknown): void => {
+        const reservation = reservationInput(inputValue); const entry = reservations.get(reservation); if (!entry) fail('reservation_missing');
+        reservations.delete(reservation); liveEntropyHandles.delete(entry.entropyHandle); reservedHandles.delete(entry.handle);
+    };
+    const exclusive = <Result>(callback: () => Result): Result => {
+        if (operationActive) { operationPoisoned = true; fail('operation_reentered'); }
+        operationActive = true; operationPoisoned = false; operationCleanup = null;
+        try {
+            const result = callback();
+            if (operationPoisoned) { discardOperationState(); fail('operation_reentered'); }
+            return result;
+        } finally { operationActive = false; operationPoisoned = false; operationCleanup = null; }
+    };
     return Object.freeze({
+        stage() { return exclusive(stage); },
+        publish(inputValue) { return exclusive(() => publish(inputValue)); },
+        abort(inputValue) { return exclusive(() => abort(inputValue)); },
         issue() {
-            const snapshot = readCurrentness(); readClock(); let sources: unknown;
-            try { sources = (host.readSources as () => unknown)(); } catch { return fail('dependency_unavailable'); }
-            const projection = resolver.resolve(sources); if (!projection) fail('dependency_unavailable');
-            let output: unknown; try { output = (boundaryValue.prepare as (request: Readonly<{ projection: PatientInsightProjection }>) => unknown)(Object.freeze({ projection })); } catch { return fail('dependency_unavailable'); }
-            const result = accepted(output); if (!result) fail('proposal_invalid'); const handle = issueHandle(); if (issued.has(handle)) fail('handle_collision');
-            currentnessChanged(snapshot, readCurrentness());
-            issued.add(handle); records.set(handle, Object.freeze({ currentness: snapshot, accepted: result })); return handle;
+            return exclusive(() => publish(stage(), false));
         },
         consume(inputValue) {
-            const input = exact(inputValue, ['handle']); if (!input || typeof input.handle !== 'string' || !handlePattern.test(input.handle)) fail('input_invalid');
-            if (consumed.has(input.handle)) fail('handle_replayed'); const entry = records.get(input.handle); if (!entry) fail('handle_missing'); records.delete(input.handle); consumed.add(input.handle);
-            readClock(); currentnessChanged(entry.currentness, readCurrentness()); return entry.accepted;
+            return exclusive(() => {
+                const input = exact(inputValue, ['handle']); if (!input || typeof input.handle !== 'string' || !handlePattern.test(input.handle)) fail('input_invalid');
+                if (consumed.has(input.handle)) fail('handle_replayed'); const entry = records.get(input.handle); if (!entry) fail('handle_missing'); records.delete(input.handle); liveEntropyHandles.delete(entry.entropyHandle); consumed.add(input.handle);
+                readClock(); ensureNotPoisoned(); const current = readCurrentness(); ensureNotPoisoned(); currentnessChanged(entry.currentness, current); return entry.accepted;
+            });
         },
     });
 }


### PR DESCRIPTION
## Summary\n- recomposes the accepted Patient Insight broker on the stable-observation stack\n- preserves the private stage, publish and abort reservation lifecycle\n- denies hostile callable/result proxies, replay and reentry without publication residue\n\n## Verification\n- fresh independent archive review accepted exact head 97a8c5c71776c31411a213e70c5d9750235772ef\n- broker, projection, boundary, atomic lease, P4 owner and cascade suites passed\n- independent adversarial probes, typecheck, focused ESLint, guards and Next webpack 108/108 passed\n\n## Risk / Notes\n- synthetic-only; no PHI/PII or real clinical data\n- candidate transactional broker only\n- P4 authenticity, broker-to-lease identity, commit-last composition, route/provider/persistence, integration and release remain separate\n\n## Ticket\nRefs WUL-522