### PR TITLE
feat(auth): authenticate projection owners

### DIFF
--- a/lib/security/server-session-projection-owner.test.ts
+++ b/lib/security/server-session-projection-owner.test.ts
@@ -5,6 +5,7 @@ import { afterEach, test } from 'node:test';
 
 import {
     createServerSessionProjectionOwnerRegistry,
+    isServerSessionProjectionOwner,
     ServerSessionProjectionOwnerError,
 } from './server-session-projection-owner.ts';
 import { clearAllSessions, createSession, deleteSession, getSession, type ServerSession } from './server-session.ts';
@@ -39,6 +40,94 @@ test('acquire creates one owner and reuses its identity for the canonical sessio
     assert.equal(first, second);
     assert.equal(registry.lookup(value.id), first);
     assert.equal(constructions, 1);
+});
+
+test('recognizes only published module owners and isolates registry identity', () => {
+    const firstRegistry = createServerSessionProjectionOwnerRegistry();
+    const secondRegistry = createServerSessionProjectionOwnerRegistry();
+    const value = session();
+    const owner = firstRegistry.acquire(value);
+    const lookalike = Object.freeze({ ...owner });
+
+    assert.equal(isServerSessionProjectionOwner(owner), true);
+    assert.equal(firstRegistry.isAuthenticOwner(owner), true);
+    assert.equal(secondRegistry.isAuthenticOwner(owner), false);
+    assert.equal(isServerSessionProjectionOwner(lookalike), false);
+    assert.equal(firstRegistry.isAuthenticOwner(lookalike), false);
+    assert.equal(isServerSessionProjectionOwner(Object.create(owner)), false);
+    for (const malformed of [null, undefined, false, 1, 'owner', [], {}, Object.create(null)]) {
+        assert.equal(isServerSessionProjectionOwner(malformed), false);
+        assert.equal(firstRegistry.isAuthenticOwner(malformed), false);
+    }
+    let reads = 0;
+    const accessor = Object.defineProperty({}, 'dispose', { get() { reads += 1; return owner.dispose; } });
+    assert.equal(isServerSessionProjectionOwner(accessor), false);
+    assert.equal(firstRegistry.isAuthenticOwner(accessor), false);
+    assert.equal(reads, 0);
+});
+
+test('rejects owner proxies before traps or structural reflection', () => {
+    const registry = createServerSessionProjectionOwnerRegistry();
+    const owner = registry.acquire(session());
+    let traps = 0;
+    const proxy = new Proxy(owner, {
+        get() { traps += 1; throw new Error('synthetic get trap'); },
+        getOwnPropertyDescriptor() { traps += 1; throw new Error('synthetic descriptor trap'); },
+        getPrototypeOf() { traps += 1; throw new Error('synthetic prototype trap'); },
+        has() { traps += 1; throw new Error('synthetic has trap'); },
+        ownKeys() { traps += 1; throw new Error('synthetic ownKeys trap'); },
+    });
+    const transparentProxy = new Proxy(owner, {});
+
+    assert.equal(isServerSessionProjectionOwner(proxy), false);
+    assert.equal(registry.isAuthenticOwner(proxy), false);
+    assert.equal(isServerSessionProjectionOwner(transparentProxy), false);
+    assert.equal(registry.isAuthenticOwner(transparentProxy), false);
+    assert.equal(traps, 0);
+});
+
+test('uses captured identity intrinsics after ambient prototype mutation', () => {
+    const originalAdd = WeakSet.prototype.add;
+    const originalHas = WeakSet.prototype.has;
+    const originalApply = Reflect.apply;
+    try {
+        WeakSet.prototype.add = () => { throw new Error('synthetic ambient add'); };
+        WeakSet.prototype.has = () => { throw new Error('synthetic ambient has'); };
+        Reflect.apply = () => { throw new Error('synthetic ambient apply'); };
+        const registry = createServerSessionProjectionOwnerRegistry();
+        const owner = registry.acquire(session());
+        assert.equal(isServerSessionProjectionOwner(owner), true);
+        assert.equal(registry.isAuthenticOwner(owner), true);
+    } finally {
+        WeakSet.prototype.add = originalAdd;
+        WeakSet.prototype.has = originalHas;
+        Reflect.apply = originalApply;
+    }
+});
+
+test('publishes authenticity only after successful construction', () => {
+    const value = session();
+    const registry = createServerSessionProjectionOwnerRegistry({ entropy: () => {
+        deleteSession(value.id);
+        return new Uint8Array(16);
+    } });
+
+    assert.throws(() => registry.acquire(value), rejects('session_ineligible'));
+    assert.equal(registry.lookup(value.id), null);
+    assert.equal(isServerSessionProjectionOwner(Object.freeze({})), false);
+});
+
+test('keeps disposed identity recognizable while operations remain terminal', () => {
+    const registry = createServerSessionProjectionOwnerRegistry({ resolve: (_session, pair) => pair });
+    const value = session();
+    const owner = registry.acquire(value);
+    owner.issueSelection({ expectedEpoch: 0, ...PAIR });
+    owner.dispose();
+
+    assert.equal(isServerSessionProjectionOwner(owner), true);
+    assert.equal(registry.isAuthenticOwner(owner), true);
+    assert.equal(registry.lookup(value.id), null);
+    assert.throws(() => owner.withLeaseCriticalSection(value, () => 'unused'), rejects('session_unavailable'));
 });
 
 test('acquire rejects synchronous source reentrancy with one fixed error', () => {

--- a/lib/security/server-session-projection-owner.ts
+++ b/lib/security/server-session-projection-owner.ts
@@ -2,6 +2,7 @@
 import 'server-only';
 
 import { randomBytes } from 'node:crypto';
+import { types } from 'node:util';
 import { createTypedProjectionBroker, ProjectionBrokerError, type TypedProjectionBrokerConfig } from '../typed-projection-broker';
 import { bindProjectionBrokerToServerSession } from './server-session-projection-broker';
 import { getSession, peekSession, registerServerSessionResource, type ServerSession } from './server-session';
@@ -23,6 +24,20 @@ type SelectionLease = Readonly<{
     leaseRef: string; expiresAt: number;
 }>;
 type SelectionState = CanonicalPair & SelectionLease;
+
+const authenticOwners = new WeakSet<object>();
+const weakSetAdd = WeakSet.prototype.add;
+const weakSetHas = WeakSet.prototype.has;
+const applyIntrinsic = Reflect.apply;
+const isProxy = types.isProxy;
+
+function addOwnerIdentity(registry: WeakSet<object>, owner: object): void {
+    applyIntrinsic(weakSetAdd, registry, [owner]);
+}
+
+function hasOwnerIdentity(registry: WeakSet<object>, candidate: object): boolean {
+    return applyIntrinsic(weakSetHas, registry, [candidate]);
+}
 
 export type ServerSessionProjectionOwnerErrorCode =
     | 'broker_factory_failed' | 'broker_unavailable' | 'epoch_conflict' | 'input_invalid' | 'lease_expired' | 'owner_disposed'
@@ -48,6 +63,11 @@ export type ServerSessionProjectionOwner = Readonly<{
     withLeaseCriticalSection<T>(session: ServerSession, callback: (selection: CanonicalPair) => T): T;
     dispose(): void;
 }>;
+
+export function isServerSessionProjectionOwner(candidate: unknown): candidate is ServerSessionProjectionOwner {
+    if (typeof candidate !== 'object' || candidate === null || isProxy(candidate)) return false;
+    return hasOwnerIdentity(authenticOwners, candidate);
+}
 
 type SelectionLeaseTuple = Readonly<{ sessionRef: string; selectionEpoch: number; patientRef: string;
     ambulatoryRef: string; leaseRef: string }>;
@@ -88,10 +108,15 @@ function exact(input: unknown, keys: readonly string[]): Record<string, unknown>
 export function createServerSessionProjectionOwnerRegistry(sourceOverrides: Partial<SelectionSources> = {}) {
     const sources = Object.freeze({ ...defaultSources, ...sourceOverrides });
     const owners = new Map<string, ServerSessionProjectionOwner>();
+    const registryOwners = new WeakSet<object>();
     const retired = new Set<string>();
     const acquiring = new Set<string>();
 
     const registry = {
+        isAuthenticOwner(candidate: unknown): candidate is ServerSessionProjectionOwner {
+            if (!isServerSessionProjectionOwner(candidate)) return false;
+            return hasOwnerIdentity(registryOwners, candidate);
+        },
         lookup(sessionId: string): ServerSessionProjectionOwner | null {
             return owners.get(sessionId) ?? null;
         },
@@ -340,6 +365,8 @@ export function createServerSessionProjectionOwnerRegistry(sourceOverrides: Part
             unregisterOwner = registerServerSessionResource(session.id, () => finish(false));
             if (!unregisterOwner) return fail('session_ineligible');
             owners.set(session.id, owner);
+            addOwnerIdentity(registryOwners, owner);
+            addOwnerIdentity(authenticOwners, owner);
             return owner;
             } finally {
                 acquiring.delete(session.id);


### PR DESCRIPTION
## Summary
- add module-private authenticity for server-session projection owners
- isolate owner identity per registry and reject forged or proxied owners before reflection
- preserve the exact previously reviewed owner-auth runtime blobs on the new ADR base

## Verification
- focused projection-owner and auth-lockout tests: 30/30
- `npm run typecheck`
- full lint and focused review
- claims, AI-write, never-regress, Node runtime, OpenAPI/schema drift and writer guards
- `git diff --check`

## Risk / Notes
- Owner-auth candidate only; this packet does not implement the commit turn.
- No OCR ancestry, capability binding, provider, route, persistence, write, or apply scope.
- Not integrated, release-ready, or released.

## Ticket
Refs WUL-522