### PR TITLE
feat(ocr): aggiungi esecuzione Apple Vision governata

### DIFF
--- a/lib/ai-providers/fabric/local-ocr-apple-vision-execution.test.ts
+++ b/lib/ai-providers/fabric/local-ocr-apple-vision-execution.test.ts
@@ -1,0 +1,51 @@
+/* @Codex */
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createLocalOcrAppleVisionExecutionAdapter } from './local-ocr-apple-vision-execution.ts';
+
+const freeze = <T>(value: T): T => Object.freeze(value);
+const evidence = freeze({
+    status: 'composed', code: null,
+    binding: freeze({ provider: 'apple_vision', venue: 'on_device', egress: 'none' }),
+    receipt: freeze({ schemaVersion: 'mediflow.ai.local-ocr-provider-receipt.v1', provider: 'apple_vision', venue: 'on_device', egress: 'none', authority: 'review_only', applyPolicy: 'none', writesPerformed: 0 }),
+    provenance: freeze({ schemaVersion: 'mediflow.ai.local-ocr-provider-provenance.v1', provider: 'apple_vision', venue: 'on_device', egress: 'none', receiptProvider: 'apple_vision' }),
+    fallback: 'denied_by_contract', applyPolicy: 'none', writesPerformed: 0,
+});
+const request = (overrides: Record<string, unknown> = {}) => ({ evidence, image: { source: 'host_attachment', mimeType: 'image/png', payload: 'c3ludGhldGljLW9jci1pbWFnZQ==' }, mode: 'full', ...overrides });
+
+test('denies hostile options, requests, and host evidence before any Apple runner can be reached', async () => {
+    let reads = 0;
+    const adapter = createLocalOcrAppleVisionExecutionAdapter({ readHostEvidence: async () => { reads += 1; return evidence; } });
+    for (const input of [
+        new Proxy(request(), {}),
+        request({ provider: 'apple_vision' }),
+        request({ image: { source: 'host_attachment', mimeType: 'image/png', payload: 'data:synthetic' } }),
+        request({ mode: 'apply' }),
+    ]) assert.equal((await adapter.execute(input)).code, 'request_invalid');
+    assert.equal(reads, 0);
+    let traps = 0;
+    const hostile = new Proxy({ readHostEvidence: async () => evidence }, { get: () => { traps += 1; throw new Error('trap'); } });
+    assert.equal((await createLocalOcrAppleVisionExecutionAdapter(hostile).execute(request())).code, 'host_unavailable');
+    assert.equal(traps, 0);
+    const thenable = request();
+    Object.defineProperty(thenable, 'then', { enumerable: true, get: () => { traps += 1; throw new Error('then trap'); } });
+    assert.equal((await adapter.execute(thenable)).code, 'request_invalid');
+    const hostileCallable = new Proxy(async () => evidence, { apply: () => { traps += 1; return evidence; } });
+    assert.equal((await createLocalOcrAppleVisionExecutionAdapter({ readHostEvidence: hostileCallable }).execute(request())).code, 'host_unavailable');
+    assert.equal((await createLocalOcrAppleVisionExecutionAdapter({ readHostEvidence: async () => ({ ...evidence }) }).execute(request())).code, 'host_evidence_invalid');
+    assert.equal((await createLocalOcrAppleVisionExecutionAdapter({ readHostEvidence: async () => { throw new Error('sanitized'); } }).execute(request())).code, 'host_unavailable');
+    assert.equal(traps, 0);
+});
+
+test('returns one frozen, review-only no-fallback denial when the fixed system boundary is unavailable', async () => {
+    const original = process.platform;
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' });
+    try {
+        const result = await createLocalOcrAppleVisionExecutionAdapter({ readHostEvidence: async () => evidence }).execute(request());
+        assert.deepEqual(result, {
+            status: 'denied', code: 'platform_unavailable', binding: null, mode: null, output: null, receipt: null, provenance: null,
+            fallback: 'denied_by_contract', applyPolicy: 'none', writesPerformed: 0,
+        });
+        assert.equal(Object.isFrozen(result), true);
+    } finally { Object.defineProperty(process, 'platform', { configurable: true, value: original }); }
+});

