### PR TITLE
feat(ocr): definisci il contratto provider locale

### DIFF
--- a/lib/ai-providers/fabric/local-ocr-provider-contract.test.ts
+++ b/lib/ai-providers/fabric/local-ocr-provider-contract.test.ts
@@ -101,12 +101,32 @@ test('rejects cross-provider evidence plus malformed venue, egress, authority, a
 test('rejects extra keys, accessors, and non-plain prototypes without reading hostile accessors', () => {
     assert.equal(resolveLocalOcrProvider({ ...ollamaOcrInput(), receipt: { ...ollamaOcrInput().receipt, extra: true } }), null);
 
+    let accessorReads = 0;
     const accessorReceipt = { ...ollamaOcrInput().receipt };
-    Object.defineProperty(accessorReceipt, 'provider', { enumerable: true, get: () => { throw new Error('must not read'); } });
+    Object.defineProperty(accessorReceipt, 'provider', { enumerable: true, get: () => { accessorReads += 1; return 'ollama_ocr'; } });
     assert.equal(resolveLocalOcrProvider({ ...ollamaOcrInput(), receipt: accessorReceipt }), null);
+    assert.equal(accessorReads, 0);
+
+    const nonEnumerableReceipt = { ...ollamaOcrInput().receipt };
+    Object.defineProperty(nonEnumerableReceipt, 'provider', { enumerable: false, value: 'ollama_ocr' });
+    assert.equal(resolveLocalOcrProvider({ ...ollamaOcrInput(), receipt: nonEnumerableReceipt }), null);
 
     const prototypeReceipt = Object.assign(Object.create({ inherited: true }), ollamaOcrInput().receipt);
     assert.equal(resolveLocalOcrProvider({ ...ollamaOcrInput(), receipt: prototypeReceipt }), null);
+});
+
+test('rejects outer and nested proxies before executing reflection traps', () => {
+    const trapCounters = { outer: 0, receipt: 0, provenance: 0 };
+    const traps = (key: keyof typeof trapCounters): ProxyHandler<object> => ({
+        get: () => { trapCounters[key] += 1; throw new Error('must not read'); },
+        getOwnPropertyDescriptor: () => { trapCounters[key] += 1; throw new Error('must not reflect'); },
+        getPrototypeOf: () => { trapCounters[key] += 1; throw new Error('must not reflect'); },
+        ownKeys: () => { trapCounters[key] += 1; throw new Error('must not reflect'); },
+    });
+    assert.equal(resolveLocalOcrProvider(new Proxy(ollamaOcrInput(), traps('outer'))), null);
+    assert.equal(resolveLocalOcrProvider({ ...ollamaOcrInput(), receipt: new Proxy(ollamaOcrInput().receipt, traps('receipt')) }), null);
+    assert.equal(resolveLocalOcrProvider({ ...ollamaOcrInput(), provenance: new Proxy(ollamaOcrInput().provenance, traps('provenance')) }), null);
+    assert.deepEqual(trapCounters, { outer: 0, receipt: 0, provenance: 0 });
 });
 
 test('snapshots accepted metadata so later input or result mutation cannot change the receipt', () => {

--- a/lib/ai-providers/fabric/local-ocr-provider-contract.test.ts
+++ b/lib/ai-providers/fabric/local-ocr-provider-contract.test.ts
@@ -1,0 +1,121 @@
+/* @Codex */
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { resolveLocalOcrProvider } from './local-ocr-provider-contract.ts';
+
+function ollamaOcrInput() {
+    return {
+        provider: 'ollama_ocr',
+        readiness: 'ready',
+        receipt: {
+            schemaVersion: 'mediflow.ai.local-ocr-provider-receipt.v1',
+            provider: 'ollama_ocr',
+            venue: 'local_process',
+            egress: 'none',
+            authority: 'review_only',
+            applyPolicy: 'none',
+            writesPerformed: 0,
+        },
+        provenance: {
+            schemaVersion: 'mediflow.ai.local-ocr-provider-provenance.v1',
+            provider: 'ollama_ocr',
+            venue: 'local_process',
+            egress: 'none',
+            receiptProvider: 'ollama_ocr',
+        },
+    };
+}
+
+function appleVisionInput() {
+    return {
+        provider: 'apple_vision',
+        readiness: 'ready',
+        receipt: {
+            schemaVersion: 'mediflow.ai.local-ocr-provider-receipt.v1',
+            provider: 'apple_vision',
+            venue: 'on_device',
+            egress: 'none',
+            authority: 'review_only',
+            applyPolicy: 'none',
+            writesPerformed: 0,
+        },
+        provenance: {
+            schemaVersion: 'mediflow.ai.local-ocr-provider-provenance.v1',
+            provider: 'apple_vision',
+            venue: 'on_device',
+            egress: 'none',
+            receiptProvider: 'apple_vision',
+        },
+    };
+}
+
+test('resolves one explicit ready Ollama OCR provider into review-only metadata', () => {
+    const result = resolveLocalOcrProvider(ollamaOcrInput());
+
+    assert.deepEqual(result, {
+        outcome: 'ready',
+        provider: 'ollama_ocr',
+        receipt: ollamaOcrInput().receipt,
+        provenance: ollamaOcrInput().provenance,
+        writesPerformed: 0,
+        applyPolicy: 'none',
+    });
+    assert.ok(Object.isFrozen(result));
+    assert.ok(Object.isFrozen(result.receipt));
+    assert.ok(Object.isFrozen(result.provenance));
+});
+
+test('resolves Apple Vision only from its independent ready receipt and provenance', () => {
+    const result = resolveLocalOcrProvider(appleVisionInput());
+
+    assert.deepEqual(result, {
+        outcome: 'ready',
+        provider: 'apple_vision',
+        receipt: appleVisionInput().receipt,
+        provenance: appleVisionInput().provenance,
+        writesPerformed: 0,
+        applyPolicy: 'none',
+    });
+});
+
+test('fails closed for a missing or unready provider and for an implicit fallback', () => {
+    assert.equal(resolveLocalOcrProvider(undefined), null);
+    assert.equal(resolveLocalOcrProvider({ ...ollamaOcrInput(), readiness: 'unready' }), null);
+    assert.equal(resolveLocalOcrProvider({ ...ollamaOcrInput(), provider: undefined }), null);
+    assert.equal(resolveLocalOcrProvider({ ...ollamaOcrInput(), fallback: 'apple_vision' }), null);
+});
+
+test('rejects cross-provider evidence plus malformed venue, egress, authority, and apply metadata', () => {
+    const cases = [
+        { ...ollamaOcrInput(), receipt: { ...ollamaOcrInput().receipt, provider: 'apple_vision' } },
+        { ...ollamaOcrInput(), provenance: { ...ollamaOcrInput().provenance, receiptProvider: 'apple_vision' } },
+        { ...ollamaOcrInput(), receipt: { ...ollamaOcrInput().receipt, venue: 'cloud' } },
+        { ...ollamaOcrInput(), receipt: { ...ollamaOcrInput().receipt, egress: 'redacted_explicit_consent' } },
+        { ...ollamaOcrInput(), receipt: { ...ollamaOcrInput().receipt, authority: 'review_or_apply' } },
+        { ...ollamaOcrInput(), receipt: { ...ollamaOcrInput().receipt, applyPolicy: 'propose' } },
+        { ...ollamaOcrInput(), receipt: { ...ollamaOcrInput().receipt, writesPerformed: 1 } },
+    ];
+    for (const input of cases) assert.equal(resolveLocalOcrProvider(input), null);
+});
+
+test('rejects extra keys, accessors, and non-plain prototypes without reading hostile accessors', () => {
+    assert.equal(resolveLocalOcrProvider({ ...ollamaOcrInput(), receipt: { ...ollamaOcrInput().receipt, extra: true } }), null);
+
+    const accessorReceipt = { ...ollamaOcrInput().receipt };
+    Object.defineProperty(accessorReceipt, 'provider', { enumerable: true, get: () => { throw new Error('must not read'); } });
+    assert.equal(resolveLocalOcrProvider({ ...ollamaOcrInput(), receipt: accessorReceipt }), null);
+
+    const prototypeReceipt = Object.assign(Object.create({ inherited: true }), ollamaOcrInput().receipt);
+    assert.equal(resolveLocalOcrProvider({ ...ollamaOcrInput(), receipt: prototypeReceipt }), null);
+});
+
+test('snapshots accepted metadata so later input or result mutation cannot change the receipt', () => {
+    const input = ollamaOcrInput();
+    const result = resolveLocalOcrProvider(input);
+    assert.ok(result);
+    input.receipt.provider = 'apple_vision';
+    input.provenance.receiptProvider = 'apple_vision';
+    assert.equal(result.receipt.provider, 'ollama_ocr');
+    assert.equal(result.provenance.receiptProvider, 'ollama_ocr');
+    assert.throws(() => { (result as { provider: string }).provider = 'apple_vision'; }, TypeError);
+});

--- a/lib/ai-providers/fabric/local-ocr-provider-contract.ts
+++ b/lib/ai-providers/fabric/local-ocr-provider-contract.ts
@@ -1,0 +1,62 @@
+/* @Codex */
+export type LocalOcrProvider = 'ollama_ocr' | 'apple_vision';
+
+export type LocalOcrProviderResolution = Readonly<{
+    outcome: 'ready';
+    provider: LocalOcrProvider;
+    receipt: Readonly<{
+        schemaVersion: 'mediflow.ai.local-ocr-provider-receipt.v1';
+        provider: LocalOcrProvider;
+        venue: 'local_process' | 'on_device';
+        egress: 'none';
+        authority: 'review_only';
+        applyPolicy: 'none';
+        writesPerformed: 0;
+    }>;
+    provenance: Readonly<{
+        schemaVersion: 'mediflow.ai.local-ocr-provider-provenance.v1';
+        provider: LocalOcrProvider;
+        venue: 'local_process' | 'on_device';
+        egress: 'none';
+        receiptProvider: LocalOcrProvider;
+    }>;
+    writesPerformed: 0;
+    applyPolicy: 'none';
+}>;
+
+function record(value: unknown, keys: readonly string[]): Record<string, unknown> | null {
+    try {
+        if (!value || typeof value !== 'object' || Array.isArray(value) || Object.getPrototypeOf(value) !== Object.prototype) return null;
+        const ownKeys = Reflect.ownKeys(value);
+        if (ownKeys.length !== keys.length || ownKeys.some((key) => typeof key !== 'string' || !keys.includes(key))) return null;
+        const output: Record<string, unknown> = {};
+        for (const key of keys) {
+            const descriptor = Object.getOwnPropertyDescriptor(value, key);
+            if (!descriptor || !('value' in descriptor)) return null;
+            output[key] = descriptor.value;
+        }
+        return output;
+    } catch {
+        return null;
+    }
+}
+
+/** Resolves explicit, review-only metadata for one ready local OCR provider. */
+export function resolveLocalOcrProvider(value: unknown): LocalOcrProviderResolution | null {
+    const input = record(value, ['provider', 'readiness', 'receipt', 'provenance']);
+    const receipt = input && record(input.receipt, ['schemaVersion', 'provider', 'venue', 'egress', 'authority', 'applyPolicy', 'writesPerformed']);
+    const provenance = input && record(input.provenance, ['schemaVersion', 'provider', 'venue', 'egress', 'receiptProvider']);
+    const provider = input?.provider === 'ollama_ocr' || input?.provider === 'apple_vision' ? input.provider : null;
+    const venue = provider === 'ollama_ocr' ? 'local_process' : provider === 'apple_vision' ? 'on_device' : null;
+    if (
+        !input || !receipt || !provenance || !provider || !venue || input.readiness !== 'ready'
+        || receipt.schemaVersion !== 'mediflow.ai.local-ocr-provider-receipt.v1' || receipt.provider !== provider
+        || receipt.venue !== venue || receipt.egress !== 'none' || receipt.authority !== 'review_only'
+        || receipt.applyPolicy !== 'none' || receipt.writesPerformed !== 0
+        || provenance.schemaVersion !== 'mediflow.ai.local-ocr-provider-provenance.v1' || provenance.provider !== provider
+        || provenance.venue !== venue || provenance.egress !== 'none' || provenance.receiptProvider !== provider
+    ) return null;
+    const receiptSnapshot = Object.freeze({ schemaVersion: 'mediflow.ai.local-ocr-provider-receipt.v1' as const, provider, venue, egress: 'none' as const, authority: 'review_only' as const, applyPolicy: 'none' as const, writesPerformed: 0 as const });
+    const provenanceSnapshot = Object.freeze({ schemaVersion: 'mediflow.ai.local-ocr-provider-provenance.v1' as const, provider, venue, egress: 'none' as const, receiptProvider: provider });
+    return Object.freeze({ outcome: 'ready' as const, provider, receipt: receiptSnapshot, provenance: provenanceSnapshot, writesPerformed: 0 as const, applyPolicy: 'none' as const });
+}

--- a/lib/ai-providers/fabric/local-ocr-provider-contract.ts
+++ b/lib/ai-providers/fabric/local-ocr-provider-contract.ts
@@ -1,4 +1,6 @@
 /* @Codex */
+import { types } from 'node:util';
+
 export type LocalOcrProvider = 'ollama_ocr' | 'apple_vision';
 
 export type LocalOcrProviderResolution = Readonly<{
@@ -26,13 +28,13 @@ export type LocalOcrProviderResolution = Readonly<{
 
 function record(value: unknown, keys: readonly string[]): Record<string, unknown> | null {
     try {
-        if (!value || typeof value !== 'object' || Array.isArray(value) || Object.getPrototypeOf(value) !== Object.prototype) return null;
+        if (!value || typeof value !== 'object' || Array.isArray(value) || types.isProxy(value) || Object.getPrototypeOf(value) !== Object.prototype) return null;
         const ownKeys = Reflect.ownKeys(value);
         if (ownKeys.length !== keys.length || ownKeys.some((key) => typeof key !== 'string' || !keys.includes(key))) return null;
         const output: Record<string, unknown> = {};
         for (const key of keys) {
             const descriptor = Object.getOwnPropertyDescriptor(value, key);
-            if (!descriptor || !('value' in descriptor)) return null;
+            if (!descriptor || !descriptor.enumerable || !('value' in descriptor)) return null;
             output[key] = descriptor.value;
         }
         return output;


### PR DESCRIPTION
## Summary
- definisce il contratto provider OCR locale con binding espliciti
- distingue Ollama local_process da Apple Vision on_device
- mantiene fallback negato, writesPerformed=0 e applyPolicy=none

## Verification
- review indipendente exact-head su P0a
- suite provider, host, currentness e OCR: 70/70
- typecheck, ESLint, claims, AI-write, never-regress e runtime
- OpenAPI e schema drift/writers, git diff --check

## Risk / Notes
- candidato stacked su #246; non integra admission, execution, route o provider reale
- nessun fallback, persistenza, write o apply
- fixture solo sintetiche; nessuna PHI/PII

## Ticket
Refs WUL-522