### PR TITLE
fix(db): migra gli allegati con currentness storica

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -81,6 +81,9 @@ jobs:
           exit 1
 
       - name: Run Playwright suite
+        # @Codex: the preceding steps seed and start an isolated synthetic DB.
+        env:
+          MF085_SYNTHETIC_E2E: "1"
         run: npx playwright test --workers=1
 
       # Seconda fase di `npm run check:terminology-parity`, l'unica che non

--- a/lib/db-server-attachment-currentness-bootstrap.test.ts
+++ b/lib/db-server-attachment-currentness-bootstrap.test.ts
@@ -146,3 +146,77 @@ test('serializes concurrent O1b workers without busy errors or duplicate renames
         } finally { db.close(); }
     } finally { fs.rmSync(current.dataDir, { recursive: true, force: true }); }
 });
+
+/* @Codex */
+// Historical installed schema: currentness exists, but created_at follows OCR
+// metadata and the counters have no safe-integer upper-bound constraint.
+function historicalCurrentness(dbPath: string): void {
+    const db = new Database(dbPath);
+    try {
+        db.exec(`ALTER TABLE attachments RENAME TO historical_fixture;
+            CREATE TABLE attachments (
+                id TEXT PRIMARY KEY NOT NULL, patient_id TEXT NOT NULL, name TEXT NOT NULL,
+                type TEXT NOT NULL, size INTEGER NOT NULL, path TEXT NOT NULL, data TEXT,
+                summary_snapshot TEXT, parse_evidence_artifact_snapshot TEXT,
+                ocr_queue_state TEXT, ocr_queue_reason TEXT, ocr_queue_updated_at INTEGER,
+                ocr_replay_artifact_snapshot TEXT, created_at INTEGER DEFAULT (unixepoch()),
+                document_source_ref TEXT NOT NULL UNIQUE CHECK (
+                    length(document_source_ref) = 64 AND document_source_ref NOT GLOB '*[^0-9a-f]*'
+                ),
+                document_revision INTEGER NOT NULL CHECK (
+                    typeof(document_revision) = 'integer' AND document_revision >= 1
+                ),
+                document_freshness_epoch INTEGER NOT NULL CHECK (
+                    typeof(document_freshness_epoch) = 'integer' AND document_freshness_epoch >= 1
+                ),
+                FOREIGN KEY (patient_id) REFERENCES patients(id) ON UPDATE NO ACTION ON DELETE NO ACTION
+            );
+            INSERT INTO attachments (${columns}, document_source_ref, document_revision, document_freshness_epoch)
+                SELECT ${columns}, '${'b'.repeat(64)}', 7, 9 FROM historical_fixture;
+            DROP TABLE historical_fixture;
+            CREATE INDEX attachments_patient_idx ON attachments(patient_id)`);
+    } finally { db.close(); }
+}
+
+/* @Codex */
+test('upgrades historical installed currentness preserving every value and replays without changes', async () => {
+    const current = tempCase();
+    try {
+        historicalCurrentness(current.dbPath);
+        const before = JSON.parse(attachmentSnapshot(current.dbPath)).rows;
+        const results = await Promise.all(Array.from({ length: 3 }, () => bootstrapAsync(current.dataDir)));
+        for (const result of results) assert.equal(result.code, 0, result.output);
+        assert.deepEqual(JSON.parse(attachmentSnapshot(current.dbPath)).rows, before);
+        const migrated = attachmentSnapshot(current.dbPath);
+        assert.equal(bootstrap(current.dataDir).status, 0);
+        assert.equal(attachmentSnapshot(current.dbPath), migrated);
+        const db = new Database(current.dbPath);
+        try {
+            for (const counter of ['document_revision', 'document_freshness_epoch']) {
+                assert.throws(() => db.exec(`UPDATE attachments SET ${counter} = 9007199254740992`), /CHECK constraint failed/u);
+            }
+        } finally { db.close(); }
+    } finally { fs.rmSync(current.dataDir, { recursive: true, force: true }); }
+});
+
+/* @Codex */
+test('historical currentness rejects invalid counters and schema drift atomically', () => {
+    for (const mutation of [
+        'UPDATE attachments SET document_revision = 9007199254740992',
+        'UPDATE attachments SET document_freshness_epoch = 9007199254740992',
+        "PRAGMA ignore_check_constraints = ON; UPDATE attachments SET document_source_ref = 'invalid'",
+        'ALTER TABLE attachments ADD COLUMN unknown_metadata TEXT',
+        'CREATE INDEX unexpected_index ON attachments(name)',
+    ]) {
+        const current = tempCase();
+        try {
+            historicalCurrentness(current.dbPath);
+            const db = new Database(current.dbPath); db.exec(mutation); db.close();
+            const before = attachmentSnapshot(current.dbPath);
+            const result = bootstrap(current.dataDir);
+            assert.notEqual(result.status, 0);
+            assert.match(`${result.stdout}${result.stderr}`, /ATTACHMENT_CURRENTNESS_MIGRATION_UNSUPPORTED/u);
+            assert.equal(attachmentSnapshot(current.dbPath), before);
+        } finally { fs.rmSync(current.dataDir, { recursive: true, force: true }); }
+    }
+});