--- a/lib/ai-providers/fabric/local-ocr-apple-vision-execution.ts
+++ b/lib/ai-providers/fabric/local-ocr-apple-vision-execution.ts
@@ -1,0 +1,97 @@
+/* @Codex */
+import 'server-only';
+
+import { types } from 'node:util';
+import { getAttachmentPayloadByteSize, resolveMaxAttachmentBytes } from '../../attachment-payload';
+import { systemAppleVisionOcrRunner } from './local-ocr-apple-vision-process-runner';
+import { createLocalOcrExecutionContract, type LocalOcrExecutionResult } from './local-ocr-execution-contract';
+
+const MAX_OUTPUT_BYTES = 32 * 1024;
+const MIN_RECOGNIZED_TEXT_CHARS = 3;
+
+type Mode = 'full' | 'patient' | 'labs';
+type Request = Readonly<{ evidence: unknown; image: Readonly<{ source: 'host_attachment'; mimeType: 'image/png' | 'image/jpeg' | 'image/webp'; payload: string }>; mode: Mode }>;
+type ResultMeta = Readonly<{ fallback: 'denied_by_contract'; applyPolicy: 'none'; writesPerformed: 0 }>;
+
+export type LocalOcrAppleVisionExecutionDenialCode =
+    | 'request_invalid' | 'host_unavailable' | 'host_evidence_invalid'
+    | 'platform_unavailable' | 'execution_failed' | 'recognition_unavailable';
+
+export type LocalOcrAppleVisionExecutionResult = ResultMeta & (
+    | Extract<LocalOcrExecutionResult, Readonly<{ status: 'succeeded' }>>
+    | Readonly<{ status: 'denied'; code: LocalOcrAppleVisionExecutionDenialCode; binding: null; mode: null; output: null; receipt: null; provenance: null }>
+);
+
+function record(value: unknown, keys: readonly string[]): Record<string, unknown> | null {
+    try {
+        if (!value || typeof value !== 'object' || Array.isArray(value) || types.isProxy(value) || Object.getPrototypeOf(value) !== Object.prototype) return null;
+        const ownKeys = Reflect.ownKeys(value);
+        if (ownKeys.length !== keys.length || ownKeys.some((key) => typeof key !== 'string' || !keys.includes(key))) return null;
+        const snapshot: Record<string, unknown> = {};
+        for (const key of keys) {
+            const descriptor = Object.getOwnPropertyDescriptor(value, key);
+            if (!descriptor || !descriptor.enumerable || !('value' in descriptor)) return null;
+            snapshot[key] = descriptor.value;
+        }
+        return snapshot;
+    } catch { return null; }
+}
+
+function deny(code: LocalOcrAppleVisionExecutionDenialCode): LocalOcrAppleVisionExecutionResult {
+    return Object.freeze({ status: 'denied' as const, code, binding: null, mode: null, output: null, receipt: null, provenance: null,
+        fallback: 'denied_by_contract' as const, applyPolicy: 'none' as const, writesPerformed: 0 as const });
+}
+
+function snapshotRequest(value: unknown): Request | null {
+    const input = record(value, ['evidence', 'image', 'mode']);
+    const image = input && record(input.image, ['source', 'mimeType', 'payload']);
+    if (!input || !image || image.source !== 'host_attachment'
+        || (image.mimeType !== 'image/png' && image.mimeType !== 'image/jpeg' && image.mimeType !== 'image/webp')
+        || typeof image.payload !== 'string' || !image.payload || image.payload.startsWith('ENC:') || image.payload.startsWith('data:')
+        || (input.mode !== 'full' && input.mode !== 'patient' && input.mode !== 'labs')) return null;
+    const size = getAttachmentPayloadByteSize(image.payload);
+    const payload = Buffer.from(image.payload, 'base64');
+    if (!size.ok || size.size <= 0 || size.size > resolveMaxAttachmentBytes() || payload.length === 0 || payload.length > resolveMaxAttachmentBytes()) return null;
+    return Object.freeze({ evidence: input.evidence, image: Object.freeze({ source: 'host_attachment' as const, mimeType: image.mimeType, payload: image.payload }), mode: input.mode });
+}
+
+function isAcceptedAppleVisionEnvelope(request: Request): boolean {
+    const result = createLocalOcrExecutionContract().freeze({ ...request, outcome: { kind: 'success', text: 'ok' } });
+    return result.status === 'succeeded' && result.binding.provider === 'apple_vision' && result.binding.venue === 'on_device';
+}
+
+function recognizedText(value: string): string | null {
+    try {
+        const output = record(JSON.parse(value), ['ok', 'engine', 'avg_confidence', 'text']);
+        if (!output || output.ok !== true || output.engine !== 'apple_vision' || typeof output.avg_confidence !== 'number'
+            || !Number.isFinite(output.avg_confidence) || output.avg_confidence < 0 || output.avg_confidence > 1 || typeof output.text !== 'string') return null;
+        const text = output.text.trim();
+        return text.length >= MIN_RECOGNIZED_TEXT_CHARS && text.length <= MAX_OUTPUT_BYTES ? text : null;
+    } catch { return null; }
+}
+
+/** Server-only X0 executor: exact host evidence and one fixed Apple Vision system runner. */
+export function createLocalOcrAppleVisionExecutionAdapter(options: unknown) {
+    const snapshot = record(options, ['readHostEvidence']);
+    const candidate = snapshot?.readHostEvidence;
+    const readHostEvidence = typeof candidate === 'function' && !types.isProxy(candidate) ? candidate as () => Promise<unknown> : null;
+    return Object.freeze({
+        async execute(value: unknown): Promise<LocalOcrAppleVisionExecutionResult> {
+            const request = snapshotRequest(value);
+            if (!request || !isAcceptedAppleVisionEnvelope(request)) return deny('request_invalid');
+            if (!readHostEvidence) return deny('host_unavailable');
+            let hostEvidence: unknown;
+            try { hostEvidence = await readHostEvidence(); } catch { return deny('host_unavailable'); }
+            if (hostEvidence === null || hostEvidence === undefined) return deny('host_unavailable');
+            if (hostEvidence !== request.evidence) return deny('host_evidence_invalid');
+            if (process.platform !== 'darwin') return deny('platform_unavailable');
+            let executed: Awaited<ReturnType<typeof systemAppleVisionOcrRunner.run>>;
+            try { executed = await systemAppleVisionOcrRunner.run({ mimeType: request.image.mimeType, payload: request.image.payload }); } catch { return deny('execution_failed'); }
+            if (executed.status === 'failed') return deny('execution_failed');
+            const text = recognizedText(executed.output);
+            if (!text) return deny('recognition_unavailable');
+            const frozen = createLocalOcrExecutionContract().freeze({ ...request, outcome: { kind: 'success', text } });
+            return frozen.status === 'succeeded' ? frozen : deny('recognition_unavailable');
+        },
+    });
+}


### PR DESCRIPTION
## Summary
- aggiunge adapter execution Apple Vision on_device
- valida evidenza host-owned prima della singola invocazione del runner
- conserva receipt, provenance e failure fail-closed senza fallback

## Verification
- review indipendente exact-head Apple Vision execution
- OCR execution, runner e contratti P0: 34/34
- typecheck, ESLint, claims, AI-write, never-regress e runtime
- OpenAPI e schema drift/writers, git diff --check

## Risk / Notes
- candidato stacked su #269; nessuna invocazione Vision o processo reale è stata eseguita
- nessuna route, persistenza, write/apply o fallback
- fixture solo sintetiche; nessuna PHI/PII

## Ticket
Refs WUL-522