### PR TITLE
feat(security): add host-owned lease commit turns

### DIFF
--- a/lib/security/server-session-projection-owner.test.ts
+++ b/lib/security/server-session-projection-owner.test.ts
@@ -7,6 +7,8 @@ import {
     createServerSessionProjectionOwnerRegistry,
     isServerSessionProjectionOwner,
     ServerSessionProjectionOwnerError,
+    spendLeaseCommitTurn,
+    withLeaseCommitTurn,
 } from './server-session-projection-owner.ts';
 import { clearAllSessions, createSession, deleteSession, getSession, type ServerSession } from './server-session.ts';
 import { ProjectionBrokerError } from '../typed-projection-broker.ts';
@@ -128,6 +130,124 @@ test('keeps disposed identity recognizable while operations remain terminal', ()
     assert.equal(registry.isAuthenticOwner(owner), true);
     assert.equal(registry.lookup(value.id), null);
     assert.throws(() => owner.withLeaseCriticalSection(value, () => 'unused'), rejects('session_unavailable'));
+});
+
+test('requires an authentic live turn for synchronous commit and abort work', () => {
+    const registry = createServerSessionProjectionOwnerRegistry({ resolve: (_session, pair) => pair });
+    const value = session(); const owner = registry.acquire(value);
+    owner.issueSelection({ expectedEpoch: 0, ...PAIR });
+    const events: string[] = [];
+
+    withLeaseCommitTurn(owner, value,
+        (selection) => Object.freeze({ selection }),
+        (prepared, turn) => {
+            assert.equal(prepared.selection.patientId, PAIR.patientId);
+            assert.equal(Object.getPrototypeOf(turn), null);
+            assert.equal(Object.isFrozen(turn), true);
+            spendLeaseCommitTurn(owner, value, turn, 'commit');
+            events.push('commit');
+        },
+        (turn) => {
+            spendLeaseCommitTurn(owner, value, turn, 'abort');
+            events.push('abort');
+        });
+
+    assert.deepEqual(events, ['commit']);
+});
+
+test('aborts once on a precommit thenable without leaking native rejections', async () => {
+    const registry = createServerSessionProjectionOwnerRegistry({ resolve: (_session, pair) => pair });
+    const value = session(); const owner = registry.acquire(value); owner.issueSelection({ expectedEpoch: 0, ...PAIR });
+    const unhandled: unknown[] = []; let resurrection: unknown;
+    const observe = (reason: unknown) => unhandled.push(reason);
+    process.on('unhandledRejection', observe);
+    try {
+        assert.throws(() => withLeaseCommitTurn(owner, value,
+            () => Promise.reject(new Error('synthetic prepare rejection')),
+            () => assert.fail('commit must not run'),
+            (turn) => {
+                spendLeaseCommitTurn(owner, value, turn, 'abort');
+                queueMicrotask(() => { try { spendLeaseCommitTurn(owner, value, turn, 'abort'); } catch (error) { resurrection = error; } });
+                return Promise.reject(new Error('synthetic late abort'));
+            }),
+        rejects('input_invalid'));
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        assert.equal(resurrection instanceof ServerSessionProjectionOwnerError && resurrection.code, 'selection_unavailable');
+        assert.deepEqual(unhandled, []);
+    } finally { process.off('unhandledRejection', observe); }
+});
+
+test('closes spent turns before late work and keeps a spent commit terminal', async () => {
+    const registry = createServerSessionProjectionOwnerRegistry({ resolve: (_session, pair) => pair });
+    const value = session(); const owner = registry.acquire(value); owner.issueSelection({ expectedEpoch: 0, ...PAIR });
+    let late: unknown; let later: unknown; let aborts = 0; const unhandled: unknown[] = []; const observe = (reason: unknown) => unhandled.push(reason);
+    process.on('unhandledRejection', observe);
+    try {
+        withLeaseCommitTurn(owner, value, () => 'prepared', (_prepared, turn) => {
+            spendLeaseCommitTurn(owner, value, turn, 'commit');
+            assert.throws(() => spendLeaseCommitTurn(owner, value, turn, 'commit'), rejects('selection_unavailable'));
+            queueMicrotask(() => { try { spendLeaseCommitTurn(owner, value, turn, 'commit'); } catch (error) { late = error; } });
+            setImmediate(() => { try { spendLeaseCommitTurn(owner, value, turn, 'commit'); } catch (error) { later = error; } });
+            return Promise.reject(new Error('synthetic late commit'));
+        }, () => { aborts += 1; });
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        assert.equal(aborts, 0);
+        assert.equal(late instanceof ServerSessionProjectionOwnerError && late.code, 'selection_unavailable');
+        assert.equal(later instanceof ServerSessionProjectionOwnerError && later.code, 'selection_unavailable');
+        assert.deepEqual(unhandled, []);
+
+        withLeaseCommitTurn(owner, value, () => 'prepared-again', (_prepared, turn) => {
+            spendLeaseCommitTurn(owner, value, turn, 'commit');
+            throw new Error('synthetic post-spend throw');
+        }, () => { aborts += 1; });
+        assert.equal(aborts, 0);
+    } finally { process.off('unhandledRejection', observe); }
+});
+
+test('denies dynamic commit and abort completions before they can spend a turn', async () => {
+    const registry = createServerSessionProjectionOwnerRegistry({ resolve: (_session, pair) => pair });
+    const value = session(); const owner = registry.acquire(value); owner.issueSelection({ expectedEpoch: 0, ...PAIR });
+    const unhandled: unknown[] = []; const observe = (reason: unknown) => unhandled.push(reason);
+    process.on('unhandledRejection', observe);
+    try {
+        assert.throws(() => withLeaseCommitTurn(owner, value, () => 'prepared',
+            () => Promise.reject(new Error('synthetic unspent commit')),
+            (turn) => spendLeaseCommitTurn(owner, value, turn, 'abort')), rejects('selection_unavailable'));
+        assert.throws(() => withLeaseCommitTurn(owner, value, () => 'prepared-again',
+            () => { throw Promise.reject(new Error('synthetic thrown commit')); },
+            (turn) => spendLeaseCommitTurn(owner, value, turn, 'abort')), rejects('input_invalid'));
+        assert.throws(() => withLeaseCommitTurn(owner, value, () => { throw new Error('synthetic prepare failure'); },
+            () => assert.fail('commit must not run'), () => Promise.reject(new Error('synthetic unspent abort'))),
+        rejects('selection_unavailable'));
+        let thenReads = 0; const originalThen = Object.getOwnPropertyDescriptor(Object.prototype, 'then');
+        try {
+            Object.defineProperty(Object.prototype, 'then', { configurable: true, get() { thenReads += 1; return undefined; } });
+            assert.throws(() => withLeaseCommitTurn(owner, value, () => Object.freeze({ staged: true }),
+                () => assert.fail('commit must not run'), (turn) => spendLeaseCommitTurn(owner, value, turn, 'abort')), rejects('input_invalid'));
+            assert.equal(thenReads, 0);
+        } finally {
+            if (originalThen) Object.defineProperty(Object.prototype, 'then', originalThen);
+            else delete (Object.prototype as { then?: unknown }).then;
+        }
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        assert.deepEqual(unhandled, []);
+    } finally { process.off('unhandledRejection', observe); }
+});
+
+test('denies unspent, forged, cross-session, and late clock commit attempts before publication', () => {
+    let now = Date.now();
+    const registry = createServerSessionProjectionOwnerRegistry({ resolve: (_session, pair) => pair, clock: () => now });
+    const value = session(); const other = session(); const owner = registry.acquire(value); owner.issueSelection({ expectedEpoch: 0, ...PAIR });
+    let aborts = 0; let traps = 0;
+    assert.throws(() => withLeaseCommitTurn(owner, value, () => 'prepared', (_prepared, turn) => {
+        assert.throws(() => spendLeaseCommitTurn(owner, other, turn, 'commit'), rejects('selection_unavailable'));
+        assert.throws(() => spendLeaseCommitTurn(owner, value, new Proxy(turn, { get() { traps += 1; return undefined; } }), 'commit'), rejects('input_invalid'));
+    }, (turn) => { aborts += 1; spendLeaseCommitTurn(owner, value, turn, 'abort'); }), rejects('selection_unavailable'));
+    assert.deepEqual({ aborts, traps }, { aborts: 1, traps: 0 });
+
+    const second = registry.acquire(other); second.issueSelection({ expectedEpoch: 0, ...PAIR });
+    assert.throws(() => withLeaseCommitTurn(second, other, () => { now = other.expiresAt + 1; return 'late'; },
+        () => assert.fail('commit must not run'), (turn) => spendLeaseCommitTurn(second, other, turn, 'abort')), rejects('lease_expired'));
 });
 
 test('acquire rejects synchronous source reentrancy with one fixed error', () => {

--- a/lib/security/server-session-projection-owner.ts
+++ b/lib/security/server-session-projection-owner.ts
@@ -28,8 +28,15 @@ type SelectionState = CanonicalPair & SelectionLease;
 const authenticOwners = new WeakSet<object>();
 const weakSetAdd = WeakSet.prototype.add;
 const weakSetHas = WeakSet.prototype.has;
+const weakMapSet = WeakMap.prototype.set;
+const weakMapGet = WeakMap.prototype.get;
 const applyIntrinsic = Reflect.apply;
 const isProxy = types.isProxy;
+const isAsyncFunction = types.isAsyncFunction;
+const isPromise = types.isPromise;
+const getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+const getPrototypeOf = Object.getPrototypeOf;
+const promiseThen = Promise.prototype.then;
 
 function addOwnerIdentity(registry: WeakSet<object>, owner: object): void {
     applyIntrinsic(weakSetAdd, registry, [owner]);
@@ -37,6 +44,14 @@ function addOwnerIdentity(registry: WeakSet<object>, owner: object): void {
 
 function hasOwnerIdentity(registry: WeakSet<object>, candidate: object): boolean {
     return applyIntrinsic(weakSetHas, registry, [candidate]);
+}
+
+function setWeakMapValue<T>(registry: WeakMap<object, T>, key: object, value: T): void {
+    applyIntrinsic(weakMapSet, registry, [key, value]);
+}
+
+function getWeakMapValue<T>(registry: WeakMap<object, T>, key: object): T | undefined {
+    return applyIntrinsic(weakMapGet, registry, [key]);
 }
 
 export type ServerSessionProjectionOwnerErrorCode =
@@ -63,6 +78,68 @@ export type ServerSessionProjectionOwner = Readonly<{
     withLeaseCriticalSection<T>(session: ServerSession, callback: (selection: CanonicalPair) => T): T;
     dispose(): void;
 }>;
+
+export type LeaseCommitTurn = object;
+export type LeaseCommitTurnPhase = 'abort' | 'commit';
+type LeaseCommitTurnState = {
+    owner: ServerSessionProjectionOwner; session: ServerSession; phase: 'abort' | 'closed' | 'commit' | 'prepare';
+    live: boolean; spent: boolean;
+};
+type LeaseCommitTurnRunner = (session: ServerSession, prepare: (selection: CanonicalPair) => unknown,
+    commit: (prepared: unknown, turn: LeaseCommitTurn) => unknown, abort: (turn: LeaseCommitTurn) => unknown) => void;
+
+const commitTurnRunners = new WeakMap<object, LeaseCommitTurnRunner>();
+const commitTurnStates = new WeakMap<object, LeaseCommitTurnState>();
+
+function synchronousCallback(candidate: unknown): candidate is (...args: never[]) => unknown {
+    return typeof candidate === 'function' && !isProxy(candidate) && !isAsyncFunction(candidate);
+}
+
+function observeNativePromise(value: unknown): void {
+    if ((typeof value !== 'object' || value === null) && typeof value !== 'function') return;
+    if (isProxy(value) || !isPromise(value)) return;
+    try { applyIntrinsic(promiseThen, value, [undefined, () => undefined]); } catch { /* A late completion stays opaque. */ }
+}
+
+function hasThenable(value: unknown): boolean {
+    if ((typeof value !== 'object' || value === null) && typeof value !== 'function') return false;
+    if (isProxy(value) || isPromise(value)) return true;
+    try {
+        let cursor: object | null = value;
+        while (cursor) {
+            if (isProxy(cursor) || getOwnPropertyDescriptor(cursor, 'then')) return true;
+            cursor = getPrototypeOf(cursor);
+        }
+    } catch { return true; }
+    return false;
+}
+
+function rejectThenable(value: unknown): void {
+    if (!hasThenable(value)) return;
+    observeNativePromise(value);
+    return fail('input_invalid');
+}
+
+export function spendLeaseCommitTurn(owner: unknown, session: ServerSession, turn: unknown, phase: LeaseCommitTurnPhase): void {
+    if (!isServerSessionProjectionOwner(owner) || (phase !== 'abort' && phase !== 'commit')
+        || typeof turn !== 'object' || turn === null || isProxy(turn)) return fail('input_invalid');
+    const state = getWeakMapValue(commitTurnStates, turn);
+    if (!state || !state.live || state.spent || state.owner !== owner || state.session !== session || state.phase !== phase) {
+        return fail('selection_unavailable');
+    }
+    state.spent = true;
+}
+
+export function withLeaseCommitTurn<T>(owner: unknown, session: ServerSession,
+    prepare: (selection: CanonicalPair) => T, commit: (prepared: T, turn: LeaseCommitTurn) => unknown,
+    abort: (turn: LeaseCommitTurn) => unknown): void {
+    if (!isServerSessionProjectionOwner(owner) || !synchronousCallback(prepare)
+        || !synchronousCallback(commit) || !synchronousCallback(abort)) return fail('input_invalid');
+    const runner = getWeakMapValue(commitTurnRunners, owner);
+    if (!runner) return fail('owner_disposed');
+    runner(session, prepare as (selection: CanonicalPair) => unknown,
+        commit as (prepared: unknown, turn: LeaseCommitTurn) => unknown, abort as (turn: LeaseCommitTurn) => unknown);
+}
 
 export function isServerSessionProjectionOwner(candidate: unknown): candidate is ServerSessionProjectionOwner {
     if (typeof candidate !== 'object' || candidate === null || isProxy(candidate)) return false;
@@ -202,6 +279,60 @@ export function createServerSessionProjectionOwnerRegistry(sourceOverrides: Part
             };
             const rejectLeaseCriticalSectionReentry = () => {
                 if (leaseCriticalSectionActive) fail('selection_busy');
+            };
+            const commitTurnRunner: LeaseCommitTurnRunner = (presentedSession, prepare, commit, abort) => {
+                if (leaseCriticalSectionActive) return fail('selection_busy');
+                const current = selection;
+                const expectedSelectionEpoch = epoch;
+                const expectedReviewContextEpoch = reviewContextEpoch;
+                const assertCurrent = () => {
+                    requireCurrentSession(presentedSession);
+                    if (!current || selection !== current || epoch !== expectedSelectionEpoch || reviewContextEpoch !== expectedReviewContextEpoch) {
+                        return fail('stale_selection');
+                    }
+                    const now = readClock();
+                    requireCurrentSession(presentedSession);
+                    if (selection !== current || epoch !== expectedSelectionEpoch || reviewContextEpoch !== expectedReviewContextEpoch) {
+                        return fail('stale_selection');
+                    }
+                    if (now >= current.expiresAt) { expire(); return fail('lease_expired'); }
+                };
+                leaseCriticalSectionActive = true;
+                const turn = Object.freeze(Object.create(null));
+                const state: LeaseCommitTurnState = { owner, session: presentedSession, phase: 'prepare', live: true, spent: false };
+                setWeakMapValue(commitTurnStates, turn, state);
+                const abortOnce = (cause: unknown): never => {
+                    state.phase = 'abort';
+                    let outcome: unknown;
+                    const unsafeCause = hasThenable(cause);
+                    observeNativePromise(cause);
+                    try { outcome = abort(turn); } catch (error) { observeNativePromise(error); /* The primary precommit outcome remains authoritative. */ }
+                    observeNativePromise(outcome);
+                    if (!state.spent) return fail('selection_unavailable');
+                    if (unsafeCause) return fail('input_invalid');
+                    throw cause;
+                };
+                try {
+                    let prepared: unknown;
+                    try { assertCurrent(); prepared = prepare(Object.freeze({ patientId: current!.patientId, ambulatoryId: current!.ambulatoryId })); }
+                    catch (error) { return abortOnce(error); }
+                    try { rejectThenable(prepared); assertCurrent(); }
+                    catch (error) { return abortOnce(error); }
+                    state.phase = 'commit';
+                    let outcome: unknown;
+                    try { outcome = commit(prepared, turn); } catch (error) {
+                        observeNativePromise(error);
+                        if (state.spent) return;
+                        return abortOnce(error);
+                    }
+                    observeNativePromise(outcome);
+                    if (state.spent) return;
+                    return abortOnce(new ServerSessionProjectionOwnerError('selection_unavailable'));
+                } finally {
+                    state.live = false;
+                    state.phase = 'closed';
+                    leaseCriticalSectionActive = false;
+                }
             };
             const candidateControl = (candidate: unknown): TypedBroker['control'] | null => {
                 if (typeof candidate !== 'object' || candidate === null) return null;
@@ -367,6 +498,7 @@ export function createServerSessionProjectionOwnerRegistry(sourceOverrides: Part
             owners.set(session.id, owner);
             addOwnerIdentity(registryOwners, owner);
             addOwnerIdentity(authenticOwners, owner);
+            setWeakMapValue(commitTurnRunners, owner, commitTurnRunner);
             return owner;
             } finally {
                 acquiring.delete(session.id);


### PR DESCRIPTION
## Summary
- add an opaque host-owned lease commit turn bound to the authentic owner, exact session, and critical phase
- enforce single spend, precommit abort, terminal commit, and turn closure before late work
- reject forged, proxied, cross-session, cross-phase, replayed, and closed turns

## Verification
- owner fresh archive security/composition tests: 73/73
- independent security archive tests: 106/106
- `npm run typecheck` and full lint
- claims, AI-write, never-regress, Node runtime, OpenAPI/schema drift and writer guards
- `git diff --check`

## Risk / Notes
- Shared in-process primitive only; capability-private PI/OCR binding remains a separate required packet.
- A callback that spends the turn is terminal success even if it later throws or returns a Promise/thenable; the closed turn prevents later protected mutation. No postcommit denial or abort is permitted.
- This does not provide provider execution, persistence, multiprocess leases, routes, writes, or apply.
- No PHI/PII or real patient data. Not integrated, release-ready, or released.

## Ticket
Refs WUL-522