--- a/lib/db-server.ts
+++ b/lib/db-server.ts
@@ -398,6 +398,29 @@ const ATTACHMENT_CURRENTNESS_CANONICAL_DDL = `
     )
 `;
 /* @Codex */
+// Installed currentness schema before the safe-integer constraints. Preserve
+// existing identities and counters when upgrading this exact fingerprint.
+const ATTACHMENT_CURRENTNESS_HISTORICAL_DDL = `
+    CREATE TABLE attachments (
+        id TEXT PRIMARY KEY NOT NULL, patient_id TEXT NOT NULL, name TEXT NOT NULL,
+        type TEXT NOT NULL, size INTEGER NOT NULL, path TEXT NOT NULL, data TEXT,
+        summary_snapshot TEXT,
+        parse_evidence_artifact_snapshot TEXT, ocr_queue_state TEXT,
+        ocr_queue_reason TEXT, ocr_queue_updated_at INTEGER,
+        ocr_replay_artifact_snapshot TEXT, created_at INTEGER DEFAULT (unixepoch()),
+        document_source_ref TEXT NOT NULL UNIQUE CHECK (
+            length(document_source_ref) = 64 AND document_source_ref NOT GLOB '*[^0-9a-f]*'
+        ),
+        document_revision INTEGER NOT NULL CHECK (
+            typeof(document_revision) = 'integer' AND document_revision >= 1
+        ),
+        document_freshness_epoch INTEGER NOT NULL CHECK (
+            typeof(document_freshness_epoch) = 'integer' AND document_freshness_epoch >= 1
+        ),
+        FOREIGN KEY (patient_id) REFERENCES patients(id) ON UPDATE NO ACTION ON DELETE NO ACTION
+    )
+`;
+/* @Codex */
 const ATTACHMENT_CURRENTNESS_LEGACY_SCHEMA = normalizeSchemaSql(ATTACHMENT_CURRENTNESS_LEGACY_DDL);
 /* @Codex */
 const ATTACHMENT_CURRENTNESS_CANONICAL_SCHEMA = normalizeSchemaSql(ATTACHMENT_CURRENTNESS_CANONICAL_DDL);
@@ -418,12 +441,15 @@ function denyAttachmentCurrentnessMigration(): never {
     throw new Error(ATTACHMENT_CURRENTNESS_ERROR);
 }
 /* @Codex */
