### PR TITLE
feat(ocr): aggiungi admission host locale

### DIFF
--- a/lib/ai-providers/fabric/local-ocr-host-admission.test.ts
+++ b/lib/ai-providers/fabric/local-ocr-host-admission.test.ts
@@ -1,0 +1,60 @@
+/* @Codex */
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createHostLocalOcrAdmissionService, type HostLocalOcrAdmissionResult } from './local-ocr-host-admission.ts';
+
+type Provider = 'ollama_ocr' | 'apple_vision';
+const venue = (provider: Provider) => provider === 'ollama_ocr' ? 'local_process' : 'on_device';
+const policy = (provider: Provider) => ({ provider, venue: venue(provider), egress: 'none', authority: 'review_only', applyPolicy: 'none' });
+const readiness = (provider: Provider, state: 'available' | 'unavailable' = 'available') => ({ provider, venue: venue(provider), state });
+const service = (hostPolicy: unknown, hostReadiness: unknown) => createHostLocalOcrAdmissionService({
+    readPolicy: async () => hostPolicy as never, readReadiness: async () => hostReadiness as never,
+});
+const deny = (code: string) => ({ status: 'denied', code, binding: null, readiness: null,
+    fallback: 'denied_by_contract', applyPolicy: 'none', writesPerformed: 0 });
+
+test('binds exactly the host-selected available local provider with frozen local-only readiness', async () => {
+    for (const provider of ['ollama_ocr', 'apple_vision'] as const) {
+        const result = await service(policy(provider), readiness(provider)).admit();
+        assert.deepEqual(result, { status: 'admitted', code: null,
+            binding: { provider, venue: venue(provider), egress: 'none' },
+            readiness: { provider, venue: venue(provider), egress: 'none', state: 'available', schemaVersion: 'mediflow.ai.local-ocr-host-readiness.v1' },
+            fallback: 'denied_by_contract', applyPolicy: 'none', writesPerformed: 0 });
+        assert.ok(Object.isFrozen(result));
+        assert.ok(Object.isFrozen(result.binding));
+        assert.ok(Object.isFrozen(result.readiness));
+    }
+});
+
+test('denies unavailable, mismatched, and caller-supplied alternate providers without fallback', async () => {
+    const unavailable = service(policy('ollama_ocr'), readiness('ollama_ocr', 'unavailable'));
+    const result = await (unavailable.admit as (input: unknown) => Promise<HostLocalOcrAdmissionResult>)({ provider: 'apple_vision' });
+    assert.deepEqual(result, deny('provider_unavailable'));
+    assert.equal(JSON.stringify(result).includes('apple_vision'), false);
+    for (const input of [readiness('apple_vision'), { ...readiness('ollama_ocr'), venue: 'on_device' }]) {
+        assert.deepEqual(await service(policy('ollama_ocr'), input).admit(), deny('readiness_mismatch'));
+    }
+});
+
+test('rejects ambiguous, hostile, accessor, and prototype host inputs without reading accessors', async () => {
+    let reads = 0;
+    const accessor = {};
+    Object.defineProperty(accessor, 'provider', { enumerable: true, get: () => { reads += 1; return 'ollama_ocr'; } });
+    const inherited = Object.assign(Object.create({ inherited: true }), readiness('ollama_ocr'));
+    for (const [hostPolicy, hostReadiness, code] of [
+        [{ ...policy('ollama_ocr'), fallback: 'apple_vision' }, readiness('ollama_ocr'), 'policy_invalid'],
+        [accessor, readiness('ollama_ocr'), 'policy_invalid'],
+        [policy('ollama_ocr'), { ...readiness('ollama_ocr'), extra: true }, 'readiness_invalid'],
+        [policy('ollama_ocr'), accessor, 'readiness_invalid'],
+        [policy('ollama_ocr'), inherited, 'readiness_invalid'],
+    ] as const) assert.deepEqual(await service(hostPolicy, hostReadiness).admit(), deny(code));
+    assert.equal(reads, 0);
+});
+
+test('redacts host reader failures', async () => {
+    const failedPolicy = createHostLocalOcrAdmissionService({ readPolicy: async () => { throw new Error('synthetic policy secret'); }, readReadiness: async () => readiness('ollama_ocr') });
+    const failedReadiness = createHostLocalOcrAdmissionService({ readPolicy: async () => policy('ollama_ocr'), readReadiness: async () => { throw new Error('synthetic readiness secret'); } });
+    const results = [await failedPolicy.admit(), await failedReadiness.admit()];
+    assert.deepEqual(results, [deny('policy_unavailable'), deny('readiness_unavailable')]);
+    assert.equal(JSON.stringify(results).includes('synthetic'), false);
+});

