### PR TITLE
feat(ocr): aggiungi runner Apple Vision isolato

### DIFF
--- a/lib/ai-providers/fabric/local-ocr-apple-vision-process-runner.test.ts
+++ b/lib/ai-providers/fabric/local-ocr-apple-vision-process-runner.test.ts
@@ -1,0 +1,96 @@
+/* @Codex */
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import test from 'node:test';
+import { createAppleVisionOcrProcessRunner } from './local-ocr-apple-vision-process-runner.ts';
+
+class Child extends EventEmitter {
+    readonly stdout = new EventEmitter();
+    readonly stderr = new EventEmitter();
+    readonly kills: string[] = [];
+    kill(signal?: NodeJS.Signals) { this.kills.push(signal ?? ''); return true; }
+}
+
+function harness(options: Readonly<{ cleanupFails?: boolean; directoryMode?: number; directorySymlink?: boolean; spawnThrows?: boolean; uid?: number }> = {}) {
+    const children: Child[] = []; const spawns: unknown[][] = []; const removals: string[] = [];
+    let timeout: (() => void) | undefined;
+    const runner = createAppleVisionOcrProcessRunner({
+        platform: () => 'darwin',
+        uid: () => options.uid ?? (typeof process.getuid === 'function' ? process.getuid() : undefined),
+        spawn: (...args: unknown[]) => { if (options.spawnThrows) throw new Error('launch'); spawns.push(args); const child = new Child(); children.push(child); return child; },
+        chmod: async () => undefined,
+        lstat: async (path: string) => ({ isDirectory: () => true, isFile: () => true, isSymbolicLink: () => path === '/tmp/ocr-test' && Boolean(options.directorySymlink), mode: path === '/tmp/ocr-test' ? (options.directoryMode ?? 0o700) : 0o600, uid: typeof process.getuid === 'function' ? process.getuid() : undefined }),
+        mkdtemp: async () => '/tmp/ocr-test',
+        open: async () => ({ writeFile: async () => undefined, close: async () => undefined }),
+        rm: async (path: string) => { removals.push(path); if (options.cleanupFails) throw new Error('cleanup'); },
+        setTimer: (callback: () => void) => { timeout = callback; return {}; },
+        clearTimer: () => undefined,
+    });
+    const start = async () => {
+        const pending = runner.run({ mimeType: 'image/png', payload: 'iVBORw0KGgo=' });
+        for (let index = 0; index < 12; index += 1) await Promise.resolve();
+        const child = children.at(-1); if (!child) throw new Error('child not started');
+        return { child, pending };
+    };
+    return { children, spawns, removals, run: () => runner.run({ mimeType: 'image/png', payload: 'iVBORw0KGgo=' }), runWith: (value: unknown) => runner.run(value), start, timeout: () => timeout };
+}
+
+test('uses one fixed Swift invocation and cleans the private directory after success', async () => {
+    const subject = harness(); const run = await subject.start();
+    assert.equal(subject.spawns.length, 1);
+    assert.equal(subject.spawns[0]?.[0], '/usr/bin/swift');
+    assert.deepEqual(subject.spawns[0]?.[2], { cwd: '/', env: { PATH: '/usr/bin:/bin', LANG: 'C', LC_ALL: 'C' }, shell: false, stdio: ['ignore', 'pipe', 'pipe'], windowsHide: true });
+    assert.match(String((subject.spawns[0]?.[1] as string[])[0]), /scripts\/apple-vision-ocr\.swift$/);
+    assert.equal((subject.spawns[0]?.[1] as string[])[1], '/tmp/ocr-test/input.png');
+    run.child.stdout.emit('data', Buffer.from('synthetic raw OCR'));
+    run.child.emit('close', 0, null);
+    assert.deepEqual(await run.pending, { status: 'succeeded', output: 'synthetic raw OCR' });
+    assert.deepEqual(subject.removals, ['/tmp/ocr-test']);
+});
+
+test('fails closed without invocation when the private directory mode is not 0700', async () => {
+    const subject = harness({ directoryMode: 0o755 });
+    const pending = subject.run();
+    for (let index = 0; index < 12; index += 1) await Promise.resolve();
+    assert.deepEqual(subject.spawns, []);
+    assert.deepEqual(await pending, { status: 'failed' });
+    assert.deepEqual(subject.removals, ['/tmp/ocr-test']);
+});
+
+test('fails closed for a symlinked or foreign temporary directory and malformed inputs', async () => {
+    for (const subject of [harness({ directorySymlink: true }), harness({ uid: -1 })]) {
+        assert.deepEqual(await subject.run(), { status: 'failed' });
+        assert.deepEqual(subject.spawns, []);
+        assert.deepEqual(subject.removals, ['/tmp/ocr-test']);
+    }
+    const subject = harness();
+    const runner = createAppleVisionOcrProcessRunner(new Proxy({} as never, {}));
+    const accessor = Object.defineProperty({}, 'payload', { enumerable: true, get: () => 'iVBORw0KGgo=' });
+    Object.defineProperty(accessor, 'mimeType', { enumerable: true, value: 'image/png' });
+    assert.deepEqual(await runner.run({ mimeType: 'image/png', payload: 'iVBORw0KGgo=' }), { status: 'failed' });
+    assert.deepEqual(await subject.runWith(accessor), { status: 'failed' });
+    assert.deepEqual(await subject.runWith(Object.create({ mimeType: 'image/png', payload: 'iVBORw0KGgo=' })), { status: 'failed' });
+    assert.deepEqual(subject.spawns, []);
+});
+
+test('fails closed for launch, child, overflow, timeout, late output, and cleanup failures', async () => {
+    const launch = harness({ spawnThrows: true });
+    assert.deepEqual(await launch.run(), { status: 'failed' });
+    assert.equal(launch.spawns.length, 0);
+    const cases = [
+        async (subject: ReturnType<typeof harness>, run: Awaited<ReturnType<ReturnType<typeof harness>['start']>>) => { run.child.emit('error', new Error('synthetic')); },
+        async (subject: ReturnType<typeof harness>, run: Awaited<ReturnType<ReturnType<typeof harness>['start']>>) => { run.child.emit('close', 2, null); },
+        async (subject: ReturnType<typeof harness>, run: Awaited<ReturnType<ReturnType<typeof harness>['start']>>) => { run.child.emit('close', null, 'SIGTERM'); },
+        async (subject: ReturnType<typeof harness>, run: Awaited<ReturnType<ReturnType<typeof harness>['start']>>) => { run.child.stdout.emit('data', Buffer.alloc(32 * 1024 + 1)); assert.deepEqual(run.child.kills, ['SIGKILL']); },
+        async (subject: ReturnType<typeof harness>, run: Awaited<ReturnType<ReturnType<typeof harness>['start']>>) => { run.child.stderr.emit('data', Buffer.alloc(32 * 1024 + 1)); assert.deepEqual(run.child.kills, ['SIGKILL']); },
+        async (subject: ReturnType<typeof harness>, run: Awaited<ReturnType<ReturnType<typeof harness>['start']>>) => { subject.timeout()?.(); assert.deepEqual(run.child.kills, ['SIGKILL']); run.child.stdout.emit('data', Buffer.from('late')); run.child.emit('close', 0, null); },
+    ];
+    for (const close of cases) {
+        const subject = harness(); const run = await subject.start(); await close(subject, run);
+        assert.deepEqual(await run.pending, { status: 'failed' });
+        assert.deepEqual(subject.removals, ['/tmp/ocr-test']);
+    }
+    const subject = harness({ cleanupFails: true }); const run = await subject.start();
+    run.child.stdout.emit('data', Buffer.from('synthetic raw OCR')); run.child.emit('close', 0, null);
+    assert.deepEqual(await run.pending, { status: 'failed' });
+});