-function attachmentCurrentnessSchemaMatches(expected: string, canonical: boolean): boolean {
+function attachmentCurrentnessSchemaMatches(expected: string, canonical: boolean, historical = false): boolean {
     const table = sqlite.prepare("SELECT name, sql FROM sqlite_master WHERE type = 'table' AND lower(name) = 'attachments'").get() as { name?: unknown; sql?: unknown } | undefined;
     const columns = sqlite.prepare('PRAGMA table_xinfo(attachments)').all() as Array<{ name?: unknown; type?: unknown; notnull?: unknown; dflt_value?: unknown; pk?: unknown; hidden?: unknown }>;
-    const expectedColumns = canonical
-        ? [...ATTACHMENT_CURRENTNESS_COLUMNS, ['document_source_ref', 'TEXT', 1, null, 0], ['document_revision', 'INTEGER', 1, null, 0], ['document_freshness_epoch', 'INTEGER', 1, null, 0]]
+    const baseColumns = historical
+        ? [...ATTACHMENT_CURRENTNESS_COLUMNS.slice(0, 7), ...ATTACHMENT_CURRENTNESS_COLUMNS.slice(8), ATTACHMENT_CURRENTNESS_COLUMNS[7]]
         : ATTACHMENT_CURRENTNESS_COLUMNS;
+    const expectedColumns = canonical
+        ? [...baseColumns, ['document_source_ref', 'TEXT', 1, null, 0], ['document_revision', 'INTEGER', 1, null, 0], ['document_freshness_epoch', 'INTEGER', 1, null, 0]]
+        : baseColumns;
     const foreignKeys = sqlite.prepare('PRAGMA foreign_key_list(attachments)').all() as Array<Record<string, unknown>>;
     const indexes = sqlite.prepare('PRAGMA index_list(attachments)').all() as Array<{ name?: unknown; unique?: unknown; origin?: unknown; partial?: unknown }>;
     const expectedIndexes = canonical ? 3 : 2;
@@ -452,15 +478,17 @@ function upgradeLegacyAttachmentCurrentness(): void {
         const stale = sqlite.prepare("SELECT 1 FROM sqlite_master WHERE lower(name) = 'attachments_currentness_legacy' LIMIT 1").get();
         const trigger = sqlite.prepare("SELECT 1 FROM sqlite_master WHERE type = 'trigger' AND lower(tbl_name) = 'attachments' LIMIT 1").get();
         if (stale || trigger) denyAttachmentCurrentnessMigration();
-        if (attachmentCurrentnessSchemaMatches(ATTACHMENT_CURRENTNESS_CANONICAL_SCHEMA, true)) {
+        const canonical = attachmentCurrentnessSchemaMatches(ATTACHMENT_CURRENTNESS_CANONICAL_SCHEMA, true);
+        const historical = !canonical && attachmentCurrentnessSchemaMatches(normalizeSchemaSql(ATTACHMENT_CURRENTNESS_HISTORICAL_DDL), true, true);
+        if (canonical || historical) {
             const invalid = sqlite.prepare(`SELECT 1 FROM attachments WHERE typeof(document_source_ref) != 'text'
                 OR length(document_source_ref) != 64 OR document_source_ref GLOB '*[^0-9a-f]*'
                 OR typeof(document_revision) != 'integer' OR document_revision NOT BETWEEN 1 AND 9007199254740991
                 OR typeof(document_freshness_epoch) != 'integer' OR document_freshness_epoch NOT BETWEEN 1 AND 9007199254740991 LIMIT 1`).get();
             if (invalid) denyAttachmentCurrentnessMigration();
-            return;
+            if (canonical) return;
         }
-        if (!attachmentCurrentnessSchemaMatches(ATTACHMENT_CURRENTNESS_LEGACY_SCHEMA, false)) denyAttachmentCurrentnessMigration();
+        if (!historical && !attachmentCurrentnessSchemaMatches(ATTACHMENT_CURRENTNESS_LEGACY_SCHEMA, false)) denyAttachmentCurrentnessMigration();
         if (sqlite.prepare('SELECT 1 FROM attachments AS attachment LEFT JOIN patients AS patient ON patient.id = attachment.patient_id WHERE patient.id IS NULL LIMIT 1').get()) denyAttachmentCurrentnessMigration();
         sqlite.exec('ALTER TABLE attachments RENAME TO attachments_currentness_legacy');
         sqlite.exec(ATTACHMENT_CURRENTNESS_CANONICAL_DDL);
@@ -469,7 +497,8 @@ function upgradeLegacyAttachmentCurrentness(): void {
             document_source_ref, document_revision, document_freshness_epoch)
             SELECT id, patient_id, name, type, size, path, data, created_at, summary_snapshot,
             parse_evidence_artifact_snapshot, ocr_queue_state, ocr_queue_reason, ocr_queue_updated_at, ocr_replay_artifact_snapshot,
-            lower(hex(randomblob(32))), 1, 1 FROM attachments_currentness_legacy`);
+            ${historical ? 'document_source_ref, document_revision, document_freshness_epoch' : 'lower(hex(randomblob(32))), 1, 1'}
+            FROM attachments_currentness_legacy`);
         sqlite.exec('DROP TABLE attachments_currentness_legacy');
         sqlite.exec('CREATE INDEX attachments_patient_idx ON attachments(patient_id)');
     } catch (error) {

--- a/lib/security/headless-soap-active-role-enrollment.test.ts
+++ b/lib/security/headless-soap-active-role-enrollment.test.ts
@@ -15,6 +15,8 @@ const USERNAME = 'synthetic-soap-admin';
 const SESSION_ID = 'a'.repeat(64);
 const NOW = Math.floor(Date.now() / 1_000) * 1_000;
 const TTL_MS = 8 * 60 * 60 * 1_000;
+// @Codex: future fixtures must remain future under full-suite CI scheduling.
+const FUTURE = NOW + TTL_MS;
 const baseSession = { id: SESSION_ID, userId: ACTOR, username: USERNAME, role: 'admin', authChannel: 'web', createdAt: NOW - 2_000, expiresAt: NOW + TTL_MS };
 function session(change: Record<string, unknown> = {}): unknown {
     return Object.freeze(Object.assign(Object.create(null), baseSession, change));
@@ -76,7 +78,7 @@ test('denies invalid PIN, non-current session, credential mismatch, and every se
         await assert.rejects(createHeadlessSoapActiveRoleEnrollmentService(sources({ resolveCurrentWebAdmin: async () => { observed++; return session(); } })).enroll(invalid as never), hasCode('enrollment_denied'));
         assert.equal(observed, 0);
     }
-    for (const current of [null, session({ role: 'doctor' }), session({ authChannel: 'native' }), session({ createdAt: NOW - 2_000, expiresAt: NOW - 1_000 }), session({ createdAt: NOW + 1_000, expiresAt: NOW + TTL_MS })]) {
+    for (const current of [null, session({ role: 'doctor' }), session({ authChannel: 'native' }), session({ createdAt: NOW - 2_000, expiresAt: NOW - 1_000 }), session({ createdAt: FUTURE, expiresAt: FUTURE + TTL_MS })]) {
         let verified = 0;
         await assert.rejects(createHeadlessSoapActiveRoleEnrollmentService(sources({ resolveCurrentWebAdmin: async () => current, verifyCredentials: async () => { verified++; return { kind: 'denied' }; } })).enroll(PIN), hasCode('enrollment_denied'));
         assert.equal(verified, 0);
@@ -97,7 +99,7 @@ test('maps dependency and forged lifecycle failures to sanitized fail-closed err
     await assert.rejects(createHeadlessSoapActiveRoleEnrollmentService(sources({ readAttestation: () => ({ kind: 'unavailable' }) })).enroll(PIN), hasCode('storage_unavailable'));
     for (const forged of [attestation({ actorRef: 'other' }), attestation({ status: 'revoked', revocationGeneration: 1 }),
         attestation({ activatedAt: new Date(NOW - TTL_MS - 1_000), expiresAt: new Date(NOW - 1_000), createdAt: new Date(NOW - TTL_MS - 2_000), updatedAt: new Date(NOW - TTL_MS - 1_000) }),
-        attestation({ activatedAt: new Date(NOW + 1_000), expiresAt: new Date(NOW + 1_000 + TTL_MS), updatedAt: new Date(NOW + 1_000) }),
+        attestation({ activatedAt: new Date(FUTURE), expiresAt: new Date(FUTURE + TTL_MS), updatedAt: new Date(FUTURE) }),
         attestation({ expiresAt: new Date(NOW - 999) })]) {
         await assert.rejects(createHeadlessSoapActiveRoleEnrollmentService(sources({ activate: () => ({ kind: 'ok', value: forged }) })).enroll(PIN), hasCode('storage_unavailable'));
     }

--- a/scripts/check-attachment-currentness-writers.mjs
+++ b/scripts/check-attachment-currentness-writers.mjs
@@ -28,7 +28,7 @@ export const CONTRACT = [
     record('lib/backup-restore-executor.ts', 'restore-insert-binding', 'd047e211add695dc', 1),
     record('lib/backup-restore-executor.ts', 'restore-insert', 'e9d1fc20c04fbedd', 1),
     record('lib/backup-restore-executor.ts', 'restore-table-binding', '58e16648da2bfbac', 1),
-    record('lib/db-server.ts', 'raw-insert-into', 'a4323ba425fdf647', 1, 'migration'),
+    record('lib/db-server.ts', 'raw-insert-into', 'ad4d3f978bf6eeb3', 1, 'migration'),
     record('lib/network-attachment-write.ts', 'orm-insert', '616925ed8587e1e5', 1),
     record('lib/patient-cascade.ts', 'purge-delete', '1544def1d89b8873', 1),
     record('lib/patient-cascade.ts', 'purge-delete', '4dd20c8a366b6640', 1),


### PR DESCRIPTION
## Summary
- Corregge il blocco di avvio `ATTACHMENT_CURRENTNESS_MIGRATION_UNSUPPORTED` per lo schema storico degli allegati con currentness già presente.
- Migra soltanto il fingerprint storico riconosciuto, preservando riferimenti, revisioni, epoch e contenuti; applica i vincoli canonici nella transazione di bootstrap esistente.
- Aggiunge regressioni sintetiche per conservazione dei valori, replay, concorrenza e rifiuto atomico di valori invalidi o schema sconosciuto; aggiorna il fingerprint del writer di migrazione.

- Sblocca la verifica CI dichiarando l’ambiente sintetico nello step Playwright già isolato e rendendo stabili le fixture temporali di due test; nessuna modifica al runtime auth.

## Verification
- Sul commit `b961aa1c305f62f77f065e5345c5a34d47d5af36`, tutti i sette check obbligatori remoti sono SUCCESS: repository-guards, web-core, lint/typecheck, build/start Linux, macOS e Windows, E2E.
- Test bootstrap currentness: 7/7; prima del fix il nuovo caso storico falliva con lo stesso errore di avvio.
- `npm run test:db-bootstrap-concurrency`: 1/1.
- `npm run check:attachment-currentness-writers` e test del guard: 5/5.
- Cinque test di `headless-soap-active-role-enrollment.test.ts`, ESLint del file e parsing YAML del workflow corretti: superati.
- `npm run lint`, `npm run typecheck`, `npm run check:never-regress`, `npm run check:claims`, `git diff --check`.
- `npm run build -- --webpack`, incluso postbuild standalone: superati con dipendenze fisiche del worktree e Node 24.19.0.
- Verifica locale dopo backup SQLite: pagina iniziale e endpoint di revisione HTTP 200, integrità SQLite OK, valori degli allegati invariati rispetto al backup. Nessun contenuto del database è incluso nella PR.

## Risk / Notes
- Migrazione limitata allo schema storico esatto; schemi sconosciuti e contatori fuori dal range safe-integer restano rifiutati.
- Nessun impatto sul contratto API, nessuna PHI/PII o dato paziente reale nelle fixture o nel diff.
- La verifica locale non sostituisce la CI remota richiesta per il merge. Nessuna nuova release o distribuzione firmata è inclusa.
- Il job non obbligatorio Headless Windows fallisce su `empty-env control contains unapproved keys`: stesso errore già presente sulla base `5cbbf777e9ee` ([run main](https://github.com/Wulfgardr/mediflow/actions/runs/33961402632), [run PR](https://github.com/Wulfgardr/mediflow/actions/runs/33980095818)). Il supervisor e i relativi test Windows non sono modificati da questa PR; il problema resta fuori dal fix della migrazione.
