### PR TITLE
docs(adr): require host-owned commit turns

### DIFF
--- a/docs/adr/0096-owner-sessione-selezione-e-lifetime-broker.md
+++ b/docs/adr/0096-owner-sessione-selezione-e-lifetime-broker.md
@@ -143,6 +143,20 @@ Una sessione `local-api`, `system` o equivalente non prova l'identita del
 medico e non puo creare un owner clinico. Il token locale resta un meccanismo
 di trasporto o servizio entro i suoi scope, non una sessione medica.
 
+### 6. Commit protetto solo con turno autenticato dell'host
+
+Il commit finale di un'operazione protetta richiede un turno o capability
+effimero, autenticato e host-owned, valido soltanto dentro la sezione critica
+del lease. Stato capability non puo pubblicare o mutare senza quel turno.
+
+L'abort prima del commit e al piu una volta. Dopo il commit non sono ammesse
+mutazioni capability asincrone o capaci di negare l'esito. Callback dinamiche
+che restituiscono Promise o thenable non sono un confine di enforcement
+accettabile: il runtime deve possedere e verificare il turno fino al commit.
+
+Questa regola non definisce API, provider, route, persistenza o apply; questi
+restano packet separati e sottoposti ai rispettivi gate.
+
 ## DAG di implementazione
 
 ```text


### PR DESCRIPTION
## Summary
- require a host-owned, authenticated ephemeral turn for protected final commits
- prohibit capability mutation without the live lease turn
- keep provider, route, persistence, and apply semantics outside this ADR packet

## Verification
- `git diff --check`
- Markdown inventory: 174 files
- `npm run check:claims`
- `npm run check:never-regress`

## Risk / Notes
- Documentation candidate only; runtime enforcement is delivered in separate stacked packets.
- No PHI/PII, patient data, provider invocation, write, or apply path.
- Not integrated, release-ready, or released.

## Ticket
Refs WUL-522