### PR TITLE
feat(ocr): compone receipt e provenance host-owned

### DIFF
--- a/lib/ai-providers/fabric/local-ocr-receipt-provenance-composer.test.ts
+++ b/lib/ai-providers/fabric/local-ocr-receipt-provenance-composer.test.ts
@@ -1,0 +1,124 @@
+/* @Codex */
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createHostLocalOcrAdmissionService } from './local-ocr-host-admission.ts';
+import { createHostLocalOcrReceiptProvenanceComposer } from './local-ocr-receipt-provenance-composer.ts';
+
+type Provider = 'ollama_ocr' | 'apple_vision';
+
+const venue = (provider: Provider) => provider === 'ollama_ocr' ? 'local_process' : 'on_device';
+const policy = (provider: Provider) => ({ provider, venue: venue(provider), egress: 'none', authority: 'review_only', applyPolicy: 'none' });
+const readiness = (provider: Provider, state: 'available' | 'unavailable' = 'available') => ({ provider, venue: venue(provider), state });
+const receipt = (provider: Provider) => ({
+    schemaVersion: 'mediflow.ai.local-ocr-provider-receipt.v1', provider, venue: venue(provider), egress: 'none',
+    authority: 'review_only', applyPolicy: 'none', writesPerformed: 0,
+});
+const provenance = (provider: Provider) => ({
+    schemaVersion: 'mediflow.ai.local-ocr-provider-provenance.v1', provider, venue: venue(provider), egress: 'none', receiptProvider: provider,
+});
+const admit = (provider: Provider, state: 'available' | 'unavailable' = 'available') => createHostLocalOcrAdmissionService({
+    readPolicy: async () => policy(provider), readReadiness: async () => readiness(provider, state),
+}).admit();
+const deny = (code: string) => ({ status: 'denied', code, binding: null, receipt: null, provenance: null,
+    fallback: 'denied_by_contract', applyPolicy: 'none', writesPerformed: 0 });
+
+test('composes independently frozen receipt and provenance bound to each admitted provider and venue', async () => {
+    const composer = createHostLocalOcrReceiptProvenanceComposer();
+    for (const provider of ['ollama_ocr', 'apple_vision'] as const) {
+        const result = composer.compose({ admission: await admit(provider), receipt: receipt(provider), provenance: provenance(provider) });
+        assert.deepEqual(result, {
+            status: 'composed', code: null, binding: { provider, venue: venue(provider), egress: 'none' },
+            receipt: receipt(provider), provenance: provenance(provider),
+            fallback: 'denied_by_contract', applyPolicy: 'none', writesPerformed: 0,
+        });
+        assert.ok(Object.isFrozen(result));
+        assert.ok(Object.isFrozen(result.binding));
+        assert.ok(Object.isFrozen(result.receipt));
+        assert.ok(Object.isFrozen(result.provenance));
+    }
+});
+
+test('denies unavailable or denied packet-A results and never accepts a caller provider or fallback', async () => {
+    const composer = createHostLocalOcrReceiptProvenanceComposer();
+    const unavailable = await admit('ollama_ocr', 'unavailable');
+    assert.deepEqual(composer.compose({ admission: unavailable, receipt: receipt('ollama_ocr'), provenance: provenance('ollama_ocr') }), deny('admission_denied'));
+    assert.deepEqual((composer.compose as (input: unknown) => unknown)({
+        admission: await admit('ollama_ocr'), provider: 'apple_vision', receipt: receipt('ollama_ocr'), provenance: provenance('ollama_ocr'),
+    }), deny('composition_invalid'));
+});
+
+test('denies mismatched, malformed, hostile, and cross-provider evidence without fallback', async () => {
+    const composer = createHostLocalOcrReceiptProvenanceComposer();
+    const admission = await admit('ollama_ocr');
+    let accessorReads = 0;
+    const hostile = { ...receipt('ollama_ocr') };
+    Object.defineProperty(hostile, 'provider', { enumerable: true, get: () => { accessorReads += 1; return 'ollama_ocr'; } });
+    for (const evidence of [
+        { receipt: receipt('apple_vision'), provenance: provenance('ollama_ocr') },
+        { receipt: receipt('ollama_ocr'), provenance: provenance('apple_vision') },
+        { receipt: { ...receipt('ollama_ocr'), venue: 'on_device' }, provenance: provenance('ollama_ocr') },
+        { receipt: hostile, provenance: provenance('ollama_ocr') },
+        { receipt: receipt('ollama_ocr'), provenance: { ...provenance('ollama_ocr'), extra: true } },
+    ]) {
+        assert.deepEqual(composer.compose({ admission, ...evidence }), deny('evidence_invalid'));
+    }
+    assert.equal(accessorReads, 0);
+});
+
+test('rejects request, admission, receipt, and provenance proxies before executing any traps', async () => {
+    const composer = createHostLocalOcrReceiptProvenanceComposer();
+    const admission = await admit('ollama_ocr');
+    const counters = { request: 0, admission: 0, receipt: 0, provenance: 0 };
+    const wrap = <T extends object>(value: T, key: keyof typeof counters, throwing: boolean) => new Proxy(value, {
+        get: (target, property, receiver) => { counters[key] += 1; if (throwing) throw new Error('must not read'); return Reflect.get(target, property, receiver); },
+        getOwnPropertyDescriptor: (target, property) => { counters[key] += 1; if (throwing) throw new Error('must not reflect'); return Reflect.getOwnPropertyDescriptor(target, property); },
+        getPrototypeOf: (target) => { counters[key] += 1; if (throwing) throw new Error('must not reflect'); return Reflect.getPrototypeOf(target); },
+        isExtensible: (target) => { counters[key] += 1; if (throwing) throw new Error('must not reflect'); return Reflect.isExtensible(target); },
+        ownKeys: (target) => { counters[key] += 1; if (throwing) throw new Error('must not reflect'); return Reflect.ownKeys(target); },
+        preventExtensions: (target) => { counters[key] += 1; if (throwing) throw new Error('must not reflect'); return Reflect.preventExtensions(target); },
+    });
+    const evidence = { receipt: receipt('ollama_ocr'), provenance: provenance('ollama_ocr') };
+    for (const throwing of [false, true]) {
+        assert.deepEqual(composer.compose(wrap({ admission, ...evidence }, 'request', throwing)), deny('composition_invalid'));
+        assert.deepEqual(composer.compose({ admission: wrap(admission, 'admission', throwing), ...evidence }), deny('admission_invalid'));
+        assert.deepEqual(composer.compose({ admission, receipt: wrap(evidence.receipt, 'receipt', throwing), provenance: evidence.provenance }), deny('evidence_invalid'));
+        assert.deepEqual(composer.compose({ admission, receipt: evidence.receipt, provenance: wrap(evidence.provenance, 'provenance', throwing) }), deny('evidence_invalid'));
+    }
+    assert.deepEqual(counters, { request: 0, admission: 0, receipt: 0, provenance: 0 });
+});
+
+test('rejects non-enumerable, symbol, extra, accessor, and prototype request shapes without reads', async () => {
+    const composer = createHostLocalOcrReceiptProvenanceComposer();
+    const admission = await admit('ollama_ocr');
+    const evidence = { receipt: receipt('ollama_ocr'), provenance: provenance('ollama_ocr') };
+    let reads = 0;
+    const accessor = { admission, ...evidence };
+    Object.defineProperty(accessor, 'receipt', { enumerable: true, get: () => { reads += 1; return evidence.receipt; } });
+    const nonEnumerable = { admission, ...evidence };
+    Object.defineProperty(nonEnumerable, 'receipt', { enumerable: false, value: evidence.receipt });
+    const inherited = Object.assign(Object.create({ inherited: true }), { admission, ...evidence });
+    for (const input of [
+        nonEnumerable,
+        accessor,
+        { admission, ...evidence, extra: true },
+        { admission, ...evidence, [Symbol('authority')]: 'apply' },
+        inherited,
+    ]) assert.deepEqual(composer.compose(input), deny('composition_invalid'));
+    assert.equal(reads, 0);
+});
+
+test('requires the frozen packet-A admitted binding and snapshots results independently of host evidence', async () => {
+    const composer = createHostLocalOcrReceiptProvenanceComposer();
+    const admission = await admit('ollama_ocr');
+    const mutableAdmission = { ...admission, binding: { ...admission.binding }, readiness: { ...admission.readiness } };
+    assert.deepEqual(composer.compose({ admission: mutableAdmission, receipt: receipt('ollama_ocr'), provenance: provenance('ollama_ocr') }), deny('admission_invalid'));
+
+    const hostReceipt = receipt('ollama_ocr');
+    const hostProvenance = provenance('ollama_ocr');
+    const result = composer.compose({ admission, receipt: hostReceipt, provenance: hostProvenance });
+    assert.equal(result.status, 'composed');
+    hostReceipt.provider = 'apple_vision';
+    hostProvenance.receiptProvider = 'apple_vision';
+    assert.equal(result.status === 'composed' && result.receipt.provider, 'ollama_ocr');
+    assert.equal(result.status === 'composed' && result.provenance.receiptProvider, 'ollama_ocr');
+});

