### PR TITLE
fix(ai): autentica e ripulisci il broker Patient Insight

### DIFF
--- a/lib/ai-providers/fabric/patient-insight-broker.test.ts
+++ b/lib/ai-providers/fabric/patient-insight-broker.test.ts
@@ -2,6 +2,7 @@
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
+import { types } from 'node:util';
 
 import { createPatientInsightHostBoundary } from './patient-insight-host-boundary.ts';
 import { PatientInsightBrokerError, createPatientInsightBroker, isPatientInsightBrokerCapability, type PatientInsightBrokerHost } from './patient-insight-broker.ts';
@@ -59,6 +60,40 @@ test('aborts a staged reservation on every precommit denial and releases fixed e
     const fixed = Uint8Array.from({ length: 16 }, (_, index) => index); const fixture = host({ entropy: () => fixed }); const broker = createPatientInsightBroker(fixture.value);
     const denied = broker.stage(); fixture.setCurrentness(state({ revision: 4 })); reject(() => broker.publish(denied), 'revision_stale'); reject(() => broker.abort(denied), 'reservation_missing');
     fixture.setCurrentness(state()); const retry = broker.stage(); assert.equal(broker.publish(retry), `pib_${'000102030405060708090a0b0c0d0e0f'}`);
+});
+
+test('cleans an authentic reservation when ambient reflection denies precommit validation', () => {
+    const fixed = Uint8Array.from({ length: 16 }, (_, index) => index);
+    const expectedHandle = `pib_${'000102030405060708090a0b0c0d0e0f'}`;
+    const hostileIntrinsics = [
+        [Object, 'getPrototypeOf'],
+        [Reflect, 'ownKeys'],
+        [Array, 'isArray'],
+        [types, 'isProxy'],
+        [Object, 'isFrozen'],
+    ] as const;
+
+    for (const [target, key] of hostileIntrinsics) {
+        for (const operation of ['publish', 'abort'] as const) {
+            const broker = createPatientInsightBroker(host({ entropy: () => fixed }).value);
+            const reservation = broker.stage();
+            const descriptor = Object.getOwnPropertyDescriptor(target, key);
+            assert.ok(descriptor, `missing ${key} descriptor`);
+            try {
+                Object.defineProperty(target, key, { ...descriptor, value() { throw new Error(`hostile ${key}`); } });
+                reject(() => broker[operation](reservation), 'input_invalid');
+            } finally {
+                Object.defineProperty(target, key, descriptor);
+            }
+
+            reject(() => broker.consume({ handle: expectedHandle }), 'handle_missing');
+            reject(() => broker.publish(reservation), 'reservation_missing');
+            reject(() => broker.abort(reservation), 'reservation_missing');
+            const retry = broker.stage();
+            assert.equal(broker.publish(retry), expectedHandle, `${operation}/${key} must release fixed entropy and hidden handle state`);
+            assert.equal(broker.consume({ handle: expectedHandle }).status, 'available');
+        }
+    }
 });
 
 test('rejects fixed entropy only while its reservation or handle remains live', () => {

--- a/lib/ai-providers/fabric/patient-insight-broker.test.ts
+++ b/lib/ai-providers/fabric/patient-insight-broker.test.ts
@@ -4,7 +4,7 @@ import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
 import { createPatientInsightHostBoundary } from './patient-insight-host-boundary.ts';
-import { PatientInsightBrokerError, createPatientInsightBroker, type PatientInsightBrokerHost } from './patient-insight-broker.ts';
+import { PatientInsightBrokerError, createPatientInsightBroker, isPatientInsightBrokerCapability, type PatientInsightBrokerHost } from './patient-insight-broker.ts';
 
 const ref = (prefix: string) => `${prefix}_${'a'.repeat(32)}`;
 const now = '2026-08-23T12:00:00.000Z';
@@ -55,12 +55,10 @@ test('aborts every staged record and releases fixed entropy for a retry', () => 
     const afterConsume = broker.publish(broker.stage()); assert.notEqual(afterConsume, handle); reject(() => broker.consume({ handle }), 'handle_replayed'); assert.equal(broker.consume({ handle: afterConsume }).status, 'available');
 });
 
-test('retains a stage on denial so abort is complete and no denial or throw leaves a live reservation', () => {
+test('aborts a staged reservation on every precommit denial and releases fixed entropy', () => {
     const fixed = Uint8Array.from({ length: 16 }, (_, index) => index); const fixture = host({ entropy: () => fixed }); const broker = createPatientInsightBroker(fixture.value);
-    const denied = broker.stage(); fixture.setCurrentness(state({ revision: 4 })); reject(() => broker.publish(denied), 'revision_stale'); broker.abort(denied);
-    fixture.setCurrentness(state()); const afterDenial = broker.stage(); broker.abort(afterDenial);
-    const afterThrow = broker.stage(); try { throw new Error('synthetic P4 denial'); } catch { broker.abort(afterThrow); }
-    assert.equal(Object.getPrototypeOf(broker.stage()), null);
+    const denied = broker.stage(); fixture.setCurrentness(state({ revision: 4 })); reject(() => broker.publish(denied), 'revision_stale'); reject(() => broker.abort(denied), 'reservation_missing');
+    fixture.setCurrentness(state()); const retry = broker.stage(); assert.equal(broker.publish(retry), `pib_${'000102030405060708090a0b0c0d0e0f'}`);
 });
 
 test('rejects fixed entropy only while its reservation or handle remains live', () => {
@@ -85,6 +83,34 @@ test('rejects forged, cross-broker, duplicate, accessor, Proxy, symbol, and then
     assert.equal(thenReads, 0); reject(() => first.publish(reservation), 'reservation_missing'); reject(() => first.abort(reservation), 'reservation_missing');
 });
 
+test('recognizes only the module-issued broker and reservation identities without Proxy traps', () => {
+    const broker = createPatientInsightBroker(host().value); const reservation = broker.stage(); let traps = 0;
+    const brokerProxy = new Proxy(broker, { get() { traps += 1; throw new Error('synthetic broker Proxy'); } });
+    const reservationProxy = new Proxy(reservation, { get() { traps += 1; throw new Error('synthetic reservation Proxy'); }, ownKeys() { traps += 1; throw new Error('synthetic reservation Proxy'); } });
+    const brokerLike = Object.freeze({ stage: broker.stage, publish: broker.publish, abort: broker.abort, issue: broker.issue, consume: broker.consume });
+    const reservationLike = Object.freeze(Object.create(null));
+    assert.equal(isPatientInsightBrokerCapability(broker), true); assert.equal(isPatientInsightBrokerCapability(brokerLike), false); assert.equal(isPatientInsightBrokerCapability(brokerProxy), false);
+    reject(() => broker.publish(reservationLike), 'reservation_missing'); reject(() => broker.publish(reservationProxy), 'input_invalid'); reject(() => broker.abort(reservationProxy), 'input_invalid');
+    assert.equal(traps, 0); broker.abort(reservation);
+});
+
+test('commits with captured collection intrinsics and performs no postcommit denial', () => {
+    const broker = createPatientInsightBroker(host().value); const reservation = broker.stage();
+    const methods = [
+        [Map.prototype, 'get'], [Map.prototype, 'set'], [Map.prototype, 'has'], [Map.prototype, 'delete'],
+        [Set.prototype, 'add'], [Set.prototype, 'has'], [Set.prototype, 'delete'],
+        [WeakMap.prototype, 'get'], [WeakMap.prototype, 'set'], [WeakMap.prototype, 'delete'],
+        [WeakSet.prototype, 'has'],
+    ] as const;
+    const originals = methods.map(([target, key]) => [target, key, Object.getOwnPropertyDescriptor(target, key)] as const);
+    try {
+        for (const [target, key] of methods) Object.defineProperty(target, key, { configurable: true, value() { throw new Error(`hostile ${key}`); } });
+        const handle = broker.publish(reservation); assert.match(handle, /^pib_[0-9a-f]{32}$/u);
+    } finally {
+        for (const [target, key, descriptor] of originals) if (descriptor) Object.defineProperty(target, key, descriptor);
+    }
+});
+
 test('fails closed on lifecycle reentry without publishing or reserving a partial result', () => {
     const fixture = host({ clock: () => { broker.stage(); return now; } }); const broker = createPatientInsightBroker(fixture.value);
     reject(() => broker.stage(), 'operation_reentered');
@@ -104,11 +130,11 @@ test('makes swallowed currentness reentry sticky at stage and releases the same 
     const retry = broker.stage(); assert.equal(broker.publish(retry), `pib_${'000102030405060708090a0b0c0d0e0f'}`);
 });
 
-test('makes swallowed currentness reentry sticky at publish without consuming its reservation', () => {
+test('aborts a reservation when currentness reentry denies publish', () => {
     const fixed = Uint8Array.from({ length: 16 }, (_, index) => index); let reenter = false; const lifecycle = { reservation: null as object | null };
     const fixture = host({ entropy: () => fixed, readCurrentness: () => { if (reenter && lifecycle.reservation) { try { broker.abort(lifecycle.reservation); } catch (error) { assert.equal((error as PatientInsightBrokerError).code, 'operation_reentered'); } } return Object.freeze({ selectionEpoch: 7, revision: 3, freshnessToken: 'fresh_token_0123456789abcdef', isRevoked: () => false }); } }); const broker = createPatientInsightBroker(fixture.value);
     lifecycle.reservation = broker.stage(); reenter = true; reject(() => broker.publish(lifecycle.reservation), 'operation_reentered'); reenter = false;
-    broker.abort(lifecycle.reservation); const retry = broker.stage(); assert.equal(broker.publish(retry), `pib_${'000102030405060708090a0b0c0d0e0f'}`);
+    reject(() => broker.abort(lifecycle.reservation), 'reservation_missing'); const retry = broker.stage(); assert.equal(broker.publish(retry), `pib_${'000102030405060708090a0b0c0d0e0f'}`);
 });
 
 test('fails closed after selection, revision, freshness, or revocation changes', () => {

--- a/lib/ai-providers/fabric/patient-insight-broker.ts
+++ b/lib/ai-providers/fabric/patient-insight-broker.ts
@@ -133,6 +133,11 @@ export function createPatientInsightBroker(value: PatientInsightBrokerHost): Pat
     const abortEntry = (reservation: object, entry: ReservationEntry): void => {
         weakMapDelete(reservations, reservation); setDelete(liveEntropyHandles, entry.entropyHandle); setDelete(reservedHandles, entry.handle);
     };
+    const liveReservationEntry = (value: unknown): Readonly<{ reservation: object; entry: ReservationEntry }> | null => {
+        if (!value || typeof value !== 'object' || !weakSetHas(authenticReservations, value)) return null;
+        const entry = weakMapGet(reservations, value);
+        return entry ? { reservation: value, entry } : null;
+    };
     const completeRecord = (handle: string, entropyHandle: string, snapshot: Currentness, result: Extract<PatientInsightHostResult, { status: 'available' }>): RecordEntry => Object.freeze({ handle, entropyHandle, currentness: snapshot, accepted: result });
     const validPreparedEntry = (entry: ReservationEntry): boolean => Object.isFrozen(entry) && Object.isFrozen(entry.record) && entry.record.handle === entry.handle && entry.record.entropyHandle === entry.entropyHandle && handlePattern.test(entry.handle) && handlePattern.test(entry.entropyHandle) && Object.isFrozen(entry.record.currentness) && Object.isFrozen(entry.record.accepted);
     const stage = (): object => {
@@ -151,10 +156,11 @@ export function createPatientInsightBroker(value: PatientInsightBrokerHost): Pat
         return reservation;
     };
     const publish = (inputValue: unknown, verifyCurrentness = true): string => {
-        const reservation = reservationInput(inputValue);
-        if (!weakSetHas(authenticReservations, reservation)) fail('reservation_missing');
-        const entry = weakMapGet(reservations, reservation); if (!entry) fail('reservation_missing');
+        const live = liveReservationEntry(inputValue);
+        if (!live) { reservationInput(inputValue); fail('reservation_missing'); }
+        const { reservation, entry } = live;
         try {
+            reservationInput(reservation);
             if (!validPreparedEntry(entry)) fail('reservation_missing');
             if (verifyCurrentness) { readClock(); ensureNotPoisoned(); const current = readCurrentness(); ensureNotPoisoned(); currentnessChanged(entry.record.currentness, current); }
             ensureNotPoisoned();
@@ -165,8 +171,11 @@ export function createPatientInsightBroker(value: PatientInsightBrokerHost): Pat
         } catch (error) { abortEntry(reservation, entry); throw error; }
     };
     const abort = (inputValue: unknown): void => {
-        const reservation = reservationInput(inputValue); if (!weakSetHas(authenticReservations, reservation)) fail('reservation_missing'); const entry = weakMapGet(reservations, reservation); if (!entry) fail('reservation_missing');
-        abortEntry(reservation, entry);
+        const live = liveReservationEntry(inputValue);
+        if (!live) { reservationInput(inputValue); fail('reservation_missing'); }
+        const { reservation, entry } = live;
+        try { reservationInput(reservation); abortEntry(reservation, entry); }
+        catch (error) { abortEntry(reservation, entry); throw error; }
     };
     const exclusive = <Result>(callback: () => Result, commitLast = false): Result => {
         if (operationActive) { operationPoisoned = true; fail('operation_reentered'); }

--- a/lib/ai-providers/fabric/patient-insight-broker.ts
+++ b/lib/ai-providers/fabric/patient-insight-broker.ts
@@ -26,10 +26,29 @@ export type PatientInsightBroker = Readonly<{
 }>;
 
 type Currentness = Readonly<{ selectionEpoch: number; revision: number; freshnessToken: string }>;
-type RecordEntry = Readonly<{ entropyHandle: string; currentness: Currentness; accepted: Extract<PatientInsightHostResult, { status: 'available' }> }>;
-type ReservationEntry = Readonly<{ entropyHandle: string; handle: string; currentness: Currentness; accepted: Extract<PatientInsightHostResult, { status: 'available' }> }>;
+type RecordEntry = Readonly<{ handle: string; entropyHandle: string; currentness: Currentness; accepted: Extract<PatientInsightHostResult, { status: 'available' }> }>;
+type ReservationEntry = Readonly<{ entropyHandle: string; handle: string; record: RecordEntry }>;
 const handlePattern = /^pib_[0-9a-f]{32}$/u;
 const tokenPattern = /^[A-Za-z][A-Za-z0-9._:-]{15,159}$/u;
+const authenticBrokers = new WeakSet<object>();
+const authenticReservations = new WeakSet<object>();
+const mapGet = Function.prototype.call.bind(Map.prototype.get) as <Key, Value>(map: Map<Key, Value>, key: Key) => Value | undefined;
+const mapSet = Function.prototype.call.bind(Map.prototype.set) as <Key, Value>(map: Map<Key, Value>, key: Key, value: Value) => Map<Key, Value>;
+const mapDelete = Function.prototype.call.bind(Map.prototype.delete) as <Key, Value>(map: Map<Key, Value>, key: Key) => boolean;
+const mapHas = Function.prototype.call.bind(Map.prototype.has) as <Key, Value>(map: Map<Key, Value>, key: Key) => boolean;
+const setAdd = Function.prototype.call.bind(Set.prototype.add) as <Value>(set: Set<Value>, value: Value) => Set<Value>;
+const setDelete = Function.prototype.call.bind(Set.prototype.delete) as <Value>(set: Set<Value>, value: Value) => boolean;
+const setHas = Function.prototype.call.bind(Set.prototype.has) as <Value>(set: Set<Value>, value: Value) => boolean;
+const weakMapGet = Function.prototype.call.bind(WeakMap.prototype.get) as <Key extends object, Value>(map: WeakMap<Key, Value>, key: Key) => Value | undefined;
+const weakMapSet = Function.prototype.call.bind(WeakMap.prototype.set) as <Key extends object, Value>(map: WeakMap<Key, Value>, key: Key, value: Value) => WeakMap<Key, Value>;
+const weakMapDelete = Function.prototype.call.bind(WeakMap.prototype.delete) as <Key extends object, Value>(map: WeakMap<Key, Value>, key: Key) => boolean;
+const weakSetAdd = Function.prototype.call.bind(WeakSet.prototype.add) as <Value extends object>(set: WeakSet<Value>, value: Value) => WeakSet<Value>;
+const weakSetHas = Function.prototype.call.bind(WeakSet.prototype.has) as <Value extends object>(set: WeakSet<Value>, value: Value) => boolean;
+
+/** Returns true only for the frozen broker capability created by this module. */
+export function isPatientInsightBrokerCapability(value: unknown): value is PatientInsightBroker {
+    try { return !!value && typeof value === 'object' && !types.isProxy(value) && weakSetHas(authenticBrokers, value); } catch { return false; }
+}
 
 function fail(code: PatientInsightBrokerErrorCode): never { throw new PatientInsightBrokerError(code); }
 function callable(value: unknown): value is () => unknown { return typeof value === 'function' && !types.isProxy(value); }
@@ -76,7 +95,7 @@ export function createPatientInsightBroker(value: PatientInsightBrokerHost): Pat
     const boundaryValue = host && exact(host.boundary, ['prepare']);
     if (!host || !Object.isFrozen(value) || !boundaryValue || !callable(host.readCurrentness) || !callable(host.readSources) || !callable(boundaryValue.prepare) || !callable(host.clock) || !callable(host.entropy)) fail('input_invalid');
     const resolver = createPatientInsightHostProjectionResolver(); const records = new Map<string, RecordEntry>(); const reservations = new WeakMap<object, ReservationEntry>(); const liveEntropyHandles = new Set<string>(); const reservedHandles = new Set<string>(); const consumed = new Set<string>();
-    let operationActive = false; let operationPoisoned = false; let operationCleanup: (() => void) | null = null;
+    let operationActive = false; let operationPoisoned = false;
     const readCurrentness = () => {
         let result: unknown; try { result = (host.readCurrentness as () => unknown)(); } catch { return fail('dependency_unavailable'); }
         const snapshot = currentness(result); if (!snapshot) fail('dependency_unavailable'); return snapshot;
@@ -105,16 +124,17 @@ export function createPatientInsightBroker(value: PatientInsightBrokerHost): Pat
     };
     const availableHandle = (entropyHandle: string): string => {
         let candidate = entropyHandle;
-        while (records.has(candidate) || reservedHandles.has(candidate) || consumed.has(candidate)) {
+        while (mapHas(records, candidate) || setHas(reservedHandles, candidate) || setHas(consumed, candidate)) {
             const next = nextHandle(candidate); if (!next) fail('handle_collision'); candidate = next;
         }
         return candidate;
     };
-    const discardOperationState = (): void => {
-        const cleanup = operationCleanup as (() => void) | null; operationCleanup = null;
-        if (cleanup) cleanup();
+    const ensureNotPoisoned = (): void => { if (operationPoisoned) fail('operation_reentered'); };
+    const abortEntry = (reservation: object, entry: ReservationEntry): void => {
+        weakMapDelete(reservations, reservation); setDelete(liveEntropyHandles, entry.entropyHandle); setDelete(reservedHandles, entry.handle);
     };
-    const ensureNotPoisoned = (): void => { if (operationPoisoned) { discardOperationState(); fail('operation_reentered'); } };
+    const completeRecord = (handle: string, entropyHandle: string, snapshot: Currentness, result: Extract<PatientInsightHostResult, { status: 'available' }>): RecordEntry => Object.freeze({ handle, entropyHandle, currentness: snapshot, accepted: result });
+    const validPreparedEntry = (entry: ReservationEntry): boolean => Object.isFrozen(entry) && Object.isFrozen(entry.record) && entry.record.handle === entry.handle && entry.record.entropyHandle === entry.entropyHandle && handlePattern.test(entry.handle) && handlePattern.test(entry.entropyHandle) && Object.isFrozen(entry.record.currentness) && Object.isFrozen(entry.record.accepted);
     const stage = (): object => {
         const snapshot = readCurrentness(); ensureNotPoisoned(); readClock(); ensureNotPoisoned(); let sources: unknown;
         try { sources = (host.readSources as () => unknown)(); } catch { return fail('dependency_unavailable'); }
@@ -123,51 +143,55 @@ export function createPatientInsightBroker(value: PatientInsightBrokerHost): Pat
         let output: unknown; try { output = (boundaryValue.prepare as (request: Readonly<{ projection: PatientInsightProjection }>) => unknown)(Object.freeze({ projection })); } catch { return fail('dependency_unavailable'); }
         ensureNotPoisoned();
         const result = accepted(output); if (!result) fail('proposal_invalid'); const entropyHandle = issueHandle();
-        if (liveEntropyHandles.has(entropyHandle)) fail('handle_collision'); const handle = availableHandle(entropyHandle);
+        if (setHas(liveEntropyHandles, entropyHandle)) fail('handle_collision'); const handle = availableHandle(entropyHandle);
         const current = readCurrentness(); ensureNotPoisoned(); currentnessChanged(snapshot, current);
-        const reservation = Object.freeze(Object.create(null)) as object; const entry = Object.freeze({ entropyHandle, handle, currentness: snapshot, accepted: result });
-        reservations.set(reservation, entry); liveEntropyHandles.add(entropyHandle); reservedHandles.add(handle);
-        operationCleanup = () => { if (reservations.get(reservation) === entry) { reservations.delete(reservation); liveEntropyHandles.delete(entry.entropyHandle); reservedHandles.delete(entry.handle); } };
-        ensureNotPoisoned();
+        const record = completeRecord(handle, entropyHandle, snapshot, result); const reservation = Object.freeze(Object.create(null)) as object; const entry = Object.freeze({ entropyHandle, handle, record });
+        if (!validPreparedEntry(entry)) fail('proposal_invalid');
+        weakMapSet(reservations, reservation, entry); weakSetAdd(authenticReservations, reservation); setAdd(liveEntropyHandles, entropyHandle); setAdd(reservedHandles, handle);
         return reservation;
     };
     const publish = (inputValue: unknown, verifyCurrentness = true): string => {
-        const reservation = reservationInput(inputValue); const entry = reservations.get(reservation); if (!entry) fail('reservation_missing');
-        if (verifyCurrentness) { readClock(); ensureNotPoisoned(); const current = readCurrentness(); ensureNotPoisoned(); currentnessChanged(entry.currentness, current); }
-        ensureNotPoisoned();
-        if (records.has(entry.handle)) fail('handle_collision');
-        const record = Object.freeze({ entropyHandle: entry.entropyHandle, currentness: entry.currentness, accepted: entry.accepted });
-        reservations.delete(reservation); reservedHandles.delete(entry.handle); records.set(entry.handle, record);
-        operationCleanup = () => { if (records.get(entry.handle) === record) { records.delete(entry.handle); liveEntropyHandles.delete(record.entropyHandle); } };
-        ensureNotPoisoned();
-        return entry.handle;
+        const reservation = reservationInput(inputValue);
+        if (!weakSetHas(authenticReservations, reservation)) fail('reservation_missing');
+        const entry = weakMapGet(reservations, reservation); if (!entry) fail('reservation_missing');
+        try {
+            if (!validPreparedEntry(entry)) fail('reservation_missing');
+            if (verifyCurrentness) { readClock(); ensureNotPoisoned(); const current = readCurrentness(); ensureNotPoisoned(); currentnessChanged(entry.record.currentness, current); }
+            ensureNotPoisoned();
+            if (mapHas(records, entry.handle) || !setHas(reservedHandles, entry.handle) || !setHas(liveEntropyHandles, entry.entropyHandle)) fail('handle_collision');
+            // @Codex: Commit uses only captured collection intrinsics and prepared private data.
+            weakMapDelete(reservations, reservation); setDelete(reservedHandles, entry.handle); mapSet(records, entry.handle, entry.record);
+            return entry.handle;
+        } catch (error) { abortEntry(reservation, entry); throw error; }
     };
     const abort = (inputValue: unknown): void => {
-        const reservation = reservationInput(inputValue); const entry = reservations.get(reservation); if (!entry) fail('reservation_missing');
-        reservations.delete(reservation); liveEntropyHandles.delete(entry.entropyHandle); reservedHandles.delete(entry.handle);
+        const reservation = reservationInput(inputValue); if (!weakSetHas(authenticReservations, reservation)) fail('reservation_missing'); const entry = weakMapGet(reservations, reservation); if (!entry) fail('reservation_missing');
+        abortEntry(reservation, entry);
     };
-    const exclusive = <Result>(callback: () => Result): Result => {
+    const exclusive = <Result>(callback: () => Result, commitLast = false): Result => {
         if (operationActive) { operationPoisoned = true; fail('operation_reentered'); }
-        operationActive = true; operationPoisoned = false; operationCleanup = null;
+        operationActive = true; operationPoisoned = false;
         try {
             const result = callback();
-            if (operationPoisoned) { discardOperationState(); fail('operation_reentered'); }
+            if (!commitLast && operationPoisoned) fail('operation_reentered');
             return result;
-        } finally { operationActive = false; operationPoisoned = false; operationCleanup = null; }
+        } finally { operationActive = false; operationPoisoned = false; }
     };
-    return Object.freeze({
+    const broker = Object.freeze({
         stage() { return exclusive(stage); },
-        publish(inputValue) { return exclusive(() => publish(inputValue)); },
-        abort(inputValue) { return exclusive(() => abort(inputValue)); },
+        publish(inputValue: unknown) { return exclusive(() => publish(inputValue), true); },
+        abort(inputValue: unknown) { return exclusive(() => abort(inputValue), true); },
         issue() {
-            return exclusive(() => publish(stage(), false));
+            return exclusive(() => publish(stage(), false), true);
         },
-        consume(inputValue) {
+        consume(inputValue: unknown) {
             return exclusive(() => {
                 const input = exact(inputValue, ['handle']); if (!input || typeof input.handle !== 'string' || !handlePattern.test(input.handle)) fail('input_invalid');
-                if (consumed.has(input.handle)) fail('handle_replayed'); const entry = records.get(input.handle); if (!entry) fail('handle_missing'); records.delete(input.handle); liveEntropyHandles.delete(entry.entropyHandle); consumed.add(input.handle);
+                if (setHas(consumed, input.handle)) fail('handle_replayed'); const entry = mapGet(records, input.handle); if (!entry) fail('handle_missing'); mapDelete(records, input.handle); setDelete(liveEntropyHandles, entry.entropyHandle); setAdd(consumed, input.handle);
                 readClock(); ensureNotPoisoned(); const current = readCurrentness(); ensureNotPoisoned(); currentnessChanged(entry.currentness, current); return entry.accepted;
             });
         },
     });
+    weakSetAdd(authenticBrokers, broker);
+    return broker;
 }


### PR DESCRIPTION
## Summary
- rende module-authentic il broker Patient Insight e le reservation private
- prepara il record completo prima del commit e impedisce denial post-commit
- garantisce cleanup di reservation, entropy e handle per ogni denial pre-commit
- mantiene il risultato review-only con writesPerformed=0 e applyPolicy=none

## Verification
- PI, broker, host, projection, lease, P4, session e review: 84/84
- patient cascade: 3/3
- typecheck e lint completo
- claims, AI-write, never-regress e node-runtime
- OpenAPI drift e schema drift/writers
- Next Webpack build e static generation: 108/108
- review indipendente su archive fresco Node 24.19.0

## Risk / Notes
- candidato A1 stacked su #261; non include binding broker-lease o P4 ricostruito
- nessun provider, route, persistenza, schema, UI, write o apply
- solo fixture sintetiche; nessuna PHI/PII o dato paziente reale

## Ticket
Refs WUL-522