--- a/lib/ai-providers/fabric/local-ocr-apple-vision-process-runner.test.ts
+++ b/lib/ai-providers/fabric/local-ocr-apple-vision-process-runner.test.ts
@@ -90,6 +90,19 @@ test('contains a throwing platform facade and returns a frozen failed result', a
     assertResult(await harness({ platformThrows: true }).run(), 'failed');
 });
 
+test('latches child error without cleanup until close confirms termination', async () => {
+    const subject = harness(); const run = await subject.start(); let settled = false;
+    void run.pending.then(() => { settled = true; });
+    run.child.emit('error', new Error('synthetic'));
+    assert.deepEqual(run.child.kills, ['SIGKILL']);
+    assert.deepEqual(subject.removals, []);
+    for (let index = 0; index < 4; index += 1) await Promise.resolve();
+    assert.equal(settled, false);
+    run.child.emit('close', null, 'SIGKILL');
+    assertResult(await run.pending, 'failed');
+    assert.deepEqual(subject.removals, ['/tmp/ocr-test']);
+});
+
 test('waits for a terminal child event after timer failure or a refused kill', async () => {
     const timer = harness({ setTimerThrows: true }); const timerRun = await timer.start();
     assert.deepEqual(timerRun.child.kills, ['SIGKILL']);
@@ -126,7 +139,7 @@ test('fails closed for launch, child, overflow, timeout, late output, and cleanu
     assertResult(await launch.run(), 'failed');
     assert.equal(launch.spawns.length, 0);
     const cases = [
-        async (subject: ReturnType<typeof harness>, run: Awaited<ReturnType<ReturnType<typeof harness>['start']>>) => { run.child.emit('error', new Error('synthetic')); },
+        async (subject: ReturnType<typeof harness>, run: Awaited<ReturnType<ReturnType<typeof harness>['start']>>) => { run.child.emit('error', new Error('synthetic')); run.child.emit('close', null, 'SIGKILL'); },
         async (subject: ReturnType<typeof harness>, run: Awaited<ReturnType<ReturnType<typeof harness>['start']>>) => { run.child.emit('close', 2, null); },
         async (subject: ReturnType<typeof harness>, run: Awaited<ReturnType<ReturnType<typeof harness>['start']>>) => { run.child.emit('close', null, 'SIGTERM'); },
         async (subject: ReturnType<typeof harness>, run: Awaited<ReturnType<ReturnType<typeof harness>['start']>>) => { run.child.stdout.emit('data', Buffer.alloc(32 * 1024 + 1)); assert.deepEqual(run.child.kills, ['SIGKILL']); run.child.emit('close', null, 'SIGKILL'); },

--- a/lib/ai-providers/fabric/local-ocr-apple-vision-process-runner.test.ts
+++ b/lib/ai-providers/fabric/local-ocr-apple-vision-process-runner.test.ts
@@ -8,22 +8,35 @@ class Child extends EventEmitter {
     readonly stdout = new EventEmitter();
     readonly stderr = new EventEmitter();
     readonly kills: string[] = [];
-    kill(signal?: NodeJS.Signals) { this.kills.push(signal ?? ''); return true; }
+    constructor(private readonly killResult = true) { super(); }
+    kill(signal?: NodeJS.Signals) { this.kills.push(signal ?? ''); return this.killResult; }
 }
 
-function harness(options: Readonly<{ cleanupFails?: boolean; directoryMode?: number; directorySymlink?: boolean; spawnThrows?: boolean; uid?: number }> = {}) {
+function facade<T extends object>(value: T): T { return Object.freeze(Object.assign(Object.create(null), value)); }
+
+function assertResult(value: unknown, status: 'failed' | 'succeeded', output?: string) {
+    assert.equal(Object.getPrototypeOf(value), null);
+    assert.equal(Object.isFrozen(value), true);
+    assert.equal((value as { status?: string }).status, status);
+    assert.equal((value as { output?: string }).output, output);
+}
+
+function harness(options: Readonly<{ cleanupFails?: boolean; directoryMode?: number; directorySymlink?: boolean; fileMode?: number; fileSymlink?: boolean; fileUid?: number; killFalse?: boolean; missingUid?: boolean; platformThrows?: boolean; setTimerThrows?: boolean; spawnThrows?: boolean; uid?: number }> = {}) {
     const children: Child[] = []; const spawns: unknown[][] = []; const removals: string[] = [];
     let timeout: (() => void) | undefined;
     const runner = createAppleVisionOcrProcessRunner({
-        platform: () => 'darwin',
-        uid: () => options.uid ?? (typeof process.getuid === 'function' ? process.getuid() : undefined),
-        spawn: (...args: unknown[]) => { if (options.spawnThrows) throw new Error('launch'); spawns.push(args); const child = new Child(); children.push(child); return child; },
+        platform: () => { if (options.platformThrows) throw new Error('platform'); return 'darwin'; },
+        uid: () => options.missingUid ? undefined : (options.uid ?? (typeof process.getuid === 'function' ? process.getuid() : undefined)),
+        spawn: (...args: unknown[]) => { if (options.spawnThrows) throw new Error('launch'); spawns.push(args); const child = new Child(!options.killFalse); children.push(child); return child; },
         chmod: async () => undefined,
-        lstat: async (path: string) => ({ isDirectory: () => true, isFile: () => true, isSymbolicLink: () => path === '/tmp/ocr-test' && Boolean(options.directorySymlink), mode: path === '/tmp/ocr-test' ? (options.directoryMode ?? 0o700) : 0o600, uid: typeof process.getuid === 'function' ? process.getuid() : undefined }),
+        lstat: async (path: string) => {
+            const input = path.startsWith('/tmp/ocr-test/input.');
+            return facade({ isDirectory: () => true, isFile: () => true, isSymbolicLink: () => path === '/tmp/ocr-test' ? Boolean(options.directorySymlink) : (input && Boolean(options.fileSymlink)), mode: path === '/tmp/ocr-test' ? (options.directoryMode ?? 0o700) : (input ? (options.fileMode ?? 0o600) : 0o600), uid: path === '/tmp/ocr-test' ? (typeof process.getuid === 'function' ? process.getuid() : undefined) : (input ? (options.fileUid ?? (typeof process.getuid === 'function' ? process.getuid() : undefined)) : (typeof process.getuid === 'function' ? process.getuid() : undefined)) });
+        },
         mkdtemp: async () => '/tmp/ocr-test',
-        open: async () => ({ writeFile: async () => undefined, close: async () => undefined }),
+        open: async () => facade({ writeFile: async () => undefined, close: async () => undefined }),
         rm: async (path: string) => { removals.push(path); if (options.cleanupFails) throw new Error('cleanup'); },
-        setTimer: (callback: () => void) => { timeout = callback; return {}; },
+        setTimer: (callback: () => void) => { if (options.setTimerThrows) throw new Error('timer'); timeout = callback; return {}; },
         clearTimer: () => undefined,
     });
     const start = async () => {
@@ -44,7 +57,7 @@ test('uses one fixed Swift invocation and cleans the private directory after suc
     assert.equal((subject.spawns[0]?.[1] as string[])[1], '/tmp/ocr-test/input.png');
     run.child.stdout.emit('data', Buffer.from('synthetic raw OCR'));
     run.child.emit('close', 0, null);
-    assert.deepEqual(await run.pending, { status: 'succeeded', output: 'synthetic raw OCR' });
+    assertResult(await run.pending, 'succeeded', 'synthetic raw OCR');
     assert.deepEqual(subject.removals, ['/tmp/ocr-test']);
 });
 
@@ -53,44 +66,79 @@ test('fails closed without invocation when the private directory mode is not 070
     const pending = subject.run();
     for (let index = 0; index < 12; index += 1) await Promise.resolve();
     assert.deepEqual(subject.spawns, []);
-    assert.deepEqual(await pending, { status: 'failed' });
+    assertResult(await pending, 'failed');
     assert.deepEqual(subject.removals, ['/tmp/ocr-test']);
 });
 
 test('fails closed for a symlinked or foreign temporary directory and malformed inputs', async () => {
-    for (const subject of [harness({ directorySymlink: true }), harness({ uid: -1 })]) {
-        assert.deepEqual(await subject.run(), { status: 'failed' });
+    for (const [subject, removals] of [[harness({ directorySymlink: true }), ['/tmp/ocr-test']], [harness({ uid: -1 }), ['/tmp/ocr-test']], [harness({ missingUid: true }), []], [harness({ fileUid: -1 }), ['/tmp/ocr-test']], [harness({ fileMode: 0o644 }), ['/tmp/ocr-test']], [harness({ fileSymlink: true }), ['/tmp/ocr-test']]] as const) {
+        assertResult(await subject.run(), 'failed');
         assert.deepEqual(subject.spawns, []);
-        assert.deepEqual(subject.removals, ['/tmp/ocr-test']);
+        assert.deepEqual(subject.removals, removals);
     }
     const subject = harness();
     const runner = createAppleVisionOcrProcessRunner(new Proxy({} as never, {}));
     const accessor = Object.defineProperty({}, 'payload', { enumerable: true, get: () => 'iVBORw0KGgo=' });
     Object.defineProperty(accessor, 'mimeType', { enumerable: true, value: 'image/png' });
-    assert.deepEqual(await runner.run({ mimeType: 'image/png', payload: 'iVBORw0KGgo=' }), { status: 'failed' });
-    assert.deepEqual(await subject.runWith(accessor), { status: 'failed' });
-    assert.deepEqual(await subject.runWith(Object.create({ mimeType: 'image/png', payload: 'iVBORw0KGgo=' })), { status: 'failed' });
+    assertResult(await runner.run({ mimeType: 'image/png', payload: 'iVBORw0KGgo=' }), 'failed');
+    assertResult(await subject.runWith(accessor), 'failed');
+    assertResult(await subject.runWith(Object.create({ mimeType: 'image/png', payload: 'iVBORw0KGgo=' })), 'failed');
     assert.deepEqual(subject.spawns, []);
+});
+
+test('contains a throwing platform facade and returns a frozen failed result', async () => {
+    assertResult(await harness({ platformThrows: true }).run(), 'failed');
+});
+
+test('waits for a terminal child event after timer failure or a refused kill', async () => {
+    const timer = harness({ setTimerThrows: true }); const timerRun = await timer.start();
+    assert.deepEqual(timerRun.child.kills, ['SIGKILL']);
+    assert.deepEqual(timer.removals, []);
+    timerRun.child.emit('close', null, 'SIGKILL');
+    assertResult(await timerRun.pending, 'failed');
+    assert.deepEqual(timer.removals, ['/tmp/ocr-test']);
+
+    const refused = harness({ killFalse: true }); const refusedRun = await refused.start();
+    refusedRun.child.stdout.emit('data', Buffer.alloc(32 * 1024 + 1));
+    refused.timeout()?.();
+    assert.deepEqual(refusedRun.child.kills, ['SIGKILL']);
+    assert.deepEqual(refused.removals, []);
+    refusedRun.child.emit('close', 0, null);
+    assertResult(await refusedRun.pending, 'failed');
+    assert.deepEqual(refused.removals, ['/tmp/ocr-test']);
+});
+
+test('does not read an ambient then getter for safe facade results or runner output', async () => {
+    let reads = 0;
+    Object.defineProperty(Object.prototype, 'then', { configurable: true, get: () => { reads += 1; return undefined; } });
+    try {
+        const subject = harness(); const pending = subject.run();
+        for (let index = 0; index < 12; index += 1) await Promise.resolve();
+        const child = subject.children.at(-1); if (!child) throw new Error('child not started');
+        child.emit('close', 0, null);
+        assertResult(await pending, 'succeeded', '');
+        assert.equal(reads, 0);
+    } finally { delete (Object.prototype as { then?: unknown }).then; }
 });
 
 test('fails closed for launch, child, overflow, timeout, late output, and cleanup failures', async () => {
     const launch = harness({ spawnThrows: true });
-    assert.deepEqual(await launch.run(), { status: 'failed' });
+    assertResult(await launch.run(), 'failed');
     assert.equal(launch.spawns.length, 0);
     const cases = [
         async (subject: ReturnType<typeof harness>, run: Awaited<ReturnType<ReturnType<typeof harness>['start']>>) => { run.child.emit('error', new Error('synthetic')); },
         async (subject: ReturnType<typeof harness>, run: Awaited<ReturnType<ReturnType<typeof harness>['start']>>) => { run.child.emit('close', 2, null); },
         async (subject: ReturnType<typeof harness>, run: Awaited<ReturnType<ReturnType<typeof harness>['start']>>) => { run.child.emit('close', null, 'SIGTERM'); },
-        async (subject: ReturnType<typeof harness>, run: Awaited<ReturnType<ReturnType<typeof harness>['start']>>) => { run.child.stdout.emit('data', Buffer.alloc(32 * 1024 + 1)); assert.deepEqual(run.child.kills, ['SIGKILL']); },
-        async (subject: ReturnType<typeof harness>, run: Awaited<ReturnType<ReturnType<typeof harness>['start']>>) => { run.child.stderr.emit('data', Buffer.alloc(32 * 1024 + 1)); assert.deepEqual(run.child.kills, ['SIGKILL']); },
+        async (subject: ReturnType<typeof harness>, run: Awaited<ReturnType<ReturnType<typeof harness>['start']>>) => { run.child.stdout.emit('data', Buffer.alloc(32 * 1024 + 1)); assert.deepEqual(run.child.kills, ['SIGKILL']); run.child.emit('close', null, 'SIGKILL'); },
+        async (subject: ReturnType<typeof harness>, run: Awaited<ReturnType<ReturnType<typeof harness>['start']>>) => { run.child.stderr.emit('data', Buffer.alloc(32 * 1024 + 1)); assert.deepEqual(run.child.kills, ['SIGKILL']); run.child.emit('close', null, 'SIGKILL'); },
         async (subject: ReturnType<typeof harness>, run: Awaited<ReturnType<ReturnType<typeof harness>['start']>>) => { subject.timeout()?.(); assert.deepEqual(run.child.kills, ['SIGKILL']); run.child.stdout.emit('data', Buffer.from('late')); run.child.emit('close', 0, null); },
     ];
     for (const close of cases) {
         const subject = harness(); const run = await subject.start(); await close(subject, run);
-        assert.deepEqual(await run.pending, { status: 'failed' });
+        assertResult(await run.pending, 'failed');
         assert.deepEqual(subject.removals, ['/tmp/ocr-test']);
     }
     const subject = harness({ cleanupFails: true }); const run = await subject.start();
     run.child.stdout.emit('data', Buffer.from('synthetic raw OCR')); run.child.emit('close', 0, null);
-    assert.deepEqual(await run.pending, { status: 'failed' });
+    assertResult(await run.pending, 'failed');
 });

--- a/lib/ai-providers/fabric/local-ocr-apple-vision-process-runner.ts
+++ b/lib/ai-providers/fabric/local-ocr-apple-vision-process-runner.ts
@@ -154,7 +154,7 @@ async function hasFixedBoundary(runtime: AppleVisionOcrProcessRuntime): Promise<
 
 function invoke(runtime: AppleVisionOcrProcessRuntime, imagePath: string): Promise<string | null> {
     return new Promise((resolve) => {
-        let output = Buffer.alloc(0); let errors = Buffer.alloc(0); let settled = false; let terminating = false;
+        let output = Buffer.alloc(0); let errors = Buffer.alloc(0); let settled = false; let terminating = false; let childFailed = false;
         const timer = { value: undefined as unknown };
         const finish = (value: string | null) => {
             if (settled) return;
@@ -182,8 +182,8 @@ function invoke(runtime: AppleVisionOcrProcessRuntime, imagePath: string): Promi
         };
         child.stdout.on('data', (chunk: Buffer | string) => collect('stdout', chunk));
         child.stderr.on('data', (chunk: Buffer | string) => collect('stderr', chunk));
-        child.once('error', () => finish(null));
-        child.once('close', (code, signal) => finish(!terminating && code === 0 && signal === null ? output.toString('utf8') : null));
+        child.once('error', () => { childFailed = true; terminate(); });
+        child.once('close', (code, signal) => finish(!childFailed && !terminating && code === 0 && signal === null ? output.toString('utf8') : null));
         try { timer.value = runtime.setTimer(terminate, TIMEOUT_MS); } catch { terminate(); }
     });
 }

--- a/lib/ai-providers/fabric/local-ocr-apple-vision-process-runner.ts
+++ b/lib/ai-providers/fabric/local-ocr-apple-vision-process-runner.ts
@@ -42,6 +42,15 @@ export type AppleVisionOcrProcessRuntime = Readonly<{
     clearTimer: (timer: unknown) => void;
 }>;
 
+function frozenResult(status: 'failed'): AppleVisionOcrProcessResult;
+function frozenResult(status: 'succeeded', output: string): AppleVisionOcrProcessResult;
+function frozenResult(status: 'failed' | 'succeeded', output?: string): AppleVisionOcrProcessResult {
+    const result = Object.create(null) as { status: 'failed' | 'succeeded'; output?: string };
+    result.status = status;
+    if (status === 'succeeded') result.output = output;
+    return Object.freeze(result) as AppleVisionOcrProcessResult;
+}
+
 function record(value: unknown, keys: readonly string[]): Record<string, unknown> | null {
     try {
         if (!value || typeof value !== 'object' || Array.isArray(value) || types.isProxy(value) || Object.getPrototypeOf(value) !== Object.prototype) return null;
@@ -74,28 +83,61 @@ function runtimeSnapshot(value: unknown): AppleVisionOcrProcessRuntime | null {
     return Object.freeze(snapshot as unknown as AppleVisionOcrProcessRuntime);
 }
 
+function safeFacadeRecord(value: unknown, keys: readonly string[]): Record<string, unknown> | null {
+    try {
+        if (!value || typeof value !== 'object' || types.isProxy(value) || Object.getPrototypeOf(value) !== null || !Object.isFrozen(value)) return null;
+        const ownKeys = Reflect.ownKeys(value);
+        if (ownKeys.length !== keys.length || ownKeys.some((key) => typeof key !== 'string' || !keys.includes(key))) return null;
+        const snapshot: Record<string, unknown> = Object.create(null);
+        for (const key of keys) {
+            const descriptor = Object.getOwnPropertyDescriptor(value, key);
+            if (!descriptor || !descriptor.enumerable || !('value' in descriptor)) return null;
+            snapshot[key] = descriptor.value;
+        }
+        return snapshot;
+    } catch { return null; }
+}
+
+function safeStats(value: unknown): FileStats | null {
+    const stats = safeFacadeRecord(value, ['isDirectory', 'isFile', 'isSymbolicLink', 'mode', 'uid']);
+    return stats && typeof stats.isDirectory === 'function' && typeof stats.isFile === 'function' && typeof stats.isSymbolicLink === 'function'
+        && typeof stats.mode === 'number' && (typeof stats.uid === 'number' || stats.uid === undefined) ? stats as FileStats : null;
+}
+
+function safeFile(value: unknown): PrivateFile | null {
+    const file = safeFacadeRecord(value, ['writeFile', 'close']);
+    return file && typeof file.writeFile === 'function' && typeof file.close === 'function' ? file as PrivateFile : null;
+}
+
+function frozenFacade<T extends object>(value: T): T {
+    return Object.freeze(Object.assign(Object.create(null), value)) as T;
+}
+
 function extensionFor(mimeType: ImageInput['mimeType']): 'png' | 'jpg' | 'webp' {
     return mimeType === 'image/jpeg' ? 'jpg' : mimeType.slice('image/'.length) as 'png' | 'webp';
 }
 
 function isPrivateDirectory(info: FileStats, uid: number | undefined): boolean {
     return info.isDirectory() && !info.isSymbolicLink() && (info.mode & 0o777) === 0o700
-        && (uid === undefined || info.uid === uid);
+        && typeof uid === 'number' && info.uid === uid;
 }
 
 async function writePrivateImage(runtime: AppleVisionOcrProcessRuntime, image: ImageInput): Promise<Readonly<{ directory: string; path: string }>> {
+    const uid = runtime.uid();
+    if (typeof uid !== 'number') throw new Error('private owner unavailable');
     const directory = await runtime.mkdtemp(join(tmpdir(), 'mediflow-local-ocr-'));
     try {
         await runtime.chmod(directory, 0o700);
-        const directoryInfo = await runtime.lstat(directory);
-        if (!isPrivateDirectory(directoryInfo, runtime.uid())) throw new Error('private directory unavailable');
+        const directoryInfo = safeStats(await runtime.lstat(directory));
+        if (!directoryInfo || !isPrivateDirectory(directoryInfo, uid)) throw new Error('private directory unavailable');
         const path = join(directory, `input.${extensionFor(image.mimeType)}`);
-        const file = await runtime.open(path, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW, 0o600);
+        const file = safeFile(await runtime.open(path, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW, 0o600));
+        if (!file) throw new Error('private file unavailable');
         try { await file.writeFile(Buffer.from(image.payload, 'base64')); } finally { await file.close(); }
         await runtime.chmod(path, 0o600);
-        const fileInfo = await runtime.lstat(path);
-        if (!fileInfo.isFile() || fileInfo.isSymbolicLink() || (fileInfo.mode & 0o777) !== 0o600) throw new Error('private file unavailable');
-        return Object.freeze({ directory, path });
+        const fileInfo = safeStats(await runtime.lstat(path));
+        if (!fileInfo || !fileInfo.isFile() || fileInfo.isSymbolicLink() || (fileInfo.mode & 0o777) !== 0o600 || fileInfo.uid !== uid) throw new Error('private file unavailable');
+        return frozenFacade({ directory, path });
     } catch (error) {
         await runtime.rm(directory, { recursive: true, force: true, maxRetries: 2, retryDelay: 25 }).catch(() => undefined);
         throw error;
@@ -104,14 +146,15 @@ async function writePrivateImage(runtime: AppleVisionOcrProcessRuntime, image: I
 
 async function hasFixedBoundary(runtime: AppleVisionOcrProcessRuntime): Promise<boolean> {
     try {
-        const [executable, script] = await Promise.all([runtime.lstat(SWIFT_EXECUTABLE), runtime.lstat(APPLE_VISION_SCRIPT)]);
-        return executable.isFile() && !executable.isSymbolicLink() && script.isFile() && !script.isSymbolicLink();
+        const executable = safeStats(await runtime.lstat(SWIFT_EXECUTABLE));
+        const script = safeStats(await runtime.lstat(APPLE_VISION_SCRIPT));
+        return Boolean(executable?.isFile() && !executable.isSymbolicLink() && script?.isFile() && !script.isSymbolicLink());
     } catch { return false; }
 }
 
 function invoke(runtime: AppleVisionOcrProcessRuntime, imagePath: string): Promise<string | null> {
     return new Promise((resolve) => {
-        let output = Buffer.alloc(0); let errors = Buffer.alloc(0); let settled = false;
+        let output = Buffer.alloc(0); let errors = Buffer.alloc(0); let settled = false; let terminating = false;
         const timer = { value: undefined as unknown };
         const finish = (value: string | null) => {
             if (settled) return;
@@ -125,10 +168,13 @@ function invoke(runtime: AppleVisionOcrProcessRuntime, imagePath: string): Promi
                 cwd: '/', env: FIXED_ENV, shell: false, stdio: ['ignore', 'pipe', 'pipe'], windowsHide: true,
             });
         } catch { finish(null); return; }
-        const terminate = () => { try { child.kill('SIGKILL'); } catch { /* @Codex: child failures are sanitized. */ } finish(null); };
-        timer.value = runtime.setTimer(terminate, TIMEOUT_MS);
+        const terminate = () => {
+            if (settled || terminating) return;
+            terminating = true;
+            try { child.kill('SIGKILL'); } catch { /* @Codex: a terminal event remains required before cleanup. */ }
+        };
         const collect = (stream: 'stdout' | 'stderr', chunk: Buffer | string) => {
-            if (settled) return;
+            if (settled || terminating) return;
             const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
             const current = stream === 'stdout' ? output : errors;
             if (current.length + bytes.length > MAX_OUTPUT_BYTES) { terminate(); return; }
@@ -137,7 +183,8 @@ function invoke(runtime: AppleVisionOcrProcessRuntime, imagePath: string): Promi
         child.stdout.on('data', (chunk: Buffer | string) => collect('stdout', chunk));
         child.stderr.on('data', (chunk: Buffer | string) => collect('stderr', chunk));
         child.once('error', () => finish(null));
-        child.once('close', (code, signal) => finish(code === 0 && signal === null ? output.toString('utf8') : null));
+        child.once('close', (code, signal) => finish(!terminating && code === 0 && signal === null ? output.toString('utf8') : null));
+        try { timer.value = runtime.setTimer(terminate, TIMEOUT_MS); } catch { terminate(); }
     });
 }
 
@@ -147,14 +194,16 @@ export function createAppleVisionOcrProcessRunner(runtime: AppleVisionOcrProcess
     return Object.freeze({
         async run(value: unknown): Promise<AppleVisionOcrProcessResult> {
             const image = imageInput(value);
-            if (!safeRuntime || !image || safeRuntime.platform() !== 'darwin' || !await hasFixedBoundary(safeRuntime)) return Object.freeze({ status: 'failed' as const });
+            try {
+                if (!safeRuntime || !image || safeRuntime.platform() !== 'darwin' || !await hasFixedBoundary(safeRuntime)) return frozenResult('failed');
+            } catch { return frozenResult('failed'); }
             let temporary: Readonly<{ directory: string; path: string }> | null = null;
             let output: string | null = null;
             try { temporary = await writePrivateImage(safeRuntime, image); output = await invoke(safeRuntime, temporary.path); } catch { output = null; }
             try {
                 if (temporary) await safeRuntime.rm(temporary.directory, { recursive: true, force: true, maxRetries: 2, retryDelay: 25 });
-            } catch { return Object.freeze({ status: 'failed' as const }); }
-            return output === null ? Object.freeze({ status: 'failed' as const }) : Object.freeze({ status: 'succeeded' as const, output });
+            } catch { return frozenResult('failed'); }
+            return output === null ? frozenResult('failed') : frozenResult('succeeded', output);
         },
     });
 }
@@ -163,7 +212,17 @@ const systemRuntime: AppleVisionOcrProcessRuntime = Object.freeze({
     platform: () => process.platform,
     uid: () => typeof process.getuid === 'function' ? process.getuid() : undefined,
     spawn: (command: string, args: readonly string[], options) => spawn(command, [...args], options as never) as unknown as Child,
-    chmod, lstat, mkdtemp, open, rm,
+    chmod,
+    lstat: async (path: string) => {
+        const stats = await lstat(path);
+        return frozenFacade({ isDirectory: () => stats.isDirectory(), isFile: () => stats.isFile(), isSymbolicLink: () => stats.isSymbolicLink(), mode: stats.mode, uid: stats.uid });
+    },
+    mkdtemp,
+    open: async (path: string, flags: number, mode: number) => {
+        const file = await open(path, flags, mode);
+        return frozenFacade({ writeFile: (data: Uint8Array) => file.writeFile(data), close: () => file.close() });
+    },
+    rm,
     setTimer: (callback: () => void, milliseconds: number) => setTimeout(callback, milliseconds),
     clearTimer: (timer: unknown) => clearTimeout(timer as NodeJS.Timeout),
 });

--- a/lib/ai-providers/fabric/local-ocr-apple-vision-process-runner.ts
+++ b/lib/ai-providers/fabric/local-ocr-apple-vision-process-runner.ts
@@ -1,0 +1,171 @@
+/* @Codex */
+import 'server-only';
+
+import { spawn } from 'node:child_process';
+import { constants } from 'node:fs';
+import { chmod, lstat, mkdtemp, open, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { types } from 'node:util';
+import { getAttachmentPayloadByteSize, resolveMaxAttachmentBytes } from '../../attachment-payload';
+
+const SWIFT_EXECUTABLE = '/usr/bin/swift';
+const APPLE_VISION_SCRIPT = fileURLToPath(new URL('../../../scripts/apple-vision-ocr.swift', import.meta.url));
+const TIMEOUT_MS = 30_000;
+const MAX_OUTPUT_BYTES = 32 * 1024;
+const FIXED_ENV = Object.freeze({ PATH: '/usr/bin:/bin', LANG: 'C', LC_ALL: 'C' });
+
+type ImageInput = Readonly<{ mimeType: 'image/png' | 'image/jpeg' | 'image/webp'; payload: string }>;
+export type AppleVisionOcrProcessResult = Readonly<{ status: 'succeeded'; output: string }> | Readonly<{ status: 'failed' }>;
+type FileStats = Readonly<{ isDirectory: () => boolean; isFile: () => boolean; isSymbolicLink: () => boolean; mode: number; uid?: number }>;
+type PrivateFile = Readonly<{ writeFile: (data: Uint8Array) => Promise<void>; close: () => Promise<void> }>;
+type Child = Readonly<{
+    stdout: Readonly<{ on: (event: 'data', listener: (chunk: Buffer | string) => void) => unknown }>;
+    stderr: Readonly<{ on: (event: 'data', listener: (chunk: Buffer | string) => void) => unknown }>;
+    once: {
+        (event: 'error', listener: () => void): unknown;
+        (event: 'close', listener: (code: number | null, signal: NodeJS.Signals | null) => void): unknown;
+    };
+    kill: (signal: NodeJS.Signals) => boolean;
+}>;
+export type AppleVisionOcrProcessRuntime = Readonly<{
+    platform: () => NodeJS.Platform;
+    uid: () => number | undefined;
+    spawn: (command: string, args: readonly string[], options: Readonly<{ cwd: '/'; env: Readonly<Record<string, string>>; shell: false; stdio: ['ignore', 'pipe', 'pipe']; windowsHide: true }>) => Child;
+    chmod: (path: string, mode: number) => Promise<void>;
+    lstat: (path: string) => Promise<FileStats>;
+    mkdtemp: (prefix: string) => Promise<string>;
+    open: (path: string, flags: number, mode: number) => Promise<PrivateFile>;
+    rm: (path: string, options: Readonly<{ recursive: true; force: true; maxRetries: number; retryDelay: number }>) => Promise<void>;
+    setTimer: (callback: () => void, milliseconds: number) => unknown;
+    clearTimer: (timer: unknown) => void;
+}>;
+
+function record(value: unknown, keys: readonly string[]): Record<string, unknown> | null {
+    try {
+        if (!value || typeof value !== 'object' || Array.isArray(value) || types.isProxy(value) || Object.getPrototypeOf(value) !== Object.prototype) return null;
+        const ownKeys = Reflect.ownKeys(value);
+        if (ownKeys.length !== keys.length || ownKeys.some((key) => typeof key !== 'string' || !keys.includes(key))) return null;
+        const snapshot: Record<string, unknown> = {};
+        for (const key of keys) {
+            const descriptor = Object.getOwnPropertyDescriptor(value, key);
+            if (!descriptor || !descriptor.enumerable || !('value' in descriptor)) return null;
+            snapshot[key] = descriptor.value;
+        }
+        return snapshot;
+    } catch { return null; }
+}
+
+function imageInput(value: unknown): ImageInput | null {
+    const input = record(value, ['mimeType', 'payload']);
+    if (!input || (input.mimeType !== 'image/png' && input.mimeType !== 'image/jpeg' && input.mimeType !== 'image/webp')
+        || typeof input.payload !== 'string' || !input.payload || input.payload.startsWith('ENC:') || input.payload.startsWith('data:')) return null;
+    const size = getAttachmentPayloadByteSize(input.payload);
+    const payload = Buffer.from(input.payload, 'base64');
+    if (!size.ok || size.size <= 0 || size.size > resolveMaxAttachmentBytes() || payload.length === 0 || payload.length > resolveMaxAttachmentBytes()) return null;
+    return Object.freeze({ mimeType: input.mimeType, payload: input.payload });
+}
+
+function runtimeSnapshot(value: unknown): AppleVisionOcrProcessRuntime | null {
+    const keys = ['platform', 'uid', 'spawn', 'chmod', 'lstat', 'mkdtemp', 'open', 'rm', 'setTimer', 'clearTimer'] as const;
+    const snapshot = record(value, keys);
+    if (!snapshot || keys.some((key) => typeof snapshot[key] !== 'function')) return null;
+    return Object.freeze(snapshot as unknown as AppleVisionOcrProcessRuntime);
+}
+
+function extensionFor(mimeType: ImageInput['mimeType']): 'png' | 'jpg' | 'webp' {
+    return mimeType === 'image/jpeg' ? 'jpg' : mimeType.slice('image/'.length) as 'png' | 'webp';
+}
+
+function isPrivateDirectory(info: FileStats, uid: number | undefined): boolean {
+    return info.isDirectory() && !info.isSymbolicLink() && (info.mode & 0o777) === 0o700
+        && (uid === undefined || info.uid === uid);
+}
+
+async function writePrivateImage(runtime: AppleVisionOcrProcessRuntime, image: ImageInput): Promise<Readonly<{ directory: string; path: string }>> {
+    const directory = await runtime.mkdtemp(join(tmpdir(), 'mediflow-local-ocr-'));
+    try {
+        await runtime.chmod(directory, 0o700);
+        const directoryInfo = await runtime.lstat(directory);
+        if (!isPrivateDirectory(directoryInfo, runtime.uid())) throw new Error('private directory unavailable');
+        const path = join(directory, `input.${extensionFor(image.mimeType)}`);
+        const file = await runtime.open(path, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW, 0o600);
+        try { await file.writeFile(Buffer.from(image.payload, 'base64')); } finally { await file.close(); }
+        await runtime.chmod(path, 0o600);
+        const fileInfo = await runtime.lstat(path);
+        if (!fileInfo.isFile() || fileInfo.isSymbolicLink() || (fileInfo.mode & 0o777) !== 0o600) throw new Error('private file unavailable');
+        return Object.freeze({ directory, path });
+    } catch (error) {
+        await runtime.rm(directory, { recursive: true, force: true, maxRetries: 2, retryDelay: 25 }).catch(() => undefined);
+        throw error;
+    }
+}
+
+async function hasFixedBoundary(runtime: AppleVisionOcrProcessRuntime): Promise<boolean> {
+    try {
+        const [executable, script] = await Promise.all([runtime.lstat(SWIFT_EXECUTABLE), runtime.lstat(APPLE_VISION_SCRIPT)]);
+        return executable.isFile() && !executable.isSymbolicLink() && script.isFile() && !script.isSymbolicLink();
+    } catch { return false; }
+}
+
+function invoke(runtime: AppleVisionOcrProcessRuntime, imagePath: string): Promise<string | null> {
+    return new Promise((resolve) => {
+        let output = Buffer.alloc(0); let errors = Buffer.alloc(0); let settled = false;
+        const timer = { value: undefined as unknown };
+        const finish = (value: string | null) => {
+            if (settled) return;
+            settled = true;
+            try { runtime.clearTimer(timer.value); } catch { /* @Codex: a timer cleanup error must not expose a child result. */ }
+            resolve(value);
+        };
+        let child: Child;
+        try {
+            child = runtime.spawn(SWIFT_EXECUTABLE, [APPLE_VISION_SCRIPT, imagePath], {
+                cwd: '/', env: FIXED_ENV, shell: false, stdio: ['ignore', 'pipe', 'pipe'], windowsHide: true,
+            });
+        } catch { finish(null); return; }
+        const terminate = () => { try { child.kill('SIGKILL'); } catch { /* @Codex: child failures are sanitized. */ } finish(null); };
+        timer.value = runtime.setTimer(terminate, TIMEOUT_MS);
+        const collect = (stream: 'stdout' | 'stderr', chunk: Buffer | string) => {
+            if (settled) return;
+            const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+            const current = stream === 'stdout' ? output : errors;
+            if (current.length + bytes.length > MAX_OUTPUT_BYTES) { terminate(); return; }
+            if (stream === 'stdout') output = Buffer.concat([output, bytes]); else errors = Buffer.concat([errors, bytes]);
+        };
+        child.stdout.on('data', (chunk: Buffer | string) => collect('stdout', chunk));
+        child.stderr.on('data', (chunk: Buffer | string) => collect('stderr', chunk));
+        child.once('error', () => finish(null));
+        child.once('close', (code, signal) => finish(code === 0 && signal === null ? output.toString('utf8') : null));
+    });
+}
+
+/** Internal server-only runner. Runtime injection is construction-only for deterministic lifecycle tests. */
+export function createAppleVisionOcrProcessRunner(runtime: AppleVisionOcrProcessRuntime) {
+    const safeRuntime = runtimeSnapshot(runtime);
+    return Object.freeze({
+        async run(value: unknown): Promise<AppleVisionOcrProcessResult> {
+            const image = imageInput(value);
+            if (!safeRuntime || !image || safeRuntime.platform() !== 'darwin' || !await hasFixedBoundary(safeRuntime)) return Object.freeze({ status: 'failed' as const });
+            let temporary: Readonly<{ directory: string; path: string }> | null = null;
+            let output: string | null = null;
+            try { temporary = await writePrivateImage(safeRuntime, image); output = await invoke(safeRuntime, temporary.path); } catch { output = null; }
+            try {
+                if (temporary) await safeRuntime.rm(temporary.directory, { recursive: true, force: true, maxRetries: 2, retryDelay: 25 });
+            } catch { return Object.freeze({ status: 'failed' as const }); }
+            return output === null ? Object.freeze({ status: 'failed' as const }) : Object.freeze({ status: 'succeeded' as const, output });
+        },
+    });
+}
+
+const systemRuntime: AppleVisionOcrProcessRuntime = Object.freeze({
+    platform: () => process.platform,
+    uid: () => typeof process.getuid === 'function' ? process.getuid() : undefined,
+    spawn: (command: string, args: readonly string[], options) => spawn(command, [...args], options as never) as unknown as Child,
+    chmod, lstat, mkdtemp, open, rm,
+    setTimer: (callback: () => void, milliseconds: number) => setTimeout(callback, milliseconds),
+    clearTimer: (timer: unknown) => clearTimeout(timer as NodeJS.Timeout),
+});
+
+export const systemAppleVisionOcrRunner = createAppleVisionOcrProcessRunner(systemRuntime);


### PR DESCRIPTION
## Summary
- aggiunge il runner locale Apple Vision con lifecycle e ownership espliciti
- contiene timeout, terminazione e cleanup del processo senza fallback
- mantiene output e failure sanitizzati prima del contratto execution

## Verification
- review indipendente exact-head del runner
- suite runner e OCR focalizzate con falsificatori lifecycle e ownership
- typecheck, ESLint, claims, AI-write, never-regress e runtime
- OpenAPI e schema drift/writers, git diff --check

## Risk / Notes
- candidato stacked su #268; diff esatto due file +387/-0 dopo hardening lifecycle separato e già revisionato
- nessun processo Apple Vision reale, rete, route, persistenza, write/apply o fallback
- fixture solo sintetiche; nessuna PHI/PII

## Ticket
Refs WUL-522