--- a/lib/ai-providers/fabric/local-ocr-receipt-provenance-composer.ts
+++ b/lib/ai-providers/fabric/local-ocr-receipt-provenance-composer.ts
@@ -1,0 +1,100 @@
+/* @Codex */
+import 'server-only';
+
+import { types } from 'node:util';
+import { resolveLocalOcrProvider, type LocalOcrProviderResolution } from './local-ocr-provider-contract';
+
+type LocalOcrProvider = 'ollama_ocr' | 'apple_vision';
+type LocalOcrVenue = 'local_process' | 'on_device';
+type Binding = Readonly<{ provider: LocalOcrProvider; venue: LocalOcrVenue; egress: 'none' }>;
+type ResultMeta = Readonly<{ fallback: 'denied_by_contract'; applyPolicy: 'none'; writesPerformed: 0 }>;
+
+export type HostLocalOcrReceiptProvenanceCompositionDenialCode =
+    | 'composition_invalid' | 'admission_denied' | 'admission_invalid' | 'evidence_invalid';
+
+export type HostLocalOcrReceiptProvenanceCompositionResult = ResultMeta & (
+    | Readonly<{
+        status: 'composed';
+        code: null;
+        binding: Binding;
+        receipt: LocalOcrProviderResolution['receipt'];
+        provenance: LocalOcrProviderResolution['provenance'];
+    }>
+    | Readonly<{ status: 'denied'; code: HostLocalOcrReceiptProvenanceCompositionDenialCode; binding: null; receipt: null; provenance: null }>
+);
+
+function record(value: unknown, keys: readonly string[]): Record<string, unknown> | null {
+    try {
+        if (!value || typeof value !== 'object' || types.isProxy(value) || Array.isArray(value) || Object.getPrototypeOf(value) !== Object.prototype) return null;
+        const ownKeys = Reflect.ownKeys(value);
+        if (ownKeys.length !== keys.length || ownKeys.some((key) => typeof key !== 'string' || !keys.includes(key))) return null;
+        const snapshot: Record<string, unknown> = {};
+        for (const key of keys) {
+            const descriptor = Object.getOwnPropertyDescriptor(value, key);
+            if (!descriptor || !descriptor.enumerable || !('value' in descriptor)) return null;
+            snapshot[key] = descriptor.value;
+        }
+        return snapshot;
+    } catch { return null; }
+}
+
+function venueFor(provider: LocalOcrProvider): LocalOcrVenue {
+    return provider === 'ollama_ocr' ? 'local_process' : 'on_device';
+}
+
+function isFrozen(value: unknown): boolean {
+    try { return Boolean(value) && typeof value === 'object' && !types.isProxy(value) && Object.isFrozen(value); } catch { return false; }
+}
+
+function admittedBinding(value: unknown): Binding | null {
+    const admission = record(value, ['status', 'code', 'binding', 'readiness', 'fallback', 'applyPolicy', 'writesPerformed']);
+    if (!admission || !isFrozen(value) || admission.status !== 'admitted' || admission.code !== null
+        || admission.fallback !== 'denied_by_contract' || admission.applyPolicy !== 'none' || admission.writesPerformed !== 0
+        || !isFrozen(admission.binding) || !isFrozen(admission.readiness)) return null;
+    const binding = record(admission.binding, ['provider', 'venue', 'egress']);
+    const readiness = record(admission.readiness, ['provider', 'venue', 'egress', 'schemaVersion', 'state']);
+    const provider = binding?.provider === 'ollama_ocr' || binding?.provider === 'apple_vision' ? binding.provider : null;
+    const venue = provider ? venueFor(provider) : null;
+    if (!binding || !readiness || !provider || !venue || binding.venue !== venue || binding.egress !== 'none'
+        || readiness.provider !== provider || readiness.venue !== binding.venue || readiness.egress !== 'none'
+        || readiness.schemaVersion !== 'mediflow.ai.local-ocr-host-readiness.v1' || readiness.state !== 'available') return null;
+    return Object.freeze({ provider, venue, egress: 'none' as const });
+}
+
+function deniedAdmission(value: unknown): boolean {
+    const admission = record(value, ['status', 'code', 'binding', 'readiness', 'fallback', 'applyPolicy', 'writesPerformed']);
+    return Boolean(admission && isFrozen(value) && admission.status === 'denied' && typeof admission.code === 'string'
+        && admission.binding === null && admission.readiness === null && admission.fallback === 'denied_by_contract'
+        && admission.applyPolicy === 'none' && admission.writesPerformed === 0);
+}
+
+function deny(code: HostLocalOcrReceiptProvenanceCompositionDenialCode): HostLocalOcrReceiptProvenanceCompositionResult {
+    return Object.freeze({ status: 'denied' as const, code, binding: null, receipt: null, provenance: null,
+        fallback: 'denied_by_contract' as const, applyPolicy: 'none' as const, writesPerformed: 0 as const });
+}
+
+/** Server-only packet B: compose provider evidence from one frozen packet-A admission, never invoke a provider. */
+export function createHostLocalOcrReceiptProvenanceComposer() {
+    return Object.freeze({
+        compose(input: unknown): HostLocalOcrReceiptProvenanceCompositionResult {
+            const request = record(input, ['admission', 'receipt', 'provenance']);
+            if (!request) return deny('composition_invalid');
+            if (deniedAdmission(request.admission)) return deny('admission_denied');
+            const binding = admittedBinding(request.admission);
+            if (!binding) return deny('admission_invalid');
+            const resolution = resolveLocalOcrProvider({
+                provider: binding.provider,
+                readiness: 'ready',
+                receipt: request.receipt,
+                provenance: request.provenance,
+            });
+            if (!resolution || resolution.provider !== binding.provider || resolution.receipt.venue !== binding.venue
+                || resolution.provenance.venue !== binding.venue || resolution.provenance.receiptProvider !== binding.provider) {
+                return deny('evidence_invalid');
+            }
+            return Object.freeze({ status: 'composed' as const, code: null, binding,
+                receipt: resolution.receipt, provenance: resolution.provenance,
+                fallback: 'denied_by_contract' as const, applyPolicy: 'none' as const, writesPerformed: 0 as const });
+        },
+    });
+}


### PR DESCRIPTION
## Summary
- aggiunge il composer OCR per receipt e provenance host-owned
- lega provider, venue e readiness senza authority union
- mantiene output congelati, fallback negato e applyPolicy=none

## Verification
- review indipendente exact-head su P0c
- suite OCR combinata e falsificatori hostile-record verdi
- typecheck, ESLint, claims, AI-write, never-regress e runtime
- OpenAPI e schema drift/writers, git diff --check

## Risk / Notes
- candidato stacked su #265; non invoca provider, route, persistenza o UI
- nessun write/apply e nessun fallback implicito
- fixture solo sintetiche; nessuna PHI/PII

## Ticket
Refs WUL-522