--- a/lib/ai-providers/fabric/local-ocr-host-admission.test.ts
+++ b/lib/ai-providers/fabric/local-ocr-host-admission.test.ts
@@ -38,17 +38,39 @@ test('denies unavailable, mismatched, and caller-supplied alternate providers wi
 
 test('rejects ambiguous, hostile, accessor, and prototype host inputs without reading accessors', async () => {
     let reads = 0;
-    const accessor = {};
-    Object.defineProperty(accessor, 'provider', { enumerable: true, get: () => { reads += 1; return 'ollama_ocr'; } });
+    const accessorPolicy = { ...policy('ollama_ocr') };
+    Object.defineProperty(accessorPolicy, 'provider', { enumerable: true, get: () => { reads += 1; return 'ollama_ocr'; } });
+    const accessorReadiness = { ...readiness('ollama_ocr') };
+    Object.defineProperty(accessorReadiness, 'provider', { enumerable: true, get: () => { reads += 1; return 'ollama_ocr'; } });
+    const nonEnumerablePolicy = { ...policy('ollama_ocr') };
+    Object.defineProperty(nonEnumerablePolicy, 'provider', { enumerable: false, value: 'ollama_ocr' });
+    const nonEnumerableReadiness = { ...readiness('ollama_ocr') };
+    Object.defineProperty(nonEnumerableReadiness, 'provider', { enumerable: false, value: 'ollama_ocr' });
     const inherited = Object.assign(Object.create({ inherited: true }), readiness('ollama_ocr'));
     for (const [hostPolicy, hostReadiness, code] of [
         [{ ...policy('ollama_ocr'), fallback: 'apple_vision' }, readiness('ollama_ocr'), 'policy_invalid'],
-        [accessor, readiness('ollama_ocr'), 'policy_invalid'],
+        [accessorPolicy, readiness('ollama_ocr'), 'policy_invalid'],
+        [nonEnumerablePolicy, readiness('ollama_ocr'), 'policy_invalid'],
         [policy('ollama_ocr'), { ...readiness('ollama_ocr'), extra: true }, 'readiness_invalid'],
-        [policy('ollama_ocr'), accessor, 'readiness_invalid'],
+        [policy('ollama_ocr'), accessorReadiness, 'readiness_invalid'],
+        [policy('ollama_ocr'), nonEnumerableReadiness, 'readiness_invalid'],
         [policy('ollama_ocr'), inherited, 'readiness_invalid'],
     ] as const) assert.deepEqual(await service(hostPolicy, hostReadiness).admit(), deny(code));
     assert.equal(reads, 0);
+});
+
+test('rejects transparent and throwing policy or readiness proxies before executing traps', async () => {
+    const counters = { transparentPolicy: 0, throwingPolicy: 0, transparentReadiness: 0, throwingReadiness: 0 };
+    const wrap = <T extends object>(value: T, key: keyof typeof counters, throwing: boolean) => new Proxy(value, {
+        getOwnPropertyDescriptor: (target, property) => { counters[key] += 1; if (throwing) throw new Error('must not reflect'); return Reflect.getOwnPropertyDescriptor(target, property); },
+        getPrototypeOf: (target) => { counters[key] += 1; if (throwing) throw new Error('must not reflect'); return Reflect.getPrototypeOf(target); },
+        ownKeys: (target) => { counters[key] += 1; if (throwing) throw new Error('must not reflect'); return Reflect.ownKeys(target); },
+    });
+    assert.deepEqual(await service(wrap(policy('ollama_ocr'), 'transparentPolicy', false), readiness('ollama_ocr')).admit(), deny('policy_invalid'));
+    assert.deepEqual(await service(wrap(policy('ollama_ocr'), 'throwingPolicy', true), readiness('ollama_ocr')).admit(), deny('policy_invalid'));
+    assert.deepEqual(await service(policy('ollama_ocr'), wrap(readiness('ollama_ocr'), 'transparentReadiness', false)).admit(), deny('readiness_invalid'));
+    assert.deepEqual(await service(policy('ollama_ocr'), wrap(readiness('ollama_ocr'), 'throwingReadiness', true)).admit(), deny('readiness_invalid'));
+    assert.deepEqual(counters, { transparentPolicy: 0, throwingPolicy: 0, transparentReadiness: 0, throwingReadiness: 0 });
 });
 
 test('redacts host reader failures', async () => {

--- a/lib/ai-providers/fabric/local-ocr-host-admission.ts
+++ b/lib/ai-providers/fabric/local-ocr-host-admission.ts
@@ -1,0 +1,87 @@
+/* @Codex */
+import 'server-only';
+
+type LocalOcrProvider = 'ollama_ocr' | 'apple_vision';
+type LocalOcrVenue = 'local_process' | 'on_device';
+type Binding = Readonly<{ provider: LocalOcrProvider; venue: LocalOcrVenue; egress: 'none' }>;
+type Readiness = Readonly<Binding & {
+    schemaVersion: 'mediflow.ai.local-ocr-host-readiness.v1';
+    state: 'available';
+}>;
+type ResultMeta = Readonly<{ fallback: 'denied_by_contract'; applyPolicy: 'none'; writesPerformed: 0 }>;
+
+export type HostLocalOcrAdmissionDenialCode =
+    | 'policy_unavailable' | 'policy_invalid' | 'readiness_unavailable' | 'readiness_invalid'
+    | 'readiness_mismatch' | 'provider_unavailable';
+
+export type HostLocalOcrAdmissionResult = ResultMeta & (
+    | Readonly<{ status: 'admitted'; code: null; binding: Binding; readiness: Readiness }>
+    | Readonly<{ status: 'denied'; code: HostLocalOcrAdmissionDenialCode; binding: null; readiness: null }>
+);
+
+type Policy = Readonly<{ provider: LocalOcrProvider; venue: LocalOcrVenue }>;
+type ReadinessState = Readonly<{ provider: LocalOcrProvider; venue: LocalOcrVenue; state: 'available' | 'unavailable' }>;
+type Reader = () => Promise<unknown>;
+
+function record(value: unknown, keys: readonly string[]): Record<string, unknown> | null {
+    try {
+        if (!value || typeof value !== 'object' || Array.isArray(value) || Object.getPrototypeOf(value) !== Object.prototype) return null;
+        const ownKeys = Reflect.ownKeys(value);
+        if (ownKeys.length !== keys.length || ownKeys.some((key) => typeof key !== 'string' || !keys.includes(key))) return null;
+        const snapshot: Record<string, unknown> = {};
+        for (const key of keys) {
+            const descriptor = Object.getOwnPropertyDescriptor(value, key);
+            if (!descriptor || !('value' in descriptor)) return null;
+            snapshot[key] = descriptor.value;
+        }
+        return snapshot;
+    } catch { return null; }
+}
+
+function venueFor(provider: LocalOcrProvider): LocalOcrVenue {
+    return provider === 'ollama_ocr' ? 'local_process' : 'on_device';
+}
+
+function policySnapshot(value: unknown): Policy | null {
+    const input = record(value, ['provider', 'venue', 'egress', 'authority', 'applyPolicy']);
+    if (!input || (input.provider !== 'ollama_ocr' && input.provider !== 'apple_vision')) return null;
+    const venue = venueFor(input.provider);
+    return input.venue === venue && input.egress === 'none' && input.authority === 'review_only' && input.applyPolicy === 'none'
+        ? Object.freeze({ provider: input.provider, venue }) : null;
+}
+
+function readinessSnapshot(value: unknown): ReadinessState | null {
+    const input = record(value, ['provider', 'venue', 'state']);
+    if (!input || (input.provider !== 'ollama_ocr' && input.provider !== 'apple_vision')) return null;
+    if ((input.venue !== 'local_process' && input.venue !== 'on_device') || (input.state !== 'available' && input.state !== 'unavailable')) return null;
+    return Object.freeze({ provider: input.provider, venue: input.venue, state: input.state });
+}
+
+function deny(code: HostLocalOcrAdmissionDenialCode): HostLocalOcrAdmissionResult {
+    return Object.freeze({ status: 'denied' as const, code, binding: null, readiness: null,
+        fallback: 'denied_by_contract' as const, applyPolicy: 'none' as const, writesPerformed: 0 as const });
+}
+
+function decide(policy: Policy, readiness: ReadinessState): HostLocalOcrAdmissionResult {
+    if (readiness.provider !== policy.provider || readiness.venue !== policy.venue) return deny('readiness_mismatch');
+    if (readiness.state !== 'available') return deny('provider_unavailable');
+    const binding = Object.freeze({ provider: policy.provider, venue: policy.venue, egress: 'none' as const });
+    const evidence = Object.freeze({ ...binding, schemaVersion: 'mediflow.ai.local-ocr-host-readiness.v1' as const, state: 'available' as const });
+    return Object.freeze({ status: 'admitted' as const, code: null, binding, readiness: evidence,
+        fallback: 'denied_by_contract' as const, applyPolicy: 'none' as const, writesPerformed: 0 as const });
+}
+
+/** Server-only packet A: host readers decide binding/readiness; consumers only call `admit()`. */
+export function createHostLocalOcrAdmissionService(options: Readonly<{ readPolicy: Reader; readReadiness: Reader }>) {
+    const { readPolicy, readReadiness } = options;
+    return Object.freeze({
+        async admit(): Promise<HostLocalOcrAdmissionResult> {
+            let policy: Policy | null;
+            try { policy = policySnapshot(await readPolicy()); } catch { return deny('policy_unavailable'); }
+            if (!policy) return deny('policy_invalid');
+            let readiness: ReadinessState | null;
+            try { readiness = readinessSnapshot(await readReadiness()); } catch { return deny('readiness_unavailable'); }
+            return readiness ? decide(policy, readiness) : deny('readiness_invalid');
+        },
+    });
+}

--- a/lib/ai-providers/fabric/local-ocr-host-admission.ts
+++ b/lib/ai-providers/fabric/local-ocr-host-admission.ts
@@ -1,6 +1,8 @@
 /* @Codex */
 import 'server-only';
 
+import { types } from 'node:util';
+
 type LocalOcrProvider = 'ollama_ocr' | 'apple_vision';
 type LocalOcrVenue = 'local_process' | 'on_device';
 type Binding = Readonly<{ provider: LocalOcrProvider; venue: LocalOcrVenue; egress: 'none' }>;
@@ -25,13 +27,13 @@ type Reader = () => Promise<unknown>;
 
 function record(value: unknown, keys: readonly string[]): Record<string, unknown> | null {
     try {
-        if (!value || typeof value !== 'object' || Array.isArray(value) || Object.getPrototypeOf(value) !== Object.prototype) return null;
+        if (!value || typeof value !== 'object' || Array.isArray(value) || types.isProxy(value) || Object.getPrototypeOf(value) !== Object.prototype) return null;
         const ownKeys = Reflect.ownKeys(value);
         if (ownKeys.length !== keys.length || ownKeys.some((key) => typeof key !== 'string' || !keys.includes(key))) return null;
         const snapshot: Record<string, unknown> = {};
         for (const key of keys) {
             const descriptor = Object.getOwnPropertyDescriptor(value, key);
-            if (!descriptor || !('value' in descriptor)) return null;
+            if (!descriptor || !descriptor.enumerable || !('value' in descriptor)) return null;
             snapshot[key] = descriptor.value;
         }
         return snapshot;


### PR DESCRIPTION
## Summary
- aggiunge admission host-owned per policy e readiness OCR locali
- rifiuta Proxy, accessor, chiavi extra e descrittori non enumerabili
- conserva provider e venue espliciti senza fallback

## Verification
- review indipendente exact-head su P0b
- test provider, host source e admission focalizzati
- typecheck, ESLint, claims, AI-write, never-regress e runtime
- OpenAPI e schema drift/writers, git diff --check

## Risk / Notes
- candidato stacked su #264; non invoca provider e non aggiunge route o persistenza
- writesPerformed=0, applyPolicy=none, fallback negato
- fixture solo sintetiche; nessuna PHI/PII

## Ticket
Refs WUL-522